### PR TITLE
Update copyright notice in GCC and Newlib patches

### DIFF
--- a/utils/dc-chain/patches/gcc-12.2.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-12.2.0-kos.diff
@@ -56,7 +56,7 @@ diff --color -ruN gcc-12.2.0/libgcc/config/sh/crt1.S gcc-12.2.0-kos/libgcc/confi
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/gcc-4.7.4-kos.diff
+++ b/utils/dc-chain/patches/gcc-4.7.4-kos.diff
@@ -762,7 +762,7 @@ diff --color -ruN --no-dereference gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-k
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/gcc-9.3.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-9.3.0-kos.diff
@@ -34,7 +34,7 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/historical/gcc-4.4.0-kos.diff
+++ b/utils/dc-chain/patches/historical/gcc-4.4.0-kos.diff
@@ -8,7 +8,7 @@ diff -ruN gcc-4.4.0/gcc/config/sh/crt1.asm gcc-4.4.0-kos/gcc/config/sh/crt1.asm
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/historical/gcc-4.4.4-kos.diff
+++ b/utils/dc-chain/patches/historical/gcc-4.4.4-kos.diff
@@ -8,7 +8,7 @@ diff -ruN gcc-4.4.4/gcc/config/sh/crt1.asm gcc-4.4.4-kos/gcc/config/sh/crt1.asm
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/historical/gcc-4.5.2-kos.diff
+++ b/utils/dc-chain/patches/historical/gcc-4.5.2-kos.diff
@@ -8,7 +8,7 @@ diff -ruN gcc-4.5.2/gcc/config/sh/crt1.asm gcc-4.5.2-kos/gcc/config/sh/crt1.asm
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/historical/gcc-4.7.0-kos.diff
+++ b/utils/dc-chain/patches/historical/gcc-4.7.0-kos.diff
@@ -32,7 +32,7 @@ diff -ruN gcc-4.7.0/libgcc/config/sh/crt1.S gcc-4.7.0-kos/libgcc/config/sh/crt1.
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/historical/gcc-4.7.3-kos.diff
+++ b/utils/dc-chain/patches/historical/gcc-4.7.3-kos.diff
@@ -57,7 +57,7 @@ diff -ruN gcc-4.7.3/libgcc/config/sh/crt1.S gcc-4.7.3-kos/libgcc/config/sh/crt1.
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/historical/gcc-4.8.1-kos.diff
+++ b/utils/dc-chain/patches/historical/gcc-4.8.1-kos.diff
@@ -19,7 +19,7 @@ diff -ruN gcc-4.8.1/libgcc/config/sh/crt1.S gcc-4.8.1-kos/libgcc/config/sh/crt1.
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/historical/gcc-4.8.2-kos.diff
+++ b/utils/dc-chain/patches/historical/gcc-4.8.2-kos.diff
@@ -19,7 +19,7 @@ diff -ruN gcc-4.8.1/libgcc/config/sh/crt1.S gcc-4.8.1-kos/libgcc/config/sh/crt1.
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/historical/gcc-9.2.0-kos.diff
+++ b/utils/dc-chain/patches/historical/gcc-9.2.0-kos.diff
@@ -19,7 +19,7 @@ diff -ruN gcc-9.2.0/libgcc/config/sh/crt1.S gcc-9.2.0-kos/libgcc/config/sh/crt1.
 +! KallistiOS ##version##
 +!
 +! startup.s
-+! (c)2000-2001 Dan Potter
++! (c)2000-2001 Megan Potter
 +!
 +! This file must appear FIRST in your linking order, or your program won't
 +! work correctly as a raw binary.

--- a/utils/dc-chain/patches/historical/newlib-1.18.0-kos.diff
+++ b/utils/dc-chain/patches/historical/newlib-1.18.0-kos.diff
@@ -142,7 +142,7 @@ diff -ruN newlib-1.18.0/newlib/libc/sys/sh/sys/lock.h newlib-1.18.0-kos/newlib/l
 +/* KallistiOS ##version##
 +
 +   lock_common.h
-+   Copyright (C)2004 Dan Potter
++   Copyright (C)2004 Megan Potter
 +
 +*/
 +

--- a/utils/dc-chain/patches/historical/newlib-1.19.0-kos.diff
+++ b/utils/dc-chain/patches/historical/newlib-1.19.0-kos.diff
@@ -142,7 +142,7 @@ diff -ruN newlib-1.19.0-orig/newlib/libc/sys/sh/sys/lock.h newlib-1.19.0/newlib/
 +/* KallistiOS ##version##
 +
 +   lock_common.h
-+   Copyright (C)2004 Dan Potter
++   Copyright (C)2004 Megan Potter
 +
 +*/
 +

--- a/utils/dc-chain/patches/historical/newlib-1.20.0-kos.diff
+++ b/utils/dc-chain/patches/historical/newlib-1.20.0-kos.diff
@@ -142,7 +142,7 @@ diff -ruN newlib-1.20.0/newlib/libc/sys/sh/sys/lock.h newlib-1.20.0-kos/newlib/l
 +/* KallistiOS ##version##
 +
 +   lock_common.h
-+   Copyright (C)2004 Dan Potter
++   Copyright (C)2004 Megan Potter
 +
 +*/
 +

--- a/utils/dc-chain/patches/newlib-2.0.0-kos.diff
+++ b/utils/dc-chain/patches/newlib-2.0.0-kos.diff
@@ -154,7 +154,7 @@ diff -ruN newlib-2.0.0/newlib/libc/sys/sh/sys/lock.h newlib-2.0.0-kos/newlib/lib
 +/* KallistiOS ##version##
 +
 +   lock_common.h
-+   Copyright (C)2004 Dan Potter
++   Copyright (C)2004 Megan Potter
 +
 +*/
 +

--- a/utils/dc-chain/patches/newlib-3.3.0-kos.diff
+++ b/utils/dc-chain/patches/newlib-3.3.0-kos.diff
@@ -270,7 +270,7 @@ diff -ruN newlib-3.3.0/newlib/libc/sys/sh/sys/lock.h newlib-3.3.0-kos/newlib/lib
 +/* KallistiOS ##version##
 +
 +   lock_common.h
-+   Copyright (C)2004 Dan Potter
++   Copyright (C)2004 Megan Potter
 +
 +*/
 +

--- a/utils/dc-chain/patches/newlib-4.1.0-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.1.0-kos.diff
@@ -270,7 +270,7 @@ diff --color -ruN newlib-4.1.0/newlib/libc/sys/sh/sys/lock.h newlib-4.1.0-kos/ne
 +/* KallistiOS ##version##
 +
 +   lock_common.h
-+   Copyright (C)2004 Dan Potter
++   Copyright (C)2004 Megan Potter
 +
 +*/
 +

--- a/utils/dc-chain/patches/newlib-4.3.0.20230120-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.3.0.20230120-kos.diff
@@ -270,7 +270,7 @@ diff --color -ruN newlib-4.3.0.20230120/newlib/libc/sys/sh/sys/lock.h newlib-4.3
 +/* KallistiOS ##version##
 +
 +   lock_common.h
-+   Copyright (C)2004 Dan Potter
++   Copyright (C)2004 Megan Potter
 +
 +*/
 +


### PR DESCRIPTION
This patch updates copyright notices in the GCC and Newlib patches to properly credit the author.