### PR TITLE
Flush stdout at Kernel Shutdown

### DIFF
--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -175,6 +175,8 @@ int  __attribute__((weak)) arch_auto_init() {
 }
 
 void  __attribute__((weak)) arch_auto_shutdown() {
+    fflush(stdout);
+
 #ifndef _arch_sub_naomi
     fs_dclsocket_shutdown();
     net_shutdown();


### PR DESCRIPTION
Since the GCC12 "testing" toolchain was introduced, we've been noticing that in many scenarios, such as the "hello" example, no output is ever flushed to the terminal without an explicit call to `fflush(stdout)`. 

- Standard C doesn't dictate how often the stdout buffer gets flushed
- As far as I can see, KOS is never explicitly forcing stdout to flush before exiting the program
- I believe we should be forcing a flush upon kernel exit, so that printf() and friends' output is at least never lost upon normal program execution