### PR TITLE
Seperate Pass 1 and Pass 2 GCC folders

### DIFF
--- a/utils/dc-chain/scripts/clean.mk
+++ b/utils/dc-chain/scripts/clean.mk
@@ -21,8 +21,9 @@ clean_patches_stamp:
 clean: clean_patches_stamp
 	-rm -rf build-newlib-$(sh_target)-$(newlib_ver)
 	-rm -rf build-newlib-$(arm_target)-$(newlib_ver)
-	-rm -rf build-gcc-$(sh_target)-$(sh_gcc_ver)
-	-rm -rf build-gcc-$(arm_target)-$(arm_gcc_ver)
+	-rm -rf build-gcc-$(sh_target)-$(sh_gcc_ver)-pass1
+	-rm -rf build-gcc-$(sh_target)-$(sh_gcc_ver)-pass2
+	-rm -rf build-gcc-$(arm_target)-$(arm_gcc_ver)-pass1
 	-rm -rf build-binutils-$(sh_target)-$(sh_binutils_ver)
 	-rm -rf build-binutils-$(arm_target)-$(arm_binutils_ver)
 	-rm -rf build-$(gdb_name)

--- a/utils/dc-chain/scripts/clean.mk
+++ b/utils/dc-chain/scripts/clean.mk
@@ -23,7 +23,7 @@ clean: clean_patches_stamp
 	-rm -rf build-newlib-$(arm_target)-$(newlib_ver)
 	-rm -rf build-gcc-$(sh_target)-$(sh_gcc_ver)-pass1
 	-rm -rf build-gcc-$(sh_target)-$(sh_gcc_ver)-pass2
-	-rm -rf build-gcc-$(arm_target)-$(arm_gcc_ver)-pass1
+	-rm -rf build-gcc-$(arm_target)-$(arm_gcc_ver)
 	-rm -rf build-binutils-$(sh_target)-$(sh_binutils_ver)
 	-rm -rf build-binutils-$(arm_target)-$(arm_binutils_ver)
 	-rm -rf build-$(gdb_name)

--- a/utils/dc-chain/scripts/gcc-pass1.mk
+++ b/utils/dc-chain/scripts/gcc-pass1.mk
@@ -5,9 +5,9 @@
 # Initially adapted from Stalin's build script version 0.3.
 #
 
-$(build_gcc_pass1) $(build_gcc_pass2): build = build-gcc-$(target)-$(gcc_ver)
+$(build_gcc_pass1): build = build-gcc-$(target)-$(gcc_ver)-pass1
 $(build_gcc_pass1) $(build_gcc_pass2): src_dir = gcc-$(gcc_ver)
-$(build_gcc_pass1): log = $(logdir)/$(build)-pass1.log
+$(build_gcc_pass1) $(build_gcc_pass2): log = $(logdir)/$(build).log
 $(build_gcc_pass1): logdir
 	@echo "+++ Building $(src_dir) to $(build) (pass 1)..."
 	-mkdir -p $(build)

--- a/utils/dc-chain/scripts/gcc-pass1.mk
+++ b/utils/dc-chain/scripts/gcc-pass1.mk
@@ -5,7 +5,8 @@
 # Initially adapted from Stalin's build script version 0.3.
 #
 
-$(build_gcc_pass1): build = build-gcc-$(target)-$(gcc_ver)-pass1
+build-sh4-gcc-pass1: build = build-gcc-$(target)-$(gcc_ver)-pass1
+build-arm-gcc-pass1: build = build-gcc-$(target)-$(gcc_ver)
 $(build_gcc_pass1) $(build_gcc_pass2): src_dir = gcc-$(gcc_ver)
 $(build_gcc_pass1) $(build_gcc_pass2): log = $(logdir)/$(build).log
 $(build_gcc_pass1): logdir

--- a/utils/dc-chain/scripts/gcc-pass2.mk
+++ b/utils/dc-chain/scripts/gcc-pass2.mk
@@ -5,7 +5,7 @@
 # Initially adapted from Stalin's build script version 0.3.
 #
 
-$(build_gcc_pass2): log = $(logdir)/$(build)-pass2.log
+$(build_gcc_pass2): build = build-gcc-$(target)-$(gcc_ver)-pass2
 $(build_gcc_pass2): logdir
 	@echo "+++ Building $(src_dir) to $(build) (pass 2)..."
 	-mkdir -p $(build)


### PR DESCRIPTION
Using the same build folder for both was causing an issue in Pass 2 where our gthr-kos.h file was failing to replace the gthr-default.h file. This was causing issues with libstdc++ feature detection failing to figure out our threading support and thus things like std::thread and std::mutex wouldn't work properly on the GCC9 & GCC12 toolchains (and caused a failure to build libstdc++ on GCC13).

Tested on GCC4.7, GCC9.2, GCC12.2, and the upcoming GCC13 release which all now build libstdc++ supporting our threads

Edit: This fixes issue #118 