### PR TITLE
Dockerfile - fix error unable to compile latest gdb versions

### DIFF
--- a/utils/dc-chain/docker/Dockerfile
+++ b/utils/dc-chain/docker/Dockerfile
@@ -28,6 +28,7 @@ RUN apk --update add --no-cache \
 	git \
 	python3 \
 	subversion \
+	gmp-dev \
 	&& apk --update add --no-cache libelf-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.9/main \
 	&& rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Adding gmp-dev to avoid being unable to compile the latest gdb versions. (backwards-compatible with legacy & stable toolchains)