### PR TITLE
GCC 9 fix

### DIFF
--- a/utils/dc-chain/Makefile
+++ b/utils/dc-chain/Makefile
@@ -174,7 +174,7 @@ $(build_gcc_pass1): logdir
 	> $(log)
 	cd $(build);  ../$(src_dir)/configure --target=$(target) --prefix=$(prefix) --without-headers --with-newlib --enable-languages=c --disable-libssp --disable-tls $(extra_configure_args) CXX=$(CXX) $(to_log)
 	$(MAKE) $(makejobs) -C $(build) DESTDIR=$(DESTDIR) $(to_log)
-	$(MAKE) -C $(build) install DESTDIR=$(DESTDIR) $(to_log)
+	$(MAKE) -C $(build) install-strip DESTDIR=$(DESTDIR) $(to_log)
 
 $(build_newlib): build = build-newlib-$(target)-$(newlib_ver)
 $(build_newlib): src_dir = newlib-$(newlib_ver)
@@ -212,7 +212,7 @@ $(build_gcc_pass2): logdir
 	cd $(build);  ../$(src_dir)/configure --target=$(target) --prefix=$(prefix) --with-newlib --disable-libssp --disable-tls \
 	   --enable-threads=$(thread_model) --enable-languages=$(pass2_languages) $(extra_configure_args) CXX=$(CXX) $(to_log)
 	$(MAKE) $(makejobs) -C $(build) DESTDIR=$(DESTDIR) $(to_log)
-	$(MAKE) -C $(build) install DESTDIR=$(DESTDIR) $(to_log)
+	$(MAKE) -C $(build) install-strip DESTDIR=$(DESTDIR) $(to_log)
 	$(clean_up)
 
 # ---- }}}}

--- a/utils/dc-chain/Makefile
+++ b/utils/dc-chain/Makefile
@@ -31,7 +31,7 @@ kos_base=$(CURDIR)/../..
 sh_binutils_ver=2.34
 sh_gcc_ver=9.3.0
 newlib_ver=3.3.0
-gdb_ver=7.11.1
+gdb_ver=9.1
 insight_ver=6.8-1
 
 # The ARM version of binutils/gcc is separated out as the
@@ -317,7 +317,7 @@ clean:
 	-rm -rf build-gcc-$(arm_target)-$(gcc_ver)
 	-rm -rf build-binutils-$(sh_target)-$(binutils_ver)
 	-rm -rf build-binutils-$(arm_target)-$(binutils_ver)
-	-rm -rf build-gdb-$(gdb_ver) install_gdb_stamp build_gdb_stamp unpack_gdb_stamp
+	-rm -rf build-gdb-$(gdb_ver) gdb-$(gdb_ver) gdb-$(gdb_ver).tar.gz install_gdb_stamp build_gdb_stamp unpack_gdb_stamp
 	-rm -rf build-insight-$(insight_ver) install_insight_stamp build_insight_stamp unpack_insight_stamp
 
 logdir:

--- a/utils/dc-chain/Makefile
+++ b/utils/dc-chain/Makefile
@@ -40,10 +40,10 @@ insight_ver=6.8-1
 arm_binutils_ver=2.34
 arm_gcc_ver=8.4.0
 
-# With GCC 4.x versions, the patches provide a kos thread model, so you should
-# use it. With 3.4.6, you probably want posix here. If you really don't want
-# threading support for C++ (or Objective C/Objective C++), you can set this to
-# single (why you would is beyond me, though).
+# With GCC 4.x versions and higher, the patches provide a kos thread model, 
+# so you should use it. With 3.4.6, you probably want posix here. If you 
+# really don't want threading support for C++ (or Objective C/Objective C++), 
+# you can set this to single (why you would is beyond me, though).
 thread_model=kos
 erase=1
 verbose=1

--- a/utils/dc-chain/cleanup.sh
+++ b/utils/dc-chain/cleanup.sh
@@ -5,9 +5,9 @@ export SH_GCC_VER=9.3.0
 export ARM_GCC_VER=8.4.0
 export BINUTILS_VER=2.34
 export NEWLIB_VER=3.3.0
-export GMP_VER=4.3.2
-export MPFR_VER=2.4.2
-export MPC_VER=0.8.1
+export GMP_VER=6.1.0
+export MPFR_VER=3.1.4
+export MPC_VER=1.0.3
 
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`

--- a/utils/dc-chain/download.sh
+++ b/utils/dc-chain/download.sh
@@ -5,9 +5,9 @@ export SH_GCC_VER=9.3.0
 export ARM_GCC_VER=8.4.0
 export BINUTILS_VER=2.34
 export NEWLIB_VER=3.3.0
-export GMP_VER=4.3.2
-export MPFR_VER=2.4.2
-export MPC_VER=0.8.1
+export GMP_VER=6.1.0
+export MPFR_VER=3.1.4
+export MPC_VER=1.0.3
 
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`

--- a/utils/dc-chain/unpack.sh
+++ b/utils/dc-chain/unpack.sh
@@ -5,9 +5,9 @@ export SH_GCC_VER=9.3.0
 export ARM_GCC_VER=8.4.0
 export BINUTILS_VER=2.34
 export NEWLIB_VER=3.3.0
-export GMP_VER=4.3.2
-export MPFR_VER=2.4.2
-export MPC_VER=0.8.1
+export GMP_VER=6.1.0
+export MPFR_VER=3.1.4
+export MPC_VER=1.0.3
 
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`
@@ -47,15 +47,18 @@ tar xf newlib-$NEWLIB_VER.tar.gz || exit 1
 # Unpack the GCC dependencies and move them into their required locations.
 if [ -n "$GMP_VER" ]; then
     tar jxf gmp-$GMP_VER.tar.bz2 || exit 1
-    mv gmp-$GMP_VER gcc-$GCC_VER/gmp
+    cp -pr gmp-$GMP_VER gcc-$SH_GCC_VER/gmp
+    mv gmp-$GMP_VER gcc-$ARM_GCC_VER/gmp
 fi
 
 if [ -n "$MPFR_VER" ]; then
     tar jxf mpfr-$MPFR_VER.tar.bz2 || exit 1
-    mv mpfr-$MPFR_VER gcc-$GCC_VER/mpfr
+    cp -pr mpfr-$MPFR_VER gcc-$SH_GCC_VER/mpfr
+    mv mpfr-$MPFR_VER gcc-$ARM_GCC_VER/mpfr
 fi
 
 if [ -n "$MPC_VER" ]; then
     tar zxf mpc-$MPC_VER.tar.gz || exit 1
-    mv mpc-$MPC_VER gcc-$GCC_VER/mpc
+    cp -pr mpc-$MPC_VER gcc-$SH_GCC_VER/mpc
+    mv mpc-$MPC_VER gcc-$ARM_GCC_VER/mpc
 fi


### PR DESCRIPTION
Fixes building with deps, updates the deps to higher versions, and switches to install-strip to drastically reduce final toolchain size.