### PR TITLE
Using timer when not in preempt

### DIFF
--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -655,7 +655,7 @@ static void thd_timer_hnd(irq_context_t *context) {
    sleep because it eases the load on the system for the other
    threads. */
 void thd_sleep(int ms) {
-    if(thd_mode == THD_MODE_NONE) {
+    if(thd_mode != THD_MODE_PREEMPT) {
         timer_spin_sleep(ms);
         return;
     }

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -655,7 +655,7 @@ static void thd_timer_hnd(irq_context_t *context) {
    sleep because it eases the load on the system for the other
    threads. */
 void thd_sleep(int ms) {
-    if(thd_mode != THD_MODE_PREEMPT) {
+    if(thd_mode == THD_MODE_NONE) {
         timer_spin_sleep(ms);
         return;
     }
@@ -673,6 +673,10 @@ void thd_sleep(int ms) {
        purposes. 0xffffffff definitely doesn't exist as an object, so we'll
        use that for straight up timeouts. */
     genwait_wait((void *)0xffffffff, "thd_sleep", ms, NULL);
+	
+	/* If in coop mode, send this thread to the scheduler. */
+	if(thd_mode == THD_MODE_COOP)
+		thd_schedule(1,0);
 }
 
 /* Manually cause a re-schedule */


### PR DESCRIPTION
This seems to fix the behavior of usleep in https://github.com/KallistiOS/KallistiOS/blob/1ea31b794b17c758087938cc97b529428fcf1d53/examples/dreamcast/libdream/320x240/320x240.c which is in coop threading mode. The idea is just to use the alternate timer method for sleeping when in any mode but preempt (as opposed to just when threading is not initted).