### PR TITLE
Fix compilation of GDB for Stable and Experimental Toolchains

### DIFF
--- a/utils/dc-chain/scripts/gdb.mk
+++ b/utils/dc-chain/scripts/gdb.mk
@@ -61,7 +61,7 @@ $(stamp_gdb_build):
 	@echo "+++ Building GDB..."
 	rm -f $@
 	> $(log)
-	rm -rf build-$(gdb_name)
+	-rm -rf build-$(gdb_name)
 	mkdir build-$(gdb_name)
 	cd build-$(gdb_name); \
         ../$(gdb_name)/configure \

--- a/utils/dc-chain/scripts/gdb.mk
+++ b/utils/dc-chain/scripts/gdb.mk
@@ -21,16 +21,18 @@ $(gdb_file):
 	@echo "+++ Downloading GDB..."
 	$(web_downloader) $(gdb_url)
 
-unpack_gdb: $(gdb_file) $(stamp_gdb_unpack) $(stamp_gdb_patch)
+unpack_gdb: $(stamp_gdb_unpack)
 
-$(stamp_gdb_unpack):
+$(stamp_gdb_unpack): $(gdb_file)
 	@echo "+++ Unpacking GDB..."
 	rm -f $@ $(stamp_gdb_patch)
 	rm -rf $(gdb_name)
 	tar xf $(gdb_file)
 	touch $@
 
-$(stamp_gdb_patch):
+patch_gdb: $(stamp_gdb_patch)
+
+$(stamp_gdb_patch): unpack_gdb
 	@patches=$$(echo "$(gdb_patches)" | xargs); \
 	if ! test -f "$(stamp_gdb_patch)"; then \
 		if ! test -z "$${patches}"; then \
@@ -42,7 +44,7 @@ $(stamp_gdb_patch):
 
 build_gdb: log = $(logdir)/build-$(gdb_name).log
 build_gdb: logdir
-build_gdb: unpack_gdb $(stamp_gdb_build)
+build_gdb: $(stamp_gdb_build)
 
 ifeq ($(MACOS), 1)
   ifeq ($(uname_m),arm64)
@@ -57,7 +59,7 @@ ifeq ($(MACOS), 1)
   endif
 endif
 
-$(stamp_gdb_build):
+$(stamp_gdb_build): unpack_gdb
 	@echo "+++ Building GDB..."
 	rm -f $@
 	> $(log)
@@ -76,14 +78,26 @@ $(stamp_gdb_build):
 	$(MAKE) $(makejobs) -C build-$(gdb_name) $(to_log)
 	touch $@
 
+# This step runs post install to sign the sh-elf-gdb binary on MacOS
+macos_codesign_gdb: $(stamp_gdb_install)
+	@echo "+++ Codesigning GDB..."
+	codesign --sign "-" $(sh_prefix)/bin/sh-elf-gdb
+
+# If Host is MacOS then place Codesign step into dependency chain
+ifeq ($(MACOS), 1)
+GDB_INSTALL_TARGET = macos_codesign_gdb
+else
+GDB_INSTALL_TARGET = $(stamp_gdb_install)
+endif
+
 install_gdb: log = $(logdir)/build-$(gdb_name).log
 install_gdb: logdir
-install_gdb: build_gdb $(stamp_gdb_install)
+install_gdb: $(GDB_INSTALL_TARGET)
 
 # The 'install-strip' mode support is partial in GDB so there is a little hack
 # below to remove useless debug symbols
 # See: https://sourceware.org/legacy-ml/gdb-patches/2012-01/msg00335.html
-$(stamp_gdb_install):
+$(stamp_gdb_install): build_gdb
 	@echo "+++ Installing GDB..."
 	rm -f $@
 	$(MAKE) -C build-$(gdb_name) install DESTDIR=$(DESTDIR) $(to_log)

--- a/utils/dc-chain/scripts/gdb.mk
+++ b/utils/dc-chain/scripts/gdb.mk
@@ -44,6 +44,19 @@ build_gdb: log = $(logdir)/build-$(gdb_name).log
 build_gdb: logdir
 build_gdb: unpack_gdb $(stamp_gdb_build)
 
+ifeq ($(MACOS), 1)
+  ifeq ($(uname_m),arm64)
+    $(info Fixing up MacOS arm64 environment variables)
+    $(stamp_gdb_build): export CPATH := /opt/homebrew/include
+    $(stamp_gdb_build): export LIBRARY_PATH := /opt/homebrew/lib
+  endif
+  ifeq ($(uname_m),x86_64)
+    $(info Fixing up MacOS x86_64 environment variables)
+    $(stamp_gdb_build): export CPATH := /usr/local/include
+    $(stamp_gdb_build): export LIBRARY_PATH := /usr/local/lib
+  endif
+endif
+
 $(stamp_gdb_build):
 	@echo "+++ Building GDB..."
 	rm -f $@

--- a/utils/dc-chain/scripts/host-detect.mk
+++ b/utils/dc-chain/scripts/host-detect.mk
@@ -27,6 +27,7 @@ endif
 # Retrieve the system
 uname_s := $(shell uname -s)
 uname_r := $(shell uname -r)
+uname_m := $(shell uname -m)
 
 # Determine if we are running macOS
 ifeq ($(uname_s),Darwin)

--- a/utils/dc-chain/scripts/patch.mk
+++ b/utils/dc-chain/scripts/patch.mk
@@ -43,6 +43,9 @@ ifeq (1,$(do_kos_patching))
 # Add Build Pre-Requisites for ARM Steps
   build-arm-binutils: patch-arm-binutils
   build-arm-gcc-pass1: patch-arm-gcc
+
+# Add Patching Pre-Reqs for GDB
+  build_gdb: patch_gdb
 endif
 
 uname_p := $(shell uname -p)


### PR DESCRIPTION
Fixes the issue discussed in #107. Adds both of the proper environment variables depending on the architecture as well as codesigns the sh-elf-gdb executable after installing it. 

While I was here I also cleaned up the job dependencies so that if `make  gdb  -j5` is run, it should still do things in the proper order and not try to build before downloading or install before building.

I tested this change to be sure it builds on both arm64 & x86_64 MacOS and Linux