### PR TITLE
Build and install automatically makeip when building utils

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -4,7 +4,7 @@
 # (c)2001 Dan Potter
 #
 
-DIRS = genromfs wav2adpcm vqenc scramble dcbumpgen
+DIRS = genromfs wav2adpcm vqenc scramble dcbumpgen makeip
 
 # Ok for these to fail atm...
 

--- a/utils/makeip/Makefile
+++ b/utils/makeip/Makefile
@@ -1,0 +1,10 @@
+MAKE ?= make
+
+all:
+	@cd ./src; \
+	$(MAKE); \
+	$(MAKE) install
+
+clean:
+	@cd ./src; \
+	$(MAKE) clean

--- a/utils/makeip/src/Makefile
+++ b/utils/makeip/src/Makefile
@@ -10,7 +10,7 @@ STRIP = strip
 CFLAGS = -O2 -Wall -DMAKEIP_VERSION=\"$(VERSION)\" -I/usr/local/include
 LDFLAGS = -L/usr/local/lib -lpng -lz
 
-INSTALLDIR = $(KOS_BASE)/../bin
+INSTALLDIR = ..
 
 EXECUTABLEEXTENSION =
 ifeq ($(shell echo $(OS)),Windows_NT)
@@ -27,7 +27,7 @@ $(TARGET): $(OBJECTS)
 
 install:
 	mkdir -p $(INSTALLDIR)
-	cp $(OUTPUT) $(INSTALLDIR)
+	mv $(OUTPUT) $(INSTALLDIR)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
When building KOS and related utilities, `makeip` is also built and installed automatically.