### PR TITLE
Fixed building with GCC-4.7.4 after LTO changes

### DIFF
--- a/examples/dreamcast/basic/stackprotector/Makefile
+++ b/examples/dreamcast/basic/stackprotector/Makefile
@@ -4,6 +4,9 @@ KOS_CFLAGS += -fstack-protector-all
 
 GCC_MAJOR = $(basename $(basename $(KOS_GCCVER)))
 
+clean:
+	-rm -f $(TARGET) $(OBJS)
+
 ifeq ($(GCC_MAJOR), 4) 
 
 all dist:
@@ -14,9 +17,6 @@ else
 all: rm-elf $(TARGET)
 
 include $(KOS_BASE)/Makefile.rules
-
-clean:
-	-rm -f $(TARGET) $(OBJS)
 
 rm-elf:
 	-rm -f $(TARGET)

--- a/examples/dreamcast/basic/stackprotector/Makefile
+++ b/examples/dreamcast/basic/stackprotector/Makefile
@@ -4,19 +4,19 @@ KOS_CFLAGS += -fstack-protector-all
 
 GCC_MAJOR = $(basename $(basename $(KOS_GCCVER)))
 
-clean:
-	-rm -f $(TARGET) $(OBJS)
-
 ifeq ($(GCC_MAJOR), 4) 
 
-all dist:
-	$(warning GCC4 missing stackprotector patch, skip building example)
+all dist clean:
+	$(warning GCC4 missing stackprotector patch, skipping)
 
 else
 
 all: rm-elf $(TARGET)
 
 include $(KOS_BASE)/Makefile.rules
+
+clean:
+	-rm -f $(TARGET) $(OBJS)
 
 rm-elf:
 	-rm -f $(TARGET)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -9,7 +9,7 @@ SUBDIRS = arch debug fs thread net libc exports
 STUBS = stubs/kernel_export_stubs.o stubs/arch_export_stubs.o
 
 # Everything from here up should be plain old C.
-KOS_CFLAGS += $(KOS_CSTD)
+KOS_CFLAGS += -std=gnu99
 
 all: subdirs $(STUBS)
 	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -9,7 +9,7 @@ SUBDIRS = arch debug fs thread net libc exports
 STUBS = stubs/kernel_export_stubs.o stubs/arch_export_stubs.o
 
 # Everything from here up should be plain old C.
-KOS_CFLAGS += -std=gnu99
+KOS_CFLAGS += $(KOS_CSTD)
 
 all: subdirs $(STUBS)
 	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a

--- a/utils/genexports/genexports.sh
+++ b/utils/genexports/genexports.sh
@@ -25,6 +25,11 @@ rm -f $outpfile
 echo '/* This is a generated file, do not edit!! */' > $outpfile
 echo '#define __EXPORTS_FILE' >> $outpfile
 
+# Allow us to export non-standard POSIX symbols
+echo '#ifdef __STRICT_ANSI__' >> $outpfile
+echo '#undef __STRICT_ANSI__' >> $outpfile
+echo '#endif' >> $outpfile
+
 for i in $includes; do
 	echo "#include <$i>" >> $outpfile
 done

--- a/utils/genexports/genexports.sh
+++ b/utils/genexports/genexports.sh
@@ -30,6 +30,11 @@ for i in $includes; do
 	echo "#include <$i>" >> $outpfile
 done
 
+echo '/* Newlib with GCC 4.7.4 will not export fdopen from stdio.h. */' >> $outpfile
+echo '#if __GNUC__ == 4' >> $outpfile
+echo '	extern FILE* fdopen(int fd, const char* mode);' >> $outpfile
+echo '#endif' >> $outpfile
+
 # Now write out the sym table
 echo "export_sym_t ${outpsym}[] = {" >> $outpfile
 for i in $names; do

--- a/utils/genexports/genexports.sh
+++ b/utils/genexports/genexports.sh
@@ -24,16 +24,10 @@ names=`cat $inpfile | grep -v '^#' | grep -v '^include ' | grep -v '^$' | sort`
 rm -f $outpfile
 echo '/* This is a generated file, do not edit!! */' > $outpfile
 echo '#define __EXPORTS_FILE' >> $outpfile
-echo '#define _POSIX_C_SOURCE 200809' >> $outpfile
 
 for i in $includes; do
 	echo "#include <$i>" >> $outpfile
 done
-
-echo '/* Newlib with GCC 4.7.4 will not export fdopen from stdio.h. */' >> $outpfile
-echo '#if __GNUC__ == 4' >> $outpfile
-echo '	extern FILE* fdopen(int fd, const char* mode);' >> $outpfile
-echo '#endif' >> $outpfile
 
 # Now write out the sym table
 echo "export_sym_t ${outpsym}[] = {" >> $outpfile


### PR DESCRIPTION
This PR is to address the issue found here: https://github.com/KallistiOS/KallistiOS/issues/156.

- The compiler/Newlib config for 4.7.4 was such that the POSIX function "fdopen" was never getting declared in stdio.h when generating the exports file
- Added a preprocessor check for GCC 4 that explicitly declares the function's prototype
- Also fixed a minor issue with the Makefile in the "stackprotector" not defining a rule for "clean" on GCC4, which made top-level "make clean" calls fail out on that example

Verification:
- [x] GCC-4.7.4
- [x] GCC-9.3.0
- [x] GCC-12.2.0