### PR TITLE
Binutils arm will now properly be downloaded.

### DIFF
--- a/utils/dc-chain/download.sh
+++ b/utils/dc-chain/download.sh
@@ -77,7 +77,7 @@ if [ -z "${CONFIG_GUESS_ONLY}" ]; then
   download "Newlib" "$NEWLIB_VER" "$NEWLIB_URL"
 
   # Downloading ARM components
-  download "Binutils" $ARM_BINUTILS_VER"" "$ARM_BINUTILS_URL"
+  download "Binutils" "$ARM_BINUTILS_VER" "$ARM_BINUTILS_URL"
   download "GCC" "$ARM_GCC_VER" "$ARM_GCC_URL"
   download_dependencies "arm"
 fi

--- a/utils/dc-chain/scripts/common.sh
+++ b/utils/dc-chain/scripts/common.sh
@@ -63,7 +63,7 @@ export SH_GCC_URL=ftp.gnu.org/gnu/gcc/gcc-${SH_GCC_VER}/gcc-${SH_GCC_VER}.tar.${
 export NEWLIB_URL=sourceware.org/pub/newlib/newlib-${NEWLIB_VER}.tar.${NEWLIB_TARBALL_TYPE}
 export GDB_URL=ftp.gnu.org/gnu/gdb/gdb-${GDB_VER}.tar.${GDB_TARBALL_TYPE}
 export INSIGHT_URL=mirrors.kernel.org/sourceware/insight/releases/insight-${INSIGHT_VER}a.tar.${INSIGHT_TARBALL_TYPE}
-export ARM_BINUTILS_URL=ftp.gnu.org/gnu/binutils/binutils-${SH_BINUTILS_VER}.tar.${SH_BINUTILS_TARBALL_TYPE}
+export ARM_BINUTILS_URL=ftp.gnu.org/gnu/binutils/binutils-${ARM_BINUTILS_VER}.tar.${ARM_BINUTILS_TARBALL_TYPE}
 export ARM_GCC_URL=ftp.gnu.org/gnu/gcc/gcc-${ARM_GCC_VER}/gcc-${ARM_GCC_VER}.tar.${ARM_GCC_TARBALL_TYPE}
 
 export DOWNLOAD_PROTOCOL="`get_make_var download_protocol`://"


### PR DESCRIPTION
This fixes the binutils arm tar.xz file download.