### PR TITLE
Support 32MB system RAM configurations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Josh Pearson: 2013, 2014, 2015, 2016
 Joe Fenton: 2016
 Stefan Galowicz: 2016, 2017
 Luke Benstead: 2020, 2021
+Eric Fradella: 2023
 
 Files with Specific licenses:
 -----------------------------

--- a/examples/dreamcast/basic/Makefile
+++ b/examples/dreamcast/basic/Makefile
@@ -12,6 +12,7 @@ all:
 	$(KOS_MAKE) -C stacktrace
 	$(KOS_MAKE) -C mmu
 	$(KOS_MAKE) -C stackprotector
+	$(KOS_MAKE) -C memtest32
 
 clean:
 	$(KOS_MAKE) -C exec clean
@@ -21,6 +22,7 @@ clean:
 	$(KOS_MAKE) -C stacktrace clean
 	$(KOS_MAKE) -C mmu clean
 	$(KOS_MAKE) -C stackprotector clean
+	$(KOS_MAKE) -C memtest32 clean
 
 dist:
 	$(KOS_MAKE) -C exec dist
@@ -30,5 +32,4 @@ dist:
 	$(KOS_MAKE) -C stacktrace dist
 	$(KOS_MAKE) -C mmu dist
 	$(KOS_MAKE) -C stackprotector dist
-
-
+	$(KOS_MAKE) -C memtest32 dist

--- a/examples/dreamcast/basic/memtest32/Makefile
+++ b/examples/dreamcast/basic/memtest32/Makefile
@@ -1,0 +1,23 @@
+TARGET = memtest32.elf
+
+OBJS = memtest.o main.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean:
+	-rm -f $(TARGET) $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist:
+	rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/basic/memtest32/main.c
+++ b/examples/dreamcast/basic/memtest32/main.c
@@ -1,0 +1,117 @@
+/* KallistiOS ##version##
+
+   main.c
+   Copyright (C) 2020 Thomas Sowell
+   Copyright (C) 2022 Eric Fradella
+
+   This application illustrates the use of functions related to detecting the
+   size of system memory and altering a program's behavior to suit the running
+   system's configuration.
+
+   Implemented is a memory test utility for Dreamcast consoles (both stock 16MB
+   systems and modified 32MB systems) or NAOMI systems, based on public domain
+   code by Michael Barr in memtest.c found here:
+   https://barrgroup.com/embedded-systems/how-to/memory-test-suite-c
+
+   Example output on a functional 32MB-modified Dreamcast:
+
+   Beginning memtest routine...
+    Base address: 0x8c100000
+    Number of bytes to test: 32440320
+     memTestDataBus: PASS
+     memTestAddressBus: PASS
+     memTestDevice: PASS
+   Test passed!
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "memtest.h"
+
+/* Leave space at the beginning and end of memory for this program and for the
+ * stack. Dreamcast applications are loaded at 0x8c000000 so we leave 0x100000
+ * bytes past that for the program itself and leave 65536 bytes at the top of
+ * memory for the stack. */
+#define SAFE_AREA     0x100000
+#define STACK_SIZE    65536
+#define BASE_ADDRESS  (volatile datum *) (0x8c000000 + SAFE_AREA)
+
+/* Define the number of bytes to be tested. KallistiOS provides the
+ * macros HW_MEM_16 and HW_MEM_32 which describe the number of bytes
+ * available in standard supported console configurations (16777216
+ * and 33554432, respectively). */
+#define NUM_BYTES_32  (HW_MEM_32 - SAFE_AREA - STACK_SIZE)
+#define NUM_BYTES_16  (HW_MEM_16 - SAFE_AREA - STACK_SIZE)
+
+int main(int argc, char **argv) {
+    uint32_t error, data, *address;
+    unsigned long num_bytes;
+    error = 0;
+
+    /* The HW_MEMSIZE can be called to retrieve the system's memory size.
+     * _arch_mem_top defines the top address of memory.
+     * 0x8d000000 if 16MB console, 0x8e000000 if 32MB */
+    printf("\nThis console has %ld bytes of system memory,\n with top of "
+           "memory located at 0x%0lx.\n\n", HW_MEMSIZE, _arch_mem_top);
+
+    /* The DBL_MEM boolean macro is provided as an easy, concise
+     * way to determine if extra system RAM is available */
+    num_bytes = DBL_MEM ? NUM_BYTES_32 : NUM_BYTES_16;
+
+    printf("Beginning memtest routine...\n");
+    printf(" Base address: %p\n", BASE_ADDRESS);
+    printf(" Number of bytes to test: %lu\n", num_bytes);
+
+    /* Now we run the test routines provided in memtest.c
+     * Each routine returns zero if the routine passes,
+     * else it returns the address of failure.
+     * First, let's test the data bus. */
+    printf("  memTestDataBus: ");
+    fflush(stdout);
+    data = memTestDataBus(BASE_ADDRESS);
+
+    if(data != 0) {
+        printf("FAIL: %08lx\n", data);
+        error = 1;
+    }
+    else {
+        printf("PASS\n");
+    }
+
+    fflush(stdout);
+
+    /* Now we test the address bus. */
+    printf("  memTestAddressBus: ");
+    fflush(stdout);
+    address = memTestAddressBus(BASE_ADDRESS, num_bytes);
+
+    if(address != NULL) {
+        printf("FAIL (%p)\n", address);
+        error = 1;
+    }
+    else {
+        printf("PASS\n");
+    }
+
+    fflush(stdout);
+
+    /* And now, we test the memory itself. */
+    printf("  memTestDevice: ");
+    fflush(stdout);
+    address = memTestDevice(BASE_ADDRESS, num_bytes);
+
+    if(address != NULL) {
+        printf("FAIL (%p)\n", address);
+        error = 1;
+    }
+    else {
+        printf("PASS\n");
+    }
+
+    fflush(stdout);
+
+    /* Test completed, return final result */
+    printf("Test %s\n", error ? "failed." : "passed!\n");
+    return error;
+}

--- a/examples/dreamcast/basic/memtest32/memtest.c
+++ b/examples/dreamcast/basic/memtest32/memtest.c
@@ -1,0 +1,221 @@
+/**********************************************************************
+ *
+ * Filename:    memtest.c
+ * 
+ * Description: General-purpose memory testing functions.
+ *
+ * Notes:       This software can be easily ported to systems with
+ *              different data bus widths by redefining 'datum'.
+ *
+ * 
+ * Copyright (c) 1998 by Michael Barr.  This software is placed into
+ * the public domain and may be used for any purpose.  However, this
+ * notice must not be changed or removed and no warranty is either
+ * expressed or implied by its publication or distribution.
+ **********************************************************************/
+
+
+#include "memtest.h"
+
+
+/**********************************************************************
+ *
+ * Function:    memTestDataBus()
+ *
+ * Description: Test the data bus wiring in a memory region by
+ *              performing a walking 1's test at a fixed address
+ *              within that region.  The address (and hence the
+ *              memory region) is selected by the caller.
+ *
+ * Notes:       
+ *
+ * Returns:     0 if the test succeeds.  
+ *              A non-zero result is the first pattern that failed.
+ *
+ **********************************************************************/
+datum
+memTestDataBus(volatile datum * address)
+{
+    datum pattern;
+
+
+    /*
+     * Perform a walking 1's test at the given address.
+     */
+    for (pattern = 1; pattern != 0; pattern <<= 1)
+    {
+        /*
+         * Write the test pattern.
+         */
+        *address = pattern;
+
+        /*
+         * Read it back (immediately is okay for this test).
+         */
+        if (*address != pattern) 
+        {
+            return (pattern);
+        }
+    }
+
+    return (0);
+
+}   /* memTestDataBus() */
+
+
+/**********************************************************************
+ *
+ * Function:    memTestAddressBus()
+ *
+ * Description: Test the address bus wiring in a memory region by
+ *              performing a walking 1's test on the relevant bits
+ *              of the address and checking for aliasing. This test
+ *              will find single-bit address failures such as stuck
+ *              -high, stuck-low, and shorted pins.  The base address
+ *              and size of the region are selected by the caller.
+ *
+ * Notes:       For best results, the selected base address should
+ *              have enough LSB 0's to guarantee single address bit
+ *              changes.  For example, to test a 64-Kbyte region, 
+ *              select a base address on a 64-Kbyte boundary.  Also, 
+ *              select the region size as a power-of-two--if at all 
+ *              possible.
+ *
+ * Returns:     NULL if the test succeeds.  
+ *              A non-zero result is the first address at which an
+ *              aliasing problem was uncovered.  By examining the
+ *              contents of memory, it may be possible to gather
+ *              additional information about the problem.
+ *
+ **********************************************************************/
+datum * 
+memTestAddressBus(volatile datum * baseAddress, unsigned long nBytes)
+{
+    unsigned long addressMask = (nBytes/sizeof(datum) - 1);
+    unsigned long offset;
+    unsigned long testOffset;
+
+    datum pattern     = (datum) 0xAAAAAAAA;
+    datum antipattern = (datum) 0x55555555;
+
+
+    /*
+     * Write the default pattern at each of the power-of-two offsets.
+     */
+    for (offset = 1; (offset & addressMask) != 0; offset <<= 1)
+    {
+        baseAddress[offset] = pattern;
+    }
+
+    /* 
+     * Check for address bits stuck high.
+     */
+    testOffset = 0;
+    baseAddress[testOffset] = antipattern;
+
+    for (offset = 1; (offset & addressMask) != 0; offset <<= 1)
+    {
+        if (baseAddress[offset] != pattern)
+        {
+            return ((datum *) &baseAddress[offset]);
+        }
+    }
+
+    baseAddress[testOffset] = pattern;
+
+    /*
+     * Check for address bits stuck low or shorted.
+     */
+    for (testOffset = 1; (testOffset & addressMask) != 0; testOffset <<= 1)
+    {
+        baseAddress[testOffset] = antipattern;
+
+		if (baseAddress[0] != pattern)
+		{
+			return ((datum *) &baseAddress[testOffset]);
+		}
+
+        for (offset = 1; (offset & addressMask) != 0; offset <<= 1)
+        {
+            if ((baseAddress[offset] != pattern) && (offset != testOffset))
+            {
+                return ((datum *) &baseAddress[testOffset]);
+            }
+        }
+
+        baseAddress[testOffset] = pattern;
+    }
+
+    return (NULL);
+
+}   /* memTestAddressBus() */
+
+
+/**********************************************************************
+ *
+ * Function:    memTestDevice()
+ *
+ * Description: Test the integrity of a physical memory device by
+ *              performing an increment/decrement test over the
+ *              entire region.  In the process every storage bit 
+ *              in the device is tested as a zero and a one.  The
+ *              base address and the size of the region are
+ *              selected by the caller.
+ *
+ * Notes:       
+ *
+ * Returns:     NULL if the test succeeds.
+ *
+ *              A non-zero result is the first address at which an
+ *              incorrect value was read back.  By examining the
+ *              contents of memory, it may be possible to gather
+ *              additional information about the problem.
+ *
+ **********************************************************************/
+datum * 
+memTestDevice(volatile datum * baseAddress, unsigned long nBytes)	
+{
+    unsigned long offset;
+    unsigned long nWords = nBytes / sizeof(datum);
+
+    datum pattern;
+    datum antipattern;
+
+
+    /*
+     * Fill memory with a known pattern.
+     */
+    for (pattern = 1, offset = 0; offset < nWords; pattern++, offset++)
+    {
+        baseAddress[offset] = pattern;
+    }
+
+    /*
+     * Check each location and invert it for the second pass.
+     */
+    for (pattern = 1, offset = 0; offset < nWords; pattern++, offset++)
+    {
+        if (baseAddress[offset] != pattern)
+        {
+            return ((datum *) &baseAddress[offset]);
+        }
+
+        antipattern = ~pattern;
+        baseAddress[offset] = antipattern;
+    }
+
+    /*
+     * Check each location for the inverted pattern and zero it.
+     */
+    for (pattern = 1, offset = 0; offset < nWords; pattern++, offset++)
+    {
+        antipattern = ~pattern;
+        if (baseAddress[offset] != antipattern)
+        {
+            return ((datum *) &baseAddress[offset]);
+        }
+    }
+
+    return (NULL);
+
+}   /* memTestDevice() */

--- a/examples/dreamcast/basic/memtest32/memtest.h
+++ b/examples/dreamcast/basic/memtest32/memtest.h
@@ -1,0 +1,42 @@
+/**********************************************************************
+ *
+ * Filename:    memtest.h
+ * 
+ * Description: Memory-testing module API.
+ *
+ * Notes:       The memory tests can be easily ported to systems with
+ *              different data bus widths by redefining 'datum' type.
+ *
+ * 
+ * Copyright (c) 2000 by Michael Barr.  This software is placed into
+ * the public domain and may be used for any purpose.  However, this
+ * notice must not be changed or removed and no warranty is either
+ * expressed or implied by its publication or distribution.
+ **********************************************************************/
+
+#ifndef _memtest_h
+#define _memtest_h
+
+#include <stdint.h>
+
+/*
+ * Define NULL pointer value.
+ */
+#ifndef NULL
+#define NULL  (void *) 0
+#endif
+
+/*
+ * Set the data bus width.
+ */
+typedef uint32_t datum;
+
+/*
+ * Function prototypes.
+ */
+datum   memTestDataBus(volatile datum * address);
+datum * memTestAddressBus(volatile datum * baseAddress, unsigned long nBytes);
+datum * memTestDevice(volatile datum * baseAddress, unsigned long nBytes);
+
+
+#endif /* _memtest_h */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -24,7 +24,14 @@ __BEGIN_DECLS
 #include <dc/video.h>
 
 /** \brief  Top of memory available, depending on memory size. */
+#ifdef __KOS_GCC_32MB__
 extern uint32 _arch_mem_top;
+#else
+#warning Outdated toolchain: not patched for 32MB support, limiting KOS\
+         to 16MB-only behavior to retain maximum compatibility. Please\
+         update toolchain.
+#define _arch_mem_top 0x8d000000
+#endif
 
 #define PAGESIZE        4096            /**< \brief Page size (for MMU) */
 #define PAGESIZE_BITS   12              /**< \brief Bits for page size */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -138,7 +138,7 @@ void __crtend_pullin();
 
 /** \defgroup hw_memsizes           Console memory sizes
     These are the various memory sizes, in bytes, that can be returned by the
-    hardware_memsize() function.
+    HW_MEMSIZE macro.
     @{
 */
 #define HW_MEM_16           16777216   /**< \brief 16M retail Dreamcast */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -27,10 +27,10 @@ __BEGIN_DECLS
 #ifdef __KOS_GCC_32MB__
 extern uint32 _arch_mem_top;
 #else
-#warning Outdated toolchain: not patched for 32MB support, limiting KOS\
-         to 16MB-only behavior to retain maximum compatibility. Please\
-         update toolchain.
-#define _arch_mem_top   0x8d000000
+#pragma message "Outdated toolchain: not patched for 32MB support, limiting KOS"\
+         " to 16MB-only behavior to retain maximum compatibility. Please"\
+         " update toolchain."
+#define _arch_mem_top   ((uint32) 0x8d000000)
 #endif
 
 #define PAGESIZE        4096            /**< \brief Page size (for MMU) */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -30,7 +30,7 @@ extern uint32 _arch_mem_top;
 #warning Outdated toolchain: not patched for 32MB support, limiting KOS\
          to 16MB-only behavior to retain maximum compatibility. Please\
          update toolchain.
-#define _arch_mem_top 0x8d000000
+#define _arch_mem_top   0x8d000000
 #endif
 
 #define PAGESIZE        4096            /**< \brief Page size (for MMU) */
@@ -148,12 +148,12 @@ void __crtend_pullin();
 /** \brief  Determine how much memory is installed in current machine.
     \return The total size of system memory in bytes.
 */
-#define HW_MEMSIZE ((_arch_mem_top == 0x8e000000) ? HW_MEM_32 : HW_MEM_16)
+#define HW_MEMSIZE (_arch_mem_top - 0x8c000000)
 
-/** \brief Use this macro to easily determine if system has doubled RAM.
-    \return True if doubled RAM, false if standard RAM.
+/** \brief Use this macro to easily determine if system has 32MB of RAM.
+    \return Non-zero if console has 32MB of RAM, zero otherwise
 */
-#define DBL_MEM ((_arch_mem_top == 0x8e000000) ? 1 : 0 )
+#define DBL_MEM (_arch_mem_top - 0x8d000000)
 
 /* These are in mm.c */
 /** \brief  Initialize the memory management system.

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -23,18 +23,17 @@ __BEGIN_DECLS
 
 #include <dc/video.h>
 
+/** \brief  Top of memory available, depending on memory size. */
+extern uint32 _arch_mem_top;
+
 #define PAGESIZE        4096            /**< \brief Page size (for MMU) */
 #define PAGESIZE_BITS   12              /**< \brief Bits for page size */
 #define PAGEMASK        (PAGESIZE - 1)  /**< \brief Mask for page offset */
 
-#ifndef _arch_sub_naomi
 /** \brief  Page count "variable".
 
     The number of pages is static, so we can optimize this quite a bit. */
-#define page_count      ((16*1024*1024 - 0x10000) / PAGESIZE)
-#else
-#define page_count      ((32*1024*1024 - 0x10000) / PAGESIZE)
-#endif
+#define page_count      ((_arch_mem_top - page_phys_base) / PAGESIZE)
 
 /** \brief  Base address of available physical pages. */
 #define page_phys_base  0x8c010000
@@ -129,6 +128,25 @@ void arch_dtors();
 
 /** \brief  Hook to ensure linking of crtend.c. */
 void __crtend_pullin();
+
+/** \defgroup hw_memsizes           Console memory sizes
+    These are the various memory sizes, in bytes, that can be returned by the
+    hardware_memsize() function.
+    @{
+*/
+#define HW_MEM_16           16777216   /**< \brief 16M retail Dreamcast */
+#define HW_MEM_32           33554432   /**< \brief 32M NAOMI/modded Dreamcast */
+/** @} */
+
+/** \brief  Determine how much memory is installed in current machine.
+    \return The total size of system memory in bytes.
+*/
+#define HW_MEMSIZE ((_arch_mem_top == 0x8e000000) ? HW_MEM_32 : HW_MEM_16)
+
+/** \brief Use this macro to easily determine if system has doubled RAM.
+    \return True if doubled RAM, false if standard RAM.
+*/
+#define DBL_MEM ((_arch_mem_top == 0x8e000000) ? 1 : 0 )
 
 /* These are in mm.c */
 /** \brief  Initialize the memory management system.
@@ -354,17 +372,13 @@ const char *kos_get_authors(void);
 */
 #define arch_fptr_next(fptr) (*((uint32*)(fptr+4)))
 
-#ifndef _arch_sub_naomi
 /** \brief  Returns true if the passed address is likely to be valid. Doesn't
             have to be exact, just a sort of general idea.
 
     \return                 Whether the address is valid or not for normal
                             memory access.
 */
-#define arch_valid_address(ptr) ((ptr_t)(ptr) >= 0x8c010000 && (ptr_t)(ptr) < 0x8d000000)
-#else
-#define arch_valid_address(ptr) ((ptr_t)(ptr) >= 0x8c010000 && (ptr_t)(ptr) < 0x8e000000)
-#endif
+#define arch_valid_address(ptr) ((ptr_t)(ptr) >= 0x8c010000 && (ptr_t)(ptr) < _arch_mem_top)
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/kernel/stack.c
+++ b/kernel/arch/dreamcast/kernel/stack.c
@@ -29,7 +29,7 @@ void arch_stk_trace_at(uint32 fp, int n) {
     dbgio_printf("-------- Stack Trace (innermost first) ---------\n");
 
     while(fp != 0xffffffff) {
-        if((fp & 3) || (fp < 0x8c000000) || (fp > 0x8d000000)) {
+        if((fp & 3) || (fp < 0x8c000000) || (fp > _arch_mem_top)) {
             dbgio_printf("   (invalid frame pointer)\n");
             break;
         }

--- a/kernel/mm/malloc_debug.c
+++ b/kernel/mm/malloc_debug.c
@@ -108,7 +108,7 @@ void *malloc(size_t amt) {
     spinlock_unlock(&mutex);
 
     printf("Thread %d/%08lx allocated %d bytes at %08lx; %08lx left\n",
-           ctl->thread, ctl->addr, ctl->size, space, 0x8d000000 - (uint32)sbrk(0));
+           ctl->thread, ctl->addr, ctl->size, space, _arch_mem_top - (uint32)sbrk(0));
 
     assert(!(((uint32)space) & 7));
 
@@ -178,7 +178,7 @@ void free(void *block) {
     printf("Thread %d/%08x freeing block @ %08x\n",
            thd_current->tid, pr, (uint32)block);
 
-    if(((uint32)block) & 7 || (uint32)block < 0x8c010000 || (uint32)block >= 0x8d000000) {
+    if(((uint32)block) & 7 || (uint32)block < 0x8c010000 || (uint32)block >= _arch_mem_top) {
         printf("   ATTEMPT TO FREE INVALID ADDRESS!\n");
         spinlock_unlock(&mutex);
         return;

--- a/utils/dc-chain/patches/arm-Darwin/gcc-9.3.0-kos.diff
+++ b/utils/dc-chain/patches/arm-Darwin/gcc-9.3.0-kos.diff
@@ -1,20 +1,6 @@
-diff -ruN gcc-9.3.0/gcc/config.host gcc-9.3.0-kos/gcc/config.host
---- gcc-9.3.0/gcc/config.host	2020-03-12 05:07:21.000000000 -0600
-+++ gcc-9.3.0-kos/gcc/config.host	2022-10-03 15:12:44.000000000 -0600
-@@ -93,8 +93,8 @@
- case ${host} in
-   *-darwin*)
-     # Generic darwin host support.
--    out_host_hook_obj=host-darwin.o
--    host_xmake_file="${host_xmake_file} x-darwin"
-+    # out_host_hook_obj=host-darwin.o
-+    # host_xmake_file="${host_xmake_file} x-darwin"
-     ;;
- esac
-
-diff -ruN gcc-9.3.0/gcc/config/host-darwin.c  gcc-9.3.0-kos/gcc/config/host-darwin.c
---- gcc-9.3.0/gcc/config/host-darwin.c	2020-03-12 05:07:21.000000000 -0600
-+++ gcc-9.3.0-kos/gcc/config/host-darwin.c	2022-10-03 15:13:15.000000000 -0600
+diff --color -ruN gcc-9.3.0/gcc/config/host-darwin.c gcc-9.3.0-kos/gcc/config/host-darwin.c
+--- gcc-9.3.0/gcc/config/host-darwin.c	2023-01-02 14:12:06.689379328 -0600
++++ gcc-9.3.0-kos/gcc/config/host-darwin.c	2023-01-02 14:12:18.411396175 -0600
 @@ -22,6 +22,8 @@
  #include "coretypes.h"
  #include "diagnostic-core.h"
@@ -30,10 +16,38 @@ diff -ruN gcc-9.3.0/gcc/config/host-darwin.c  gcc-9.3.0-kos/gcc/config/host-darw
  }
 +
 +const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
-
-diff -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
---- gcc-9.3.0/gcc/configure	2020-03-12 07:08:30.000000000 -0400
-+++ gcc-9.3.0-kos/gcc/configure	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/gcc/config/sh/sh-c.c gcc-9.3.0-kos/gcc/config/sh/sh-c.c
+--- gcc-9.3.0/gcc/config/sh/sh-c.c	2023-01-02 14:12:06.707379354 -0600
++++ gcc-9.3.0-kos/gcc/config/sh/sh-c.c	2023-01-02 14:12:47.930438599 -0600
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++   /* Custom built-in defines for KallistiOS */
++   builtin_define ("__KOS_GCC_PATCHED__");
++   cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++ 			2023010200);
++   /* Toolchain supports setting up stack for 32MB */
++   builtin_define ("__KOS_GCC_32MB__");
+ }
+diff --color -ruN gcc-9.3.0/gcc/config.host gcc-9.3.0-kos/gcc/config.host
+--- gcc-9.3.0/gcc/config.host	2023-01-02 14:12:08.496381925 -0600
++++ gcc-9.3.0-kos/gcc/config.host	2023-01-02 14:12:18.410396174 -0600
+@@ -93,8 +93,8 @@
+ case ${host} in
+   *-darwin*)
+     # Generic darwin host support.
+-    out_host_hook_obj=host-darwin.o
+-    host_xmake_file="${host_xmake_file} x-darwin"
++    # out_host_hook_obj=host-darwin.o
++    # host_xmake_file="${host_xmake_file} x-darwin"
+     ;;
+ esac
+ 
+diff --color -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
+--- gcc-9.3.0/gcc/configure	2023-01-02 14:12:08.529381973 -0600
++++ gcc-9.3.0-kos/gcc/configure	2023-01-02 14:12:18.412396177 -0600
 @@ -11862,7 +11862,7 @@
      target_thread_file='single'
      ;;
@@ -43,10 +57,10 @@ diff -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.S
---- gcc-9.3.0/libgcc/config/sh/crt1.S	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2020-04-03 16:07:04.540000000 -0400
-@@ -1,724 +1,197 @@
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.S
+--- gcc-9.3.0/libgcc/config/sh/crt1.S	2023-01-02 14:12:06.013378357 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2023-01-02 14:12:22.967402723 -0600
+@@ -1,724 +1,225 @@
 -/* Copyright (C) 2000-2019 Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
 +! KallistiOS ##version##
@@ -67,6 +81,7 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +.globl __arch_old_vbr
 +.globl __arch_old_stack
 +.globl __arch_old_fpscr
++.globl __arch_mem_top
  
 -This file is part of GCC.
 -
@@ -265,7 +280,28 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +	! Save the current stack, and set a new stack (higher up in RAM)
 +	mov.l	old_stack_addr,r0
 +	mov.l	r15,@r0
-+	mov.l	new_stack,r15
++	mov.l   new_stack_16m,r15
++
++	! Check if 0xadffffff is a mirror of 0xacffffff, or if unique
++	! If unique, then memory is 32MB instead of 16MB, and we must
++	! set up new stack even higher
++	mov.l	p2_mask,r0
++	mov	r0,r2
++	or	r15,r2
++	mov	#0xba,r1
++	mov.b	r1,@-r2			! Store 0xba to 0xacffffff
++	mov.l	new_stack_32m,r1
++	or	r0,r1
++	mov	#0xab,r0
++	mov.b	r0,@-r1			! Store 0xab in 0xadffffff
++	mov.b	@r1,r0
++	mov.b	@r2,r1			! Reloaded values
++	cmp/eq	r0,r1			! Check if values match
++	bt	memchk_done		! If so, mirror - we're done, move on
++	mov.l	new_stack_32m,r15	! If not, unique - set higher stack
++memchk_done:
++	mov.l	mem_top_addr,r0
++	mov.l	r15,@r0			! Save address of top of memory
 +
 +	! Save VBR
 +	mov.l	old_vbr_addr,r0
@@ -445,7 +481,7 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +	nop				! 6
 +	nop				! 7
 +	nop				! 8
-+	
++
 +	! Restore VBR
 +	mov.l	old_vbr,r0
 +	ldc	r0,vbr
@@ -929,8 +965,14 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +__arch_old_stack:
 +old_stack:
 +	.long	0
-+new_stack:
++__arch_mem_top:
++	.long	0
++mem_top_addr:
++	.long	__arch_mem_top
++new_stack_16m:
 +	.long	0x8d000000
++new_stack_32m:
++	.long	0x8e000000
 +p2_mask:
 +	.long	0xa0000000
 +setup_cache_addr:
@@ -951,9 +993,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +	.word	0x090d
 +ccr_data_ocram:
 +	.word	0x092d
-diff -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S
---- gcc-9.3.0/libgcc/config/sh/fake-kos.S	1969-12-31 19:00:00.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S
+--- gcc-9.3.0/libgcc/config/sh/fake-kos.S	1969-12-31 18:00:00.000000000 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2023-01-02 14:12:18.413396178 -0600
 @@ -0,0 +1,78 @@
 +! Weakly linked symbols used to get GCC to hopefully compile itself properly.
 +! These will be replaced by the real symbols in actual compiled programs.
@@ -1033,9 +1075,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/f
 +_cond_signal:
 +    rts
 +    mov     #-1, r0
-diff -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h
---- gcc-9.3.0/libgcc/config/sh/gthr-kos.h	1969-12-31 19:00:00.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h
+--- gcc-9.3.0/libgcc/config/sh/gthr-kos.h	1969-12-31 18:00:00.000000000 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2023-01-02 14:12:18.413396178 -0600
 @@ -0,0 +1,401 @@
 +/* Copyright (C) 2009, 2010, 2011, 2012, 2020 Lawrence Sebald */
 +
@@ -1438,9 +1480,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/g
 +
 +
 +#endif /* ! GCC_GTHR_KOS_H */
-diff -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
---- gcc-9.3.0/libgcc/config/sh/t-sh	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
+--- gcc-9.3.0/libgcc/config/sh/t-sh	2023-01-02 14:12:06.013378357 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2023-01-02 14:12:18.413396178 -0600
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -1450,9 +1492,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
---- gcc-9.3.0/libgcc/configure	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/configure	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
+--- gcc-9.3.0/libgcc/configure	2023-01-02 14:12:06.049378409 -0600
++++ gcc-9.3.0-kos/libgcc/configure	2023-01-02 14:12:18.413396178 -0600
 @@ -5550,6 +5550,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -1461,9 +1503,9 @@ diff -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
  esac
  
  
-diff -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2020-03-12 07:07:24.000000000 -0400
-+++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-01-02 14:12:06.264378718 -0600
++++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-01-02 14:12:18.414396179 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -1514,9 +1556,9 @@ diff -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-9.3.0/libstdc++-v3/configure gcc-9.3.0-kos/libstdc++-v3/configure
---- gcc-9.3.0/libstdc++-v3/configure	2020-03-12 07:07:24.000000000 -0400
-+++ gcc-9.3.0-kos/libstdc++-v3/configure	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libstdc++-v3/configure gcc-9.3.0-kos/libstdc++-v3/configure
+--- gcc-9.3.0/libstdc++-v3/configure	2023-01-02 14:12:06.616379224 -0600
++++ gcc-9.3.0-kos/libstdc++-v3/configure	2023-01-02 14:12:18.417396184 -0600
 @@ -15629,6 +15629,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/patches/gcc-4.7.4-kos.diff
+++ b/utils/dc-chain/patches/gcc-4.7.4-kos.diff
@@ -1,6 +1,22 @@
-diff -ruN gcc-4.7.4/gcc/configure gcc-4.7.4-new/gcc/configure
---- gcc-4.7.4/gcc/configure	2014-02-12 16:43:47.000000000 +0000
-+++ gcc-4.7.4-new/gcc/configure	2020-03-25 14:40:04.452765679 +0000
+diff --color -ruN --no-dereference gcc-4.7.4/gcc/config/sh/sh.h gcc-4.7.4-kos/gcc/config/sh/sh.h
+--- gcc-4.7.4/gcc/config/sh/sh.h	2023-01-02 13:58:37.404216244 -0600
++++ gcc-4.7.4-kos/gcc/config/sh/sh.h	2023-01-02 14:01:27.796461128 -0600
+@@ -93,6 +93,12 @@
+     builtin_define ("__FMOVD_ENABLED__"); \
+   builtin_define (TARGET_LITTLE_ENDIAN \
+ 		  ? "__LITTLE_ENDIAN__" : "__BIG_ENDIAN__"); \
++  /* Custom built-in defines for KallistiOS */ \
++  builtin_define ("__KOS_GCC_PATCHED__"); \
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d", \
++			2023010200); \
++  /* Toolchain supports setting up stack for 32MB */ \
++  builtin_define ("__KOS_GCC_32MB__"); \
+ } while (0)
+ 
+ /* Value should be nonzero if functions must have frame pointers.
+diff --color -ruN --no-dereference gcc-4.7.4/gcc/configure gcc-4.7.4-kos/gcc/configure
+--- gcc-4.7.4/gcc/configure	2023-01-02 13:58:36.285214636 -0600
++++ gcc-4.7.4-kos/gcc/configure	2023-01-02 13:58:54.491240801 -0600
 @@ -11338,7 +11338,7 @@
      target_thread_file='single'
      ;;
@@ -10,9 +26,9 @@ diff -ruN gcc-4.7.4/gcc/configure gcc-4.7.4-new/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff -ruN gcc-4.7.4/gcc/cp/cfns.h gcc-4.7.4-new/gcc/cp/cfns.h
---- gcc-4.7.4/gcc/cp/cfns.h	2009-04-21 20:03:23.000000000 +0100
-+++ gcc-4.7.4-new/gcc/cp/cfns.h	2020-03-25 14:40:04.460765725 +0000
+diff --color -ruN --no-dereference gcc-4.7.4/gcc/cp/cfns.h gcc-4.7.4-kos/gcc/cp/cfns.h
+--- gcc-4.7.4/gcc/cp/cfns.h	2023-01-02 13:58:37.377216206 -0600
++++ gcc-4.7.4-kos/gcc/cp/cfns.h	2023-01-02 13:58:54.491240801 -0600
 @@ -53,6 +53,9 @@
  static unsigned int hash (const char *, unsigned int);
  #ifdef __GNUC__
@@ -32,9 +48,9 @@ diff -ruN gcc-4.7.4/gcc/cp/cfns.h gcc-4.7.4-new/gcc/cp/cfns.h
  
    switch (hval)
      {
-diff -ruN gcc-4.7.4/gcc/doc/gcc.texi gcc-4.7.4-new/gcc/doc/gcc.texi
---- gcc-4.7.4/gcc/doc/gcc.texi	2010-06-10 00:46:33.000000000 +0100
-+++ gcc-4.7.4-new/gcc/doc/gcc.texi	2020-03-25 14:40:04.464765748 +0000
+diff --color -ruN --no-dereference gcc-4.7.4/gcc/doc/gcc.texi gcc-4.7.4-kos/gcc/doc/gcc.texi
+--- gcc-4.7.4/gcc/doc/gcc.texi	2023-01-02 13:58:36.278214626 -0600
++++ gcc-4.7.4-kos/gcc/doc/gcc.texi	2023-01-02 13:58:54.491240801 -0600
 @@ -86,9 +86,9 @@
  @item GNU Press
  @tab Website: www.gnupress.org
@@ -47,32 +63,14 @@ diff -ruN gcc-4.7.4/gcc/doc/gcc.texi gcc-4.7.4-new/gcc/doc/gcc.texi
  @item 51 Franklin Street, Fifth Floor
  @tab Tel 617-542-5942
  @item Boston, MA 02110-1301 USA
-diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.S
---- gcc-4.7.4/libgcc/config/sh/crt1.S	2011-11-02 14:33:56.000000000 +0000
-+++ gcc-4.7.4-new/libgcc/config/sh/crt1.S	2020-03-25 14:40:04.485765870 +0000
-@@ -1,1369 +1,202 @@
+diff --color -ruN --no-dereference gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/sh/crt1.S
+--- gcc-4.7.4/libgcc/config/sh/crt1.S	2023-01-02 13:58:36.183214490 -0600
++++ gcc-4.7.4-kos/libgcc/config/sh/crt1.S	2023-01-02 13:59:37.563302704 -0600
+@@ -1,1369 +1,225 @@
 -/* Copyright (C) 2000, 2001, 2003, 2004, 2005, 2006, 2009, 2011
 -   Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
-+! KallistiOS ##version##
-+!
-+! startup.s
-+! (c)2000-2001 Dan Potter
-+!
-+! This file must appear FIRST in your linking order, or your program won't
-+! work correctly as a raw binary.
-+!
-+! This is very loosely based on Marcus' crt0.s/startup.s
-+!
-+
-+.globl start
-+.globl _start
-+.globl _arch_real_exit
-+.globl __arch_old_sr
-+.globl __arch_old_vbr
-+.globl __arch_old_stack
-+.globl __arch_old_fpscr
- 
+-
 -This file is part of GCC.
 -
 -GCC is free software; you can redistribute it and/or modify it
@@ -216,8 +214,7 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	shori	sym & 65535, reg
 -#endif
 -	.global start
-+_start:
- start:
+-start:
 -	LOAD_ADDR (_stack, r15)
 -
 -#ifdef MMU_SUPPORT
@@ -762,12 +759,32 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	.long 0
 -#endif
 -
--
++! KallistiOS ##version##
++!
++! startup.s
++! (c)2000-2001 Dan Potter
++!
++! This file must appear FIRST in your linking order, or your program won't
++! work correctly as a raw binary.
++!
++! This is very loosely based on Marcus' crt0.s/startup.s
++!
++
++.globl start
++.globl _start
++.globl _arch_real_exit
++.globl __arch_old_sr
++.globl __arch_old_vbr
++.globl __arch_old_stack
++.globl __arch_old_fpscr
++.globl __arch_mem_top
+ 
 -	.section .text
 -	.global	start
 -	.import ___rtos_profiler_start_timer
 -	.weak   ___rtos_profiler_start_timer
--start:
++_start:
+ start:
 -	mov.l	stack_k,r15
 -
 -#if defined (__SH3__) || (defined (__SH_FPU_ANY__) && ! defined (__SH2A__)) || defined (__SH4_NOFPU__)
@@ -908,21 +925,37 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
  
 -	! call init
 -	mov.l	init_k,r0
--	jsr	@r0
--	nop
 +	! Save the current stack, and set a new stack (higher up in RAM)
 +	mov.l	old_stack_addr,r0
 +	mov.l	r15,@r0
-+	mov.l	new_stack,r15
++	mov.l   new_stack_16m,r15
++
++	! Check if 0xadffffff is a mirror of 0xacffffff, or if unique
++	! If unique, then memory is 32MB instead of 16MB, and we must
++	! set up new stack even higher
++	mov.l	p2_mask,r0
++	mov	r0,r2
++	or	r15,r2
++	mov	#0xba,r1
++	mov.b	r1,@-r2			! Store 0xba to 0xacffffff
++	mov.l	new_stack_32m,r1
++	or	r0,r1
++	mov	#0xab,r0
++	mov.b	r0,@-r1			! Store 0xab in 0xadffffff
++	mov.b	@r1,r0
++	mov.b	@r2,r1			! Reloaded values
++	cmp/eq	r0,r1			! Check if values match
++	bt	memchk_done		! If so, mirror - we're done, move on
++	mov.l	new_stack_32m,r15	! If not, unique - set higher stack
++memchk_done:
++	mov.l	mem_top_addr,r0
++	mov.l	r15,@r0			! Save address of top of memory
 +
 +	! Save VBR
 +	mov.l	old_vbr_addr,r0
 +	stc	vbr,r1
 +	mov.l	r1,@r0
- 
--	! call the mainline	
--	mov.l	main_k,r0
-+#if defined (__SH_FPU_ANY__)
++
 +	! Save FPSCR
 +	mov.l	old_fpscr_addr,r0
 +	sts	fpscr,r1
@@ -934,13 +967,22 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
  	jsr	@r0
 -	nop
 +	shll16	r4
-+#endif
+ 
+-	! call the mainline	
+-	mov.l	main_k,r0
+-	jsr	@r0
+-	nop
++	! Setup a sentinel value for frame pointer in case we're using
++	! FRAME_POINTERS for stack tracing.
++	mov	#-1,r14
  
 -	! call exit
 -	mov	r0,r4
 -	mov.l	exit_k,r0
--	jsr	@r0
--	nop
++	! Jump to the kernel main
++	mov.l	main_addr,r0
+ 	jsr	@r0
+ 	nop
 -	
 -		.balign 4
 -#ifdef PROFILE
@@ -949,17 +991,11 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	mov.l	profiling_enabled_k2, r0
 -	mov	#0, r1
 -	mov.l	r1, @r0
-+	! Setup a sentinel value for frame pointer in case we're using
-+	! FRAME_POINTERS for stack tracing.
-+	mov	#-1,r14
  
 -	# call mcleanup
 -	mov.l	mcleanup_k, r0
 -	jmp	@r0
-+	! Jump to the kernel main
-+	mov.l	main_addr,r0
-+	jsr	@r0
- 	nop
+-	nop
 -		
 -		.balign 4
 -mcleanup_k:
@@ -979,7 +1015,7 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -set_fpscr_k:
 -	.long	___set_fpscr
 -#endif /*  defined (__SH_FPU_ANY__) */
- 
+-
 -stack_k:
 -	.long	_stack	
 -edata_k:
@@ -1008,32 +1044,7 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	! Whether profiling or not, keep interrupts masked,
 -	! the RTOS will enable these if required.
 -	.long 0x600000f1 
-+	! Program can return here (not likely) or jump here directly
-+	! from anywhere in it to go straight back to the monitor
-+_arch_real_exit:
-+	! Reset SR
-+	mov.l	old_sr,r0
-+	ldc	r0,sr
-+
-+	! Disable MMU, invalidate TLB
-+	mov	#4,r0
-+	mov.l	mmu_addr,r1
-+	mov.l	r0,@r1
-+
-+	! Wait (just in case)
-+	nop				! 1
-+	nop				! 2
-+	nop				! 3
-+	nop				! 4
-+	nop				! 5
-+	nop				! 6
-+	nop				! 7
-+	nop				! 8
-+	
-+	! Restore VBR
-+	mov.l	old_vbr,r0
-+	ldc	r0,vbr
- 
+-
 -rtos_start_fn:
 -	.long ___rtos_profiler_start_timer
 -	
@@ -1043,33 +1054,19 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	! For bare machine, we need to enable interrupts to get profiling working
 -	.long 0x60000001
 -#else
-+	! If we're working under dcload, call its EXIT syscall
-+	mov.l	dcload_magic_addr,r0
-+	mov.l	@r0,r0
-+	mov.l	dcload_magic_value,r1
-+	cmp/eq	r0,r1
-+	bf	normal_exit
- 
+-
 -sr_initial_bare:
 -	! Privileged mode RB 1 BL 0. Keep BL 0 to allow default trap handlers to work.
 -	! Keep interrupts disabled - the application will enable as required.
 -	.long 0x600000f1
 -#endif
-+	mov.l	dcload_syscall,r0
-+	mov.l	@r0,r0
-+	jsr	@r0
-+	mov	#15,r4
- 
+-
 -	! supplied for backward compatibility only, in case of linking
 -	! code whose main() was compiled with an older version of GCC.
 -	.global ___main
 -___main:
-+	! Set back the stack and return (presumably to a serial debug)
-+normal_exit:
-+	mov.l	old_stack,r15
-+	lds.l	@r15+,pr
- 	rts
- 	nop
+-	rts
+-	nop
 -#ifdef VBR_SETUP
 -! Exception handlers	
 -	.section .text.vbr, "ax"
@@ -1111,6 +1108,31 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	mov.l	r6,@-r15
 -	mov.l	r7,@-r15
 -	sts.l	pr,@-r15
++	! Program can return here (not likely) or jump here directly
++	! from anywhere in it to go straight back to the monitor
++_arch_real_exit:
++	! Reset SR
++	mov.l	old_sr,r0
++	ldc	r0,sr
++
++	! Disable MMU, invalidate TLB
++	mov	#4,r0
++	mov.l	mmu_addr,r1
++	mov.l	r0,@r1
++
++	! Wait (just in case)
++	nop				! 1
++	nop				! 2
++	nop				! 3
++	nop				! 4
++	nop				! 5
++	nop				! 6
++	nop				! 7
++	nop				! 8
++
++	! Restore VBR
++	mov.l	old_vbr,r0
++	ldc	r0,vbr
  
 -	! r4 is frompc.
 -	! r5 is selfpc
@@ -1224,56 +1246,12 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	! jmp to trap handler to avoid disturbing pr. 
 -	jmp @r2
 -	nop
-+! Misc variables
-+	.align	2
-+dcload_magic_addr:
-+	.long	0x8c004004
-+dcload_magic_value:
-+	.long	0xdeadbeef
-+dcload_syscall:
-+	.long	0x8c004008
-+__arch_old_sr:
-+old_sr:
-+	.long	0
-+__arch_old_vbr:
-+old_vbr:
-+	.long	0
-+__arch_old_fpscr:
-+old_fpscr:
-+	.long	0
-+init_sr:
-+	.long	0x500000f0
-+old_sr_addr:
-+	.long	old_sr
-+old_vbr_addr:
-+	.long	old_vbr
-+old_fpscr_addr:
-+	.long	old_fpscr
-+old_stack_addr:
-+	.long	old_stack
-+__arch_old_stack:
-+old_stack:
-+	.long	0
-+new_stack:
-+	.long	0x8d000000
-+p2_mask:
-+	.long	0xa0000000
-+setup_cache_addr:
-+	.long	setup_cache
-+init_addr:
-+	.long	init
-+main_addr:
-+	.long	_arch_main
-+mmu_addr:
-+	.long	0xff000010
-+kos_init_flags_addr:
-+	.long	___kos_init_flags
-+ccr_addr:
-+	.long	0xff00001c
-+ccr_data:
-+	.word	0x090d
-+ccr_data_ocram:
-+	.word	0x092d
++	! If we're working under dcload, call its EXIT syscall
++	mov.l	dcload_magic_addr,r0
++	mov.l	@r0,r0
++	mov.l	dcload_magic_value,r1
++	cmp/eq	r0,r1
++	bf	normal_exit
  
 -	.org 0x600
 -vbr_600:
@@ -1307,7 +1285,8 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	mov.l	pervading_precision_k,r0
 -	fmov	fr4,@-r15
 -	fmov	fr5,@-r15
--	mov.l	@r0,r0
++	mov.l	dcload_syscall,r0
+ 	mov.l	@r0,r0
 -	fmov	fr6,@-r15
 -	fmov	fr7,@-r15
 -	lds	r0,fpscr
@@ -1390,10 +1369,7 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	.long __timer_stack	! The high end of the stack
 -timer_handler_k:
 -	.long __profil_counter
-+#if defined (__SH_FPU_ANY__)
-+fpscr_addr:
-+	.long	___set_fpscr	! in libgcc
- #endif
+-#endif
 -expevt_k:
 -	.long 0xff000024 ! Address of expevt
 -chandler_k:	
@@ -1428,7 +1404,15 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	mov	r14,r15
 -	mov.l	@r15+,r14
 -	rts	
--	nop
++	jsr	@r0
++	mov	#15,r4
++
++	! Set back the stack and return (presumably to a serial debug)
++normal_exit:
++	mov.l	old_stack,r15
++	lds.l	@r15+,pr
++	rts
+ 	nop
 -.LFE1:
 -.Lfe1:
 -	.size	__superh_trap_handler,.Lfe1-__superh_trap_handler
@@ -1601,9 +1585,68 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-new/libgcc/config/sh/crt1.
 -	.ualong	0x0
 -#endif /* VBR_SETUP */
 -#endif /* ! __SH5__ */
-diff -ruN gcc-4.7.4/libgcc/config/sh/fake-kos.S gcc-4.7.4-new/libgcc/config/sh/fake-kos.S
---- gcc-4.7.4/libgcc/config/sh/fake-kos.S	1970-01-01 01:00:00.000000000 +0100
-+++ gcc-4.7.4-new/libgcc/config/sh/fake-kos.S	2020-03-25 14:40:04.486765876 +0000
++
++! Misc variables
++	.align	2
++dcload_magic_addr:
++	.long	0x8c004004
++dcload_magic_value:
++	.long	0xdeadbeef
++dcload_syscall:
++	.long	0x8c004008
++__arch_old_sr:
++old_sr:
++	.long	0
++__arch_old_vbr:
++old_vbr:
++	.long	0
++__arch_old_fpscr:
++old_fpscr:
++	.long	0
++init_sr:
++	.long	0x500000f0
++old_sr_addr:
++	.long	old_sr
++old_vbr_addr:
++	.long	old_vbr
++old_fpscr_addr:
++	.long	old_fpscr
++old_stack_addr:
++	.long	old_stack
++__arch_old_stack:
++old_stack:
++	.long	0
++__arch_mem_top:
++	.long	0
++mem_top_addr:
++	.long	__arch_mem_top
++new_stack_16m:
++	.long	0x8d000000
++new_stack_32m:
++	.long	0x8e000000
++p2_mask:
++	.long	0xa0000000
++setup_cache_addr:
++	.long	setup_cache
++init_addr:
++	.long	init
++main_addr:
++	.long	_arch_main
++mmu_addr:
++	.long	0xff000010
++fpscr_addr:
++	.long	___set_fpscr	! in libgcc
++kos_init_flags_addr:
++	.long	___kos_init_flags
++ccr_addr:
++	.long	0xff00001c
++ccr_data:
++	.word	0x090d
++ccr_data_ocram:
++	.word	0x092d
+diff --color -ruN --no-dereference gcc-4.7.4/libgcc/config/sh/fake-kos.S gcc-4.7.4-kos/libgcc/config/sh/fake-kos.S
+--- gcc-4.7.4/libgcc/config/sh/fake-kos.S	1969-12-31 18:00:00.000000000 -0600
++++ gcc-4.7.4-kos/libgcc/config/sh/fake-kos.S	2023-01-02 13:58:54.492240803 -0600
 @@ -0,0 +1,75 @@
 +! Weakly linked symbols used to get GCC to hopefully compile itself properly.
 +! These will be replaced by the real symbols in actual compiled programs.
@@ -1681,9 +1724,9 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/fake-kos.S gcc-4.7.4-new/libgcc/config/sh/f
 +    mov     #-1, r0
 +    
 \ No newline at end of file
-diff -ruN gcc-4.7.4/libgcc/config/sh/gthr-kos.h gcc-4.7.4-new/libgcc/config/sh/gthr-kos.h
---- gcc-4.7.4/libgcc/config/sh/gthr-kos.h	1970-01-01 01:00:00.000000000 +0100
-+++ gcc-4.7.4-new/libgcc/config/sh/gthr-kos.h	2020-03-25 14:40:04.486765876 +0000
+diff --color -ruN --no-dereference gcc-4.7.4/libgcc/config/sh/gthr-kos.h gcc-4.7.4-kos/libgcc/config/sh/gthr-kos.h
+--- gcc-4.7.4/libgcc/config/sh/gthr-kos.h	1969-12-31 18:00:00.000000000 -0600
++++ gcc-4.7.4-kos/libgcc/config/sh/gthr-kos.h	2023-01-02 13:58:54.492240803 -0600
 @@ -0,0 +1,355 @@
 +/* Copyright (C) 2009, 2010, 2011, 2012 Lawrence Sebald */
 +
@@ -2040,9 +2083,9 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/gthr-kos.h gcc-4.7.4-new/libgcc/config/sh/g
 +#endif /* _LIBOBJC */
 +
 +#endif /* ! GCC_GTHR_KOS_H */
-diff -ruN gcc-4.7.4/libgcc/config/sh/t-sh gcc-4.7.4-new/libgcc/config/sh/t-sh
---- gcc-4.7.4/libgcc/config/sh/t-sh	2011-11-07 17:14:32.000000000 +0000
-+++ gcc-4.7.4-new/libgcc/config/sh/t-sh	2020-03-25 14:40:04.488765888 +0000
+diff --color -ruN --no-dereference gcc-4.7.4/libgcc/config/sh/t-sh gcc-4.7.4-kos/libgcc/config/sh/t-sh
+--- gcc-4.7.4/libgcc/config/sh/t-sh	2023-01-02 13:58:36.183214490 -0600
++++ gcc-4.7.4-kos/libgcc/config/sh/t-sh	2023-01-02 13:58:54.492240803 -0600
 @@ -24,6 +24,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -2052,9 +2095,9 @@ diff -ruN gcc-4.7.4/libgcc/config/sh/t-sh gcc-4.7.4-new/libgcc/config/sh/t-sh
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff -ruN gcc-4.7.4/libgcc/configure gcc-4.7.4-new/libgcc/configure
---- gcc-4.7.4/libgcc/configure	2012-08-06 15:34:27.000000000 +0100
-+++ gcc-4.7.4-new/libgcc/configure	2020-03-25 14:40:04.508766004 +0000
+diff --color -ruN --no-dereference gcc-4.7.4/libgcc/configure gcc-4.7.4-kos/libgcc/configure
+--- gcc-4.7.4/libgcc/configure	2023-01-02 13:58:36.168214468 -0600
++++ gcc-4.7.4-kos/libgcc/configure	2023-01-02 13:58:54.492240803 -0600
 @@ -4480,6 +4480,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -2063,9 +2106,9 @@ diff -ruN gcc-4.7.4/libgcc/configure gcc-4.7.4-new/libgcc/configure
  esac
  
  # Substitute configuration variables
-diff -ruN gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h gcc-4.7.4-new/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h	2020-03-25 15:15:51.300215413 +0000
-+++ gcc-4.7.4-new/libstdc++-v3/config/cpu/sh/atomicity.h	2020-03-25 15:16:20.010371542 +0000
+diff --color -ruN --no-dereference gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h gcc-4.7.4-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h	2023-01-02 13:58:35.186213057 -0600
++++ gcc-4.7.4-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-01-02 13:58:54.493240804 -0600
 @@ -80,7 +80,12 @@
  
  namespace 

--- a/utils/dc-chain/patches/gcc-9.3.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-9.3.0-kos.diff
@@ -1,6 +1,21 @@
-diff -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
---- gcc-9.3.0/gcc/configure	2020-03-12 07:08:30.000000000 -0400
-+++ gcc-9.3.0-kos/gcc/configure	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/gcc/config/sh/sh-c.c gcc-9.3.0-kos/gcc/config/sh/sh-c.c
+--- gcc-9.3.0/gcc/config/sh/sh-c.c	2023-01-02 13:49:34.172435526 -0600
++++ gcc-9.3.0-kos/gcc/config/sh/sh-c.c	2023-01-02 13:53:48.671801287 -0600
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff --color -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
+--- gcc-9.3.0/gcc/configure	2023-01-02 13:49:36.017438178 -0600
++++ gcc-9.3.0-kos/gcc/configure	2023-01-02 13:51:59.907644974 -0600
 @@ -11862,7 +11862,7 @@
      target_thread_file='single'
      ;;
@@ -10,10 +25,10 @@ diff -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.S
---- gcc-9.3.0/libgcc/config/sh/crt1.S	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2020-04-03 16:07:04.540000000 -0400
-@@ -1,724 +1,197 @@
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.S
+--- gcc-9.3.0/libgcc/config/sh/crt1.S	2023-01-02 13:49:33.499434559 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2023-01-02 13:52:08.879657868 -0600
+@@ -1,724 +1,225 @@
 -/* Copyright (C) 2000-2019 Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
 +! KallistiOS ##version##
@@ -34,6 +49,7 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +.globl __arch_old_vbr
 +.globl __arch_old_stack
 +.globl __arch_old_fpscr
++.globl __arch_mem_top
  
 -This file is part of GCC.
 -
@@ -232,7 +248,28 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +	! Save the current stack, and set a new stack (higher up in RAM)
 +	mov.l	old_stack_addr,r0
 +	mov.l	r15,@r0
-+	mov.l	new_stack,r15
++	mov.l   new_stack_16m,r15
++
++	! Check if 0xadffffff is a mirror of 0xacffffff, or if unique
++	! If unique, then memory is 32MB instead of 16MB, and we must
++	! set up new stack even higher
++	mov.l	p2_mask,r0
++	mov	r0,r2
++	or	r15,r2
++	mov	#0xba,r1
++	mov.b	r1,@-r2			! Store 0xba to 0xacffffff
++	mov.l	new_stack_32m,r1
++	or	r0,r1
++	mov	#0xab,r0
++	mov.b	r0,@-r1			! Store 0xab in 0xadffffff
++	mov.b	@r1,r0
++	mov.b	@r2,r1			! Reloaded values
++	cmp/eq	r0,r1			! Check if values match
++	bt	memchk_done		! If so, mirror - we're done, move on
++	mov.l	new_stack_32m,r15	! If not, unique - set higher stack
++memchk_done:
++	mov.l	mem_top_addr,r0
++	mov.l	r15,@r0			! Save address of top of memory
 +
 +	! Save VBR
 +	mov.l	old_vbr_addr,r0
@@ -412,7 +449,7 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +	nop				! 6
 +	nop				! 7
 +	nop				! 8
-+	
++
 +	! Restore VBR
 +	mov.l	old_vbr,r0
 +	ldc	r0,vbr
@@ -896,8 +933,14 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +__arch_old_stack:
 +old_stack:
 +	.long	0
-+new_stack:
++__arch_mem_top:
++	.long	0
++mem_top_addr:
++	.long	__arch_mem_top
++new_stack_16m:
 +	.long	0x8d000000
++new_stack_32m:
++	.long	0x8e000000
 +p2_mask:
 +	.long	0xa0000000
 +setup_cache_addr:
@@ -918,9 +961,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.
 +	.word	0x090d
 +ccr_data_ocram:
 +	.word	0x092d
-diff -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S
---- gcc-9.3.0/libgcc/config/sh/fake-kos.S	1969-12-31 19:00:00.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S
+--- gcc-9.3.0/libgcc/config/sh/fake-kos.S	1969-12-31 18:00:00.000000000 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2023-01-02 13:51:59.907644974 -0600
 @@ -0,0 +1,78 @@
 +! Weakly linked symbols used to get GCC to hopefully compile itself properly.
 +! These will be replaced by the real symbols in actual compiled programs.
@@ -1000,9 +1043,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/f
 +_cond_signal:
 +    rts
 +    mov     #-1, r0
-diff -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h
---- gcc-9.3.0/libgcc/config/sh/gthr-kos.h	1969-12-31 19:00:00.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h
+--- gcc-9.3.0/libgcc/config/sh/gthr-kos.h	1969-12-31 18:00:00.000000000 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2023-01-02 13:51:59.907644974 -0600
 @@ -0,0 +1,401 @@
 +/* Copyright (C) 2009, 2010, 2011, 2012, 2020 Lawrence Sebald */
 +
@@ -1405,9 +1448,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/g
 +
 +
 +#endif /* ! GCC_GTHR_KOS_H */
-diff -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
---- gcc-9.3.0/libgcc/config/sh/t-sh	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
+--- gcc-9.3.0/libgcc/config/sh/t-sh	2023-01-02 13:49:33.500434561 -0600
++++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2023-01-02 13:51:59.907644974 -0600
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -1417,9 +1460,9 @@ diff -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
---- gcc-9.3.0/libgcc/configure	2020-03-12 07:07:23.000000000 -0400
-+++ gcc-9.3.0-kos/libgcc/configure	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
+--- gcc-9.3.0/libgcc/configure	2023-01-02 13:49:33.533434608 -0600
++++ gcc-9.3.0-kos/libgcc/configure	2023-01-02 13:51:59.908644975 -0600
 @@ -5550,6 +5550,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -1428,9 +1471,9 @@ diff -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
  esac
  
  
-diff -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2020-03-12 07:07:24.000000000 -0400
-+++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-01-02 13:49:33.731434893 -0600
++++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-01-02 13:51:59.915644985 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -1481,9 +1524,9 @@ diff -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-9.3.0/libstdc++-v3/configure gcc-9.3.0-kos/libstdc++-v3/configure
---- gcc-9.3.0/libstdc++-v3/configure	2020-03-12 07:07:24.000000000 -0400
-+++ gcc-9.3.0-kos/libstdc++-v3/configure	2020-04-03 16:07:04.540000000 -0400
+diff --color -ruN gcc-9.3.0/libstdc++-v3/configure gcc-9.3.0-kos/libstdc++-v3/configure
+--- gcc-9.3.0/libstdc++-v3/configure	2023-01-02 13:49:34.054435357 -0600
++++ gcc-9.3.0-kos/libstdc++-v3/configure	2023-01-02 13:51:59.918644989 -0600
 @@ -15629,6 +15629,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;


### PR DESCRIPTION
Patches introduce
- Check in startup.s to determine if 32MB system RAM is present, and if so, set up stack appropriately
- _arch_mem_top variable representing top of memory, along with related kernel tweaks and macros
- Example memory-testing program demonstrating use of new 32MB features
- Patches for GCC 4.7.4 and 9.3.0 (including Apple Silicon patch) supporting stack changes
- Patches for GCC 4.7.4 and 9.3.0 adding builtin defines KOS_GCC_PATCHED, KOS_GCC_PATCHLEVEL, and KOS_GCC_32MB.

Thanks go to
- tsowell for discovering how to add 32MB to Dreamcast consoles and for original AMX3 patch
- GyroVorbis for his invaluable assistance and support
- Cepawiel for his support and creating lxdream-nitro branch with 32MB support