### PR TITLE
Cap needed_samples so req isnt greather than buffer_size

### DIFF
--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -480,6 +480,7 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
 
     if(needed_samples > 0) {
         if(streams[hnd].stereo) {
+            needed_samples = (needed_samples > streams[hnd].buffer_size/4) ? streams[hnd].buffer_size/4 : needed_samples;
             data = streams[hnd].get_data(hnd, needed_samples * 4, &got_samples);
             process_filters(hnd, &data, &got_samples);
 
@@ -491,6 +492,7 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
             }
         }
         else {
+            needed_samples = needed_samples > streams[hnd].buffer_size/2 ? streams[hnd].buffer_size/2 : needed_samples;
             data = streams[hnd].get_data(hnd, needed_samples * 2, &got_samples);
             process_filters(hnd, &data, &got_samples);
 


### PR DESCRIPTION
I am writing a sound streaming library and came across an issue with stopping and playing a sound stream.  The issue is after starting the stream(after having stopped it), the request for data [int req]:

`file_callback(snd_stream_hnd_t hnd, int req, int* done)`

Value would sometimes be greater than the buffer size I allocated for it in:

`snd_stream_alloc(callback, SND_STREAM_BUFFER_MAX);`

This causes a buffer overflow I think.  So I capped the value of needed_samples and it seems to fix the issue.  

The reason needed_samples value is so large is that it derives its value from 
**current_play_pos** and **streams[hnd].last_write_pos**.  Uncommenting the debug statement already in the code, starting out from playing the first time I get print statements like this:

last_write_pos      0, current_play_pos      0, needed_samples      0
last_write_pos      0, current_play_pos   4256, needed_samples   4096
...

Then after stoping and hitting play again I get this:

last_write_pos      0, current_play_pos  20127, needed_samples  18432
last_write_pos  16384, current_play_pos   4256, needed_samples  16384

For stereo we request needed_samples x 4 => 18432*4 = 73728 > SND_STREAM_BUFFER_MAX(65536).

