### PR TITLE
Fixed broken pvrmark example.

### DIFF
--- a/examples/dreamcast/pvr/pvrmark/pvrmark.c
+++ b/examples/dreamcast/pvr/pvrmark/pvrmark.c
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
     setup();
 
     /* Start off with something obscene */
-    switch_tests(2000000 / 60);
+    switch_tests(200000 / 60);
     start = time(NULL);
 
     for(;;) {


### PR DESCRIPTION
Apparently the initial polygon per second count was a little "too" obscene (as the comments say), and was causing nothing to be rendered to the screen and for all of the PPS calculations to become incorrect and even negative. 

Reduced the starting pps count by 10x. 