### PR TITLE
Add missing examples in make all

### DIFF
--- a/examples/dreamcast/network/Makefile
+++ b/examples/dreamcast/network/Makefile
@@ -10,6 +10,8 @@ all:
 	$(KOS_MAKE) -C ping6
 	$(KOS_MAKE) -C udpecho6
 	$(KOS_MAKE) -C dns-client
+	$(KOS_MAKE) -C httpd
+	$(KOS_MAKE) -C isp-settings
 
 clean:
 	$(KOS_MAKE) -C basic clean
@@ -17,6 +19,8 @@ clean:
 	$(KOS_MAKE) -C ping6 clean
 	$(KOS_MAKE) -C udpecho6 clean
 	$(KOS_MAKE) -C dns-client clean
+	$(KOS_MAKE) -C httpd clean
+	$(KOS_MAKE) -C isp-settings clean
 
 dist:
 	$(KOS_MAKE) -C basic dist
@@ -24,3 +28,5 @@ dist:
 	$(KOS_MAKE) -C ping6 dist
 	$(KOS_MAKE) -C udpecho6 dist
 	$(KOS_MAKE) -C dns-client dist
+	$(KOS_MAKE) -C httpd dist
+	$(KOS_MAKE) -C isp-settings dist

--- a/examples/dreamcast/parallax/Makefile
+++ b/examples/dreamcast/parallax/Makefile
@@ -4,7 +4,7 @@
 # (c)2002 Dan Potter
 #
 
-TARGETS = font bubbles raster_melt sinus delay_cube rotocube
+TARGETS = font bubbles raster_melt sinus delay_cube rotocube serpent_dma
 
 all:
 	for i in $(TARGETS); do $(KOS_MAKE) -C $$i || exit -1; done


### PR DESCRIPTION
/network/httpd
/network/isp-settings
/parallax/serpent_dma
are not built automatically when you do a make all on the /examples folder.
This fixes that.