### PR TITLE
Link-Time Optimizations (LTO)

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -159,6 +159,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Add timespec_get C11 function to koslib's libc [LS]
 - DC  Added timer_ns_gettime64() and performance counters [AB]
 - *** Added check to allow strict C++17+ to use timespec_get [FG]
+- *** Add support for compiling with LTO [Paul Cercueil == PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -74,6 +74,8 @@ export KOS_AFLAGS=""
 # GCC seems to have made -fomit-frame-pointer the default on many targets, so
 # hence you may need -fno-omit-frame-pointer to actually have GCC spit out frame
 # pointers. It won't hurt to have it in there either way.
+# Link-time optimizations can be enabled by adding -flto. It however requires a
+# recent toolchain (GCC 10+), and has not been thoroughly tested.
 export KOS_CFLAGS="-O2 -fomit-frame-pointer"
 # export KOS_CFLAGS="-O2 -DFRAME_POINTERS -fno-omit-frame-pointer"
 

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -28,10 +28,10 @@ export KOS_LIBS="-Wl,--start-group -lkallisti -lc -lgcc -Wl,--end-group"
 export KOS_CC="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-gcc"
 export KOS_CCPLUS="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-g++"
 export KOS_AS="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-as"
-export KOS_AR="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-ar"
+export KOS_AR="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-gcc-ar"
 export KOS_OBJCOPY="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-objcopy"
 export KOS_LD="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-ld"
-export KOS_RANLIB="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-ranlib"
+export KOS_RANLIB="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-gcc-ranlib"
 export KOS_STRIP="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-strip"
 export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_INC_PATHS} -D_arch_${KOS_ARCH} -D_arch_sub_${KOS_SUBARCH} -Wall -g -fno-builtin"
 export KOS_CPPFLAGS="${KOS_CPPFLAGS} ${KOS_INC_PATHS_CPP} -fno-operator-names"
@@ -47,9 +47,9 @@ export KOS_GCCVER="`kos-cc -dumpversion`"
 case $KOS_GCCVER in
   2* | 3*)
     echo "Your GCC version is too old. You probably will run into major problems!"
-    export KOS_LDFLAGS="${KOS_LDFLAGS} -nostartfiles -nostdlib ${KOS_LIB_PATHS}" ;;
+    export KOS_LDFLAGS="${KOS_CFLAGS} ${KOS_LDFLAGS} -nostartfiles -nostdlib ${KOS_LIB_PATHS}" ;;
   *)
-    export KOS_LDFLAGS="${KOS_LDFLAGS} ${KOS_LD_SCRIPT} -nodefaultlibs ${KOS_LIB_PATHS}" ;;
+    export KOS_LDFLAGS="${KOS_CFLAGS} ${KOS_LDFLAGS} ${KOS_LD_SCRIPT} -nodefaultlibs ${KOS_LIB_PATHS}" ;;
 esac
 
 # Some extra vars based on architecture

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -5,6 +5,9 @@
 # aware that if you try to load someone else's module later, they might
 # be needing something in here.
 
+include kos.h
+include dc/sound/sound.h
+
 # ASIC
 asic_evt_set_handler
 asic_evt_disable_all

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -5,6 +5,9 @@
 # aware that if you try to load someone else's module later, they might
 # be needing something in here.
 
+include kos.h
+include dc/sound/sound.h
+
 # ASIC
 asic_evt_set_handler
 asic_evt_disable_all

--- a/kernel/arch/dreamcast/hardware/biosfont.c
+++ b/kernel/arch/dreamcast/hardware/biosfont.c
@@ -75,6 +75,7 @@ int bfont_set_32bit_mode(int on) {
 extern uint8* get_font_address();
 __asm__("	.text\n"
         "	.align 2\n"
+	".globl _get_font_address\n"
         "_get_font_address:\n"
         "	mov.l	syscall_b4,r0\n"
         "	mov.l	@r0,r0\n"

--- a/kernel/arch/dreamcast/include/arch/mmu.h
+++ b/kernel/arch/dreamcast/include/arch/mmu.h
@@ -335,6 +335,9 @@ int mmu_init();
 */
 void mmu_shutdown();
 
+/** \brief  Reset ITLB. */
+void mmu_reset_itlb();
+
 __END_DECLS
 
 #endif  /* __ARCH_MMU_H */

--- a/kernel/arch/dreamcast/include/dc/spu.h
+++ b/kernel/arch/dreamcast/include/dc/spu.h
@@ -167,6 +167,9 @@ int spu_dma_init();
 /** \brief  Shutdown SPU DMA support. */
 void spu_dma_shutdown();
 
+/** \brief  Reset SPU channels. */
+void spu_reset_chans();
+
 __END_DECLS
 
 #endif  /* __DC_SPU_H */

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -5,6 +5,12 @@
 
 # Libc ###############################
 
+include assert.h
+include malloc.h
+include stdlib.h
+include stdio.h
+include strings.h
+
 # Malloc
 malloc
 calloc
@@ -55,6 +61,8 @@ abs
 # __error
 
 ######################################
+
+include kos.h
 
 # Name Manager
 nmmgr_lookup

--- a/kernel/libc/koslib/byteorder.c
+++ b/kernel/libc/koslib/byteorder.c
@@ -21,7 +21,7 @@ uint32_t ntohl(uint32_t value) {
 }
 
 /* Host to Network short */
-uint32_t htons(uint32_t value) {
+uint16_t htons(uint16_t value) {
     return arch_htons(value);
 }
 

--- a/utils/genexports/genexports.sh
+++ b/utils/genexports/genexports.sh
@@ -15,18 +15,19 @@ inpfile=$1
 outpfile=$2
 outpsym=$3
 
+includes=`cat $inpfile | grep '^include ' | cut -d' ' -f2 | sort`
+
 # Get the list of export names
-names=`cat $inpfile | grep -v '^#' | grep -v '^$' | sort`
+names=`cat $inpfile | grep -v '^#' | grep -v '^include ' | grep -v '^$' | sort`
 
 # Write out a header
 rm -f $outpfile
 echo '/* This is a generated file, do not edit!! */' > $outpfile
 echo '#define __EXPORTS_FILE' >> $outpfile
-echo '#include <kos/exports.h>' >> $outpfile
+echo '#define _POSIX_C_SOURCE 200809' >> $outpfile
 
-# Write out "extern" declarations
-for i in $names; do
-	echo "extern unsigned int $i;" >> $outpfile
+for i in $includes; do
+	echo "#include <$i>" >> $outpfile
 done
 
 # Now write out the sym table

--- a/utils/genexports/genexportstubs.sh
+++ b/utils/genexports/genexportstubs.sh
@@ -15,7 +15,7 @@ inpfile=$1
 outpfile=$2
 
 # Get the list of export names
-names=`cat $inpfile | grep -v '^#' | grep -v '^$' | sort`
+names=`cat $inpfile | grep -v '^#' | grep -v '^include ' | grep -v '^$' | sort`
 
 # Write out a header
 rm -f $outpfile


### PR DESCRIPTION
Add support for compiling KallistiOS and programs with Link-Time Optimizations (LTO).

Add `-flto=auto` to the default KOS_CFLAGS, as well as `-fipa-pta` which is a worthwhile optimization.

Tested with the GCC13 toolchain. This *might* work with the GCC9 toolchain, and will most likely fail with the old GCC 4.x toolchain.