### PR TITLE
Generate separate kernel lib files per subarch

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -19,6 +19,17 @@ export KOS_ARCH="dreamcast"
 #  "naomi" - a NAOMI or NAOMI 2 arcade board
 export KOS_SUBARCH="pristine"
 
+
+#suffix used to generate subarch-specific lib files
+case $KOS_SUBARCH in
+  "navi" )
+    export KOS_SUBARCH_SUFFIX="navi" ;;
+  "naomi" )
+    export KOS_SUBARCH_SUFFIX="naomi" ;;
+  *)
+    export KOS_SUBARCH_SUFFIX="" ;;
+esac
+
 # KOS main base path
 export KOS_BASE="/opt/toolchains/dc/kos"
 export KOS_PORTS="${KOS_BASE}/../kos-ports"

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -19,7 +19,6 @@ export KOS_ARCH="dreamcast"
 #  "naomi" - a NAOMI or NAOMI 2 arcade board
 export KOS_SUBARCH="pristine"
 
-
 #suffix used to generate subarch-specific lib files
 case $KOS_SUBARCH in
   "navi" )

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -19,7 +19,7 @@ export KOS_INC_PATHS="${KOS_INC_PATHS} -I${KOS_BASE}/include \
 
 # "System" libraries
 export KOS_LIB_PATHS="-L${KOS_BASE}/lib/${KOS_ARCH} -L${KOS_BASE}/addons/lib/${KOS_ARCH} -L${KOS_PORTS}/lib"
-export KOS_LIBS="-Wl,--start-group -lkallisti -lc -lgcc -Wl,--end-group"
+export KOS_LIBS="-Wl,--start-group -lkallisti${KOS_SUBARCH_SUFFIX} -lc -lgcc -Wl,--end-group"
 
 # Main arch compiler paths
 export KOS_CC="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-gcc"

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -12,9 +12,9 @@ STUBS = stubs/kernel_export_stubs.o stubs/arch_export_stubs.o
 KOS_CFLAGS += $(KOS_CSTD)
 
 all: subdirs $(STUBS)
-	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a
-	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a build/*.o
-	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti_exports.a stubs/*.o
+	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti$(KOS_SUBARCH_SUFFIX).a
+	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti$(KOS_SUBARCH_SUFFIX).a build/*.o
+	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti$(KOS_SUBARCH_SUFFIX)_exports.a stubs/*.o
 
 stubs/kernel_export_stubs.c: exports.txt
 	$(KOS_BASE)/utils/genexports/genexportstubs.sh $< stubs/kernel_export_stubs.c


### PR DESCRIPTION
As-is, the kernel lib file libkallisti.a is overwritten whenever you build for another subarch.

With this patch, separate kernel lib files are generated, depending on the subarch:
- pristine -> libkallisti.a (remains as-is, to minimize the impact on side-projects)
- navi -> libkallistinavi.a
- naomi -> libkallistinaomi.a