### PR TITLE
Ramdisk bug fix and Romdisk comment fix

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -112,6 +112,8 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - NAO Cleaned up the build process to not build certain parts of the DC hardware
       support that are either not useful or not (yet?) functional on NAOMI [LS]
 - DC  Fixed fs_path_append unsafe pointer arithmetic and made it smarter [AB]
+- DC  Fixed fs_ramdisk_attach so it does not cut off the first character of filename when
+      attaching
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Dan Potter == DP]

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -113,7 +113,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
       support that are either not useful or not (yet?) functional on NAOMI [LS]
 - DC  Fixed fs_path_append unsafe pointer arithmetic and made it smarter [AB]
 - DC  Fixed fs_ramdisk_attach so it does not cut off the first character of filename when
-      attaching
+      attaching [AB]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Dan Potter == DP]

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -114,6 +114,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Fixed fs_path_append unsafe pointer arithmetic and made it smarter [AB]
 - DC  Fixed fs_ramdisk_attach so it does not cut off the first character of filename when
       attaching [AB]
+- DC  Moved max open file constants for CD, Ramdisk, Romdisk to opts.h [AB]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Dan Potter == DP]

--- a/include/kos/fs_ramdisk.h
+++ b/include/kos/fs_ramdisk.h
@@ -29,6 +29,14 @@ __BEGIN_DECLS
 #include <kos/limits.h>
 #include <kos/fs.h>
 
+/** \brief  The maximum number of files that can be open at a time. */
+#define MAX_RAM_FILES 8
+
+/** \cond */
+int fs_ramdisk_init();
+int fs_ramdisk_shutdown();
+/** \endcond */
+
 /** \brief  Attach a block of memory as a file in the ramdisk.
 
     This function takes a block of memory and associates it with a file on the
@@ -57,11 +65,6 @@ int fs_ramdisk_attach(const char * fn, void * obj, size_t size);
     \retval -1              On failure
 */
 int fs_ramdisk_detach(const char * fn, void ** obj, size_t * size);
-
-/** \cond */
-int fs_ramdisk_init();
-int fs_ramdisk_shutdown();
-/** \endcond */
 
 __END_DECLS
 

--- a/include/kos/fs_ramdisk.h
+++ b/include/kos/fs_ramdisk.h
@@ -29,9 +29,6 @@ __BEGIN_DECLS
 #include <kos/limits.h>
 #include <kos/fs.h>
 
-/** \brief  The maximum number of files that can be open at a time. */
-#define MAX_RAM_FILES 8
-
 /** \cond */
 int fs_ramdisk_init();
 int fs_ramdisk_shutdown();

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -15,7 +15,7 @@
 
     You can choose to automount one ROMFS image by embedding it into your binary
     and using the appropriate KOS_INIT_FLAGS() setting. The embedded ROMFS will
-    mount itself on /rom. You can also mount additional images that you load
+    mount itself on /rd. You can also mount additional images that you load
     from some other source on whatever mountpoint you want.
 
     \author Dan Potter

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -31,9 +31,6 @@ __BEGIN_DECLS
 #include <kos/limits.h>
 #include <kos/fs.h>
 
-/** \brief  The maximum number of files that can be open at a time. */
-#define MAX_RD_FILES 16
-
 /** \cond */
 /* Initialize the file system */
 int fs_romdisk_init();

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -108,6 +108,9 @@ __BEGIN_DECLS
 #define VMUFS_DEBUG 1
 #endif
 
+/** \brief  The maximum number of cd files that can be open at a time. */
+#define FS_CD_MAX_FILES 8
+
 /** \brief  The maximum number of romdisk files that can be open at a time. */
 #define FS_ROMDISK_MAX_FILES 16
 

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -108,6 +108,12 @@ __BEGIN_DECLS
 #define VMUFS_DEBUG 1
 #endif
 
+/** \brief  The maximum number of romdisk files that can be open at a time. */
+#define FS_ROMDISK_MAX_FILES 16
+
+/** \brief  The maximum number of ramdisk files that can be open at a time. */
+#define FS_RAMDISK_MAX_FILES 8
+
 __END_DECLS
 
 #endif /* !__KOS_OPTS_H */

--- a/kernel/arch/dreamcast/include/dc/fs_iso9660.h
+++ b/kernel/arch/dreamcast/include/dc/fs_iso9660.h
@@ -32,9 +32,6 @@ __BEGIN_DECLS
 #include <kos/limits.h>
 #include <kos/fs.h>
 
-/** \brief  The maximum number of files that can be open at once. */
-#define MAX_ISO_FILES 8
-
 /** \brief  Reset the internal ISO9660 cache.
 
     This function resets the cache of the ISO9660 driver, breaking connections

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -87,8 +87,6 @@ static rd_dir_t  *rootdir = NULL;
 /********************************************************************************/
 /* File primitives */
 
-#define MAX_RAM_FILES 8
-
 /* File handles.. I could probably do this with a linked list, but I'm just
    too lazy right now. =) */
 static struct {

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -231,7 +231,7 @@ static void * ramdisk_open(vfs_handler_t * vfs, const char *fn, int mode) {
 
     (void)vfs;
 
-    if(!strcmp(fn, "/"))
+    if(fn[0] == '/')
         fn++;
 
     mutex_lock(&rd_mutex);
@@ -247,13 +247,13 @@ static void * ramdisk_open(vfs_handler_t * vfs, const char *fn, int mode) {
         f = root;
     }
     else {
-        f = ramdisk_find_path(rootdir, fn + 1, mode & O_DIR);
+        f = ramdisk_find_path(rootdir, fn, mode & O_DIR);
 
         if(f == NULL) {
             /* Are we planning to write anyway? */
             if(mm != O_RDONLY && !(mode & O_DIR)) {
                 /* Create a new file */
-                f = ramdisk_create_file(rootdir, fn + 1, mode & O_DIR);
+                f = ramdisk_create_file(rootdir, fn, mode & O_DIR);
 
                 if(f == NULL)
                     goto error_out;


### PR DESCRIPTION
Have ramdisk header match romdisk  (MAX_RAM_FILES publicly available in fs_ramdisk.h like MAX_RD_FILES for fs_romdisk.h)