### PR TITLE
Add GCC Version Information to KOS Banner

### DIFF
--- a/kernel/arch/dreamcast/kernel/make_banner.sh
+++ b/kernel/arch/dreamcast/kernel/make_banner.sh
@@ -40,6 +40,10 @@ printf ':' >> banner.h
 printf "$KOS_BASE" >> banner.h
 printf '\\n"\n' >> banner.h
 
+printf '"  ' >> banner.h
+tmp = `$KOS_CC --version | head -n 1`
+printf "$tmp" >> banner.h 
+printf '\\n"\n' >> banner.h
 printf ';\n' >> banner.h
 
 printf 'static const char kern_version[] = \n"' >> banner.h

--- a/kernel/arch/dreamcast/kernel/make_banner.sh
+++ b/kernel/arch/dreamcast/kernel/make_banner.sh
@@ -41,7 +41,7 @@ printf "$KOS_BASE" >> banner.h
 printf '\\n"\n' >> banner.h
 
 printf '"  ' >> banner.h
-tmp = `$KOS_CC --version | head -n 1`
+tmp=`$KOS_CC --version | head -n 1`
 printf "$tmp" >> banner.h 
 printf '\\n"\n' >> banner.h
 printf ';\n' >> banner.h


### PR DESCRIPTION
This is a simple little proposal to add the compiler version that KOS was built with to the startup log. 

Why? When juggling multiple toolchains and swapping between KOS libraries built with different versions, it's very helpful for debugging and troubleshooting to know which toolchain and GCC version the current lib was built with. This can also help us with issues from other users if they post their dc-tool logs and we can see which version they're using. 

We've been doing a bunch of toolchain work for the GCC12 and GCC-RS stuff, and this has proved useful. Don't forget, if you don't like it or think it's too much noise, there's the KOS flag for quiet init! 

Here's output from my machine:

```
KallistiOS Git revision ea74fdb-dirty:
  Thu Feb  2 02:20:41 PM EST 2023
  falco@slutserv:/opt/toolchains/dc/kos
  sh-elf-gcc (GCC) 12.2.0
maple: active drivers:
    Dreameye (Camera): Camera
    Sound Input Peripheral: Microphone
    PuruPuru (Vibration) Pack: JumpPack
    VMU Driver: Clock, LCD, MemoryCard
    Mouse Driver: Mouse
    Keyboard Driver: Keyboard
    Controller Driver: Controller
    Lightgun: LightGun
```