### PR TITLE
Add missing start to kgl examples (1/2)

### DIFF
--- a/examples/dreamcast/kgl/basic/txrenv/gltest.c
+++ b/examples/dreamcast/kgl/basic/txrenv/gltest.c
@@ -11,6 +11,7 @@
    the PVR hardware is used to perform transparency.
    User may press 'A' or 'B' to Enable or Disable rendering to Translucent list.
    Use D-Pad to toggle different blending modes.
+   Press 'Start' to exit.
 */
 
 #include <kos.h>

--- a/examples/dreamcast/kgl/basic/txrenv/gltest.c
+++ b/examples/dreamcast/kgl/basic/txrenv/gltest.c
@@ -71,14 +71,17 @@ void RenderCallback() {
     glutSwapBuffers();
 }
 
-void InputCallback() {
+int InputCallback() {
     maple_device_t *cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
 
     if(cont) {
         cont_state_t *state = (cont_state_t *)maple_dev_status(cont);
 
         if(!state)
-            return;
+            return 1;
+
+        if(state->buttons & CONT_START)
+            return 0;
 
         if(state->buttons & CONT_DPAD_UP) {
             ENV_MODE = 0;
@@ -108,6 +111,8 @@ void InputCallback() {
             BLEND = 0;
         }
     }
+
+    return 1;
 }
 
 extern uint8 romdisk[];
@@ -136,7 +141,9 @@ int main(int argc, char **argv) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_FILTER, GL_LINEAR);
 
     while(1) {
-        InputCallback();
+        if (!InputCallback())
+            return 0;
+
         RenderCallback();
     }
 

--- a/examples/dreamcast/kgl/demos/mipmap/gl-mipmap.c
+++ b/examples/dreamcast/kgl/demos/mipmap/gl-mipmap.c
@@ -40,10 +40,10 @@ int InputCallback() {
         if(!state)
             return 0;
 
-       if(state->buttons & CONT_START)
+        if(state->buttons & CONT_START)
             return INP_EXIT;
 
-       if(state->buttons & CONT_DPAD_UP)
+        if(state->buttons & CONT_DPAD_UP)
             return INP_RESIZE_UP;
 
         if(state->buttons & CONT_DPAD_DOWN)
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
                 curTexID = texID1;
                 break;
 
-           case INP_EXIT:
+            case INP_EXIT:
                 return 0;
         }
 

--- a/examples/dreamcast/kgl/demos/mipmap/gl-mipmap.c
+++ b/examples/dreamcast/kgl/demos/mipmap/gl-mipmap.c
@@ -11,6 +11,7 @@
     Y = Use Base Texture
     D-pad UP = Scale image size up
     D-pad DOWN = Scale image size down
+    Start = Exit
 */
 
 #include <kos.h>
@@ -27,6 +28,7 @@ extern GLuint glTextureLoadPVR(char *fname, unsigned char isMipMapped, unsigned 
 #define INP_RESIZE_DOWN 2
 #define INP_USE_MIP_MAP 3
 #define INP_NO_MIP_MAP  4
+#define INP_EXIT        5
 
 /* Simple Input Callback with a return value */
 int InputCallback() {
@@ -38,7 +40,10 @@ int InputCallback() {
         if(!state)
             return 0;
 
-        if(state->buttons & CONT_DPAD_UP)
+       if(state->buttons & CONT_START)
+            return INP_EXIT;
+
+       if(state->buttons & CONT_DPAD_UP)
             return INP_RESIZE_UP;
 
         if(state->buttons & CONT_DPAD_DOWN)
@@ -127,6 +132,9 @@ int main(int argc, char **argv) {
             case INP_USE_MIP_MAP:
                 curTexID = texID1;
                 break;
+
+           case INP_EXIT:
+                return 0;
         }
 
         RenderTexturedQuadCentered(curTexID, width, height);

--- a/examples/dreamcast/kgl/demos/specular/specular.c
+++ b/examples/dreamcast/kgl/demos/specular/specular.c
@@ -28,6 +28,7 @@
    Hold Right trigger, then press A,B,X, or Y to Disable Light1->4
    D-pad to rotate camera
    A,B,X,Y to move camera
+   Start to exit
 
    As Vertex Clipping and Lighting is being applied using immediate mode,
    this really is a brute-force approach to the vertex submission pipeline.
@@ -956,14 +957,17 @@ extern uint8 romdisk[];
 KOS_INIT_ROMDISK(romdisk);
 
 static unsigned char LE[8] = {0, 1, 0, 0, 0, 0, 0, 0};
-void InputCb() {
+int InputCb() {
     maple_device_t *cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
 
     if(cont) {
         cont_state_t *state = (cont_state_t *)maple_dev_status(cont);
 
         if(!state)
-            return;
+            return 1;
+
+        if(state->buttons & CONT_START)
+            return 0;
 
         if(state->ltrig > 0) {
             if(state->buttons & CONT_A)
@@ -993,6 +997,8 @@ void InputCb() {
                 LE[4] = 0;
         }
     }
+
+    return 1;
 }
 
 int main() {
@@ -1077,7 +1083,8 @@ int main() {
 
         GLuint start = GetTime();
 
-        InputCb();
+        if (!InputCb())
+           return 0;
 
         glSetCameraPosition(camFrom, camTo);
 


### PR DESCRIPTION
7 kgl examples miss an exit (start) button check.
This is a fix for 3 of them, the ones that already contain pad input checks.
(The remaining 4 will follow)