### PR TITLE
Add dc arm wrappers

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -6,6 +6,9 @@ if [ -z "${KOS_PORTS}" ] ; then
     export KOS_PORTS="${KOS_BASE}/../kos-ports"
 fi
 
+# Arch kernel folder
+export KOS_ARCH_DIR="${KOS_BASE}/kernel/arch/${KOS_ARCH}"
+
 # Pull in the arch environ file
 . ${KOS_BASE}/environ_${KOS_ARCH}.sh
 
@@ -49,8 +52,6 @@ case $KOS_GCCVER in
 esac
 
 # Some extra vars based on architecture
-export KOS_ARCH_DIR="${KOS_BASE}/kernel/arch/${KOS_ARCH}"
-
 case $KOS_GCCVER in
   2* | 3*)
     export KOS_START="${KOS_ARCH_DIR}/kernel/startup.o" ;;

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -21,4 +21,9 @@ if [ x${KOS_ARCH} = xdreamcast ]; then
 	export DC_ARM_LD="${DC_ARM_BASE}/bin/${DC_ARM_PREFIX}-ld"
 	export DC_ARM_CFLAGS="-mcpu=arm7di -Wall -O2 -fno-strict-aliasing -Wl,--fix-v4bx -Wa,--fix-v4bx"
 	export DC_ARM_AFLAGS="-mcpu=arm7di --fix-v4bx"
+	export DC_ARM_MAKE="make"
+	export DC_ARM_START="${KOS_ARCH_DIR}/sound/arm/crt0.s"
+	export DC_ARM_LDFLAGS="${DC_ARM_LDFLAGS} -Wl,-Ttext=0x00000000,-N -nostartfiles -nostdlib -e reset"
+	export DC_ARM_LIB_PATHS=""
+	export DC_ARM_LIBS="-Wl,--start-group -lgcc -Wl,--end-group"	
 fi

--- a/utils/gnu_wrappers/dc-arm-ar
+++ b/utils/gnu_wrappers/dc-arm-ar
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec ${DC_ARM_AR} "$@"

--- a/utils/gnu_wrappers/dc-arm-as
+++ b/utils/gnu_wrappers/dc-arm-as
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec ${DC_ARM_AS} ${DC_ARM_AFLAGS} "$@"

--- a/utils/gnu_wrappers/dc-arm-cc
+++ b/utils/gnu_wrappers/dc-arm-cc
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Make sure what mode we're in. The basic cc wrapper does a lot.
+ARGS=$*
+USEMODE=0
+for i in $ARGS; do
+	case "${i}" in
+		-o)
+			if [ $USEMODE != 2 ]; then
+				# Link
+				USEMODE=1
+			fi
+		;;
+		-c | -S | -E)
+			# Partial compile
+			USEMODE=2
+		;;
+		conftest.c | conftest.cc | conftest.cpp)
+			# Used in autoconf... we really probably need
+			# a better way to do this. (scan for any .c?)
+			USEMODE=1
+		;;
+		*)
+		;;
+	esac
+done
+
+case $USEMODE in
+	0)
+		# Unknown mode ... use default args and cross fingers.
+		if [ x${KOS_WRAPPERS_VERBOSE} = x"1" ]; then
+			echo ${DC_ARM_CC} "$@"
+		fi
+		exec ${DC_ARM_CC} "$@"
+	;;
+
+	1)
+		# In link mode, add all the extra processing.
+		if [ x${KOS_WRAPPERS_VERBOSE} = x"1" ]; then
+			echo ${DC_ARM_CC} ${DC_ARM_CFLAGS} ${DC_ARM_LDFLAGS} ${DC_ARM_START} "$@" ${DC_ARM_LIBS}
+		fi
+		exec ${DC_ARM_CC} ${DC_ARM_CFLAGS} ${DC_ARM_LDFLAGS} ${DC_ARM_START} "$@" ${DC_ARM_LIBS}
+	;;
+
+	2)
+		# In non-link mode, just go ahead and run CC.
+		if [ x${KOS_WRAPPERS_VERBOSE} = x"1" ]; then
+			echo ${DC_ARM_CC} ${DC_ARM_CFLAGS} "$@"
+		fi
+		exec ${DC_ARM_CC} ${DC_ARM_CFLAGS} "$@"
+	;;
+esac

--- a/utils/gnu_wrappers/dc-arm-ld
+++ b/utils/gnu_wrappers/dc-arm-ld
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec ${DC_ARM_LD} ${DC_ARM_LDFLAGS} "$@" ${DC_ARM_LIB_PATHS} ${DC_ARM_LIBS}

--- a/utils/gnu_wrappers/dc-arm-make
+++ b/utils/gnu_wrappers/dc-arm-make
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec ${DC_ARM_MAKE} "$@"

--- a/utils/gnu_wrappers/dc-arm-objcopy
+++ b/utils/gnu_wrappers/dc-arm-objcopy
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+OBJOUT=0
+
+for i in $@; do
+	if [ $i == "-O" ];then
+		OBJOUT=1
+	fi
+	if [ $i == binary -a $OBJOUT == 1 ];then
+		RMSTACK="-R.stack"
+	fi
+	if [ $i == "-Obinary" ];then
+		RMSTACK="-R.stack"
+	fi
+done
+
+${DC_ARM_OBJCOPY} $RMSTACK $@


### PR DESCRIPTION
This is not for the mass of developers.

But it is being added so that it's more straightforward when somebody wants to write their own driver & co,
it's more aligned to have them defined like for the sh-elf part.

This also facilitates integration with IDE's like Visual Studio Code if you ever want to write your own driver. 

No changes were done to the original driver on purpose, can be done later if needed.