### PR TITLE
Fixed tsnunami font example with GCC12 LTO

### DIFF
--- a/examples/dreamcast/tsunami/font/Makefile
+++ b/examples/dreamcast/tsunami/font/Makefile
@@ -18,7 +18,7 @@ rm-elf:
 
 $(TARGET): $(OBJS) romdisk.o
 	$(KOS_CC) $(KOS_CFLAGS) $(KOS_LDFLAGS) -o $(TARGET) $(KOS_START) \
-		$(OBJS) romdisk.o $(OBJEXTRA) -lstdc++ -ltsunami -lparallax -lpng -ljpeg -lkmg -lz -lkosutils -lm $(KOS_LIBS) 
+		$(OBJS) romdisk.o $(OBJEXTRA) -ltsunami -lstdc++ -lparallax -lpng -ljpeg -lkmg -lz -lkosutils -lm $(KOS_LIBS) 
 
 
 romdisk.img:


### PR DESCRIPTION
The Tsunami Font example doesn't build for me with a fresh environment and system, trying to build with GCC12 after the LTO PR was checked in. @darcagn and @cepawiel ran into the same issue in the GCC13 branch and fixed it there, but it looks like it's an issue in 12 after all. 

- Thanks to Colton for figuring out the libs were being linked to in the wrong order, which only manifested in an issue once we enabled LTO, apparently