### PR TITLE
Fix dc-chain target dependencies

### DIFF
--- a/utils/dc-chain/scripts/build.mk
+++ b/utils/dc-chain/scripts/build.mk
@@ -33,6 +33,16 @@ build_sh4_targets = build-sh4-binutils build-sh4-gcc build-sh4-gcc-pass1 \
                     build-sh4-newlib build-sh4-newlib-only build-sh4-gcc-pass2
 build_arm_targets = build-arm-binutils build-arm-gcc build-arm-gcc-pass1
 
+# Add Build Pre-Requisites for SH4 Steps
+build-sh4-binutils: patch-sh4-binutils
+build-sh4-gcc-pass1: patch-sh4-gcc build-sh4-binutils
+build-sh4-newlib-only: patch-sh4-newlib build-sh4-gcc-pass1
+build-sh4-gcc-pass2: patch-sh4-gcc fixup-sh4-newlib
+
+# Add Build Pre-Requisites for ARM Steps
+build-arm-binutils: patch-arm-binutils
+build-arm-gcc-pass1: patch-arm-gcc build-arm-binutils
+
 # Available targets for SH
 $(build_sh4_targets): prefix = $(sh_prefix)
 $(build_sh4_targets): target = $(sh_target)

--- a/utils/dc-chain/scripts/newlib.mk
+++ b/utils/dc-chain/scripts/newlib.mk
@@ -24,20 +24,21 @@ $(build_newlib): logdir
 	$(clean_up)
 
 fixup-sh4-newlib: newlib_inc = $(DESTDIR)$(sh_prefix)/$(sh_target)/include
-fixup-sh4-newlib: $(build_newlib) fixup-sh4-newlib-init
+fixup-sh4-newlib: fixup-sh4-newlib-init
+fixup-sh4-newlib-init: $(build_newlib)
 
 # Apply sh4 newlib fixups (default is yes and this should be always the case!)
 ifeq (1,$(do_auto_fixup_sh4_newlib))
   fixup-sh4-newlib: fixup-sh4-newlib-apply
 endif
 
-# Prepare the fixup (always applied)
+# Prepare the fixup
 fixup-sh4-newlib-init:
-	@echo "+++ Fixing up sh4 newlib includes..."
+	@echo "+++ Init Fixing up sh4 newlib includes..."
 	-mkdir -p $(newlib_inc)
 	-mkdir -p $(newlib_inc)/sys
 
-fixup-sh4-newlib-apply:
+fixup-sh4-newlib-apply: fixup-sh4-newlib-init
 # KOS pthread.h is modified
 # to define _POSIX_THREADS
 # pthreads to kthreads mapping


### PR DESCRIPTION
Adds Pre-Requisites for the previous build step as well as the associated patches

Binutils now depends on Binutils patches
GCC Stage 1 now depends on Binutils and GCC Patches
Newlib now depends on GCC Stage 1 and Newlib Patches
GCC Stage 2 now depends on Newlib and GCC Patches 

This now allows make to be called with more than one job without failing and will actually build the SH4 and ARM toolchains concurrently. 