### PR TITLE
Compilation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ examples/dreamcast/conio/adventure/data.c
 examples/dreamcast/conio/adventure/setup
 examples/dreamcast/png/romdisk_boot.img
 examples/dreamcast/pvr/modifier_volume_tex/romdisk/fruit.kmg
+examples/dreamcast/pvr/bumpmap/romdisk/bricks.kmg
+examples/dreamcast/pvr/bumpmap/romdisk/bumpmap.raw
 examples/dreamcast/pvr/texture_render/texture_render.bin
 utils/dc-chain/logs
 utils/dc-chain/*.tar.bz2

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ distclean: clean
 	-rm -f addons/lib/$(KOS_ARCH)/*
 
 kos-ports_all:
-	$(KOS_MAKE) -C ../kos-ports all KOS_BASE=$(CURDIR)
+	../kos-ports/utils/build-all.sh
 
 kos-ports_clean:
 	$(KOS_MAKE) -C ../kos-ports clean KOS_BASE=$(CURDIR)

--- a/examples/dreamcast/cpp/gltest/Makefile
+++ b/examples/dreamcast/cpp/gltest/Makefile
@@ -17,7 +17,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS) romdisk.o
-	kos-c++ -o $(TARGET) $(OBJS) romdisk.o -lgl -lkosutils
+	kos-c++ -o $(TARGET) $(OBJS) romdisk.o -lGL -lkosutils
 
 romdisk.img:
 	$(KOS_GENROMFS) -f romdisk.img -d romdisk -v

--- a/examples/dreamcast/parallax/bubbles/Makefile
+++ b/examples/dreamcast/parallax/bubbles/Makefile
@@ -18,7 +18,7 @@ rm-elf:
 
 $(TARGET): $(OBJS)
 	$(KOS_CC) $(KOS_CFLAGS) $(KOS_LDFLAGS) -o $(TARGET) $(KOS_START) \
-		$(OBJS) $(OBJEXTRA) -lparallax -lgl $(KOS_LIBS)
+		$(OBJS) $(OBJEXTRA) -lparallax -lGL $(KOS_LIBS)
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/tsunami/banner/Makefile
+++ b/examples/dreamcast/tsunami/banner/Makefile
@@ -18,7 +18,7 @@ rm-elf:
 
 $(TARGET): $(OBJS) romdisk.o
 	$(KOS_CC) $(KOS_CFLAGS) $(KOS_LDFLAGS) -o $(TARGET) $(KOS_START) \
-		$(OBJS) romdisk.o $(OBJEXTRA) -ltsunami -lk++ -lparallax -lpng -ljpeg -lkmg -lkosutils -lz -lm $(KOS_LIBS)
+		$(OBJS) romdisk.o $(OBJEXTRA) -ltsunami -lstdc++ -lparallax -lpng -ljpeg -lkmg -lkosutils -lz -lm $(KOS_LIBS)
 
 romdisk.img:
 	$(KOS_GENROMFS) -f romdisk.img -d romdisk -v

--- a/examples/dreamcast/tsunami/font/Makefile
+++ b/examples/dreamcast/tsunami/font/Makefile
@@ -18,7 +18,8 @@ rm-elf:
 
 $(TARGET): $(OBJS) romdisk.o
 	$(KOS_CC) $(KOS_CFLAGS) $(KOS_LDFLAGS) -o $(TARGET) $(KOS_START) \
-		$(OBJS) romdisk.o $(OBJEXTRA) -ltsunami -lk++ -lparallax -lpng -ljpeg -lkmg -lz -lkosutils -lm $(KOS_LIBS)
+		$(OBJS) romdisk.o $(OBJEXTRA) -lstdc++ -ltsunami -lparallax -lpng -ljpeg -lkmg -lz -lkosutils -lm $(KOS_LIBS) 
+
 
 romdisk.img:
 	$(KOS_GENROMFS) -f romdisk.img -d romdisk -v

--- a/utils/dc-chain/patches/gcc-4.7.3-kos-remove-doc.diff
+++ b/utils/dc-chain/patches/gcc-4.7.3-kos-remove-doc.diff
@@ -1,0 +1,20 @@
+--- gcc-4.7.3/gcc/Makefile.in	2013-04-01 10:11:11.000000000 +0200
++++ gcc-4.7.3-keep/gcc/Makefile.in	2016-10-15 00:17:04.600424979 +0200
+@@ -4255,8 +4255,6 @@
+ 
+ # Remake the info files.
+ 
+-doc: $(BUILD_INFO) $(GENERATED_MANPAGES)
+-
+ INFOFILES = doc/cpp.info doc/gcc.info doc/gccint.info \
+             doc/gccinstall.info doc/cppinternals.info
+ 
+@@ -4546,7 +4544,7 @@
+ # Install the driver last so that the window when things are
+ # broken is small.
+ install: install-common $(INSTALL_HEADERS) \
+-    install-cpp install-man install-info install-@POSUB@ \
++    install-cpp install-man install-@POSUB@ \
+     install-driver install-lto-wrapper install-gcc-ar
+ 
+ ifeq ($(enable_plugin),yes)

--- a/utils/dc-chain/patches/gcc-4.8.2-kos-remove-doc.diff
+++ b/utils/dc-chain/patches/gcc-4.8.2-kos-remove-doc.diff
@@ -1,0 +1,20 @@
+--- gcc-4.7.3/gcc/Makefile.in	2013-04-01 10:11:11.000000000 +0200
++++ gcc-4.7.3-keep/gcc/Makefile.in	2016-10-15 00:17:04.600424979 +0200
+@@ -4255,8 +4255,6 @@
+ 
+ # Remake the info files.
+ 
+-doc: $(BUILD_INFO) $(GENERATED_MANPAGES)
+-
+ INFOFILES = doc/cpp.info doc/gcc.info doc/gccint.info \
+             doc/gccinstall.info doc/cppinternals.info
+ 
+@@ -4546,7 +4544,7 @@
+ # Install the driver last so that the window when things are
+ # broken is small.
+ install: install-common $(INSTALL_HEADERS) \
+-    install-cpp install-man install-info install-@POSUB@ \
++    install-cpp install-man install-@POSUB@ \
+     install-driver install-lto-wrapper install-gcc-ar
+ 
+ ifeq ($(enable_plugin),yes)


### PR DESCRIPTION
In the container on which I build the toolchain, I have an issue while compiling gcc :

```
if [ xinfo = xinfo ]; then \
    makeinfo --split-size=5000000 --split-size=5000000 --no-split -I . -I ../../gcc-4.7.3/gcc/doc \
        -I ../../gcc-4.7.3/gcc/doc/include -o doc/gcc.info ../../gcc-4.7.3/gcc/doc/gcc.texi; \
fi
tconfig.h is unchanged
if [ xinfo = xinfo ]; then \
    makeinfo --split-size=5000000 --split-size=5000000 --no-split -I ../../gcc-4.7.3/gcc/doc \
        -I ../../gcc-4.7.3/gcc/doc/include -o doc/gccinstall.info ../../gcc-4.7.3/gcc/doc/install.texi; \
fi
/bin/bash ../../gcc-4.7.3/gcc/../move-if-change tmp-all-tree.def all-tree.def
echo timestamp > s-alltree
if [ xinfo = xinfo ]; then \
    makeinfo --split-size=5000000 --split-size=5000000 --no-split -I . -I ../../gcc-4.7.3/gcc/doc \
        -I ../../gcc-4.7.3/gcc/doc/include -o doc/cppinternals.info ../../gcc-4.7.3/gcc/doc/cppinternals.texi; \
fi
/bin/bash ../../gcc-4.7.3/gcc/../move-if-change tmp-mlib.h multilib.h
echo timestamp > s-mlib
echo timestamp > gcc.pod
perl ../../gcc-4.7.3/gcc/../contrib/texi2pod.pl ../../gcc-4.7.3/gcc/doc/invoke.texi > gcc.pod
Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/^\@strong{ <-- HERE (.*)}$/ at ../../gcc-4.7.3/gcc/../contrib/texi2pod.pl line 319.
../../gcc-4.7.3/gcc/doc/gcc.texi:89: warning: @tex should only appear at the beginning of a line
../../gcc-4.7.3/gcc/doc/gcc.texi:209: no matching `@end tex'
../../gcc-4.7.3/gcc/doc/gcc.texi:209: no matching `@end multitable'
../../gcc-4.7.3/gcc/doc/gcc.texi:209: no matching `@end titlepage'
Makefile:4342: recipe for target 'doc/gcc.info' failed
```

Maybe related to this behavior as well : https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60961

That's why I patch gcc makefile to not build documentation.

I fixed a couple of example makefiles as well.
