### PR TITLE
Libkosfat fixes

### DIFF
--- a/addons/libkosfat/directory.c
+++ b/addons/libkosfat/directory.c
@@ -594,7 +594,6 @@ int fat_find_dentry(fat_fs_t *fs, const char *fn, fat_dentry_t *rv,
         }
 
         tok = strtok_r(NULL, "/", &tmp);
-        cl = cur.cluster_low | (cur.cluster_high << 16);
     }
 
     /* One last check... If the filename the user passed in ends with a '/'

--- a/addons/libkosfat/fs_fat.c
+++ b/addons/libkosfat/fs_fat.c
@@ -1012,13 +1012,16 @@ static int fs_fat_unlink(vfs_handler_t *vfs, const char *fn) {
         return -1;
     }
 
-    /* First clean up the clusters of the file... */
+    /* First clean up the clusters of the file... (if any) */
     cluster = ent.cluster_low | (ent.cluster_high << 16);
-    if((err = fat_erase_chain(fs->fs, cluster))) {
-        /* Uh oh... This is really bad... */
-        dbglog(DBG_ERROR, "fs_fat: Error erasing FAT chain for file %s\n", fn);
-        irv = -1;
-        errno = -err;
+    if(cluster != FAT_FREE_CLUSTER) {
+        if((err = fat_erase_chain(fs->fs, cluster))) {
+            /* Uh oh... This is really bad... */
+            dbglog(DBG_ERROR, "fs_fat: Error erasing FAT chain for file %s\n",
+	           fn);
+            irv = -1;
+            errno = -err;
+        }
     }
 
     /* Next, erase the directory entry (and long name, if applicable). */


### PR DESCRIPTION
Hi, I've come across a few libkosfat bugs while using it with a ScummVM backend.  I submitted one of these commits as a merge request on SourceForge before I saw that you were accepting PRs here.  I've copied the text from that one here.  Sorry I don't have the same level of detail for the other two, but they are a little more obvious.

#### 3c28fd8: libkosfat: Fix issue erasing long name entries
You can reproduce the bug that this fixes by unlinking a file with a long filename.  You will get an EIO and an "End of directory hit..." debug message.

#### 4a44115: libkosfat: Don't try to erase chain of empty files
You can reproduce the bug that this fixes by unlinking an empty file which will cause fat_erase_chain to loop forever.

#### a4fa4c9: libkosfat: Fix cluster from fat_find_dentry
Here's the wall of text from my SourceForge merge request:

Hi, I think I've found an issue in libkosfat with truncating files in directories. I found that when I open a file in a directory with truncation and write to it, the file doesn't get truncated, and a FAT directory entry gets written into the first cluster of the file. I believe I've tracked it down to a duplicated line in fat_find_dentry which causes it to return the first cluster of a file instead of the directory table's cluster. That causes fat_update_dentry to write directory entries to the file instead of to the directory table.

Let me know if you have any questions. Here is how I reproduced the issue:

1. Prepare test filesystem:

$BLOCKDEV is the first partition (type c, W95 FAT32 (LBA)) on an SD card.

```
# mkfs.vfat -f 1 $BLOCKDEV
# mount $BLOCKDEV $MOUNTPOINT
# mkdir $MOUNTPOINT/test
# yes FOOBAR | head -n 20 > $MOUNTPOINT/test/test.txt
# umount $MOUNTPOINT
```

2. Open "test/test.txt" for writing with truncation and then close it:

```
#include <unistd.h>
#include <fcntl.h>

#include <dc/sd.h>
#include <kos/blockdev.h>
#include <fat/fs_fat.h>

int
main(int argc, char **argv)
{
        kos_blockdev_t sd_dev;
        uint8 sd_partition_type;
        int fd;

        fs_fat_init();

        sd_init();
        sd_blockdev_for_partition(0, &sd_dev, &sd_partition_type);
        fs_fat_mount("/sd", &sd_dev, FS_FAT_MOUNT_READWRITE);

        fd = open("/sd/test/test.txt", O_WRONLY | O_TRUNC);
        close(fd);

        fs_fat_sync("/sd");
        fs_fat_unmount("/sd");

        fs_fat_shutdown();

        return 0;
}
```

3. Compare results:

Expected result: /test/test.txt on the SD card should be truncated

Actual result: /test/test.txt is zerod but not truncated and has a FAT directory entry in the middle of it:

```
00000000: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000010: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000020: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000030: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000040: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000050: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000060: 5445 5354 2020 2020 5458 5420 0082 1b03  TEST    TXT ....
00000070: bd50 bd50 0000 1b03 bd50 0400 0000 0000  .P.P.....P......
00000080: 0000 0000 0000 0000 0000 0000            ............
```

Thanks!

Tom