### PR TITLE
Update types to match newlib 3.3.0

### DIFF
--- a/include/sys/_types.h
+++ b/include/sys/_types.h
@@ -108,7 +108,7 @@ typedef unsigned long __id_t;
 #endif
 
 #ifndef __ino_t_defined
-typedef unsigned long __ino_t;
+typedef unsigned short __ino_t;
 #endif
 
 #ifndef __pid_t_defined
@@ -127,7 +127,7 @@ typedef unsigned short __nlink_t;
 typedef long        __suseconds_t;  /* microseconds (signed) */
 typedef unsigned long   __useconds_t;   /* microseconds (unsigned) */
 
-#define _TIME_T_ long
+#define _TIME_T_ long long
 typedef _TIME_T_    __time_t;
 
 #ifndef __clockid_t_defined


### PR DESCRIPTION
Hi, I noticed that localtime_r() only returns the correct date the first time it was called.

For example, this code:
```
  struct tm tm;                                                                 
  time_t t;                                                                    
  t = time(0);                                                                  
  localtime_r(&t, &tm);                                         
  printf("%d\n", tm.tm_year);                                                   
  localtime_r(&t, &tm);                                         
  printf("%d\n", tm.tm_year);                                                   
  localtime_r(&t, &tm);                                         
  printf("%d\n", tm.tm_year);
```

Gives me these results:
120
4611
2978

The problem is that newlib has changed its default time_t to long long, but KOS has it hard-coded to long in include/sys/_types.h

Strangely, making time_t match in either direction (32-bit/32-bit or 64-bit/64-bit in KOS/newlib) breaks other stuff in newlib (printf, notably).  I compared the sizes of every type in _types.h between KOS and newlib and found that ino_t had also changed, from long to short.  Changing both of them at once to match newlib gets everything working again, so I think we were lucky newlib worked like this at all - things must have aligned just right!