### PR TITLE
Removed CXX flags: -fno-rtti and -fno-exceptions

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -34,7 +34,7 @@ export KOS_LD="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-ld"
 export KOS_RANLIB="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-ranlib"
 export KOS_STRIP="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-strip"
 export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_INC_PATHS} -D_arch_${KOS_ARCH} -D_arch_sub_${KOS_SUBARCH} -Wall -g -fno-builtin"
-export KOS_CPPFLAGS="${KOS_CPPFLAGS} ${KOS_INC_PATHS_CPP} -fno-operator-names -fno-rtti -fno-exceptions"
+export KOS_CPPFLAGS="${KOS_CPPFLAGS} ${KOS_INC_PATHS_CPP} -fno-operator-names"
 
 # Which standards modes we want to compile for
 # Note that this only covers KOS itself, not necessarily anything else compiled


### PR DESCRIPTION
I think the time has finally come to stop disabling these features by default. At this point so many projects and tests have been done with them enabled, and none of our toolchains have issues with them. These are not disabled by default in any normal development environment and are definitely used in many modern C++ projects (whether that's good or bad is up for debate, lol).

- RTTI will now be enabled by default for C++
- Exceptions will now be enabled by default for C++
