### PR TITLE
Update kos/time.h header for C++ support

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -157,6 +157,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Removed "navi" subarch, moved code to addons/libnavi [LS]
 - *** Removed (completely unsupported) support for GCC 3.x and older [LS]
 - *** Add timespec_get C11 function to koslib's libc [LS]
+- *** Added check to allow strict C++17+ to use timespec_get [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Dan Potter == DP]

--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -14,7 +14,7 @@
 #ifndef __KOS_TIME_H
 #define __KOS_TIME_H
 
-#if !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L)
+#if !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L)
 
 #include <kos/cdefs.h>
 

--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -29,5 +29,5 @@ extern int timespec_get(struct timespec *ts, int base);
 
 __END_DECLS
 
-#endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) */
-#endif /* !__KOS_C11TIME_H */
+#endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L) */
+#endif /* !__KOS_TIME_H */


### PR DESCRIPTION
- Notice the timespec stuff was only made available in C++17
- C++ is being built with __STRICT_ANSI__ apparently which made the code conditionally #ifdef'd out