### PR TITLE
Fixed hanging libdream video mode example

### DIFF
--- a/examples/dreamcast/libdream/320x240/320x240.c
+++ b/examples/dreamcast/libdream/320x240/320x240.c
@@ -3,10 +3,12 @@
 #define W 320
 #define H 240
 
-KOS_INIT_FLAGS(INIT_IRQ);
-
 int main(int argc, char **argv) {
     int x, y;
+
+    /* Press all buttons to exit */
+    cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
+                      (void (*)(unsigned char, long  unsigned int))arch_exit);
 
     /* Set the video mode */
     vid_set_mode(DM_320x240, PM_RGB565);
@@ -31,8 +33,9 @@ int main(int argc, char **argv) {
         bfont_draw_str(vram_s + 10 * W + x, W, 0, tmp);
     }
 
-    /* Pause to see the results */
-    usleep(5 * 1000 * 1000);
+    printf("\n\nPress all buttons simultaneously to exit.\n");
+    fflush(stdout);
+    while(1);
 
     return 0;
 }

--- a/examples/dreamcast/libdream/640x480/640x480.c
+++ b/examples/dreamcast/libdream/640x480/640x480.c
@@ -9,6 +9,10 @@
 int main(int argc, char **argv) {
     int x, y;
 
+    /* Press all buttons to exit */
+    cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
+                      (void (*)(unsigned char, long  unsigned int))arch_exit);
+
     /* Bother us with output only if something died */
     dbglog_set_level(DBG_DEAD);
 
@@ -23,8 +27,9 @@ int main(int argc, char **argv) {
                                   | ((c >> 3) << 0);
         }
 
-    /* Pause to see the results */
-    usleep(5 * 1000 * 1000);
+    printf("\n\nPress all buttons simultaneously to exit.\n");
+    fflush(stdout);
+    while(1);
 
     return 0;
 }

--- a/examples/dreamcast/libdream/800x608/800x608.c
+++ b/examples/dreamcast/libdream/800x608/800x608.c
@@ -18,6 +18,10 @@
 int main(int argc, char **argv) {
     int x, y;
 
+    /* Press all buttons to exit */
+    cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
+                      (void (*)(unsigned char, long  unsigned int))arch_exit);
+
     /* Set video mode */
     vid_set_mode(DM_800x608, PM_RGB565);
 
@@ -39,8 +43,9 @@ int main(int argc, char **argv) {
         bfont_draw_str(vram_s + 10 * W + x, W, 0, tmp);
     }
 
-    /* Pause to see the results */
-    usleep(5 * 1000 * 1000);
+    printf("\n\nPress all buttons simultaneously to exit.\n");
+    fflush(stdout);
+    while(1);
 
     return 0;
 }


### PR DESCRIPTION
The 320x240 video resolution mode example in the libdream directory was previously using KOS_INIT_FLAGS(INIT_IRQ), which disabled thread preemption and caused it to hang forever on usleep() rather than returning back to dc-load gracefully

- Removed the init flags
- Added an infinite spin loop
- Enabled the standard "press all button to exit" callback method to exit

Curiously, only 320x240 was broken, but I changed the behavior of the other two to be consistent.