### PR TITLE
Skip building stackprotector example when using GCC4

### DIFF
--- a/examples/dreamcast/basic/stackprotector/Makefile
+++ b/examples/dreamcast/basic/stackprotector/Makefile
@@ -2,6 +2,15 @@ TARGET = stackprotector.elf
 OBJS = stackprotector.o
 KOS_CFLAGS += -fstack-protector-all
 
+GCC_MAJOR = $(basename $(basename $(KOS_GCCVER)))
+
+ifeq ($(GCC_MAJOR), 4) 
+
+all dist:
+	$(warning GCC4 missing stackprotector patch, skip building example)
+
+else
+
 all: rm-elf $(TARGET)
 
 include $(KOS_BASE)/Makefile.rules
@@ -24,3 +33,5 @@ dist: $(TARGET)
 
 
 .PHONY: run dist clean rm-elf
+
+endif


### PR DESCRIPTION
Currently when attempting to build all the examples using the GCC4 toolchain by running `cd examples && make`, a failure occurs due to missing the stack protector patches to the GCC4 toolchain. This change skips building and simply outputs a warning instead.

Before:
```
make -C stackprotector
make[3]: Entering directory '/opt/toolchains/dc/kos/examples/dreamcast/basic/stackprotector'
rm -f stackprotector.elf
kos-cc  -c stackprotector.c -o stackprotector.o
kos-cc -o stackprotector.elf stackprotector.o
/opt/toolchains/dc/sh-elf/lib/gcc/sh-elf/4.7.4/../../../../sh-elf/bin/ld: stackprotector.o: in function `__stack_chk_fail':
/opt/toolchains/dc/kos/examples/dreamcast/basic/stackprotector/stackprotector.c:38: undefined reference to `___stack_chk_guard'
/opt/toolchains/dc/sh-elf/lib/gcc/sh-elf/4.7.4/../../../../sh-elf/bin/ld: stackprotector.o: in function `badfunc':
/opt/toolchains/dc/kos/examples/dreamcast/basic/stackprotector/stackprotector.c:44: undefined reference to `___stack_chk_guard'
/opt/toolchains/dc/sh-elf/lib/gcc/sh-elf/4.7.4/../../../../sh-elf/bin/ld: stackprotector.o: in function `main':
/opt/toolchains/dc/kos/examples/dreamcast/basic/stackprotector/stackprotector.c:53: undefined reference to `___stack_chk_guard'
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:16: stackprotector.elf] Error 1
make[3]: Leaving directory '/opt/toolchains/dc/kos/examples/dreamcast/basic/stackprotector'
make[2]: *** [Makefile:14: all] Error 2
```

After:
```
make -C stackprotector
make[3]: Entering directory '/opt/toolchains/dc/kos/examples/dreamcast/basic/stackprotector'
Makefile:10: GCC4 missing stackprotector patch, skip building example
make[3]: 'all' is up to date.
```