### PR TITLE
Fixed sfx vol 255 crash

### DIFF
--- a/kernel/arch/dreamcast/sound/arm/aica.c
+++ b/kernel/arch/dreamcast/sound/arm/aica.c
@@ -96,7 +96,6 @@ void aica_play(int ch, int delay) {
 
     uint32 freq_lo, freq_base = 5644800;
     int freq_hi = 7;
-    uint32 i;
     uint32 playCont;
 
     /* Stop the channel (if it's already playing) */

--- a/kernel/arch/dreamcast/sound/arm/aica.c
+++ b/kernel/arch/dreamcast/sound/arm/aica.c
@@ -124,14 +124,13 @@ void aica_play(int ch, int delay) {
     /* Write resulting values */
     CHNREG32(ch, 24) = (freq_hi << 11) | (freq_lo & 1023);
 
-    /* Set volume, pan */
+    /* Convert the incoming pan into a hardware value and set it */
     CHNREG8(ch, 36) = calc_aica_pan(pan);
     CHNREG8(ch, 37) = 0xf;
     /* turn off Low Pass Filter (LPF) */
     CHNREG8(ch, 40) = 0x24;
-    /* Convert the incoming volume and pan into hardware values */
-    /* Vol starts at zero so we can ramp */
-    CHNREG8(ch, 41) = 0xff;
+    /* Convert the incoming volume into a hardware value and set it */
+    CHNREG8(ch, 41) = calc_aica_vol(vol);
 
     /* If we supported volume envelopes (which we don't yet) then
        this value would set that up. The top 4 bits determine the
@@ -149,21 +148,15 @@ void aica_play(int ch, int delay) {
        also set the bits to start playback here. */
     CHNREG32(ch, 4) = smpptr & 0xffff;
     playCont = (mode << 7) | (smpptr >> 16);
-    vol = calc_aica_vol(vol);
 
     if(loopflag)
         playCont |= 0x0200;
 
     if(delay) {
         CHNREG32(ch, 0) = playCont;         /* key off */
-        CHNREG8(ch, 41) = vol;
     }
     else {
         CHNREG32(ch, 0) = 0xc000 | playCont;    /* key on */
-
-        /* ramp up the volume */
-        for(i = 0xff; i >= vol; i--)
-            CHNREG8(ch, 41) = i;
     }
 }
 

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -432,7 +432,7 @@ void snd_stream_stop(snd_stream_hnd_t hnd) {
 
     /* Channel 1 */
     cmd->cmd_id = streams[hnd].ch[1];
-    snd_sh4_to_aica(tmp, AICA_CMDSTR_CHANNEL_SIZE);
+    snd_sh4_to_aica(tmp, cmd->size);
 }
 
 /* The DMA will chain to this to start the second DMA. */
@@ -476,7 +476,7 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
 
     /* round it a little bit */
     needed_samples &= ~0x7ff;
-    /* printf("last_write_pos %6i, current_play_pos %6i, needed_samples %6i\n",last_write_pos,current_play_pos,needed_samples); */
+    /* printf("last_write_pos %6u, current_play_pos %6u, needed_samples %6i\n",streams[hnd].last_write_pos,current_play_pos,needed_samples); */
 
     if(needed_samples > 0) {
         if(streams[hnd].stereo) {


### PR DESCRIPTION
Fixes audio crash issue when trying to play sound effects using
`snd_sfx_play(hnd, vol, pan)`
with vol = 255.

Streaming sounds doesn't suffer from this issue and I can see why.  We hard set the value while for sound effects we "ramp up" to the value.  Still not sure why that ramp up for-loop crashes the Aica for 255 only but why do we need to ramp up anyway?  I see in the sound example provided at http://mc.pp.se/dc/files/sound.tar.gz we hard set the value and even in libs3m (which doesn't exist anymore in current kos-ports) we hard set it as well https://github.com/losinggeneration/kos-ports/blob/master/libs3m/s3mplay/aica.c#L161.

Not sure where ramping up came from but it looks like that approach no longer works.