### PR TITLE
Correct typo in cdrom_change_dataype function to cdrom_change_datatype

### DIFF
--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -186,7 +186,7 @@ int cdrom_get_status(int *status, int *disc_type) {
 }
 
 /* Wrapper for the change datatype syscall */
-int cdrom_change_dataype(int sector_part, int cdxa, int sector_size) {
+int cdrom_change_datatype(int sector_part, int cdxa, int sector_size) {
     int rv = ERR_OK;
     uint32  params[4];
 
@@ -271,7 +271,7 @@ int cdrom_reinit_ex(int sector_part, int cdxa, int sector_size) {
         return r;
     }
 
-    r = cdrom_change_dataype(sector_part, cdxa, sector_size);
+    r = cdrom_change_datatype(sector_part, cdxa, sector_size);
     mutex_unlock(&_g1_ata_mutex);
     
     return r;

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -185,6 +185,11 @@ int cdrom_get_status(int *status, int *disc_type) {
     return rv;
 }
 
+/* Helper function to account for long-standing typo */
+int cdrom_change_dataype(int sector_part, int cdxa, int sector_size) {
+    return cdrom_change_datatype(sector_part, cdxa, sector_size);
+}
+
 /* Wrapper for the change datatype syscall */
 int cdrom_change_datatype(int sector_part, int cdxa, int sector_size) {
     int rv = ERR_OK;

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -234,6 +234,17 @@ int cdrom_get_status(int *status, int *disc_type);
 
 /** \brief    Change the datatype of disc.
 
+    \note                   This function is formally deprecated. It should not
+                            be used in any future code, and may be removed in
+                            the future. You should instead use
+                            cdrom_change_dataype.
+*/
+
+int cdrom_change_dataype(int sector_part, int cdxa, int sector_size)
+                        __depr("Use cdrom_change_datatype instead.");
+
+/** \brief    Change the datatype of disc.
+
     This function will take in all parameters to pass to the change_datatype 
     syscall. This allows these parameters to be modified without a reinit. 
     Each parameter allows -1 as a default, which is tied to the former static 

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -237,9 +237,8 @@ int cdrom_get_status(int *status, int *disc_type);
     \note                   This function is formally deprecated. It should not
                             be used in any future code, and may be removed in
                             the future. You should instead use
-                            cdrom_change_dataype.
+                            cdrom_change_datatype.
 */
-
 int cdrom_change_dataype(int sector_part, int cdxa, int sector_size)
                         __depr("Use cdrom_change_datatype instead.");
 

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -246,7 +246,7 @@ int cdrom_get_status(int *status, int *disc_type);
     \return                 \ref cd_cmd_response
     \see    cd_read_sector_part
 */
-int cdrom_change_dataype(int sector_part, int cdxa, int sector_size);
+int cdrom_change_datatype(int sector_part, int cdxa, int sector_size);
 
 /** \brief  Re-initialize the GD-ROM drive.
 
@@ -288,7 +288,7 @@ int cdrom_read_toc(CDROM_TOC *toc_buffer, int session);
 
     This function reads the specified number of sectors from the disc, starting
     where requested. This will respect the size of the sectors set with
-    cdrom_change_dataype(). The buffer must have enough space to store the
+    cdrom_change_datatype(). The buffer must have enough space to store the
     specified number of sectors.
 
     \param  buffer          Space to store the read sectors.


### PR DESCRIPTION
Simple typo fix. 