### PR TITLE
Fix: make_banner.sh

### DIFF
--- a/kernel/arch/dreamcast/kernel/make_banner.sh
+++ b/kernel/arch/dreamcast/kernel/make_banner.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Re-creates the banner.h file for each compilation run
 

--- a/kernel/arch/dreamcast/kernel/make_banner.sh
+++ b/kernel/arch/dreamcast/kernel/make_banner.sh
@@ -10,7 +10,7 @@ relver='##version##'
 printf '"KallistiOS ' >> banner.h
 if [ -d "$KOS_BASE/.git" ]; then
     printf 'Git revision ' >> banner.h
-    gitrev=`git describe --dirty`
+    gitrev=`git describe --dirty --always`
     printf "$gitrev" >> banner.h
     printf ':\\n\"\n' >> banner.h
 else


### PR DESCRIPTION
Hi,

i had some trouble building the latest toolchain. There were two problems in "make_banner.sh" for me.
First, line 13 "git describe" didn't give me any value back. I've forced it using "--always".

Also the if-block in [line 47](https://github.com/Nold360/KallistiOS/blob/72be57894c7c9aab7dd69f5dd085ca05cf79ac5e/kernel/arch/dreamcast/kernel/make_banner.sh#L4) fails on a distribution where /bin/sh is not simply a link to /bin/bash (like debian).