### PR TITLE
Added ARM driver stream.drv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ kernel/stubs/*.c
 kernel/exports/kernel_exports.c
 kernel/arch/dreamcast/kernel/arch_exports.c
 kernel/arch/dreamcast/kernel/banner.h
+kernel/arch/dreamcast/sound/arm/stream.drv
 lib/dreamcast/*.a
 addons/lib/dreamcast/*.a
 utils/bincnv/bincnv


### PR DESCRIPTION
Surely I'm not the only one who keeps accidentally almost committing this thing? Assuming the binary actually belongs in the repo, if it should ever need be updated, it can be done with `git add -f` in the future. 