### PR TITLE
Change default SCIF baud rate to 115200 and add support for external clock

### DIFF
--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -58,7 +58,7 @@ extern uint32 _arch_mem_top;
 #define DEFAULT_PIXEL_MODE  PM_RGB565
 
 /** \brief  Default serial bitrate. */
-#define DEFAULT_SERIAL_BAUD 57600
+#define DEFAULT_SERIAL_BAUD 115200
 
 /** \brief  Default serial FIFO behavior. */
 #define DEFAULT_SERIAL_FIFO 1


### PR DESCRIPTION
It seems to me that the time has passed when one should be afraid to use 115200 :) I've been using this value just fine for many years now with various adapters.
In fact, in some cases even works 500000. But this is not good as default value of course. I use it for dc-load-serial if can't use dc-load-ip by some reason.