### PR TITLE
Add use_kos_patches option to dc-chain config

### DIFF
--- a/utils/dc-chain/Makefile
+++ b/utils/dc-chain/Makefile
@@ -29,7 +29,7 @@ include scripts/init.mk
 # Makefile variables
 include scripts/variables.mk
 
-all: patch build
+all: build
 
 # ---- patch {{{
 

--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -237,12 +237,22 @@ This flag is here mainly for producing [DreamSDK](https://dreamsdk.org).
 ### Automatic fixup SH-4 Newlib (use with care)
 
 Set `auto_fixup_sh4_newlib` to `0` if you want to disable the automatic fixup
-SH-4 Newlib needed by KallistiOS. This will keep the generated toolchain
-completely raw.
+SH-4 Newlib needed by KallistiOS. Setting this option along with 
+`use_kos_patches=0` will keep the generated toolchain completely raw. 
 
 **Note:** If you disable this flag, the KallistiOS threading model (`kos`) will
 be unavailable. Also, this may be a problem if you still apply the KallistiOS
 patches. **Use this flag with care**.
+
+### Automatic KOS Patching (use with care)
+Set `use_kos_patches` to `0` if you want to skip applying the KOS patches
+to the downloaded sources before building. Setting this option along with 
+`auto_fixup_sh4_newlib=0` will keep the generated toolchain completely raw.
+
+**Note:** If you disable this flag, the KallistiOS threading model (`kos`) will
+be unavailable. Also, this may be a problem if you still apply the KallistiOS
+patches. **Use this flag with care**.
+
 
 ## Usage
 

--- a/utils/dc-chain/config.mk.legacy.sample
+++ b/utils/dc-chain/config.mk.legacy.sample
@@ -141,10 +141,14 @@ install_mode=install-strip
 
 # Automatic fixup SH-4 Newlib (1|0)
 # Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
-# KallistiOS. This will keep the generated toolchain completely raw. This will
-# also disable the 'kos' thread model. Don't mess with that flag unless you know
-# exactly what you are doing.
+# KallistiOS. This will also disable the 'kos' thread model. Don't mess with that 
+# flag unless you know exactly what you are doing.
 #auto_fixup_sh4_newlib=0
+
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
 
 # Force installation of BFD for SH (1|0)
 # Uncomment this if you want to force the installation of 'libbfd' for the SH

--- a/utils/dc-chain/config.mk.stable.sample
+++ b/utils/dc-chain/config.mk.stable.sample
@@ -146,6 +146,11 @@ install_mode=install-strip
 # exactly what you are doing.
 #auto_fixup_sh4_newlib=0
 
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
 # Force installation of BFD for SH (1|0)
 # Uncomment this if you want to force the installation of 'libbfd' for the SH
 # toolchain. This is required for MinGW/MSYS and can't be disabled in this

--- a/utils/dc-chain/config.mk.testing.sample
+++ b/utils/dc-chain/config.mk.testing.sample
@@ -146,6 +146,11 @@ install_mode=install-strip
 # exactly what you are doing.
 #auto_fixup_sh4_newlib=0
 
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
 # Force installation of BFD for SH (1|0)
 # Uncomment this if you want to force the installation of 'libbfd' for the SH
 # toolchain. This is required for MinGW/MSYS and can't be disabled in this

--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -114,12 +114,26 @@ curl_cmd=curl -C - -O
 do_auto_fixup_sh4_newlib := 1
 ifdef auto_fixup_sh4_newlib
   ifeq (0,$(auto_fixup_sh4_newlib))
+    $(warning 'Disabling Newlib Auto Fixup)
     do_auto_fixup_sh4_newlib := 0
   endif
 endif
 
-ifeq (0,$(do_auto_fixup_sh4_newlib))
-  ifeq (kos,$(thread_model))
+# Determine if we want to apply KOS patches to GCC/Newlib/Binutils
+do_kos_patching := 1
+ifdef use_kos_patches
+  ifeq (0,$(use_kos_patches))
+    $(warning 'Disabling KOS Patches)
+    do_kos_patching := 0
+  endif
+endif
+
+# Report an error if KOS threading is enabled when patching or fixup is disabled
+ifeq (kos,$(thread_model))
+  ifeq (0,$(do_auto_fixup_sh4_newlib))
     $(error kos thread model is unsupported when Newlib fixup is disabled)
+  endif
+  ifeq (0,$(do_kos_patching))
+    $(error kos thread model is unsupported when KOS patches are disabled)
   endif
 endif

--- a/utils/dc-chain/scripts/patch.mk
+++ b/utils/dc-chain/scripts/patch.mk
@@ -32,6 +32,19 @@ patch_gcc           = patch-sh4-gcc patch-arm-gcc
 patch_newlib        = patch-sh4-newlib
 patch_kos           = patch-kos
 
+# Patch
+# Apply sh4 newlib fixups (default is yes and this should be always the case!)
+ifeq (1,$(do_kos_patching))
+# Add Build Pre-Requisites for SH4 Steps
+  build-sh4-binutils: patch-sh4-binutils
+  build-sh4-gcc-pass1 build-sh4-gcc-pass2: patch-sh4-gcc
+  build-sh4-newlib-only: patch-sh4-newlib
+
+# Add Build Pre-Requisites for ARM Steps
+  build-arm-binutils: patch-arm-binutils
+  build-arm-gcc-pass1: patch-arm-gcc
+endif
+
 uname_p := $(shell uname -p)
 uname_s := $(shell uname -s)
 


### PR DESCRIPTION
Adds the ability to build fully raw toolchains without applying any KOS patches. As it was the patches would still be applied causing modifications to the sh-elf target's compile options. The notes for the the `auto_fixup_sh4_newlib` option in the README made it sound like that setting along should generate a raw toolchain, which really isn't the case.