### PR TITLE
Add ability to specify git repos for dc-chain sources

### DIFF
--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -135,17 +135,18 @@ Doing so will use your custom versions of **GMP**, **MPC**, **MPFR** and
 if you have trouble using the `contrib/download_prerequisites` script provided
 with GCC.
 
-Please note that you have the possibility to specify the `tarball_type`
-extensions you want to download too; this may be useful if a package
-changes its extension on the servers. For example, for GCC `4.7.4`, there is no
-`xz` tarball file, so you may change this to `gz`.
+Please note that you have the possibility to specify the tarball extensions
+you want to download using `download_type`; this may be useful if a
+package changes its extension on the servers. For example, for GCC `4.7.4`, 
+there is no `xz` tarball file, so you may change this to `gz`. In the case that
+`download_type` is not specified, `tarball_type` will be checked as a fallback to
+support legacy `config.mk` files.
 
-Git repositories can also be used to obtain source files. The download method 
-is controlled by the `download_type` variable, where `tarball` (default) and 
-`git` are the currently valid options. When using the git download method,
-the reposity and branch set in the respective `git_repo` and `git_branch` 
-variables will be used to clone the repository. Using this download method will
-also requite that git be installed.
+Git repositories can also be used to obtain source files. The git download method 
+can be selected by specifying `git` as the `download_type`. This enables
+the use of `git_repo` and `git_branch` variables to specify the repository
+and branch respectively. If `git_branch` is omitted, the default for the
+repository will be used.
 
 **Note:** All download URL are computed in the `scripts/common.sh` file, but
 you shouldn't update/change this.

--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -140,6 +140,13 @@ extensions you want to download too; this may be useful if a package
 changes its extension on the servers. For example, for GCC `4.7.4`, there is no
 `xz` tarball file, so you may change this to `gz`.
 
+Git repositories can also be used to obtain source files. The download method 
+is controlled by the `download_type` variable, where `tarball` (default) and 
+`git` are the currently valid options. When using the git download method,
+the reposity and branch set in the respective `git_repo` and `git_branch` 
+variables will be used to clone the repository. Using this download method will
+also requite that git be installed.
+
 **Note:** All download URL are computed in the `scripts/common.sh` file, but
 you shouldn't update/change this.
 

--- a/utils/dc-chain/cleanup.sh
+++ b/utils/dc-chain/cleanup.sh
@@ -25,52 +25,30 @@ done
 function cleanup_dependency()
 {
   local type="$1"
-  local dep_name="$2"  
-  local dep_ver="$3"
-  local dep_type="$4"
+  local dep_name="$2"
+  local dep_ver=$3_VER
+  local dep_type=$3_TARBALL_TYPE
 
-  local dep="${dep_name}-${dep_ver}"
+  local dep="${dep_name}-${!dep_ver}"
 
-  if [ -n "$dep_ver" ]; then
+  if [ -n "${!dep_ver}" ]; then
     if [ "$type" == "package" ]; then
-      rm -f "${dep}.tar.${dep_type}"
-	else
-	  rm -rf "${dep}"
+      rm -f "${dep}.tar.${!dep_type}"
+	  else
+	    rm -rf "${dep}"
     fi
   fi
 }
 
 function cleanup_dependencies()
 {
-  local arch=$1
   local type=$2
 
-  local gmp_ver=$SH_GMP_VER
-  local mpfr_ver=$SH_MPFR_VER
-  local mpc_ver=$SH_MPC_VER
-  local isl_ver=$SH_ISL_VER
-  local gmp_tarball_type=$SH_GMP_TARBALL_TYPE
-  local mpfr_tarball_type=$SH_MPFR_TARBALL_TYPE
-  local mpc_tarball_type=$SH_MPC_TARBALL_TYPE
-  local isl_tarball_type=$SH_ISL_TARBALL_TYPE
-
-  if [ "$arch" == "arm" ]; then
-    gcc_ver=$ARM_GCC_VER
-    gmp_ver=$ARM_GMP_VER
-    mpfr_ver=$ARM_MPFR_VER
-    mpc_ver=$ARM_MPC_VER
-    isl_ver=$ARM_ISL_VER
-    gmp_tarball_type=$ARM_GMP_TARBALL_TYPE
-    mpfr_tarball_type=$ARM_MPFR_TARBALL_TYPE
-    mpc_tarball_type=$ARM_MPC_TARBALL_TYPE
-    isl_tarball_type=$ARM_ISL_TARBALL_TYPE
-  fi
-
   if [ "$USE_CUSTOM_DEPENDENCIES" == "1" ]; then
-    cleanup_dependency "$type" "GMP"  "$gmp_ver"  "$gmp_tarball_type"
-    cleanup_dependency "$type" "MPFR" "$mpfr_ver" "$mpfr_tarball_type"
-    cleanup_dependency "$type" "MPC"  "$mpc_ver"  "$mpc_tarball_type"
-    cleanup_dependency "$type" "ISL"  "$isl_ver"  "$isl_tarball_type"
+    cleanup_dependency "$type" "GMP" "$1_GMP"
+    cleanup_dependency "$type" "MPFR" "$1_MPFR"
+    cleanup_dependency "$type" "MPC" "$1_MPC"
+    cleanup_dependency "$type" "ISL" "$1_ISL"
   fi
 }
 
@@ -85,8 +63,8 @@ if [ -z $KEEP_DOWNLOADS ]; then
         newlib-$NEWLIB_VER.tar.$NEWLIB_TARBALL_TYPE
 
   if [ "$USE_CUSTOM_DEPENDENCIES" == "1" ]; then
-    cleanup_dependencies "sh" "package"
-    cleanup_dependencies "arm" "package"
+    cleanup_dependencies "SH" "package"
+    cleanup_dependencies "ARM" "package"
   fi
 
   if [ -f "gdb-$GDB_VER.tar.$GDB_TARBALL_TYPE" ]; then
@@ -109,8 +87,8 @@ rm -rf binutils-$SH_BINUTILS_VER binutils-$ARM_BINUTILS_VER \
        *.stamp	   
 
 if [ "$USE_CUSTOM_DEPENDENCIES" == "1" ]; then
-  cleanup_dependencies "sh" "dir"
-  cleanup_dependencies "arm" "dir"
+  cleanup_dependencies "SH" "dir"
+  cleanup_dependencies "ARM" "dir"
 fi
 
 if [ -d "gdb-$GDB_VER" ]; then

--- a/utils/dc-chain/config.mk.legacy.sample
+++ b/utils/dc-chain/config.mk.legacy.sample
@@ -25,9 +25,9 @@ gdb_ver=9.2
 insight_ver=6.8-1
 
 # Tarball extensions to download for SH
-sh_binutils_tarball_type=xz
-sh_gcc_tarball_type=bz2
-newlib_tarball_type=gz
+sh_binutils_download_type=xz
+sh_gcc_download_type=bz2
+newlib_download_type=gz
 gdb_tarball_type=xz
 insight_tarball_type=bz2
 
@@ -38,8 +38,8 @@ arm_binutils_ver=2.34
 arm_gcc_ver=4.7.4
 
 # Tarball extensions to download for ARM
-arm_binutils_tarball_type=xz
-arm_gcc_tarball_type=bz2
+arm_binutils_download_type=xz
+arm_gcc_download_type=bz2
 
 # GCC custom dependencies
 # Specify here if you want to use custom GMP, MPFR and MPC libraries as they are
@@ -61,10 +61,10 @@ sh_mpc_ver=0.8.1
 #sh_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for SH
-sh_gmp_tarball_type=bz2
-sh_mpfr_tarball_type=bz2
-sh_mpc_tarball_type=gz
-sh_isl_tarball_type=bz2
+sh_gmp_download_type=bz2
+sh_mpfr_download_type=bz2
+sh_mpc_download_type=gz
+sh_isl_download_type=bz2
 
 # GCC dependencies for ARM
 arm_gmp_ver=4.3.2
@@ -73,10 +73,10 @@ arm_mpc_ver=0.8.1
 #arm_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for ARM
-arm_gmp_tarball_type=bz2
-arm_mpfr_tarball_type=bz2
-arm_mpc_tarball_type=gz
-arm_isl_tarball_type=bz2
+arm_gmp_download_type=bz2
+arm_mpfr_download_type=bz2
+arm_mpc_download_type=gz
+arm_isl_download_type=bz2
 
 # Toolchains base
 # Indicate the root directory where toolchains will be installed

--- a/utils/dc-chain/config.mk.stable.sample
+++ b/utils/dc-chain/config.mk.stable.sample
@@ -25,9 +25,9 @@ gdb_ver=9.2
 insight_ver=6.8-1
 
 # Tarball extensions to download for SH
-sh_binutils_tarball_type=xz
-sh_gcc_tarball_type=xz
-newlib_tarball_type=gz
+sh_binutils_download_type=xz
+sh_gcc_download_type=xz
+newlib_download_type=gz
 gdb_tarball_type=xz
 insight_tarball_type=bz2
 
@@ -38,8 +38,8 @@ arm_binutils_ver=2.34
 arm_gcc_ver=8.4.0
 
 # Tarball extensions to download for ARM
-arm_binutils_tarball_type=xz
-arm_gcc_tarball_type=xz
+arm_binutils_download_type=xz
+arm_gcc_download_type=xz
 
 # GCC custom dependencies
 # Specify here if you want to use custom GMP, MPFR and MPC libraries as they are
@@ -61,10 +61,10 @@ sh_mpc_ver=1.0.3
 sh_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for SH
-sh_gmp_tarball_type=bz2
-sh_mpfr_tarball_type=bz2
-sh_mpc_tarball_type=gz
-sh_isl_tarball_type=bz2
+sh_gmp_download_type=bz2
+sh_mpfr_download_type=bz2
+sh_mpc_download_type=gz
+sh_isl_download_type=bz2
 
 # GCC dependencies for ARM
 arm_gmp_ver=6.1.0
@@ -73,10 +73,10 @@ arm_mpc_ver=1.0.3
 arm_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for ARM
-arm_gmp_tarball_type=bz2
-arm_mpfr_tarball_type=bz2
-arm_mpc_tarball_type=gz
-arm_isl_tarball_type=bz2
+arm_gmp_download_type=bz2
+arm_mpfr_download_type=bz2
+arm_mpc_download_type=gz
+arm_isl_download_type=bz2
 
 # Toolchains base
 # Indicate the root directory where toolchains will be installed

--- a/utils/dc-chain/config.mk.testing.sample
+++ b/utils/dc-chain/config.mk.testing.sample
@@ -25,9 +25,9 @@ gdb_ver=13.1
 insight_ver=6.8-1
 
 # Tarball extensions to download for SH
-sh_binutils_tarball_type=xz
-sh_gcc_tarball_type=xz
-newlib_tarball_type=gz
+sh_binutils_download_type=xz
+sh_gcc_download_type=xz
+newlib_download_type=gz
 gdb_tarball_type=xz
 insight_tarball_type=bz2
 
@@ -38,8 +38,8 @@ arm_binutils_ver=2.40
 arm_gcc_ver=8.4.0
 
 # Tarball extensions to download for ARM
-arm_binutils_tarball_type=xz
-arm_gcc_tarball_type=xz
+arm_binutils_download_type=xz
+arm_gcc_download_type=xz
 
 # GCC custom dependencies
 # Specify here if you want to use custom GMP, MPFR and MPC libraries as they are
@@ -61,10 +61,10 @@ sh_mpc_ver=1.2.1
 sh_isl_ver=0.24
 
 # Tarball extensions to download for GCC dependencies for SH
-sh_gmp_tarball_type=bz2
-sh_mpfr_tarball_type=bz2
-sh_mpc_tarball_type=gz
-sh_isl_tarball_type=bz2
+sh_gmp_download_type=bz2
+sh_mpfr_download_type=bz2
+sh_mpc_download_type=gz
+sh_isl_download_type=bz2
 
 # GCC dependencies for ARM
 arm_gmp_ver=6.1.0
@@ -73,10 +73,10 @@ arm_mpc_ver=1.0.3
 arm_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for ARM
-arm_gmp_tarball_type=bz2
-arm_mpfr_tarball_type=bz2
-arm_mpc_tarball_type=gz
-arm_isl_tarball_type=bz2
+arm_gmp_download_type=bz2
+arm_mpfr_download_type=bz2
+arm_mpc_download_type=gz
+arm_isl_download_type=bz2
 
 # Toolchains base
 # Indicate the root directory where toolchains will be installed

--- a/utils/dc-chain/scripts/common.sh
+++ b/utils/dc-chain/scripts/common.sh
@@ -49,17 +49,17 @@ function setup_download_var()
   export $1_GIT_REPO=`get_make_var $(tolower $1)_git_repo`
   export $1_GIT_BRANCH=`get_make_var $(tolower $1)_git_branch`
 
-  # Tarball Releases
-  export $1_TARBALL_TYPE=`get_make_var $(tolower $1)_tarball_type`
-
-  # asdf
+  # Fall back to older tarball_type if download_type was not specified
   local download_type="$1_DOWNLOAD_TYPE"
   if [ -z ${!download_type} ]; then
-    export $1_DOWNLOAD_TYPE="tarball"
+    echo $(tolower $1)_download_type not specified, falling back to $(tolower $1)_tarball_type
+    export $1_DOWNLOAD_TYPE=`get_make_var $(tolower $1)_tarball_type`
   fi
 
-  if [ "${!download_type}" != "git" ] && [ "${!download_type}" != "tarball" ]; then
-    echo >&2 "${!download_type} is an invalid option for $(tolower $1)_download_type" || exit 1
+  # If Git was not specified, assume tarball
+  if [ "${!download_type}" != "git" ]; then
+    export $1_TARBALL_TYPE="${!download_type}"
+    export $1_DOWNLOAD_TYPE="tarball"
   fi
 }
 

--- a/utils/dc-chain/scripts/common.sh
+++ b/utils/dc-chain/scripts/common.sh
@@ -27,11 +27,40 @@ function tolower()
   echo "$1" | awk '{print tolower($0)}'
 }
 
+function toupper()
+{
+  echo "$1" | awk '{print toupper($0)}'
+}
+
 function print_banner()
 {
   local var="$1"
   local banner_text=`get_make_var banner_text scripts/banner-variables.mk`
   printf "*** ${var} Utility for ${banner_text} ***\n\n" 
+}
+
+function setup_download_var()
+{
+  # Common Config Options
+  export $1_DOWNLOAD_TYPE=`get_make_var $(tolower $1)_download_type`
+  export $1_VER=`get_make_var $(tolower $1)_ver`
+  
+  # Git Repo Config Options
+  export $1_GIT_REPO=`get_make_var $(tolower $1)_git_repo`
+  export $1_GIT_BRANCH=`get_make_var $(tolower $1)_git_branch`
+
+  # Tarball Releases
+  export $1_TARBALL_TYPE=`get_make_var $(tolower $1)_tarball_type`
+
+  # asdf
+  local download_type="$1_DOWNLOAD_TYPE"
+  if [ -z ${!download_type} ]; then
+    export $1_DOWNLOAD_TYPE="tarball"
+  fi
+
+  if [ "${!download_type}" != "git" ] && [ "${!download_type}" != "tarball" ]; then
+    echo >&2 "${!download_type} is an invalid option for $(tolower $1)_download_type" || exit 1
+  fi
 }
 
 # Check for config.mk
@@ -42,60 +71,47 @@ fi
   
 export CONFIG_GUESS="config.guess"
 
-export SH_BINUTILS_VER=`get_make_var sh_binutils_ver`
-export SH_GCC_VER=`get_make_var sh_gcc_ver`
-export NEWLIB_VER=`get_make_var newlib_ver`
-export GDB_VER=`get_make_var gdb_ver`
-export INSIGHT_VER=`get_make_var insight_ver`
-export ARM_BINUTILS_VER=`get_make_var arm_binutils_ver`
-export ARM_GCC_VER=`get_make_var arm_gcc_ver`
+setup_download_var SH_BINUTILS
+setup_download_var SH_GCC
+setup_download_var NEWLIB
+setup_download_var GDB
+setup_download_var INSIGHT
+setup_download_var ARM_BINUTILS
+setup_download_var ARM_GCC
 
-export SH_BINUTILS_TARBALL_TYPE=`get_make_var sh_binutils_tarball_type`
-export SH_GCC_TARBALL_TYPE=`get_make_var sh_gcc_tarball_type`
-export NEWLIB_TARBALL_TYPE=`get_make_var newlib_tarball_type`
-export GDB_TARBALL_TYPE=`get_make_var gdb_tarball_type`
-export INSIGHT_TARBALL_TYPE=`get_make_var insight_tarball_type`
-export ARM_BINUTILS_TARBALL_TYPE=`get_make_var arm_binutils_tarball_type`
-export ARM_GCC_TARBALL_TYPE=`get_make_var arm_gcc_tarball_type`
 
-export SH_BINUTILS_URL=ftp.gnu.org/gnu/binutils/binutils-${SH_BINUTILS_VER}.tar.${SH_BINUTILS_TARBALL_TYPE}
-export SH_GCC_URL=ftp.gnu.org/gnu/gcc/gcc-${SH_GCC_VER}/gcc-${SH_GCC_VER}.tar.${SH_GCC_TARBALL_TYPE}
-export NEWLIB_URL=sourceware.org/pub/newlib/newlib-${NEWLIB_VER}.tar.${NEWLIB_TARBALL_TYPE}
-export GDB_URL=ftp.gnu.org/gnu/gdb/gdb-${GDB_VER}.tar.${GDB_TARBALL_TYPE}
-export INSIGHT_URL=mirrors.kernel.org/sourceware/insight/releases/insight-${INSIGHT_VER}a.tar.${INSIGHT_TARBALL_TYPE}
-export ARM_BINUTILS_URL=ftp.gnu.org/gnu/binutils/binutils-${ARM_BINUTILS_VER}.tar.${ARM_BINUTILS_TARBALL_TYPE}
-export ARM_GCC_URL=ftp.gnu.org/gnu/gcc/gcc-${ARM_GCC_VER}/gcc-${ARM_GCC_VER}.tar.${ARM_GCC_TARBALL_TYPE}
+# export GNU_MIRROR_URL=mirrors.kernel.org/gnu
+export GNU_MIRROR_URL=ftp.gnu.org
+export SH_BINUTILS_TARBALL_URL=$GNU_MIRROR_URL/gnu/binutils/binutils-$SH_BINUTILS_VER.tar.$SH_BINUTILS_TARBALL_TYPE
+export SH_GCC_TARBALL_URL=$GNU_MIRROR_URL/gnu/gcc/gcc-$SH_GCC_VER/gcc-$SH_GCC_VER.tar.$SH_GCC_TARBALL_TYPE
+export NEWLIB_TARBALL_URL=sourceware.org/pub/newlib/newlib-$NEWLIB_VER.tar.$NEWLIB_TARBALL_TYPE
+export GDB_TARBALL_URL=$GNU_MIRROR_URL/gnu/gdb/gdb-$GDB_VER.tar.$GDB_TARBALL_TYPE
+export INSIGHT_TARBALL_URL=$GNU_MIRROR_URL/sourceware/insight/releases/insight-$INSIGHT_VER.tar.$INSIGHT_TARBALL_TYPE
+export ARM_BINUTILS_TARBALL_URL=$GNU_MIRROR_URL/gnu/binutils/binutils-$ARM_BINUTILS_VER.tar.$ARM_BINUTILS_TARBALL_TYPE
+export ARM_GCC_TARBALL_URL=$GNU_MIRROR_URL/gnu/gcc/gcc-$ARM_GCC_VER/gcc-$ARM_GCC_VER.tar.$ARM_GCC_TARBALL_TYPE
+
 
 export DOWNLOAD_PROTOCOL="`get_make_var download_protocol`://"
 
 export USE_CUSTOM_DEPENDENCIES=`get_make_var use_custom_dependencies`
 
-export SH_GMP_VER=`get_make_var sh_gmp_ver`
-export SH_MPFR_VER=`get_make_var sh_mpfr_ver`
-export SH_MPC_VER=`get_make_var sh_mpc_ver`
-export SH_ISL_VER=`get_make_var sh_isl_ver`
-export ARM_GMP_VER=`get_make_var arm_gmp_ver`
-export ARM_MPFR_VER=`get_make_var arm_mpfr_ver`
-export ARM_MPC_VER=`get_make_var arm_mpc_ver`
-export ARM_ISL_VER=`get_make_var arm_isl_ver`
+setup_download_var SH_GMP
+setup_download_var SH_MPFR
+setup_download_var SH_MPC
+setup_download_var SH_ISL
+setup_download_var ARM_GMP
+setup_download_var ARM_MPFR
+setup_download_var ARM_MPC
+setup_download_var ARM_ISL
 
-export SH_GMP_TARBALL_TYPE=`get_make_var sh_gmp_tarball_type`
-export SH_MPFR_TARBALL_TYPE=`get_make_var sh_mpfr_tarball_type`
-export SH_MPC_TARBALL_TYPE=`get_make_var sh_mpc_tarball_type`
-export SH_ISL_TARBALL_TYPE=`get_make_var sh_isl_tarball_type`
-export ARM_GMP_TARBALL_TYPE=`get_make_var arm_gmp_tarball_type`
-export ARM_MPFR_TARBALL_TYPE=`get_make_var arm_mpfr_tarball_type`
-export ARM_MPC_TARBALL_TYPE=`get_make_var arm_mpc_tarball_type`
-export ARM_ISL_TARBALL_TYPE=`get_make_var arm_isl_tarball_type`
-
-export SH_GMP_URL=gcc.gnu.org/pub/gcc/infrastructure/gmp-${SH_GMP_VER}.tar.${SH_GMP_TARBALL_TYPE}
-export SH_MPFR_URL=gcc.gnu.org/pub/gcc/infrastructure/mpfr-${SH_MPFR_VER}.tar.${SH_MPFR_TARBALL_TYPE}
-export SH_MPC_URL=gcc.gnu.org/pub/gcc/infrastructure/mpc-${SH_MPC_VER}.tar.${SH_MPC_TARBALL_TYPE}
-export SH_ISL_URL=gcc.gnu.org/pub/gcc/infrastructure/isl-${SH_ISL_VER}.tar.${SH_ISL_TARBALL_TYPE}
-export ARM_GMP_URL=gcc.gnu.org/pub/gcc/infrastructure/gmp-${ARM_GMP_VER}.tar.${ARM_GMP_TARBALL_TYPE}
-export ARM_MPFR_URL=gcc.gnu.org/pub/gcc/infrastructure/mpfr-${ARM_MPFR_VER}.tar.${ARM_MPFR_TARBALL_TYPE}
-export ARM_MPC_URL=gcc.gnu.org/pub/gcc/infrastructure/mpc-${ARM_MPC_VER}.tar.${ARM_MPC_TARBALL_TYPE}
-export ARM_ISL_URL=gcc.gnu.org/pub/gcc/infrastructure/isl-${ARM_ISL_VER}.tar.${ARM_ISL_TARBALL_TYPE}
+export SH_GMP_TARBALL_URL=gcc.gnu.org/pub/gcc/infrastructure/gmp-${SH_GMP_VER}.tar.${SH_GMP_TARBALL_TYPE}
+export SH_MPFR_TARBALL_URL=gcc.gnu.org/pub/gcc/infrastructure/mpfr-${SH_MPFR_VER}.tar.${SH_MPFR_TARBALL_TYPE}
+export SH_MPC_TARBALL_URL=gcc.gnu.org/pub/gcc/infrastructure/mpc-${SH_MPC_VER}.tar.${SH_MPC_TARBALL_TYPE}
+export SH_ISL_TARBALL_URL=gcc.gnu.org/pub/gcc/infrastructure/isl-${SH_ISL_VER}.tar.${SH_ISL_TARBALL_TYPE}
+export ARM_GMP_TARBALL_URL=gcc.gnu.org/pub/gcc/infrastructure/gmp-${ARM_GMP_VER}.tar.${ARM_GMP_TARBALL_TYPE}
+export ARM_MPFR_TARBALL_URL=gcc.gnu.org/pub/gcc/infrastructure/mpfr-${ARM_MPFR_VER}.tar.${ARM_MPFR_TARBALL_TYPE}
+export ARM_MPC_TARBALL_URL=gcc.gnu.org/pub/gcc/infrastructure/mpc-${ARM_MPC_VER}.tar.${ARM_MPC_TARBALL_TYPE}
+export ARM_ISL_TARBALL_URL=gcc.gnu.org/pub/gcc/infrastructure/isl-${ARM_ISL_VER}.tar.${ARM_ISL_TARBALL_TYPE}
 
 # Retrieve the web downloader program available in this system.
 export IS_CURL=0

--- a/utils/dc-chain/unpack.sh
+++ b/utils/dc-chain/unpack.sh
@@ -8,92 +8,80 @@ print_banner "Unpacker"
 function unpack()
 {
   local name="$1"
-  local ver="$2"
-  local ext="$3"
+  local ver=$2_VER
+  local ext=$2_TARBALL_TYPE
+  local download_type=$2_DOWNLOAD_TYPE
 
-  local dirname=$(tolower $name)-$ver
-  local filename=$dirname.tar.$ext
+  local dirname=$(tolower $name)-${!ver}
+  local filename=$dirname.tar.${!ext}
 
-  if [ ! -f "$filename" ]; then
-    echo "Required file not found: $filename"
-    exit 1
+  if [[ "${!download_type}" == "tarball" ]]; then
+    echo "Tarball $name"
+    # Remove old directory
+    rm -rf $dirname
+
+    if [ ! -f "$filename" ]; then
+      echo "Required file not found: $filename"
+      exit 1
+    fi
+  
+    if [ ! -d "$dirname" ]; then
+      echo "Unpacking $name ${!ver}..."
+      tar xf "$filename" || exit 1
+    fi
   fi
 
-  if [ ! -d "$dirname" ]; then
-    echo "Unpacking $name $ver..."
-    tar xf "$filename" || exit 1
-  fi
+  
 }
 
 function unpack_dependency()
 {
   local gcc_ver="$1"
   local dep_name="$2"  
-  local dep_ver="$3"
-  local dep_type="$4"
+  local dep_ver=$2_VER
+  local dep_ext=$2_TARBALL_TYPE
 
+  local download_type=$(tolower "$dep_name")_DOWNLOAD_TYPE
   local path=$(tolower "$dep_name")
 
-  if [ -n "$dep_ver" ]; then
-    echo "  Unpacking $dep_name $dep_ver..."
-    tar xf $path-$dep_ver.tar.$dep_type || exit 1
-    mv $path-$dep_ver gcc-$gcc_ver/$path
+  if [[ "${!download_type}" == "tarball" ]]; then
+    if [ -n "${!dep_ver}" ]; then
+      echo "  Unpacking $dep_name ${!dep_ver}..."
+      tar xf $path-${!dep_ver}.tar.${!dep_ext} || exit 1
+      mv $path-${!dep_ver} gcc-$gcc_ver/$path
+    fi
   fi
 }
 
 function unpack_dependencies()
 {
-  local arch=$1
-
-  local gcc_ver=$SH_GCC_VER
-  local gmp_ver=$SH_GMP_VER
-  local mpfr_ver=$SH_MPFR_VER
-  local mpc_ver=$SH_MPC_VER
-  local isl_ver=$SH_ISL_VER
-  local gmp_tarball_type=$SH_GMP_TARBALL_TYPE
-  local mpfr_tarball_type=$SH_MPFR_TARBALL_TYPE
-  local mpc_tarball_type=$SH_MPC_TARBALL_TYPE
-  local isl_tarball_type=$SH_ISL_TARBALL_TYPE
-
-  if [ "$arch" == "arm" ]; then
-    gcc_ver=$ARM_GCC_VER
-    gmp_ver=$ARM_GMP_VER
-    mpfr_ver=$ARM_MPFR_VER
-    mpc_ver=$ARM_MPC_VER
-    isl_ver=$ARM_ISL_VER
-    gmp_tarball_type=$ARM_GMP_TARBALL_TYPE
-    mpfr_tarball_type=$ARM_MPFR_TARBALL_TYPE
-    mpc_tarball_type=$ARM_MPC_TARBALL_TYPE
-    isl_tarball_type=$ARM_ISL_TARBALL_TYPE
-  fi
+  local gcc_ver=$1_GCC_VER
   
-  echo "Unpacking prerequisites for GCC ${gcc_ver}..."
+  echo "Unpacking prerequisites for GCC ${!gcc_ver}..."
 
   if [ "$USE_CUSTOM_DEPENDENCIES" == "1" ]; then
-    unpack_dependency "$gcc_ver" "GMP"  "$gmp_ver"  "$gmp_tarball_type"
-    unpack_dependency "$gcc_ver" "MPFR" "$mpfr_ver" "$mpfr_tarball_type"
-    unpack_dependency "$gcc_ver" "MPC"  "$mpc_ver"  "$mpc_tarball_type"
-    unpack_dependency "$gcc_ver" "ISL"  "$isl_ver"  "$isl_tarball_type"
+    unpack_dependency "${!gcc_ver}" "$1_GMP"
+    unpack_dependency "${!gcc_ver}" "$1_MPFR"
+    unpack_dependency "${!gcc_ver}" "$1_MPC"
+    unpack_dependency "${!gcc_ver}" "$1_ISL"
   else
-    cd ./gcc-$gcc_ver && ./contrib/download_prerequisites && cd ..
+    cd ./gcc-${!gcc_ver} && ./contrib/download_prerequisites && cd ..
   fi
 }
 
-# Clean up from any old builds.
+
 echo "Preparing unpacking..."
-rm -rf binutils-$SH_BINUTILS_VER binutils-$ARM_BINUTILS_VER \
-       gcc-$SH_GCC_VER gcc-$ARM_GCC_VER \
-       newlib-$NEWLIB_VER
 
 # Unpack SH components
-unpack "Binutils" $SH_BINUTILS_VER $SH_BINUTILS_TARBALL_TYPE
-unpack "GCC" $SH_GCC_VER $SH_GCC_TARBALL_TYPE
-unpack_dependencies "sh"
-unpack "Newlib" $NEWLIB_VER $NEWLIB_TARBALL_TYPE
+unpack "Binutils" "SH_BINUTILS"
+unpack "GCC" "SH_GCC"
+unpack_dependencies "SH"
+unpack "Newlib" "NEWLIB"
+
 
 # Unpack ARM components
-unpack "Binutils" $ARM_BINUTILS_VER $ARM_BINUTILS_TARBALL_TYPE
-unpack "GCC" $ARM_GCC_VER $ARM_GCC_TARBALL_TYPE
-unpack_dependencies "arm"
+unpack "Binutils" "ARM_BINUTILS"
+unpack "GCC" "ARM_GCC"
+unpack_dependencies "ARM"
 
 echo "Done!"


### PR DESCRIPTION
These changes to dc-chain will allow the use of git repositories to download sources instead of using URLs to tarballs. The purpose of this is to be able to easily build versions of the toolchain with upstream versions of the sources in order to keep on top of new releases (i.e. GCC14, GCCRS). 

Currently the variables in `config.mk` the options for `sh_gcc` would are set as follows:
```
sh_gcc_ver=12.2.0
sh_gcc_tarball_type=xz
```
This will continue to function as it has been, but by changing the `sh_gcc_download_type` we can specify a git repo instead:
```
sh_gcc_ver=rs
sh_gcc_download_type=git
sh_gcc_git_repo=https://github.com/Rust-GCC/gccrs.git
sh_gcc_git_branch=master
```
In which case the `tarball_type` variable also becomes optional. The `sh_gcc` is just used as an example here, it should also work perfectly fine with `arm_gcc`, `newlib`, or any other package where the version and tarball type can be specified. 

From most tested to un-tested:
- [X] Linux
- [X] MacOS (Arm64) 
- [x] Windows