### PR TITLE
Fix out of memory example compiling for gcc 4.7.4

### DIFF
--- a/examples/dreamcast/cpp/out_of_memory/Makefile
+++ b/examples/dreamcast/cpp/out_of_memory/Makefile
@@ -5,7 +5,7 @@
 
 TARGET = out_of_memory.elf
 OBJS = out_of_memory.o
-KOS_CPPFLAGS += -fexceptions
+KOS_CPPFLAGS += -fexceptions -std=c++11
 
 all: rm-elf $(TARGET)
 


### PR DESCRIPTION
This example wont compile for GCC 4.7.4 because C++11 is experimental and we need to turn it on with -std=c++11.