### PR TITLE
Add missing utilities in /utils/Makefile

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -4,7 +4,7 @@
 # Copyright (C) 2001 Dan Potter
 #
 
-DIRS = genromfs wav2adpcm vqenc scramble dcbumpgen makeip
+DIRS = bin2c bincnv dcbumpgen genromfs isotest kmgenc makeip makejitter rdtest scramble vqenc wav2adpcm
 
 ifeq ($(KOS_SUBARCH), naomi)
 	DIRS += naomibintool naominetboot


### PR DESCRIPTION
A few small utilities are missing from the /utils/Makefile, forcing people to manually compile them after the installation of kos: bin2c, bincnv, isotest, kmgenc, makejitter, rdtest.

(gentextfont wasn't added because of the required additional dependencies)

Also, sorted the DIRS alphabetically.