### PR TITLE
Fix DHCP issues

### DIFF
--- a/examples/dreamcast/network/isp-settings/isp-settings.c
+++ b/examples/dreamcast/network/isp-settings/isp-settings.c
@@ -30,9 +30,12 @@ int main(int argc, char **argv) {
             printf("IP:       %i.%i.%i.%i\n", cfg.ip[0], cfg.ip[1], cfg.ip[2], cfg.ip[3]);
             printf("Netmask:  %i.%i.%i.%i\n", cfg.nm[0], cfg.nm[1], cfg.nm[2], cfg.nm[3]);
             printf("Gateway:  %i.%i.%i.%i\n", cfg.gw[0], cfg.gw[1], cfg.gw[2], cfg.gw[3]);
+            printf("Hostname: '%s'\n", cfg.hostname);
+        }
+
+        if((cfg.valid_fields & FLASHROM_ISP_DNS)) {
             printf("DNS 1:    %i.%i.%i.%i\n", cfg.dns[0][0], cfg.dns[0][1], cfg.dns[0][2], cfg.dns[0][3]);
             printf("DNS 2:    %i.%i.%i.%i\n", cfg.dns[1][0], cfg.dns[1][1], cfg.dns[1][2], cfg.dns[1][3]);
-            printf("Hostname: '%s'\n", cfg.hostname);
         }
 
         if((cfg.valid_fields & FLASHROM_ISP_EMAIL))
@@ -61,6 +64,9 @@ int main(int argc, char **argv) {
 
         if((cfg.valid_fields & FLASHROM_ISP_PPP_PASS))
             printf("PPP Pass:   '%s'\n", cfg.ppp_passwd);
+
+        if((cfg.valid_fields & FLASHROM_ISP_PHONE1))
+            printf("PPP Phone1:   '%s'\n", cfg.phone1);
     }
 
     return 0;

--- a/examples/dreamcast/network/isp-settings/isp-settings.c
+++ b/examples/dreamcast/network/isp-settings/isp-settings.c
@@ -21,11 +21,10 @@ int main(int argc, char **argv) {
     else {
         if((cfg.valid_fields & FLASHROM_ISP_IP)) {
             static const char * methods[] = {
-                "DHCP",
-                "Static",
                 "Dialup(?)",
-                "Unused",
+                "DHCP",
                 "PPPoE"
+                "Static",
             };
             printf("Method:   %s\n", methods[cfg.method]);
             printf("IP:       %i.%i.%i.%i\n", cfg.ip[0], cfg.ip[1], cfg.ip[2], cfg.ip[3]);

--- a/kernel/arch/dreamcast/hardware/flashrom.c
+++ b/kernel/arch/dreamcast/hardware/flashrom.c
@@ -267,8 +267,8 @@ typedef struct {
             /* Block 0xE0 */
             uint16  blockid;        /* Should be 0xE0 */
             uint8   prodname[4];    /* SEGA */
-            uint8   unk1;           /* 0x13 */
             uint8   method;
+            uint8   unk1;           /* 0x00 */
             uint8   unk2[2];        /* 0x00 0x00 */
             uint8   ip[4];          /* These are all in big-endian notation */
             uint8   nm[4];

--- a/kernel/arch/dreamcast/hardware/flashrom.c
+++ b/kernel/arch/dreamcast/hardware/flashrom.c
@@ -339,11 +339,51 @@ typedef struct {
             char    ppp_passwd[20];
             uint16  crc;
         } e9;
+
+        struct {
+            /* Block 0xC6 */
+            uint16  blockid;
+            char    prodname[4];
+            char    ppp_login[28];
+            char    ppp_passwd[16];
+            char    phone1_pt1[12];
+            uint16  crc;
+        } c6;
+
+        struct {
+            /* Block 0xC7 */
+            uint16  blockid;
+            char    phone1_pt2[15];
+            char    unk1[13];
+            char    phone2[27];
+            char    unk2[5];
+            uint16  crc;
+        } c7;
+
+        struct {
+            /* Block 0xC8 */
+            uint16  blockid;
+            char    unk1[8];
+            char    phone3[27];
+            char    unk4[13];
+            uint8   dns1[4];
+            uint8   dns2[4];
+            char    unk5[4];
+            uint16  crc;
+        } c8;
+
+        struct {
+            /* Block 0xEB */
+            uint16  blockid;
+            char    unk1[12];
+            char    atx[48];
+            uint16  crc;
+        } eb;
     };
 } isp_settings_t;
 
 int flashrom_get_ispcfg(flashrom_ispcfg_t * out) {
-    uint8       buffer[64];
+    uint8       buffer[sizeof(isp_settings_t)];
     isp_settings_t  * isp = (isp_settings_t *)buffer;
     int     found = 0;
 
@@ -430,6 +470,50 @@ int flashrom_get_ispcfg(flashrom_ispcfg_t * out) {
         memcpy(out->ppp_passwd, isp->e9.ppp_passwd, 20);
 
         out->valid_fields |= FLASHROM_ISP_PPP_PASS;
+        found++;
+    }
+
+    /* Grab block 0xC6 */
+    if(flashrom_get_block(FLASHROM_PT_BLOCK_1, FLASHROM_B1_DK_PPP1, buffer) >= 0) {
+        if(!(out->valid_fields & FLASHROM_ISP_PPP_USER)) {
+            /* Grab the PPP Username. */
+            strncpy(out->ppp_login, isp->c6.ppp_login, 28);
+            out->ppp_login[28] = '\0';
+            out->valid_fields |= FLASHROM_ISP_PPP_USER;
+        }
+
+        if(!(out->valid_fields & FLASHROM_ISP_PPP_PASS)) {
+            /* Grab the PPP Password. */
+            strncpy(out->ppp_passwd, isp->c6.ppp_passwd, 16);
+            out->ppp_passwd[16] = '\0';
+            out->valid_fields |= FLASHROM_ISP_PPP_PASS;
+        }
+
+        found++;
+    }
+
+    /* Grab block 0xC7 */
+    if(flashrom_get_block(FLASHROM_PT_BLOCK_1, FLASHROM_B1_DK_PPP2, buffer) >= 0) {
+        if(!(out->valid_fields & FLASHROM_ISP_PHONE1)) {
+            /* The full number is 27 digits in C6-C8,
+            so we truncate it to fit the phone1 field */
+            strncpy(out->phone1, isp->c6.phone1_pt1, 12);
+            strncpy(out->phone1 + 12, isp->c7.phone1_pt2, 25 - 12);
+            out->phone1[25] = '\0';
+            out->valid_fields |= FLASHROM_ISP_PHONE1;
+        }
+        found++;
+    }
+
+    if(flashrom_get_block(FLASHROM_PT_BLOCK_1, FLASHROM_B1_DK_DNS, buffer) >= 0) {
+        /* Only read if we didn't find it already */
+        if(!(out->valid_fields & FLASHROM_ISP_DNS)) {
+            /* Grab the two DNS addresses. */
+            memcpy(out->dns[0], isp->c8.dns1, 4);
+            memcpy(out->dns[1], isp->c8.dns2, 4);
+            out->valid_fields |= FLASHROM_ISP_DNS;
+        }
+
         found++;
     }
 
@@ -565,7 +649,7 @@ typedef struct {
             uint16  crc;
         } c5;
 
-        /* Blocks 0xC6 - 0xCB also appear to be used by PlanetWeb, but are
+        /* Blocks 0xC7 - 0xCB also appear to be used by PlanetWeb, but are
            always blank in my tests. My only guess is that they were storage
            for a potential second ISP setting set. */
     };

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -1142,6 +1142,9 @@ static void bba_set_ispcfg() {
 
     if((isp.valid_fields & FLASHROM_ISP_BROADCAST)) {
         memcpy(bba_if.broadcast, isp.bc, 4);
+    } else {
+        /* Default to 255.255.255.255 */
+        memset(bba_if.broadcast, 255, 4);
     }
 }
 

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -37,7 +37,7 @@
 #define RX_CONFIG               (RX_EARLY_THRESHOLD<<24) | (RX_FIFO_THRESHOLD<<13) | \
                                 (RX_BUFFER_LEN_SHIFT<<11) | (RX_MAX_DMA_BURST<<8) | \
                                 (RX_NOWRAP<<7)
-                                
+
 #define TX_MAX_DMA_BURST        6 /* 2^(4+n) bytes from 0-7 (16b - 2Kb) */
 #define TX_CONFIG               (TX_MAX_DMA_BURST<<8)
 
@@ -1117,22 +1117,32 @@ static void bba_if_netinput(uint8 *pkt, int pktsize) {
 /* Set ISP configuration from the flashrom, as long as we're configured staticly */
 static void bba_set_ispcfg() {
     flashrom_ispcfg_t isp;
-    uint32 fields = FLASHROM_ISP_IP | FLASHROM_ISP_NETMASK |
-                    FLASHROM_ISP_BROADCAST | FLASHROM_ISP_GATEWAY;
 
     if(flashrom_get_ispcfg(&isp) == -1)
-        return;
-
-    if((isp.valid_fields & fields) != fields)
         return;
 
     if(isp.method != FLASHROM_ISP_STATIC)
         return;
 
-    memcpy(bba_if.ip_addr, isp.ip, 4);
-    memcpy(bba_if.netmask, isp.nm, 4);
-    memcpy(bba_if.gateway, isp.gw, 4);
-    memcpy(bba_if.broadcast, isp.bc, 4);
+    if((isp.valid_fields & FLASHROM_ISP_IP)) {
+        memcpy(bba_if.ip_addr, isp.ip, 4);
+    }
+
+    if((isp.valid_fields & FLASHROM_ISP_NETMASK)) {
+        memcpy(bba_if.netmask, isp.nm, 4);
+    }
+
+    if((isp.valid_fields & FLASHROM_ISP_GATEWAY)) {
+        memcpy(bba_if.gateway, isp.gw, 4);
+    }
+
+    if((isp.valid_fields & FLASHROM_ISP_DNS)) {
+        memcpy(bba_if.dns, isp.dns[0], 4);
+    }
+
+    if((isp.valid_fields & FLASHROM_ISP_BROADCAST)) {
+        memcpy(bba_if.broadcast, isp.bc, 4);
+    }
 }
 
 /* Initialize */

--- a/kernel/arch/dreamcast/hardware/network/lan_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/lan_adapter.c
@@ -705,22 +705,32 @@ static int la_if_set_mc(netif_t *self, const uint8 *list, int count) {
 /* Set ISP configuration from the flashrom, as long as we're configured staticly */
 static void la_set_ispcfg() {
     flashrom_ispcfg_t isp;
-    uint32 fields = FLASHROM_ISP_IP | FLASHROM_ISP_NETMASK |
-                    FLASHROM_ISP_BROADCAST | FLASHROM_ISP_GATEWAY;
 
     if(flashrom_get_ispcfg(&isp) == -1)
-        return;
-
-    if((isp.valid_fields & fields) != fields)
         return;
 
     if(isp.method != FLASHROM_ISP_STATIC)
         return;
 
-    memcpy(la_if.ip_addr, isp.ip, 4);
-    memcpy(la_if.netmask, isp.nm, 4);
-    memcpy(la_if.gateway, isp.gw, 4);
-    memcpy(la_if.broadcast, isp.bc, 4);
+    if((isp.valid_fields & FLASHROM_ISP_IP)) {
+        memcpy(la_if.ip_addr, isp.ip, 4);
+    }
+
+    if((isp.valid_fields & FLASHROM_ISP_NETMASK)) {
+        memcpy(la_if.netmask, isp.nm, 4);
+    }
+
+    if((isp.valid_fields & FLASHROM_ISP_GATEWAY)) {
+        memcpy(la_if.gateway, isp.gw, 4);
+    }
+
+    if((isp.valid_fields & FLASHROM_ISP_DNS)) {
+        memcpy(la_if.dns, isp.dns[0], 4);
+    }
+
+    if((isp.valid_fields & FLASHROM_ISP_BROADCAST)) {
+        memcpy(la_if.broadcast, isp.bc, 4);
+    }
 }
 
 /* Initialize */

--- a/kernel/arch/dreamcast/hardware/network/lan_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/lan_adapter.c
@@ -730,6 +730,9 @@ static void la_set_ispcfg() {
 
     if((isp.valid_fields & FLASHROM_ISP_BROADCAST)) {
         memcpy(la_if.broadcast, isp.bc, 4);
+    } else {
+        /* Default to 255.255.255.255 */
+        memset(la_if.broadcast, 255, 4);
     }
 }
 

--- a/kernel/arch/dreamcast/include/dc/flashrom.h
+++ b/kernel/arch/dreamcast/include/dc/flashrom.h
@@ -225,10 +225,12 @@ int flashrom_get_region();
 
     @{
 */
-#define FLASHROM_ISP_DHCP   0   /**< \brief DHCP-based ethernet */
-#define FLASHROM_ISP_STATIC 1   /**< \brief Static IP-based ethernet */
-#define FLASHROM_ISP_DIALUP 2   /**< \brief Dialup ISP */
-#define FLASHROM_ISP_PPPOE  4   /**< \brief PPPoE-based ethernet */
+#define FLASHROM_ISP_DIALUP 0   /**< \brief Dialup ISP */
+#define FLASHROM_ISP_DHCP   1   /**< \brief DHCP-based ethernet */
+#define FLASHROM_ISP_PPPOE  2   /**< \brief PPPoE-based ethernet */
+#define FLASHROM_ISP_STATIC 3   /**< \brief Static IP-based ethernet */
+
+
 /** @} */
 
 /** \defgroup fr_fields Valid field constants for the flashrom_ispcfg_t struct

--- a/kernel/arch/dreamcast/include/dc/flashrom.h
+++ b/kernel/arch/dreamcast/include/dc/flashrom.h
@@ -54,6 +54,9 @@ __BEGIN_DECLS
 #define FLASHROM_B1_PW_EMAIL1       0xC3    /**< \brief PlanetWeb Email settings (BLOCK_1) */
 #define FLASHROM_B1_PW_EMAIL2       0xC4    /**< \brief PlanetWeb Email settings (BLOCK_1) */
 #define FLASHROM_B1_PW_EMAIL_PROXY  0xC5    /**< \brief PlanetWeb Email/Proxy settings (BLOCK_1) */
+#define FLASHROM_B1_DK_PPP1         0xC6    /**< \brief DreamKey PPP settings (also seen in PW) */
+#define FLASHROM_B1_DK_PPP2         0xC7    /**< \brief DreamKey PPP settings (also seen in PW) */
+#define FLASHROM_B1_DK_DNS          0xC8    /**< \brief DreamKey PPP settings (also seen in PW) */
 #define FLASHROM_B1_IP_SETTINGS     0xE0    /**< \brief IP settings for BBA (BLOCK_1) */
 #define FLASHROM_B1_EMAIL           0xE2    /**< \brief Email address (BLOCK_1) */
 #define FLASHROM_B1_SMTP            0xE4    /**< \brief SMTP server setting (BLOCK_1) */
@@ -62,6 +65,7 @@ __BEGIN_DECLS
 #define FLASHROM_B1_POP3PASSWD      0xE7    /**< \brief POP3 password setting + proxy (BLOCK_1) */
 #define FLASHROM_B1_PPPLOGIN        0xE8    /**< \brief PPP username + proxy (BLOCK_1) */
 #define FLASHROM_B1_PPPPASSWD       0xE9    /**< \brief PPP passwd (BLOCK_1) */
+#define FLASHROM_B1_PPPMODEM        0xEB    /**< \brief PPP modem settings */
 /** @} */
 
 #define FLASHROM_OFFSET_CRC         62      /**< \brief Location of CRC in each block */

--- a/kernel/net/net_core.c
+++ b/kernel/net/net_core.c
@@ -180,10 +180,9 @@ int net_init(uint32 ip) {
     net_dhcp_init();
 
     if(net_default_dev) {
-        /* Did we get a requested IP address? If so, try to lease it over
-           DHCP */
+        /* Did we get a requested IP address? this normally happens over dcload-ip. */
         if(ip) {
-            rv = net_dhcp_request(&ip);
+            rv = net_dhcp_request(ip);
             if(rv < 0) {
                 dbglog(DBG_DEBUG, "Failed to acquire the specified IP with DHCP\n");
 
@@ -197,7 +196,7 @@ int net_init(uint32 ip) {
         /* We didn't get a requested IP address, if we don't already have one
            set, then do so via DHCP. */
         else if(!net_default_dev->ip_addr[0])
-            rv = net_dhcp_request(NULL);
+            rv = net_dhcp_request(0);
     }
 
     net_initted = 1;

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -202,6 +202,7 @@ static uint16 net_dhcp_get_16bit(dhcp_pkt_t *pkt, uint8 opt, int len) {
     return 0;
 }
 
+
 int net_dhcp_request(uint32 required_address) {
     uint8 pkt[1500];
     uint16_t pkt_len;
@@ -267,7 +268,7 @@ int net_dhcp_request(uint32 required_address) {
     memcpy(qpkt->buf, pkt, pkt_len);
     qpkt->pkt_type = DHCP_MSG_DHCPDISCOVER;
     qpkt->next_send = 0;
-    qpkt->next_delay = 2000;
+    qpkt->next_delay = 4000;
 
     STAILQ_INSERT_TAIL(&dhcp_pkts, qpkt, pkt_queue);
 
@@ -337,7 +338,7 @@ static void net_dhcp_send_request(dhcp_pkt_t *pkt, int pktlen, dhcp_pkt_t *pkt2,
     memcpy(qpkt->buf, buf, sizeof(dhcp_pkt_t) + optlen);
     qpkt->pkt_type = DHCP_MSG_DHCPREQUEST;
     qpkt->next_send = 0;
-    qpkt->next_delay = 2000;
+    qpkt->next_delay = 4000;
 
     STAILQ_INSERT_TAIL(&dhcp_pkts, qpkt, pkt_queue);
 

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -76,10 +76,12 @@ static int net_dhcp_fill_options(netif_t *net, dhcp_pkt_t *req, uint8 msgtype,
     req->options[pos++] = (net->mtu >> 0) & 0xFF;
 
     /* Host Name: Dreamcast */
+    const char* host_name = "KallistiOS";
+    const uint8 size = strlen(host_name);
     req->options[pos++] = DHCP_OPTION_HOST_NAME;
-    req->options[pos++] = 10; /* Length = 10 */
-    strcpy((char *)req->options + pos, "KallistiOS");
-    pos += 10;
+    req->options[pos++] = size;
+    memcpy(req->options + pos, host_name, size);
+    pos += size;
 
     /* Client Identifier: The network adapter's MAC address */
     req->options[pos++] = DHCP_OPTION_CLIENT_ID;

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -194,7 +194,7 @@ static uint16 net_dhcp_get_16bit(dhcp_pkt_t *pkt, uint8 opt, int len) {
     return 0;
 }
 
-int net_dhcp_request(void) {
+int net_dhcp_request(uint32* required_address) {
     uint8 pkt[1500];
     dhcp_pkt_t *req = (dhcp_pkt_t *)pkt;
     int optlen;
@@ -234,7 +234,7 @@ int net_dhcp_request(void) {
 
     /* Fill in options */
     optlen = net_dhcp_fill_options(net_default_dev, req, DHCP_MSG_DHCPDISCOVER,
-                                   0, 0);
+                                   0, (required_address) ? *required_address : 0);
 
     /* Add to our packet queue */
     qpkt = (struct dhcp_pkt_out *)malloc(sizeof(struct dhcp_pkt_out));
@@ -501,7 +501,7 @@ static void net_dhcp_thd(void *obj __attribute__((unused))) {
         state = DHCP_STATE_INIT;
         srv_addr.sin_addr.s_addr = INADDR_BROADCAST;
         memset(net_default_dev->ip_addr, 0, 4);
-        net_dhcp_request();
+        net_dhcp_request(NULL);
     }
     else if(rebind_time <= now &&
             (state == DHCP_STATE_BOUND || state == DHCP_STATE_RENEWING)) {
@@ -583,7 +583,7 @@ static void net_dhcp_thd(void *obj __attribute__((unused))) {
                     else if(found == DHCP_MSG_DHCPNAK) {
                         /* We got a NAK, try to discover again. */
                         state = DHCP_STATE_INIT;
-                        net_dhcp_request();
+                        net_dhcp_request(NULL);
                     }
 
                     /* Remove the old packet from our queue */

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -29,6 +29,9 @@
 #define DHCP_SERVER_PORT 67
 #define DHCP_CLIENT_PORT 68
 
+#define DHCP_MIN_OPTIONS_SIZE 64
+
+
 static int dhcp_sock = -1;
 struct sockaddr_in srv_addr;
 
@@ -117,7 +120,10 @@ static int net_dhcp_fill_options(netif_t *net, dhcp_pkt_t *req, uint8 msgtype,
     /* The End */
     req->options[pos++] = DHCP_OPTION_END;
 
-    return pos;
+    /* DHCP is an extension of the BOOTP RFC which specifies that the
+     * vendor specific area (which became 'options' in DHCP) is 64 bytes,
+     * some routers reject DHCP packets if the options area is less than this */
+    return (pos < DHCP_MIN_OPTIONS_SIZE) ? DHCP_MIN_OPTIONS_SIZE : pos;
 }
 
 static int net_dhcp_get_message_type(dhcp_pkt_t *pkt, int len) {

--- a/kernel/net/net_dhcp.h
+++ b/kernel/net/net_dhcp.h
@@ -147,7 +147,7 @@ int net_dhcp_init(void);
 
 void net_dhcp_shutdown(void);
 
-int net_dhcp_request(uint32* required_address);
+int net_dhcp_request(uint32 required_address);
 
 __END_DECLS
 

--- a/kernel/net/net_dhcp.h
+++ b/kernel/net/net_dhcp.h
@@ -147,7 +147,7 @@ int net_dhcp_init(void);
 
 void net_dhcp_shutdown(void);
 
-int net_dhcp_request(void);
+int net_dhcp_request(uint32* required_address);
 
 __END_DECLS
 

--- a/kernel/net/net_udp.c
+++ b/kernel/net/net_udp.c
@@ -623,6 +623,7 @@ static int net_udp_socket(net_socket_t *hnd, int domain, int type, int proto) {
 static void net_udp_close(net_socket_t *hnd) {
     struct udp_sock *udpsock;
     struct udp_pkt *pkt;
+    struct udp_pkt *it;
 
     if(irq_inside_int()) {
         if(mutex_trylock(&udp_mutex) == -1) {
@@ -642,7 +643,11 @@ static void net_udp_close(net_socket_t *hnd) {
         return;
     }
 
-    TAILQ_FOREACH(pkt, &udpsock->packets, pkt_queue) {
+    it = udpsock->packets.tqh_first;
+    while(it) {
+        pkt = it;
+        it = it->pkt_queue.tqe_next;
+
         free(pkt->data);
         TAILQ_REMOVE(&udpsock->packets, pkt, pkt_queue);
         free(pkt);

--- a/kernel/net/net_udp.c
+++ b/kernel/net/net_udp.c
@@ -1420,12 +1420,6 @@ static int net_udp_send_raw(netif_t *net, const struct sockaddr_in6 *src,
             srcaddr.__s6_addr.__s6_addr16[5] = 0xFFFF;
             srcaddr.__s6_addr.__s6_addr32[3] =
                 htonl(net_ipv4_address(net->ip_addr));
-
-            if(srcaddr.__s6_addr.__s6_addr32[3] == INADDR_ANY) {
-                errno = ENETDOWN;
-                ++udp_stats.pkt_send_failed;
-                return -1;
-            }
         }
         else {
             if(IN6_IS_ADDR_LOOPBACK(&dst->sin6_addr)) {


### PR DESCRIPTION
These changes allow the dns-client example to work over dc-tool-ser and dc-tool.

The changes are:

 - Fixes a crash when closing a UDP socket when there are multiple packets to free
 - Allow sending UDP packets from 0.0.0.0 (for DHCP)
 - Make a DHCP request when running over dcload-ip and use the passed IP address as the "requested address". This ensures that networking is properly initialised with gateway, DNS, etc. and the IP is properly leased.
 - Ensure that DHCPDISCOVER options are always at least 64 bytes to comply with https://www.rfc-editor.org/rfc/rfc951
 - Read static vs DHCP setting correctly from the flashrom
 - If the method is static, use what we can from the flashrom to init the connection (BBA + LAN)
 - Read block 0xC6 from the flashrom (could be a separate PR, but I was already fiddling with this stuff)
