### PR TITLE
Disable opening/reading random device when using GCC4 Toolchain

### DIFF
--- a/examples/dreamcast/random/Makefile
+++ b/examples/dreamcast/random/Makefile
@@ -14,6 +14,8 @@ OBJS = random.o romdisk.o
 # from the named dir.
 KOS_ROMDISK_DIR = romdisk
 
+CFLAGS = -std=c99
+
 # The rm-elf step is to remove the target before building, to force the
 # re-creation of the rom disk.
 all: rm-elf $(TARGET)

--- a/examples/dreamcast/random/Makefile
+++ b/examples/dreamcast/random/Makefile
@@ -14,7 +14,7 @@ OBJS = random.o romdisk.o
 # from the named dir.
 KOS_ROMDISK_DIR = romdisk
 
-CFLAGS = -std=c99
+KOS_CFLAGS += -std=c99
 
 # The rm-elf step is to remove the target before building, to force the
 # re-creation of the rom disk.

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -122,7 +122,7 @@ int  __attribute__((weak)) arch_auto_init() {
 #if defined(__NEWLIB__) && !(__NEWLIB__ < 2 && __NEWLIB_MINOR__ < 4)
     fs_dev_init();          /* /dev/urandom etc. */
 #else
-#warning "/dev/ filesystem is not supported on Legacy (GCC4) toolchain"
+#warning "/dev filesystem is not supported with Newlib < 2.4.0"
 #endif
 
     hardware_periph_init();     /* DC peripheral init */

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -116,7 +116,14 @@ int  __attribute__((weak)) arch_auto_init() {
     fs_pty_init();          /* Pty */
     fs_ramdisk_init();      /* Ramdisk */
     fs_romdisk_init();      /* Romdisk */
+
+/* The arc4random_buf() function used for random & urandom is only
+   available in newlib starting with version 2.4.0 */
+#if defined(__NEWLIB__) && !(__NEWLIB__ < 2 && __NEWLIB_MINOR__ < 4)
     fs_dev_init();          /* /dev/urandom etc. */
+#else
+#warning "/dev/ filesystem is not supported on Legacy (GCC4) toolchain"
+#endif
 
     hardware_periph_init();     /* DC peripheral init */
 


### PR DESCRIPTION
The version of newlib we're using for GCC4 does not support the `arc4random_buf()` call being used for `/dev/random` and `/dev/urandom` so the symbol fails to be found by the linker. Fixed this by returning an error when attempting to open or read from the `random/urandom` device when using the Legacy GCC4 toolchain.

Also attempting to build the random example would fail due to GCC4's default C standard being C89 so included a fix for that as well.

Output from the random example on each toolchain after changes:
**Legacy (GCC4):**

maple: attached devices:
  A0: Dreamcast Controller          (01000000: Controller)
  A1: Visual Memory                 (0e000000: Clock, LCD, MemoryCard)
Random device not supported on Legacy (GCC4) toolchain
Unable to open /dev/urandom for reading
arch: shutting down kernel

**Stable (GCC9):**
maple: attached devices:
  A0: Dreamcast Controller          (01000000: Controller)
  A1: Visual Memory                 (0e000000: Clock, LCD, MemoryCard)
Generated the following random bytes:

0x51 0x47 0x73 0xDB 0xF7 0xA2 0x18 0x46 0x18 0x01 0x1A (continues)

arch: shutting down kernel


**Latest (GCC12):**
maple: attached devices:
  A0: Dreamcast Controller          (01000000: Controller)
  A1: Visual Memory                 (0e000000: Clock, LCD, MemoryCard)
Generated the following random bytes:

0x1A 0xC1 0x01 0x59 0x1E 0x5E 0x29 0x70 0x50 0xCF 0xDC (continues)

arch: shutting down kernel