### PR TITLE
Fix dockerfiles - use custom gcc dependencies

### DIFF
--- a/utils/dc-chain/docker/stable/Dockerfile
+++ b/utils/dc-chain/docker/stable/Dockerfile
@@ -29,6 +29,7 @@ RUN mkdir -p /opt/toolchains/dc \
 	&& git clone https://git.code.sf.net/p/cadcdev/kallistios /opt/toolchains/dc/kos \
 	&& cd /opt/toolchains/dc/kos/utils/dc-chain \
 	&& cp config.mk.stable.sample config.mk \
+	&& sed -i -e 's/#use_custom_dependencies=1/use_custom_dependencies=1/g' config.mk \
 	&& ./download.sh && ./unpack.sh && make && make gdb \
 	&& rm -rf /opt/toolchains/dc/kos
 

--- a/utils/dc-chain/docker/testing/Dockerfile
+++ b/utils/dc-chain/docker/testing/Dockerfile
@@ -29,6 +29,7 @@ RUN mkdir -p /opt/toolchains/dc \
 	&& git clone https://git.code.sf.net/p/cadcdev/kallistios /opt/toolchains/dc/kos \
 	&& cd /opt/toolchains/dc/kos/utils/dc-chain \
 	&& cp config.mk.testing.sample config.mk \
+	&& sed -i -e 's/#use_custom_dependencies=1/use_custom_dependencies=1/g' config.mk \
 	&& ./download.sh && ./unpack.sh && make && make gdb \
 	&& rm -rf /opt/toolchains/dc/kos
 


### PR DESCRIPTION
Busybox does not support the sha512sum "--check" option in gcc's download_prerequisites, so we need to use the custom dependencies.
cfr https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=0deabebedd16c9519bfb1dfbff303c2d9bd701ee

sed was used because the current scripts reads the state of use_custom_depencies from the file, instead of memory
