### PR TITLE
Support 32MB RAM modifications

### DIFF
--- a/examples/dreamcast/basic/Makefile
+++ b/examples/dreamcast/basic/Makefile
@@ -12,6 +12,7 @@ all:
 	$(KOS_MAKE) -C stacktrace
 	$(KOS_MAKE) -C mmu
 	$(KOS_MAKE) -C stackprotector
+	$(KOS_MAKE) -C memtest32
 
 clean:
 	$(KOS_MAKE) -C exec clean
@@ -21,6 +22,7 @@ clean:
 	$(KOS_MAKE) -C stacktrace clean
 	$(KOS_MAKE) -C mmu clean
 	$(KOS_MAKE) -C stackprotector clean
+	$(KOS_MAKE) -C memtest32 clean
 
 dist:
 	$(KOS_MAKE) -C exec dist
@@ -30,5 +32,4 @@ dist:
 	$(KOS_MAKE) -C stacktrace dist
 	$(KOS_MAKE) -C mmu dist
 	$(KOS_MAKE) -C stackprotector dist
-
-
+	$(KOS_MAKE) -C memtest32 dist

--- a/examples/dreamcast/basic/memtest32/Makefile
+++ b/examples/dreamcast/basic/memtest32/Makefile
@@ -1,0 +1,23 @@
+TARGET = memtest32.elf
+
+OBJS = memtest.o main.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean:
+	-rm -f $(TARGET) $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist:
+	rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/basic/memtest32/main.c
+++ b/examples/dreamcast/basic/memtest32/main.c
@@ -1,0 +1,112 @@
+/* KallistiOS ##version##
+
+   main.c
+   Copyright (C) 2020 Thomas Sowell
+   Copyright (C) 2022 Eric Fradella
+
+   This application illustrates the use of functions related to detecting the size
+   of system memory and altering a program's behavior to suit the running system's
+   configuration.
+
+   Implemented is a memory test utility for Dreamcast consoles (both stock 16MB
+   systems and modified 32MB systems) or NAOMI systems, based on public domain
+   code by Michael Barr in memtest.c found here:
+   https://barrgroup.com/embedded-systems/how-to/memory-test-suite-c
+
+   Example output on a functional 32MB-modified Dreamcast:
+
+   Beginning memtest routine...
+    Base address: 0x8c100000
+    Number of bytes to test: 32440320
+     memTestDataBus: PASS
+     memTestAddressBus: PASS
+     memTestDevice: PASS
+   Test passed!
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "memtest.h"
+
+/* Leave space at the beginning and end of memory for this program and for the
+ * stack. Dreamcast applications are loaded at 0x8c000000 so we leave 0x100000
+ * bytes past that for the program itself and leave 65536 bytes at the top of
+ * memory for the stack. */
+#define SAFE_AREA     0x100000
+#define STACK_SIZE    65536
+#define BASE_ADDRESS  (volatile datum *) (0x8c000000 + SAFE_AREA)
+
+/* Define the number of bytes that will be tested. KallistiOS provides the macros
+ * HW_MEM_16 and HW_MEM_32 which describe the number of kilobytes available in
+ * standard supported console configurations (16384 and 32768, respectively). */
+#define NUM_BYTES_32  (HW_MEM_32 * 1024 - SAFE_AREA - STACK_SIZE)
+#define NUM_BYTES_16  (HW_MEM_16 * 1024 - SAFE_AREA - STACK_SIZE)
+
+int
+main(int argc, char **argv)
+{
+   uint32_t error, data, *address;
+   unsigned long num_bytes;
+   error = 0;
+
+   /* The hardware_memsize() function can be called to retrieve the
+    * running system's size. mm_top() returns the top address of memory.
+    * 0x8d000000 if 16MB console, 0x8e000000 if 32MB */
+   printf("\nThis console has %d kilobytes of system memory,\n with top of "
+          "memory located at 0x%0x.\n\n", hardware_memsize(), mm_top());
+
+   /* The DBL_MEM boolean macro is provided as an easy, concise
+    * way to determine if extra system RAM is available */
+   num_bytes = DBL_MEM ? NUM_BYTES_32 : NUM_BYTES_16;
+
+   printf("Beginning memtest routine...\n");
+   printf(" Base address: %p\n", BASE_ADDRESS);
+   printf(" Number of bytes to test: %lu\n", num_bytes);
+
+   /* Now we run the test routines provided in memtest.c
+    * Each routine returns zero if the routine passes,
+    * else it returns the address of failure.
+    * First, let's test the data bus. */
+   printf("  memTestDataBus: ");
+   fflush(stdout);
+   data = memTestDataBus(BASE_ADDRESS);
+   if (data != 0) {
+      printf("FAIL: %08lx\n", data);
+      error = 1;
+   }
+   else {
+   printf("PASS\n");
+   }
+   fflush(stdout);
+
+   /* Now we test the address bus. */
+   printf("  memTestAddressBus: ");
+   fflush(stdout);
+   address = memTestAddressBus(BASE_ADDRESS, num_bytes);
+   if (address != NULL) {
+      printf("FAIL (%p)\n", address);
+      error = 1;
+   }
+   else {
+       printf("PASS\n");
+   }
+   fflush(stdout);
+
+   /* And now, we test the memory itself. */
+   printf("  memTestDevice: ");
+   fflush(stdout);
+   address = memTestDevice(BASE_ADDRESS, num_bytes);
+   if (address != NULL) {
+      printf("FAIL (%p)\n", address);
+      error = 1;
+   }
+   else {
+      printf("PASS\n");
+   }
+   fflush(stdout);
+
+   /* Test completed, return final result */
+   printf("Test %s\n", error ? "failed." : "passed!\n");
+   return error;
+}

--- a/examples/dreamcast/basic/memtest32/memtest.c
+++ b/examples/dreamcast/basic/memtest32/memtest.c
@@ -1,0 +1,221 @@
+/**********************************************************************
+ *
+ * Filename:    memtest.c
+ * 
+ * Description: General-purpose memory testing functions.
+ *
+ * Notes:       This software can be easily ported to systems with
+ *              different data bus widths by redefining 'datum'.
+ *
+ * 
+ * Copyright (c) 1998 by Michael Barr.  This software is placed into
+ * the public domain and may be used for any purpose.  However, this
+ * notice must not be changed or removed and no warranty is either
+ * expressed or implied by its publication or distribution.
+ **********************************************************************/
+
+
+#include "memtest.h"
+
+
+/**********************************************************************
+ *
+ * Function:    memTestDataBus()
+ *
+ * Description: Test the data bus wiring in a memory region by
+ *              performing a walking 1's test at a fixed address
+ *              within that region.  The address (and hence the
+ *              memory region) is selected by the caller.
+ *
+ * Notes:       
+ *
+ * Returns:     0 if the test succeeds.  
+ *              A non-zero result is the first pattern that failed.
+ *
+ **********************************************************************/
+datum
+memTestDataBus(volatile datum * address)
+{
+    datum pattern;
+
+
+    /*
+     * Perform a walking 1's test at the given address.
+     */
+    for (pattern = 1; pattern != 0; pattern <<= 1)
+    {
+        /*
+         * Write the test pattern.
+         */
+        *address = pattern;
+
+        /*
+         * Read it back (immediately is okay for this test).
+         */
+        if (*address != pattern) 
+        {
+            return (pattern);
+        }
+    }
+
+    return (0);
+
+}   /* memTestDataBus() */
+
+
+/**********************************************************************
+ *
+ * Function:    memTestAddressBus()
+ *
+ * Description: Test the address bus wiring in a memory region by
+ *              performing a walking 1's test on the relevant bits
+ *              of the address and checking for aliasing. This test
+ *              will find single-bit address failures such as stuck
+ *              -high, stuck-low, and shorted pins.  The base address
+ *              and size of the region are selected by the caller.
+ *
+ * Notes:       For best results, the selected base address should
+ *              have enough LSB 0's to guarantee single address bit
+ *              changes.  For example, to test a 64-Kbyte region, 
+ *              select a base address on a 64-Kbyte boundary.  Also, 
+ *              select the region size as a power-of-two--if at all 
+ *              possible.
+ *
+ * Returns:     NULL if the test succeeds.  
+ *              A non-zero result is the first address at which an
+ *              aliasing problem was uncovered.  By examining the
+ *              contents of memory, it may be possible to gather
+ *              additional information about the problem.
+ *
+ **********************************************************************/
+datum * 
+memTestAddressBus(volatile datum * baseAddress, unsigned long nBytes)
+{
+    unsigned long addressMask = (nBytes/sizeof(datum) - 1);
+    unsigned long offset;
+    unsigned long testOffset;
+
+    datum pattern     = (datum) 0xAAAAAAAA;
+    datum antipattern = (datum) 0x55555555;
+
+
+    /*
+     * Write the default pattern at each of the power-of-two offsets.
+     */
+    for (offset = 1; (offset & addressMask) != 0; offset <<= 1)
+    {
+        baseAddress[offset] = pattern;
+    }
+
+    /* 
+     * Check for address bits stuck high.
+     */
+    testOffset = 0;
+    baseAddress[testOffset] = antipattern;
+
+    for (offset = 1; (offset & addressMask) != 0; offset <<= 1)
+    {
+        if (baseAddress[offset] != pattern)
+        {
+            return ((datum *) &baseAddress[offset]);
+        }
+    }
+
+    baseAddress[testOffset] = pattern;
+
+    /*
+     * Check for address bits stuck low or shorted.
+     */
+    for (testOffset = 1; (testOffset & addressMask) != 0; testOffset <<= 1)
+    {
+        baseAddress[testOffset] = antipattern;
+
+		if (baseAddress[0] != pattern)
+		{
+			return ((datum *) &baseAddress[testOffset]);
+		}
+
+        for (offset = 1; (offset & addressMask) != 0; offset <<= 1)
+        {
+            if ((baseAddress[offset] != pattern) && (offset != testOffset))
+            {
+                return ((datum *) &baseAddress[testOffset]);
+            }
+        }
+
+        baseAddress[testOffset] = pattern;
+    }
+
+    return (NULL);
+
+}   /* memTestAddressBus() */
+
+
+/**********************************************************************
+ *
+ * Function:    memTestDevice()
+ *
+ * Description: Test the integrity of a physical memory device by
+ *              performing an increment/decrement test over the
+ *              entire region.  In the process every storage bit 
+ *              in the device is tested as a zero and a one.  The
+ *              base address and the size of the region are
+ *              selected by the caller.
+ *
+ * Notes:       
+ *
+ * Returns:     NULL if the test succeeds.
+ *
+ *              A non-zero result is the first address at which an
+ *              incorrect value was read back.  By examining the
+ *              contents of memory, it may be possible to gather
+ *              additional information about the problem.
+ *
+ **********************************************************************/
+datum * 
+memTestDevice(volatile datum * baseAddress, unsigned long nBytes)	
+{
+    unsigned long offset;
+    unsigned long nWords = nBytes / sizeof(datum);
+
+    datum pattern;
+    datum antipattern;
+
+
+    /*
+     * Fill memory with a known pattern.
+     */
+    for (pattern = 1, offset = 0; offset < nWords; pattern++, offset++)
+    {
+        baseAddress[offset] = pattern;
+    }
+
+    /*
+     * Check each location and invert it for the second pass.
+     */
+    for (pattern = 1, offset = 0; offset < nWords; pattern++, offset++)
+    {
+        if (baseAddress[offset] != pattern)
+        {
+            return ((datum *) &baseAddress[offset]);
+        }
+
+        antipattern = ~pattern;
+        baseAddress[offset] = antipattern;
+    }
+
+    /*
+     * Check each location for the inverted pattern and zero it.
+     */
+    for (pattern = 1, offset = 0; offset < nWords; pattern++, offset++)
+    {
+        antipattern = ~pattern;
+        if (baseAddress[offset] != antipattern)
+        {
+            return ((datum *) &baseAddress[offset]);
+        }
+    }
+
+    return (NULL);
+
+}   /* memTestDevice() */

--- a/examples/dreamcast/basic/memtest32/memtest.h
+++ b/examples/dreamcast/basic/memtest32/memtest.h
@@ -1,0 +1,42 @@
+/**********************************************************************
+ *
+ * Filename:    memtest.h
+ * 
+ * Description: Memory-testing module API.
+ *
+ * Notes:       The memory tests can be easily ported to systems with
+ *              different data bus widths by redefining 'datum' type.
+ *
+ * 
+ * Copyright (c) 2000 by Michael Barr.  This software is placed into
+ * the public domain and may be used for any purpose.  However, this
+ * notice must not be changed or removed and no warranty is either
+ * expressed or implied by its publication or distribution.
+ **********************************************************************/
+
+#ifndef _memtest_h
+#define _memtest_h
+
+#include <stdint.h>
+
+/*
+ * Define NULL pointer value.
+ */
+#ifndef NULL
+#define NULL  (void *) 0
+#endif
+
+/*
+ * Set the data bus width.
+ */
+typedef uint32_t datum;
+
+/*
+ * Function prototypes.
+ */
+datum   memTestDataBus(volatile datum * address);
+datum * memTestAddressBus(volatile datum * baseAddress, unsigned long nBytes);
+datum * memTestDevice(volatile datum * baseAddress, unsigned long nBytes);
+
+
+#endif /* _memtest_h */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -31,7 +31,7 @@ __BEGIN_DECLS
 /** \brief  Page count "variable".
 
     The number of pages is static, so we can optimize this quite a bit. */
-#define page_count      ((16*1024*1024 - 0x10000) / PAGESIZE)
+#define page_count      ((hardware_memsize()*1024 - 0x10000) / PAGESIZE)
 #else
 #define page_count      ((32*1024*1024 - 0x10000) / PAGESIZE)
 #endif
@@ -135,6 +135,31 @@ void __crtend_pullin();
     \retval 0               On success (no error conditions defined).
 */
 int mm_init();
+
+/** \brief  Determine the address of top of memory.
+    \return The address that forms the upper bound of system RAM.
+*/
+size_t mm_top();
+
+/** \defgroup hw_memsizes           Console memory sizes
+    These are the various memory sizes, in kilobytes, that can be returned by the
+    hardware_memsize() function.
+    @{
+*/
+#define HW_MEM_16           16384   /**< \brief 16MB retail Dreamcast */
+#define HW_MEM_32           32768   /**< \brief 32MB modded Dreamcast */
+/** @} */
+
+/** \brief  Determine how much memory is installed in current machine.
+    \return The total size of system memory in kilobytes.
+*/
+size_t hardware_memsize();
+
+/** \brief Use this macro to easily determine if system has doubled RAM.
+    \return True if doubled RAM, false if standard RAM.
+*/
+
+#define DBL_MEM ((hardware_memsize() == HW_MEM_32) ? 1 : 0 )
 
 /** \brief  Request more core memory from the system.
     \param  increment       The number of bytes requested.
@@ -361,7 +386,7 @@ const char *kos_get_authors(void);
     \return                 Whether the address is valid or not for normal
                             memory access.
 */
-#define arch_valid_address(ptr) ((ptr_t)(ptr) >= 0x8c010000 && (ptr_t)(ptr) < 0x8d000000)
+#define arch_valid_address(ptr) ((ptr_t)(ptr) >= 0x8c010000 && (ptr_t)(ptr) < mm_top())
 #else
 #define arch_valid_address(ptr) ((ptr_t)(ptr) >= 0x8c010000 && (ptr_t)(ptr) < 0x8e000000)
 #endif

--- a/kernel/arch/dreamcast/kernel/exec.c
+++ b/kernel/arch/dreamcast/kernel/exec.c
@@ -20,7 +20,7 @@ extern uint32 _arch_exec_template[];
 extern uint32 _arch_exec_template_values[];
 extern uint32 _arch_exec_template_end[];
 
-/* Pull this in from startup.s */
+/* Pull this in from startup.S */
 extern uint32 _arch_old_sr, _arch_old_vbr, _arch_old_stack, _arch_old_fpscr;
 
 /* Replace the currently running image with whatever is at

--- a/kernel/arch/dreamcast/kernel/mm.c
+++ b/kernel/arch/dreamcast/kernel/mm.c
@@ -19,19 +19,56 @@
 #include <arch/irq.h>
 #include <stdio.h>
 
+#define MCR (*((volatile size_t *) 0xff800014))
+
 /* The end of the program is always marked by the '_end' symbol. So we'll
    longword-align that and add a little for safety. sbrk() calls will
    move up from there. */
 extern unsigned long end;
 static void *sbrk_base;
+static size_t memsize;
 
 /* MM-wide initialization */
 int mm_init() {
+
+#ifndef _arch_sub_naomi
+#ifdef __KOS_GCC_AMX3_32MB__
+    if (((MCR >> 3) & 0x07) == 3) {
+        /* AMX 3, assuming 32MB SDRAM */
+        memsize = HW_MEM_32;
+    }
+    else {
+        memsize = HW_MEM_16;
+    }
+#else
+#warning Outdated toolchain: not patched for 32MB support, limiting KOS\
+         to 16MB-only behavior to retain maximum compatibility. Please\
+         update toolchain.
+    memsize = HW_MEM_16;
+#endif
+#else
+    memsize = HW_MEM_16; /* NAOMI support remains at 16MB for now */
+#endif
+
     int base = (int)(&end);
     base = (base / 4) * 4 + 4;  /* longword align */
     sbrk_base = (void*)base;
 
     return 0;
+}
+
+size_t hardware_memsize() {
+    return memsize;
+}
+
+size_t mm_top() {
+    switch (memsize) {
+        case HW_MEM_32: return 0x8e000000;
+                        break;
+        case HW_MEM_16: /* fall through */
+        default:        return 0x8d000000;
+                        break;
+	}
 }
 
 /* Simple sbrk function */
@@ -46,7 +83,7 @@ void* mm_sbrk(unsigned long increment) {
 
     sbrk_base = (void *)(increment + (unsigned long)sbrk_base);
 
-    if(((uint32)sbrk_base) >= (0x8d000000 - 65536)) {
+    if(((uint32)sbrk_base) >= (mm_top() - 65536)) {
         dbglog(DBG_DEAD, "Requested sbrk_base %p, was %p, diff %lu\n",
                sbrk_base, base, increment);
         arch_panic("out of memory; about to run over kernel stack");

--- a/kernel/arch/dreamcast/kernel/stack.c
+++ b/kernel/arch/dreamcast/kernel/stack.c
@@ -29,7 +29,7 @@ void arch_stk_trace_at(uint32 fp, int n) {
     dbgio_printf("-------- Stack Trace (innermost first) ---------\n");
 
     while(fp != 0xffffffff) {
-        if((fp & 3) || (fp < 0x8c000000) || (fp > 0x8d000000)) {
+        if((fp & 3) || (fp < 0x8c000000) || (fp > mm_top())) {
             dbgio_printf("   (invalid frame pointer)\n");
             break;
         }

--- a/kernel/arch/dreamcast/kernel/startup.S
+++ b/kernel/arch/dreamcast/kernel/startup.S
@@ -1,6 +1,6 @@
 ! KallistiOS ##version##
 !
-! startup.s
+! startup.S
 ! (c)2000-2001 Dan Potter
 !
 ! This file must appear FIRST in your linking order, or your program won't
@@ -71,7 +71,19 @@ init:
 	! Save the current stack, and set a new stack (higher up in RAM)
 	mov.l	old_stack_addr,r0
 	mov.l	r15,@r0
-	mov.l	new_stack,r15
+	mov.l	new_stack_16m,r15
+#ifndef _arch_sub_naomi
+#ifdef __KOS_GCC_AMX3_32MB__
+	! Set stack based on MCR
+	mov.l	mcr,r1
+	mov.l	@r1,r0
+	and	#0x38,r0
+	cmp/eq	#0x18,r0
+	bf	mcr_16m
+	mov.l	new_stack_32m,r15
+#endif
+#endif
+mcr_16m:
 
 	! Save VBR
 	mov.l	old_vbr_addr,r0
@@ -173,8 +185,12 @@ old_stack_addr:
 __arch_old_stack:
 old_stack:
 	.long	0
-new_stack:
+new_stack_16m:
 	.long	0x8d000000
+new_stack_32m:
+	.long	0x8e000000
+mcr:
+	.long	0xff800014
 p2_mask:
 	.long	0xa0000000
 setup_cache_addr:

--- a/kernel/mm/malloc_debug.c
+++ b/kernel/mm/malloc_debug.c
@@ -108,7 +108,7 @@ void *malloc(size_t amt) {
     spinlock_unlock(&mutex);
 
     printf("Thread %d/%08lx allocated %d bytes at %08lx; %08lx left\n",
-           ctl->thread, ctl->addr, ctl->size, space, 0x8d000000 - (uint32)sbrk(0));
+           ctl->thread, ctl->addr, ctl->size, space, mm_top() - (uint32)sbrk(0));
 
     assert(!(((uint32)space) & 7));
 
@@ -178,7 +178,7 @@ void free(void *block) {
     printf("Thread %d/%08x freeing block @ %08x\n",
            thd_current->tid, pr, (uint32)block);
 
-    if(((uint32)block) & 7 || (uint32)block < 0x8c010000 || (uint32)block >= 0x8d000000) {
+    if(((uint32)block) & 7 || (uint32)block < 0x8c010000 || (uint32)block >= mm_top()) {
         printf("   ATTEMPT TO FREE INVALID ADDRESS!\n");
         spinlock_unlock(&mutex);
         return;

--- a/utils/dc-chain/patches/arm-Darwin/gcc-9.3.0-kos.diff
+++ b/utils/dc-chain/patches/arm-Darwin/gcc-9.3.0-kos.diff
@@ -1,20 +1,6 @@
-diff -ruN gcc-9.3.0/gcc/config.host gcc-9.3.0-kos/gcc/config.host
---- gcc-9.3.0/gcc/config.host	2020-03-12 05:07:21.000000000 -0600
-+++ gcc-9.3.0-kos/gcc/config.host	2022-10-03 15:12:44.000000000 -0600
-@@ -93,8 +93,8 @@
- case ${host} in
-   *-darwin*)
-     # Generic darwin host support.
--    out_host_hook_obj=host-darwin.o
--    host_xmake_file="${host_xmake_file} x-darwin"
-+    # out_host_hook_obj=host-darwin.o
-+    # host_xmake_file="${host_xmake_file} x-darwin"
-     ;;
- esac
-
-diff -ruN gcc-9.3.0/gcc/config/host-darwin.c  gcc-9.3.0-kos/gcc/config/host-darwin.c
---- gcc-9.3.0/gcc/config/host-darwin.c	2020-03-12 05:07:21.000000000 -0600
-+++ gcc-9.3.0-kos/gcc/config/host-darwin.c	2022-10-03 15:13:15.000000000 -0600
+diff --color -ruN gcc-9.3.0/gcc/config/host-darwin.c gcc-9.3.0-kos/gcc/config/host-darwin.c
+--- gcc-9.3.0/gcc/config/host-darwin.c	2022-12-29 19:55:11
++++ gcc-9.3.0-kos/gcc/config/host-darwin.c	2022-12-29 19:55:54
 @@ -22,6 +22,8 @@
  #include "coretypes.h"
  #include "diagnostic-core.h"
@@ -30,10 +16,38 @@ diff -ruN gcc-9.3.0/gcc/config/host-darwin.c  gcc-9.3.0-kos/gcc/config/host-darw
  }
 +
 +const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
-
-diff -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
---- gcc-9.3.0/gcc/configure	2020-03-12 07:08:30.000000000 -0400
-+++ gcc-9.3.0-kos/gcc/configure	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/gcc/config/sh/sh-c.c gcc-9.3.0-kos/gcc/config/sh/sh-c.c
+--- gcc-9.3.0/gcc/config/sh/sh-c.c	2022-12-29 19:55:11
++++ gcc-9.3.0-kos/gcc/config/sh/sh-c.c	2022-12-29 20:01:38
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++                        2022123000);
++  /* Toolchain supports setting up stack for 32MB if using AMX3  */
++  builtin_define ("__KOS_GCC_AMX3_32MB__"); 
+ }
+diff --color -ruN gcc-9.3.0/gcc/config.host gcc-9.3.0-kos/gcc/config.host
+--- gcc-9.3.0/gcc/config.host	2022-12-29 19:55:24
++++ gcc-9.3.0-kos/gcc/config.host	2022-12-29 19:55:54
+@@ -93,8 +93,8 @@
+ case ${host} in
+   *-darwin*)
+     # Generic darwin host support.
+-    out_host_hook_obj=host-darwin.o
+-    host_xmake_file="${host_xmake_file} x-darwin"
++    # out_host_hook_obj=host-darwin.o
++    # host_xmake_file="${host_xmake_file} x-darwin"
+     ;;
+ esac
+ 
+diff --color -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
+--- gcc-9.3.0/gcc/configure	2022-12-29 19:55:11
++++ gcc-9.3.0-kos/gcc/configure	2022-12-29 19:55:54
 @@ -11862,7 +11862,7 @@
      target_thread_file='single'
      ;;
@@ -43,10 +57,10 @@ diff -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.S
---- gcc-9.3.0/libgcc/config/sh/crt1.S	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2020-04-03 16:07:04.540000000 -0400
-@@ -1,724 +1,197 @@
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.S
+--- gcc-9.3.0/libgcc/config/sh/crt1.S	2022-12-29 19:55:09
++++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2022-12-29 19:57:40
+@@ -1,724 +1,209 @@
 -/* Copyright (C) 2000-2019 Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
 +! KallistiOS ##version##
@@ -59,7 +73,8 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +!
 +! This is very loosely based on Marcus' crt0.s/startup.s
 +!
-+
+ 
+-This file is part of GCC.
 +.globl start
 +.globl _start
 +.globl _arch_real_exit
@@ -68,8 +83,6 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +.globl __arch_old_stack
 +.globl __arch_old_fpscr
  
--This file is part of GCC.
--
 -GCC is free software; you can redistribute it and/or modify it
 -under the terms of the GNU General Public License as published by the
 -Free Software Foundation; either version 3, or (at your option) any
@@ -123,7 +136,13 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +_start:
  start:
 -	mov.l	stack_k,r15
--
++	! Disable interrupts (if they're enabled)
++	mov.l	old_sr_addr,r0
++	stc	sr,r1
++	mov.l	r1,@r0
++	mov.l	init_sr,r0
++	ldc	r0,sr
+ 
 -#if defined (__SH3__) || (defined (__SH_FPU_ANY__) && ! defined (__SH2E__) && ! defined (__SH2A__)) || defined (__SH4_NOFPU__)
 -#define VBR_SETUP
 -	! before zeroing the bss ...
@@ -151,7 +170,13 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	add	#4,r0
 -	cmp/ge	r0,r1
 -	bt	start_l
--
++	! Run in the P2 area
++	mov.l	setup_cache_addr,r0
++	mov.l	p2_mask,r1
++	or	r1,r0
++	jmp	@r0
++	nop
+ 
 -#if defined (__SH_FPU_ANY__)
 -	mov.l set_fpscr_k, r1
 -	mov #4,r4
@@ -159,7 +184,23 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	shll16 r4	! Set DN bit (flush denormal inputs to zero)
 -	lds r3,fpscr	! Switch to default precision
 -#endif /* defined (__SH_FPU_ANY__) */
--
++setup_cache:
++	! Now that we are in P2, it's safe to enable the cache
++	! Check to see if we should enable OCRAM.
++	mov.l	kos_init_flags_addr, r0
++	add	#2, r0
++	mov.w	@r0, r0
++	tst	#1, r0
++	bf	.L_setup_cache_L0
++	mov.w	ccr_data,r1
++	bra	.L_setup_cache_L1
++	nop
++.L_setup_cache_L0:
++	mov.w	ccr_data_ocram,r1
++.L_setup_cache_L1:
++	mov.l	ccr_addr,r0
++	mov.l	r1,@r0
+ 
 -#ifdef VBR_SETUP
 -	! save the existing contents of the vbr
 -	! there will only be a prior value when using something like redboot
@@ -190,49 +231,6 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	mov.l	atexit_k,r0
 -	mov.l	fini_k,r4
 -	jsr	@r0
-+	! Disable interrupts (if they're enabled)
-+	mov.l	old_sr_addr,r0
-+	stc	sr,r1
-+	mov.l	r1,@r0
-+	mov.l	init_sr,r0
-+	ldc	r0,sr
-+
-+	! Run in the P2 area
-+	mov.l	setup_cache_addr,r0
-+	mov.l	p2_mask,r1
-+	or	r1,r0
-+	jmp	@r0
- 	nop
- 
--#ifdef PROFILE
--	! arrange for exit to call _mcleanup (via stop_profiling)
--	mova    stop_profiling,r0
--	mov.l   atexit_k,r1
--	jsr     @r1
--	mov	r0, r4
--
--	! Call profiler startup code
--	mov.l monstartup_k, r0
--	mov.l start_k, r4
--	mov.l etext_k, r5
--	jsr @r0
-+setup_cache:
-+	! Now that we are in P2, it's safe to enable the cache
-+	! Check to see if we should enable OCRAM.
-+	mov.l	kos_init_flags_addr, r0
-+	add	#2, r0
-+	mov.w	@r0, r0
-+	tst	#1, r0
-+	bf	.L_setup_cache_L0
-+	mov.w	ccr_data,r1
-+	bra	.L_setup_cache_L1
-+	nop
-+.L_setup_cache_L0:
-+	mov.w	ccr_data_ocram,r1
-+.L_setup_cache_L1:
-+	mov.l	ccr_addr,r0
-+	mov.l	r1,@r0
-+
 +	! After changing CCR, eight instructions must be executed before
 +	! it's safe to enter a cached area such as P1
 +	nop			! 1
@@ -247,6 +245,35 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +	mov	r1,r0
  	nop
  
+-#ifdef PROFILE
+-	! arrange for exit to call _mcleanup (via stop_profiling)
+-	mova    stop_profiling,r0
+-	mov.l   atexit_k,r1
+-	jsr     @r1
+-	mov	r0, r4
++init:
++	! Save old PR on old stack so we can get to it later
++	sts.l	pr,@-r15
+ 
+-	! Call profiler startup code
+-	mov.l monstartup_k, r0
+-	mov.l start_k, r4
+-	mov.l etext_k, r5
+-	jsr @r0
+-	nop
++	! Save the current stack, and set a new stack (higher up in RAM)
++	mov.l	old_stack_addr,r0
++	mov.l	r15,@r0
++	! Set stack based on MCR
++	mov.l   new_stack_16m,r15
++	mov.l   mcr,r1
++	mov.l   @r1,r0
++	and     #0x38,r0
++	cmp/eq  #0x18,r0
++	bf      mcr_16m
++	mov.l   new_stack_32m,r15
++mcr_16m:
+ 
 -	! enable profiling trap
 -	! until now any trap 33s will have been ignored
 -	! This means that all library functions called before this point
@@ -256,27 +283,22 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	mov	#1, r1
 -	mov.l	r1, @r0
 -#endif /* PROFILE */
-+init:
-+	! Save old PR on old stack so we can get to it later
-+	sts.l	pr,@-r15
- 
--	! call init
--	mov.l	init_k,r0
-+	! Save the current stack, and set a new stack (higher up in RAM)
-+	mov.l	old_stack_addr,r0
-+	mov.l	r15,@r0
-+	mov.l	new_stack,r15
-+
 +	! Save VBR
 +	mov.l	old_vbr_addr,r0
 +	stc	vbr,r1
 +	mov.l	r1,@r0
-+
+ 
+-	! call init
+-	mov.l	init_k,r0
+-	jsr	@r0
+-	nop
 +	! Save FPSCR
 +	mov.l	old_fpscr_addr,r0
 +	sts	fpscr,r1
 +	mov.l	r1,@r0
-+
+ 
+-	! call the mainline	
+-	mov.l	main_k,r0
 +	! Reset FPSCR
 +	mov	#4,r4		! Use 00040000 (DN=1)
 +	mov.l	fpscr_addr,r0
@@ -284,17 +306,13 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	nop
 +	shll16	r4
  
--	! call the mainline	
--	mov.l	main_k,r0
--	jsr	@r0
--	nop
-+	! Setup a sentinel value for frame pointer in case we're using
-+	! FRAME_POINTERS for stack tracing.
-+	mov	#-1,r14
- 
 -	! call exit
 -	mov	r0,r4
 -	mov.l	exit_k,r0
++	! Setup a sentinel value for frame pointer in case we're using
++	! FRAME_POINTERS for stack tracing.
++	mov	#-1,r14
++
 +	! Jump to the kernel main
 +	mov.l	main_addr,r0
  	jsr	@r0
@@ -325,13 +343,23 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -etext_k:
 -	.long __etext
 -#endif /* PROFILE */
--
++	! Program can return here (not likely) or jump here directly
++	! from anywhere in it to go straight back to the monitor
++_arch_real_exit:
++	! Reset SR
++	mov.l	old_sr,r0
++	ldc	r0,sr
+ 
 -	.align 2
 -#if defined (__SH_FPU_ANY__)
 -set_fpscr_k:
 -	.long	___set_fpscr
 -#endif /*  defined (__SH_FPU_ANY__) */
--
++	! Disable MMU, invalidate TLB
++	mov	#4,r0
++	mov.l	mmu_addr,r1
++	mov.l	r0,@r1
+ 
 -stack_k:
 -	.long	_stack	
 -edata_k:
@@ -354,13 +382,25 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -vbr_start_k:
 -	.long	vbr_start
 -#endif /* VBR_SETUP */
--	
++	! Wait (just in case)
++	nop				! 1
++	nop				! 2
++	nop				! 3
++	nop				! 4
++	nop				! 5
++	nop				! 6
++	nop				! 7
++	nop				! 8
+ 	
 -sr_initial_rtos:
 -	! Privileged mode RB 1 BL 0. Keep BL 0 to allow default trap handlers to work.
 -	! Whether profiling or not, keep interrupts masked,
 -	! the RTOS will enable these if required.
 -	.long 0x600000f1 
--
++	! Restore VBR
++	mov.l	old_vbr,r0
++	ldc	r0,vbr
+ 
 -rtos_start_fn:
 -	.long ___rtos_profiler_start_timer
 -	
@@ -370,24 +410,38 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	! For bare machine, we need to enable interrupts to get profiling working
 -	.long 0x60000001
 -#else
--
++	! If we're working under dcload, call its EXIT syscall
++	mov.l	dcload_magic_addr,r0
++	mov.l	@r0,r0
++	mov.l	dcload_magic_value,r1
++	cmp/eq	r0,r1
++	bf	normal_exit
+ 
 -sr_initial_bare:
 -	! Privileged mode RB 1 BL 0. Keep BL 0 to allow default trap handlers to work.
 -	! Keep interrupts disabled - the application will enable as required.
 -	.long 0x600000f1
 -#endif
--
++	mov.l	dcload_syscall,r0
++	mov.l	@r0,r0
++	jsr	@r0
++	mov	#15,r4
+ 
 -	! supplied for backward compatibility only, in case of linking
 -	! code whose main() was compiled with an older version of GCC.
 -	.global ___main
 -___main:
--	rts
--	nop
++	! Set back the stack and return (presumably to a serial debug)
++normal_exit:
++	mov.l	old_stack,r15
++	lds.l	@r15+,pr
+ 	rts
+ 	nop
 -#ifdef VBR_SETUP
 -! Exception handlers	
 -	.section .text.vbr, "ax"
 -vbr_start:
--
+ 
 -	.org 0x100
 -vbr_100:
 -#ifdef PROFILE
@@ -424,32 +478,7 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	mov.l	r6,@-r15
 -	mov.l	r7,@-r15
 -	sts.l	pr,@-r15
-+	! Program can return here (not likely) or jump here directly
-+	! from anywhere in it to go straight back to the monitor
-+_arch_real_exit:
-+	! Reset SR
-+	mov.l	old_sr,r0
-+	ldc	r0,sr
-+
-+	! Disable MMU, invalidate TLB
-+	mov	#4,r0
-+	mov.l	mmu_addr,r1
-+	mov.l	r0,@r1
-+
-+	! Wait (just in case)
-+	nop				! 1
-+	nop				! 2
-+	nop				! 3
-+	nop				! 4
-+	nop				! 5
-+	nop				! 6
-+	nop				! 7
-+	nop				! 8
-+	
-+	! Restore VBR
-+	mov.l	old_vbr,r0
-+	ldc	r0,vbr
- 
+-
 -	! r4 is frompc.
 -	! r5 is selfpc
 -	! r0 is the branch back address.
@@ -562,13 +591,7 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	! jmp to trap handler to avoid disturbing pr. 
 -	jmp @r2
 -	nop
-+	! If we're working under dcload, call its EXIT syscall
-+	mov.l	dcload_magic_addr,r0
-+	mov.l	@r0,r0
-+	mov.l	dcload_magic_value,r1
-+	cmp/eq	r0,r1
-+	bf	normal_exit
- 
+-
 -	.org 0x600
 -vbr_600:
 -#ifdef PROFILE	
@@ -601,8 +624,7 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	mov.l	pervading_precision_k,r0
 -	fmov	fr4,@-r15
 -	fmov	fr5,@-r15
-+	mov.l	dcload_syscall,r0
- 	mov.l	@r0,r0
+-	mov.l	@r0,r0
 -	fmov	fr6,@-r15
 -	fmov	fr7,@-r15
 -	lds	r0,fpscr
@@ -718,15 +740,7 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	mov	r14,r15
 -	mov.l	@r15+,r14
 -	rts	
-+	jsr	@r0
-+	mov	#15,r4
-+
-+	! Set back the stack and return (presumably to a serial debug)
-+normal_exit:
-+	mov.l	old_stack,r15
-+	lds.l	@r15+,pr
-+	rts
- 	nop
+-	nop
 -.LFE1:
 -.Lfe1:
 -	.size	__superh_trap_handler,.Lfe1-__superh_trap_handler
@@ -898,7 +912,6 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 -	.ualong	0x0
 -	.ualong	0x0
 -#endif /* VBR_SETUP */
-+
 +! Misc variables
 +	.align	2
 +dcload_magic_addr:
@@ -929,8 +942,12 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +__arch_old_stack:
 +old_stack:
 +	.long	0
-+new_stack:
-+	.long	0x8d000000
++new_stack_16m:
++	.long   0x8d000000
++new_stack_32m:
++	.long   0x8e000000
++mcr:
++	.long   0xff800014
 +p2_mask:
 +	.long	0xa0000000
 +setup_cache_addr:
@@ -951,9 +968,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +	.word	0x090d
 +ccr_data_ocram:
 +	.word	0x092d
-diff -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S
---- gcc-9.3.0/libgcc/config/sh/fake-kos.S	1969-12-31 19:00:00.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S
+--- gcc-9.3.0/libgcc/config/sh/fake-kos.S	1969-12-31 18:00:00
++++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2022-12-29 19:55:54
 @@ -0,0 +1,78 @@
 +! Weakly linked symbols used to get GCC to hopefully compile itself properly.
 +! These will be replaced by the real symbols in actual compiled programs.
@@ -1033,9 +1050,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/f
 +_cond_signal:
 +    rts
 +    mov     #-1, r0
-diff -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h
---- gcc-9.3.0/libgcc/config/sh/gthr-kos.h	1969-12-31 19:00:00.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h
+--- gcc-9.3.0/libgcc/config/sh/gthr-kos.h	1969-12-31 18:00:00
++++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2022-12-29 19:55:54
 @@ -0,0 +1,401 @@
 +/* Copyright (C) 2009, 2010, 2011, 2012, 2020 Lawrence Sebald */
 +
@@ -1438,9 +1455,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/g
 +
 +
 +#endif /* ! GCC_GTHR_KOS_H */
-diff -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
---- gcc-9.3.0/libgcc/config/sh/t-sh	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
+--- gcc-9.3.0/libgcc/config/sh/t-sh	2022-12-29 19:55:09
++++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2022-12-29 19:55:54
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -1450,9 +1467,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
---- gcc-9.3.0/libgcc/configure	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/configure	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
+--- gcc-9.3.0/libgcc/configure	2022-12-29 19:55:09
++++ gcc-9.3.0-kos/libgcc/configure	2022-12-29 19:55:54
 @@ -5550,6 +5550,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -1461,9 +1478,9 @@ diff -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
  esac
  
  
-diff -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2020-03-12 07:07:24.000000000 -0400
-+++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2022-12-29 19:55:24
++++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2022-12-29 19:55:54
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -1514,9 +1531,9 @@ diff -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-9.3.0/libstdc++-v3/configure gcc-9.3.0-kos/libstdc++-v3/configure
---- gcc-9.3.0/libstdc++-v3/configure	2020-03-12 07:07:24.000000000 -0400
-+++ gcc-9.3.0-kos/libstdc++-v3/configure	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libstdc++-v3/configure gcc-9.3.0-kos/libstdc++-v3/configure
+--- gcc-9.3.0/libstdc++-v3/configure	2022-12-29 19:55:24
++++ gcc-9.3.0-kos/libstdc++-v3/configure	2022-12-29 19:55:54
 @@ -15629,6 +15629,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/patches/gcc-4.7.4-kos.diff
+++ b/utils/dc-chain/patches/gcc-4.7.4-kos.diff
@@ -1,6 +1,22 @@
-diff -ruN gcc-4.7.4/gcc/configure gcc-4.7.4-new/gcc/configure
---- gcc-4.7.4/gcc/configure	2014-02-12 16:43:47.000000000 +0000
-+++ gcc-4.7.4-new/gcc/configure	2020-03-25 14:40:04.452765679 +0000
+diff -ruN --no-dereference gcc-4.7.4/gcc/config/sh/sh.h gcc-4.7.4-kos/gcc/config/sh/sh.h
+--- gcc-4.7.4/gcc/config/sh/sh.h	2022-12-29 19:24:53.850990179 -0600
++++ gcc-4.7.4-kos/gcc/config/sh/sh.h	2022-12-29 19:42:54.714327736 -0600
+@@ -93,6 +93,12 @@
+     builtin_define ("__FMOVD_ENABLED__"); \
+   builtin_define (TARGET_LITTLE_ENDIAN \
+ 		  ? "__LITTLE_ENDIAN__" : "__BIG_ENDIAN__"); \
++  /* Custom built-in defines for KallistiOS */ \
++  builtin_define ("__KOS_GCC_PATCHED__"); \
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d", \
++			2022123000); \
++  /* Toolchain supports setting up stack for 32MB if using AMX3  */ \
++  builtin_define ("__KOS_GCC_AMX3_32MB__"); \
+ } while (0)
+ 
+ /* Value should be nonzero if functions must have frame pointers.
+diff -ruN --no-dereference gcc-4.7.4/gcc/configure gcc-4.7.4-kos/gcc/configure
+--- gcc-4.7.4/gcc/configure	2022-12-29 19:24:52.915989025 -0600
++++ gcc-4.7.4-kos/gcc/configure	2022-12-29 19:25:16.801018486 -0600
 @@ -11338,7 +11338,7 @@
      target_thread_file='single'
      ;;
@@ -10,9 +26,9 @@ diff -ruN gcc-4.7.4/gcc/configure gcc-4.7.4-new/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff -ruN gcc-4.7.4/gcc/cp/cfns.h gcc-4.7.4-new/gcc/cp/cfns.h
---- gcc-4.7.4/gcc/cp/cfns.h	2009-04-21 20:03:23.000000000 +0100
-+++ gcc-4.7.4-new/gcc/cp/cfns.h	2020-03-25 14:40:04.460765725 +0000
+diff -ruN --no-dereference gcc-4.7.4/gcc/cp/cfns.h gcc-4.7.4-kos/gcc/cp/cfns.h
+--- gcc-4.7.4/gcc/cp/cfns.h	2022-12-29 19:24:52.890988994 -0600
++++ gcc-4.7.4-kos/gcc/cp/cfns.h	2022-12-29 19:25:16.801018486 -0600
 @@ -53,6 +53,9 @@
  static unsigned int hash (const char *, unsigned int);
  #ifdef __GNUC__
@@ -32,9 +48,9 @@ diff -ruN gcc-4.7.4/gcc/cp/cfns.h gcc-4.7.4-new/gcc/cp/cfns.h
  
    switch (hval)
      {
-diff -ruN gcc-4.7.4/gcc/doc/gcc.texi gcc-4.7.4-new/gcc/doc/gcc.texi
---- gcc-4.7.4/gcc/doc/gcc.texi	2010-06-10 00:46:33.000000000 +0100
-+++ gcc-4.7.4-new/gcc/doc/gcc.texi	2020-03-25 14:40:04.464765748 +0000
+diff -ruN --no-dereference gcc-4.7.4/gcc/doc/gcc.texi gcc-4.7.4-kos/gcc/doc/gcc.texi
+--- gcc-4.7.4/gcc/doc/gcc.texi	2022-12-29 19:24:52.909989017 -0600
++++ gcc-4.7.4-kos/gcc/doc/gcc.texi	2022-12-29 19:25:16.801018486 -0600
 @@ -86,9 +86,9 @@
  @item GNU Press
  @tab Website: www.gnupress.org
@@ -47,10 +63,10 @@ diff -ruN gcc-4.7.4/gcc/doc/gcc.texi gcc-4.7.4-new/gcc/doc/gcc.texi
  @item 51 Franklin Street, Fifth Floor
  @tab Tel 617-542-5942
  @item Boston, MA 02110-1301 USA
-diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.S
---- gcc-4.7.4/libgcc/config/sh/crt1.S	2011-11-02 14:33:56.000000000 +0000
-+++ gcc-4.7.4-new/libgcc/config/sh/crt1.S	2020-03-25 14:40:04.485765870 +0000
-@@ -1,1369 +1,202 @@
+diff -ruN --no-dereference gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/sh/crt1.S
+--- gcc-4.7.4/libgcc/config/sh/crt1.S	2022-12-29 19:24:52.804988888 -0600
++++ gcc-4.7.4-kos/libgcc/config/sh/crt1.S	2022-12-29 19:28:07.978229651 -0600
+@@ -1,1369 +1,214 @@
 -/* Copyright (C) 2000, 2001, 2003, 2004, 2005, 2006, 2009, 2011
 -   Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
@@ -913,7 +929,15 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 +	! Save the current stack, and set a new stack (higher up in RAM)
 +	mov.l	old_stack_addr,r0
 +	mov.l	r15,@r0
-+	mov.l	new_stack,r15
++	! Set stack based on MCR
++	mov.l   new_stack_16m,r15
++	mov.l   mcr,r1
++	mov.l   @r1,r0
++	and     #0x38,r0
++	cmp/eq  #0x18,r0
++	bf      mcr_16m
++	mov.l   new_stack_32m,r15
++mcr_16m:
 +
 +	! Save VBR
 +	mov.l	old_vbr_addr,r0
@@ -1254,8 +1278,12 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 +__arch_old_stack:
 +old_stack:
 +	.long	0
-+new_stack:
-+	.long	0x8d000000
++new_stack_16m:
++	.long   0x8d000000
++new_stack_32m:
++	.long   0x8e000000
++mcr:
++	.long   0xff800014
 +p2_mask:
 +	.long	0xa0000000
 +setup_cache_addr:
@@ -1601,9 +1629,9 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	.ualong	0x0
 -#endif /* VBR_SETUP */
 -#endif /* ! __SH5__ */
-diff -ruN gcc-4.7.4/libgcc/config/sh/fake-kos.S gcc-4.7.4-new/libgcc/config/sh/fake-kos.S
---- gcc-4.7.4/libgcc/config/sh/fake-kos.S	1970-01-01 01:00:00.000000000 +0100
-+++ gcc-4.7.4-new/libgcc/config/sh/fake-kos.S	2020-03-25 14:40:04.486765876 +0000
+diff -ruN --no-dereference gcc-4.7.4/libgcc/config/sh/fake-kos.S gcc-4.7.4-kos/libgcc/config/sh/fake-kos.S
+--- gcc-4.7.4/libgcc/config/sh/fake-kos.S	1969-12-31 18:00:00.000000000 -0600
++++ gcc-4.7.4-kos/libgcc/config/sh/fake-kos.S	2022-12-29 19:25:16.802018487 -0600
 @@ -0,0 +1,75 @@
 +! Weakly linked symbols used to get GCC to hopefully compile itself properly.
 +! These will be replaced by the real symbols in actual compiled programs.
@@ -1681,9 +1709,9 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/fake-kos.S gcc-4.7.4-new/libgcc/config/sh/f
 +    mov     #-1, r0
 +    
 \ No newline at end of file
-diff -ruN gcc-4.7.4/libgcc/config/sh/gthr-kos.h gcc-4.7.4-new/libgcc/config/sh/gthr-kos.h
---- gcc-4.7.4/libgcc/config/sh/gthr-kos.h	1970-01-01 01:00:00.000000000 +0100
-+++ gcc-4.7.4-new/libgcc/config/sh/gthr-kos.h	2020-03-25 14:40:04.486765876 +0000
+diff -ruN --no-dereference gcc-4.7.4/libgcc/config/sh/gthr-kos.h gcc-4.7.4-kos/libgcc/config/sh/gthr-kos.h
+--- gcc-4.7.4/libgcc/config/sh/gthr-kos.h	1969-12-31 18:00:00.000000000 -0600
++++ gcc-4.7.4-kos/libgcc/config/sh/gthr-kos.h	2022-12-29 19:25:16.802018487 -0600
 @@ -0,0 +1,355 @@
 +/* Copyright (C) 2009, 2010, 2011, 2012 Lawrence Sebald */
 +
@@ -2040,9 +2068,9 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/gthr-kos.h gcc-4.7.4-new/libgcc/config/sh/g
 +#endif /* _LIBOBJC */
 +
 +#endif /* ! GCC_GTHR_KOS_H */
-diff -ruN gcc-4.7.4/libgcc/config/sh/t-sh gcc-4.7.4-new/libgcc/config/sh/t-sh
---- gcc-4.7.4/libgcc/config/sh/t-sh	2011-11-07 17:14:32.000000000 +0000
-+++ gcc-4.7.4-new/libgcc/config/sh/t-sh	2020-03-25 14:40:04.488765888 +0000
+diff -ruN --no-dereference gcc-4.7.4/libgcc/config/sh/t-sh gcc-4.7.4-kos/libgcc/config/sh/t-sh
+--- gcc-4.7.4/libgcc/config/sh/t-sh	2022-12-29 19:24:52.804988888 -0600
++++ gcc-4.7.4-kos/libgcc/config/sh/t-sh	2022-12-29 19:25:16.802018487 -0600
 @@ -24,6 +24,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -2052,9 +2080,9 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/t-sh gcc-4.7.4-new/libgcc/config/sh/t-sh
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff -ruN gcc-4.7.4/libgcc/configure gcc-4.7.4-new/libgcc/configure
---- gcc-4.7.4/libgcc/configure	2012-08-06 15:34:27.000000000 +0100
-+++ gcc-4.7.4-new/libgcc/configure	2020-03-25 14:40:04.508766004 +0000
+diff -ruN --no-dereference gcc-4.7.4/libgcc/configure gcc-4.7.4-kos/libgcc/configure
+--- gcc-4.7.4/libgcc/configure	2022-12-29 19:24:52.789988869 -0600
++++ gcc-4.7.4-kos/libgcc/configure	2022-12-29 19:25:16.802018487 -0600
 @@ -4480,6 +4480,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -2063,9 +2091,9 @@ diff -ruN gcc-4.7.4/libgcc/configure gcc-4.7.4-new/libgcc/configure
  esac
  
  # Substitute configuration variables
-diff -ruN gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h gcc-4.7.4-new/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h	2020-03-25 15:15:51.300215413 +0000
-+++ gcc-4.7.4-new/libstdc++-v3/config/cpu/sh/atomicity.h	2020-03-25 15:16:20.010371542 +0000
+diff -ruN --no-dereference gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h gcc-4.7.4-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h	2022-12-29 19:24:52.024987925 -0600
++++ gcc-4.7.4-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2022-12-29 19:25:16.802018487 -0600
 @@ -80,7 +80,12 @@
  
  namespace 

--- a/utils/dc-chain/patches/gcc-9.3.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-9.3.0-kos.diff
@@ -1,6 +1,21 @@
+diff -ruN gcc-9.3.0/gcc/config/sh/sh-c.c gcc-9.3.0-kos/gcc/config/sh/sh-c.c
+--- gcc-9.3.0/gcc/config/sh/sh-c.c	2022-12-29 18:46:56.670285086 -0600
++++ gcc-9.3.0-kos/gcc/config/sh/sh-c.c	2022-12-29 19:09:47.328886123 -0600
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2022123000);
++  /* Toolchain supports setting up stack for 32MB if using AMX3  */
++  builtin_define ("__KOS_GCC_AMX3_32MB__");
+ }
 diff -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
---- gcc-9.3.0/gcc/configure	2020-03-12 07:08:30.000000000 -0400
-+++ gcc-9.3.0-kos/gcc/configure	2020-04-03 16:07:04.540000000 -0400
+--- gcc-9.3.0/gcc/configure	2022-12-29 18:46:58.648287347 -0600
++++ gcc-9.3.0-kos/gcc/configure	2022-12-29 18:47:19.889311626 -0600
 @@ -11862,7 +11862,7 @@
      target_thread_file='single'
      ;;
@@ -11,9 +26,9 @@ diff -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
      ;;
    *)
 diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.S
---- gcc-9.3.0/libgcc/config/sh/crt1.S	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2020-04-03 16:07:04.540000000 -0400
-@@ -1,724 +1,197 @@
+--- gcc-9.3.0/libgcc/config/sh/crt1.S	2022-12-29 18:46:55.934284245 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2022-12-29 18:51:26.073593036 -0600
+@@ -1,724 +1,209 @@
 -/* Copyright (C) 2000-2019 Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
 +! KallistiOS ##version##
@@ -232,7 +247,15 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +	! Save the current stack, and set a new stack (higher up in RAM)
 +	mov.l	old_stack_addr,r0
 +	mov.l	r15,@r0
-+	mov.l	new_stack,r15
++	! Set stack based on MCR
++	mov.l   new_stack_16m,r15
++	mov.l   mcr,r1
++	mov.l   @r1,r0
++	and     #0x38,r0
++	cmp/eq  #0x18,r0
++	bf      mcr_16m
++	mov.l   new_stack_32m,r15
++mcr_16m:
 +
 +	! Save VBR
 +	mov.l	old_vbr_addr,r0
@@ -896,8 +919,12 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +__arch_old_stack:
 +old_stack:
 +	.long	0
-+new_stack:
++new_stack_16m:
 +	.long	0x8d000000
++new_stack_32m:
++	.long   0x8e000000
++mcr:
++	.long   0xff800014
 +p2_mask:
 +	.long	0xa0000000
 +setup_cache_addr:
@@ -919,8 +946,8 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +ccr_data_ocram:
 +	.word	0x092d
 diff -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S
---- gcc-9.3.0/libgcc/config/sh/fake-kos.S	1969-12-31 19:00:00.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2020-04-03 16:07:04.540000000 -0400
+--- gcc-9.3.0/libgcc/config/sh/fake-kos.S	1969-12-31 18:00:00.000000000 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2022-12-29 18:47:19.890311627 -0600
 @@ -0,0 +1,78 @@
 +! Weakly linked symbols used to get GCC to hopefully compile itself properly.
 +! These will be replaced by the real symbols in actual compiled programs.
@@ -1001,8 +1028,8 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/f
 +    rts
 +    mov     #-1, r0
 diff -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h
---- gcc-9.3.0/libgcc/config/sh/gthr-kos.h	1969-12-31 19:00:00.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2020-04-03 16:07:04.540000000 -0400
+--- gcc-9.3.0/libgcc/config/sh/gthr-kos.h	1969-12-31 18:00:00.000000000 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2022-12-29 18:47:19.890311627 -0600
 @@ -0,0 +1,401 @@
 +/* Copyright (C) 2009, 2010, 2011, 2012, 2020 Lawrence Sebald */
 +
@@ -1406,8 +1433,8 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/g
 +
 +#endif /* ! GCC_GTHR_KOS_H */
 diff -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
---- gcc-9.3.0/libgcc/config/sh/t-sh	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2020-04-03 16:07:04.540000000 -0400
+--- gcc-9.3.0/libgcc/config/sh/t-sh	2022-12-29 18:46:55.934284245 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2022-12-29 18:47:19.890311627 -0600
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -1418,8 +1445,8 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
  	$(gcc_compile) -c $<
  
 diff -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
---- gcc-9.3.0/libgcc/configure	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/configure	2020-04-03 16:07:04.540000000 -0400
+--- gcc-9.3.0/libgcc/configure	2022-12-29 18:46:55.972284289 -0600
++++ gcc-9.3.0-kos/libgcc/configure	2022-12-29 18:47:19.890311627 -0600
 @@ -5550,6 +5550,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -1429,8 +1456,8 @@ diff -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
  
  
 diff -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2020-03-12 07:07:24.000000000 -0400
-+++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2020-04-03 16:07:04.540000000 -0400
+--- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2022-12-29 18:46:56.181284527 -0600
++++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2022-12-29 18:47:19.890311627 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -1482,8 +1509,8 @@ diff -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
 diff -ruN gcc-9.3.0/libstdc++-v3/configure gcc-9.3.0-kos/libstdc++-v3/configure
---- gcc-9.3.0/libstdc++-v3/configure	2020-03-12 07:07:24.000000000 -0400
-+++ gcc-9.3.0-kos/libstdc++-v3/configure	2020-04-03 16:07:04.540000000 -0400
+--- gcc-9.3.0/libstdc++-v3/configure	2022-12-29 18:46:56.479284868 -0600
++++ gcc-9.3.0-kos/libstdc++-v3/configure	2022-12-29 18:47:19.894311632 -0600
 @@ -15629,6 +15629,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;


### PR DESCRIPTION
Patches introduce:
- Kernel changes to modify stack for 32MB RAM modifications, along with related functions
- Example memory-testing program demonstrating use of above mentioned functions
- Patches for GCC 4.7.4 and 9.3.0 (including Apple Silicon patch) supporting stack changes
- Patches for GCC 4.7.4 and 9.3.0 adding builtin defines __KOS_GCC_PATCHED__, __KOS_GCC_PATCHLEVEL__, and __KOS_GCC_AMX3_32MB__. 

Thanks go to tsowell, without whom this wouldn't have been possible, as well as GyroVorbis and cepawiel for support. 