### PR TITLE
Small changes in the `utils` directory

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -4,7 +4,7 @@
 # Copyright (C) 2001 Dan Potter
 #
 
-DIRS = bin2c bincnv dcbumpgen genromfs isotest kmgenc makeip makejitter rdtest scramble vqenc wav2adpcm
+DIRS = bin2c bincnv dcbumpgen genromfs kmgenc makeip scramble vqenc wav2adpcm
 
 ifeq ($(KOS_SUBARCH), naomi)
 	DIRS += naomibintool naominetboot

--- a/utils/makejitter/makejitter.c
+++ b/utils/makejitter/makejitter.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <time.h>
 
+/* This utility requires the "libimageload" KallistiOS Port. */
 #include <imageload/jitterdefs.h>
 
 int ijitter[JITTER_TABLE_SIZE];


### PR DESCRIPTION
Some Minor changes in `utils/Makefile`:
- Removing not essential tools: `isotest` and `rdtest`.
- Removing `makejitter`, as this one requires the `libimageload` **KallistiOS Port** - so this utility can't be made when compiling KallistiOS the first time (as this root `Makefile` is used for that).

`makejitter` utility:
- Documenting that the `libimageload` **KallistiOS Port** is required for building it (see `kos-ports` repository), as this is not so easy to figure this out.