### PR TITLE
Avoid compiled "addons" libraries removal when cleaning

### DIFF
--- a/addons/Makefile.prefab
+++ b/addons/Makefile.prefab
@@ -25,6 +25,6 @@ linklib:
 clean: defaultclean
          
 defaultclean: clean_subdirs
-	-rm -f $(OBJS) $(KOS_BASE)/addons/lib/$(KOS_ARCH)/$(TARGET) $(LOCAL_CLEAN)
+	-rm -f $(OBJS) $(LOCAL_CLEAN)
 
 include $(KOS_BASE)/Makefile.rules


### PR DESCRIPTION
When doing `make clean` on **KallistiOS** root, all objects are removed including compiled binaries.
The removal of compiled libraries should be done only with the `make distclean` command.