### PR TITLE
Added support for additional Newlib configuration options

### DIFF
--- a/examples/dreamcast/cpp/clock/Makefile
+++ b/examples/dreamcast/cpp/clock/Makefile
@@ -18,7 +18,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS) romdisk.o
-	kos-c++ -o $(TARGET) $(OBJS) romdisk.o -ldcplib -lm
+	kos-c++ -o $(TARGET) $(OBJS) romdisk.o -ldcplib -lm -std=c++11
 
 romdisk.img:
 	$(KOS_GENROMFS) -f romdisk.img -d romdisk -v

--- a/kernel/arch/dreamcast/include/arch/perfcntr.h
+++ b/kernel/arch/dreamcast/include/arch/perfcntr.h
@@ -1,0 +1,189 @@
+/* KallistiOS ##version##
+
+   arch/dreamcast/include/perfcnter.h
+   (c)2023 Andy Barajas, Falco Girgis
+
+*/
+
+/** \file   arch/perfcnter.h
+    \brief  Hardware performance counter API
+
+    This file contains the API for driving the hardware 
+    performance counter peripherals.
+
+    \author Andy Barajas
+*/
+
+#ifndef __ARCH_PERFCNTER_H
+#define __ARCH_PERFCNTER_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+#include <arch/types.h>
+
+/** \defgroup   perf_counters Performance Counters
+    The performance counter API exposes the SH4's hardware profiling registers, 
+    which consist of two different sets of independently operable 64-bit 
+    counters.  
+    \sa timers
+*/
+
+/** \defgroup perf_counters_sources Performance Counter Sources
+ *  \brief The two sets of performance counter registers 
+ *  \ingroup perf_counters
+ * @{
+ */
+
+ /** \brief  SH4 Performance Counter.
+  * 
+    \note 
+    By default this peformance counter is used to 
+    enable the ns timer and to increase the precision
+    of applicable standard C/C++ timing functions.
+
+    \sa timers
+*/  
+#define PRFC0   0
+
+/** \brief  SH4 Performance Counter.
+   
+    A counter that is not used by KOS.
+*/
+#define PRFC1   1
+/** }@
+ */
+
+/** \defgroup perf_counters_types Performance Counter Cycle Count Type
+ *  \brief Counter type for configuring the performance counters
+ *  \ingroup perf_counters
+ * @{
+ */
+
+/** \brief  CPU Cycles Count Type.
+
+    Count cycles. At 5 ns increments, a 48-bit cycle counter can 
+    run continuously for 16.33 days.
+*/
+#define PMCR_COUNT_CPU_CYCLES 0
+
+/** \brief  Ratio Cycles Count Type.
+    \ingroup perf_counters
+
+    CPU/bus ratio mode where cycles (where T = C x B / 24 and T is time, 
+    C is count, and B is time of one bus cycle).
+*/
+#define PMCR_COUNT_RATIO_CYCLES 1
+/** }@
+ */
+
+/** \defgroup   perf_counters_modes Performance Counter Modes
+ * 
+    This is the list of modes that are allowed to be passed into the perf_cntr_start()
+    function, representing different things you want to count.
+    \ingroup perf_counters
+    @{
+*/
+/*                MODE DEFINITION                  VALUE   MEASURMENT TYPE & NOTES */
+#define PMCR_INIT_NO_MODE                           0x00 /**< \brief None; Just here to be complete */
+#define PMCR_OPERAND_READ_ACCESS_MODE               0x01 /**< \brief Quantity; With cache */
+#define PMCR_OPERAND_WRITE_ACCESS_MODE              0x02 /**< \brief Quantity; With cache */
+#define PMCR_UTLB_MISS_MODE                         0x03 /**< \brief Quantity */
+#define PMCR_OPERAND_CACHE_READ_MISS_MODE           0x04 /**< \brief Quantity */
+#define PMCR_OPERAND_CACHE_WRITE_MISS_MODE          0x05 /**< \brief Quantity */
+#define PMCR_INSTRUCTION_FETCH_MODE                 0x06 /**< \brief Quantity; With cache */
+#define PMCR_INSTRUCTION_TLB_MISS_MODE              0x07 /**< \brief Quantity */
+#define PMCR_INSTRUCTION_CACHE_MISS_MODE            0x08 /**< \brief Quantity */
+#define PMCR_ALL_OPERAND_ACCESS_MODE                0x09 /**< \brief Quantity */
+#define PMCR_ALL_INSTRUCTION_FETCH_MODE             0x0a /**< \brief Quantity */
+#define PMCR_ON_CHIP_RAM_OPERAND_ACCESS_MODE        0x0b /**< \brief Quantity */
+/* No 0x0c */
+#define PMCR_ON_CHIP_IO_ACCESS_MODE                 0x0d /**< \brief Quantity */
+#define PMCR_OPERAND_ACCESS_MODE                    0x0e /**< \brief Quantity; With cache, counts both reads and writes */
+#define PMCR_OPERAND_CACHE_MISS_MODE                0x0f /**< \brief Quantity */
+#define PMCR_BRANCH_ISSUED_MODE                     0x10 /**< \brief Quantity; Not the same as branch taken! */
+#define PMCR_BRANCH_TAKEN_MODE                      0x11 /**< \brief Quantity */
+#define PMCR_SUBROUTINE_ISSUED_MODE                 0x12 /**< \brief Quantity; Issued a BSR, BSRF, JSR, JSR/N */
+#define PMCR_INSTRUCTION_ISSUED_MODE                0x13 /**< \brief Quantity */
+#define PMCR_PARALLEL_INSTRUCTION_ISSUED_MODE       0x14 /**< \brief Quantity */
+#define PMCR_FPU_INSTRUCTION_ISSUED_MODE            0x15 /**< \brief Quantity */
+#define PMCR_INTERRUPT_COUNTER_MODE                 0x16 /**< \brief Quantity */
+#define PMCR_NMI_COUNTER_MODE                       0x17 /**< \brief Quantity */
+#define PMCR_TRAPA_INSTRUCTION_COUNTER_MODE         0x18 /**< \brief Quantity */
+#define PMCR_UBC_A_MATCH_MODE                       0x19 /**< \brief Quantity */
+#define PMCR_UBC_B_MATCH_MODE                       0x1a /**< \brief Quantity */
+/* No 0x1b-0x20 */
+#define PMCR_INSTRUCTION_CACHE_FILL_MODE            0x21 /**< \brief Cycles */
+#define PMCR_OPERAND_CACHE_FILL_MODE                0x22 /**< \brief Cycles */
+#define PMCR_ELAPSED_TIME_MODE                      0x23 /**< \brief Cycles; For 200MHz CPU: 5ns per count in 1 cycle = 1 count mode, or around 417.715ps per count (increments by 12) in CPU/bus ratio mode */
+#define PMCR_PIPELINE_FREEZE_BY_ICACHE_MISS_MODE    0x24 /**< \brief Cycles */
+#define PMCR_PIPELINE_FREEZE_BY_DCACHE_MISS_MODE    0x25 /**< \brief Cycles */
+/* No 0x26 */
+#define PMCR_PIPELINE_FREEZE_BY_BRANCH_MODE         0x27 /**< \brief Cycles */
+#define PMCR_PIPELINE_FREEZE_BY_CPU_REGISTER_MODE   0x28 /**< \brief Cycles */
+#define PMCR_PIPELINE_FREEZE_BY_FPU_MODE            0x29 /**< \brief Cycles */
+/** @} */
+
+/** \brief 5ns per count in 1 cycle = 1 count mode(PMCR_COUNT_CPU_CYCLES) 
+    \ingroup perf_counters
+*/
+#define PMCR_NS_PER_CYCLE      5
+
+/** \brief  Get a performance counter's settings.
+    \ingroup perf_counters
+
+    This function returns a performance counter's settings.
+
+    \param  which           The performance counter (i.e, \ref PRFC0 or PRFC1).
+    \retval 0               On success.
+*/
+uint16 perf_cntr_get_config(int which);
+
+/** \brief  Start a performance counter.
+    \ingroup perf_counters
+
+    This function starts a performance counter
+
+    \param  which           The counter to start (i.e, \ref PRFC0 or PRFC1).
+    \param  mode            Use one of the 33 modes listed above.
+    \param  count_type      PMCR_COUNT_CPU_CYCLES or PMCR_COUNT_RATIO_CYCLES.
+    \retval 0               On success.
+*/
+int perf_cntr_start(int which, int mode, int count_type);
+
+/** \brief  Stop a performance counter.
+    \ingroup perf_counters
+
+    This function stops a performance counter that was started with perf_cntr_start().
+    Stopping a counter retains its count. To clear the count use perf_cntr_clear().
+
+    \param  which           The counter to stop (i.e, \ref PRFC0 or PRFC1).
+    \retval 0               On success.
+*/
+int perf_cntr_stop(int which);
+
+/** \brief  Clear a performance counter.
+    \ingroup perf_counters
+
+    This function clears a performance counter. It resets its count to zero.
+    This function stops the counter before clearing it because you cant clear 
+    a running counter.
+
+    \param  which           The counter to clear (i.e, \ref PRFC0 or PRFC1).
+    \retval 0               On success.
+*/
+int perf_cntr_clear(int which);
+
+/** \brief  Obtain the count of a performance counter.
+    \ingroup perf_counters
+
+    This function simply returns the count of the counter.
+
+    \param  which           The counter to read (i.e, \ref PRFC0 or PRFC1).
+    \return                 The counter's count.
+*/
+uint64 perf_cntr_count(int which);
+
+__END_DECLS
+
+#endif  /* __ARCH_PERFCNTR_H */

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -26,10 +26,27 @@ __BEGIN_DECLS
 #include <arch/types.h>
 #include <arch/irq.h>
 
-/* Timer sources -- we get four on the SH4 */
+/** \defgroup   timers Timers
+ * This API exposes 3 of the 4 hardware timer peripherals.
+ * 
+ * \note 
+ * These timers are used internally by KOS for various
+ * tasks such as thread scheduling and implementing 
+ * high-level timing functions and should not typically
+ * be accessed directly.
+ * 
+ * \note The watchdog timer is not supported.
+ * \sa perf_counters
+*/
 
+/** \defgroup   timer_sources Timer Sources
+    The SH4 has 4 hardware timer peripherals. 
+    The fourth is a watchdog timer, which is unsupported.
+    \ingroup timers
+    @{
+*/
 /** \brief  SH4 Timer 0.
-
+ * 
     This timer is used for thread operation, and thus is off limits if you want
     that to work properly.
 */
@@ -52,11 +69,15 @@ __BEGIN_DECLS
     KallistiOS does not currently support using this timer.
 */
 #define WDT     3
+/** }@ **/
 
-/** \brief  Which timer does the thread system use? */
+/** \brief  Which timer does the thread system use?
+ *  \ingroup timers 
+ **/
 #define TIMER_ID TMU0
 
 /** \brief  Pre-initialize a timer, but do not start it.
+    \ingroup timers
 
     This function sets up a timer for use, but does not start it.
 
@@ -68,6 +89,7 @@ __BEGIN_DECLS
 int timer_prime(int which, uint32 speed, int interrupts);
 
 /** \brief  Start a timer.
+    \ingroup timers
 
     This function starts a timer that has been initialized with timer_prime(),
     starting raising interrupts if applicable.
@@ -78,6 +100,7 @@ int timer_prime(int which, uint32 speed, int interrupts);
 int timer_start(int which);
 
 /** \brief  Stop a timer.
+    \ingroup timers
 
     This function stops a timer that was started with timer_start(), and as a
     result stops interrupts coming in from the timer.
@@ -87,7 +110,8 @@ int timer_start(int which);
 */
 int timer_stop(int which);
 
-/** \brief  Obtain the count of a timer.
+/** \brief  Obtain the count of a timer.   
+    \ingroup timers
 
     This function simply returns the count of the timer.
 
@@ -97,6 +121,7 @@ int timer_stop(int which);
 uint32 timer_count(int which);
 
 /** \brief  Clear the underflow bit of a timer.
+    \ingroup timers
 
     This function clears the underflow bit of a timer if it was set.
 
@@ -116,6 +141,7 @@ int timer_clear(int which);
 void timer_spin_sleep(int ms);
 
 /** \brief  Enable high-priority timer interrupts.
+    \ingroup timers
 
     This function enables interrupts on the specified timer.
 
@@ -124,6 +150,7 @@ void timer_spin_sleep(int ms);
 void timer_enable_ints(int which);
 
 /** \brief  Disable timer interrupts.
+    \ingroup timers
 
     This function disables interrupts on the specified timer.
 
@@ -132,6 +159,7 @@ void timer_enable_ints(int which);
 void timer_disable_ints(int which);
 
 /** \brief  Check whether interrupts are enabled on a timer.
+    \ingroup timers
 
     This function checks whether or not interrupts are enabled on the specified
     timer.
@@ -143,21 +171,24 @@ void timer_disable_ints(int which);
 int timer_ints_enabled(int which);
 
 /** \brief  Enable the millisecond timer.
+    \ingroup timers
 
     This function enables the timer used for the gettime functions. This is on
     by default. These functions use \ref TMU2 to do their work.
 */
-void timer_ms_enable();
+void timer_ms_enable(void);
 
 /** \brief  Disable the millisecond timer.
+    \ingroup timers
 
     This function disables the timer used for the gettime functions. Generally,
     you will not want to do this, unless you have some need to use the timer
     \ref TMU2 for something else.
 */
-void timer_ms_disable();
+void timer_ms_disable(void);
 
 /** \brief  Get the current uptime of the system.
+    \ingroup timers
 
     This function retrieves the number of seconds and milliseconds since KOS was
     started.
@@ -173,6 +204,7 @@ void timer_ms_disable();
 void timer_ms_gettime(uint32 *secs, uint32 *msecs);
 
 /** \brief  Get the current uptime of the system (in milliseconds).
+    \ingroup timers
 
     This function retrieves the number of milliseconds since KOS was started. It
     is equivalent to calling timer_ms_gettime() and combining the number of
@@ -180,9 +212,10 @@ void timer_ms_gettime(uint32 *secs, uint32 *msecs);
 
     \return                 The number of milliseconds since KOS started.
 */
-uint64 timer_ms_gettime64();
+uint64 timer_ms_gettime64(void);
 
 /** \brief  Get the current uptime of the system (in microseconds).
+    \ingroup timers
 
     This function retrieves the number of microseconds since KOS was started. It
     should be more precise, in theory, than timer_ms_gettime64(), but the exact
@@ -190,12 +223,48 @@ uint64 timer_ms_gettime64();
 
     \return                 The number of microseconds since KOS started.
 */
-uint64 timer_us_gettime64();
+uint64 timer_us_gettime64(void);
 
-/** \brief  Primary timer callback type. */
+/** \brief  Enable the nanosecond timer.
+    \ingroup timers
+
+    This function enables the performance counter used for the timer_ns_gettime64() 
+    function. This is on by default. The function uses \ref PRFC0 to do the work.
+
+    \sa perf_counters
+*/
+void timer_ns_enable(void);
+
+/** \brief  Disable the nanosecond timer.
+    \ingroup timers
+
+    This function disables the performance counter used for the timer_ns_gettime64() 
+    function. Generally, you will not want to do this, unless you have some need to use 
+    the counter \ref PRFC0 for something else.
+
+    \sa perf_counters
+*/
+void timer_ns_disable(void);
+
+/** \brief  Get the current uptime of the system (in nanoseconds).
+    \ingroup timers
+
+    This function retrieves the number of nanoseconds since KOS was started.
+
+    \return                 The number of nanoseconds since KOS started.
+
+    \sa perf_counters
+*/
+uint64 timer_ns_gettime64(void);
+
+
+/** \brief  Primary timer callback type.
+ *  \ingroup timers
+ **/
 typedef void (*timer_primary_callback_t)(irq_context_t *);
 
 /** \brief  Set the primary timer callback.
+    \ingroup timers
 
     This function sets the primary timer callback to the specified function
     pointer. Generally, you should not do this, as the threading system relies
@@ -207,6 +276,7 @@ typedef void (*timer_primary_callback_t)(irq_context_t *);
 timer_primary_callback_t timer_primary_set_callback(timer_primary_callback_t callback);
 
 /** \brief  Request a primary timer wakeup.
+    \ingroup timers
 
     This function will wake the caller (by calling the primary timer callback)
     in approximately the number of milliseconds specified. You can only have one
@@ -218,35 +288,47 @@ timer_primary_callback_t timer_primary_set_callback(timer_primary_callback_t cal
 void timer_primary_wakeup(uint32 millis);
 
 /* \cond */
-/* Init function */
-int timer_init();
+/* Init function. Automatically called by KOS during initialization */
+int timer_init(void);
 
-/* Shutdown */
-void timer_shutdown();
+/* Shutdown function. Automatically called by KOS during shutdown */
+void timer_shutdown(void);
 /* \endcond */
 
 /** \defgroup   perf_counters Performance Counters
     The performance counter API exposes the SH4's hardware profiling registers, 
     which consist of two different sets of independently operable 64-bit 
     counters.  
+    \sa timers
 */
 
-/** \brief  SH4 Performance Counter.
-    \ingroup perf_counters
+/** \defgroup perf_counters_sources
+ *  \brief Performance Counter Sources 
+ *  \ingroup perf_counters
+ * @{
+ */
 
-    This counter is used by the ns_gettime function in this header.
-*/
+ /** \brief  SH4 Performance Counter.
+  * 
+    \note 
+    By default this peformance counter is used to 
+    enable the ns timer and to increase the precision
+    of applicable standard C/C++ timing functions.
+
+    \sa timers
+*/  
 #define PRFC0   0
 
 /** \brief  SH4 Performance Counter.
-    \ingroup perf_counters
-
+   
     A counter that is not used by KOS.
 */
 #define PRFC1   1
+/** }@
+ */
 
 /** \brief  CPU Cycles Count Type.
-    \ingroup perf_counters
+    \inroup perf_counters
 
     Count cycles. At 5 ns increments, a 48-bit cycle counter can 
     run continuously for 16.33 days.
@@ -363,31 +445,6 @@ int perf_cntr_clear(int which);
 */
 uint64 perf_cntr_count(int which);
 
-/** \brief  Enable the nanosecond timer.
-    \ingroup perf_counters
-
-    This function enables the performance counter used for the timer_ns_gettime64() 
-    function. This is on by default. The function uses \ref PRFC0 to do the work.
-*/
-void timer_ns_enable();
-
-/** \brief  Disable the nanosecond timer.
-    \ingroup perf_counters
-
-    This function disables the performance counter used for the timer_ns_gettime64() 
-    function. Generally, you will not want to do this, unless you have some need to use 
-    the counter \ref PRFC0 for something else.
-*/
-void timer_ns_disable();
-
-/** \brief  Get the current uptime of the system (in nanoseconds).
-    \ingroup perf_counters
-
-    This function retrieves the number of nanoseconds since KOS was started.
-
-    \return                 The number of nanoseconds since KOS started.
-*/
-uint64 timer_ns_gettime64();
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -27,15 +27,31 @@ __BEGIN_DECLS
 #include <arch/irq.h>
 
 /** \defgroup   timers Timers
+ *  \brief Driver for Hardware Timer Peripherals
  * This API exposes 3 of the 4 hardware timer peripherals.
+ * The peripherals are used by KOS to implement the various
+ * timing query functions. The 4th timer is the Watchdog timer,
+ * and is not supported by KOS.
  * 
- * \note 
+ * \warning 
  * These timers are used internally by KOS for various
  * tasks such as thread scheduling and implementing 
  * high-level timing functions and should not typically
- * be accessed directly.
+ * be reconfigured or manipulated directly. Instead, you
+ * should simply be utilizing the various high-level 
+ * gettime queries, if you wish to use this API directly:
  * 
- * \note The watchdog timer is not supported.
+ * - timer_ms_gettime()
+ * - timer_us_gettime()
+ * - timer_ns_gettime()
+ * 
+ * \note
+ * Ideally, as an application-level developer, you would 
+ * not ever need to directly use this API within your code.
+ * This API is utilized by our Newlib implementation, 
+ * allowing you to leverage them via platform independent
+ * C or C++ standard library (time/chrono) or POSIX calls.
+ * 
  * \sa perf_counters
 */
 

--- a/kernel/arch/dreamcast/kernel/Makefile
+++ b/kernel/arch/dreamcast/kernel/Makefile
@@ -10,7 +10,7 @@
 # that minimum set must be present.
 
 COPYOBJS = banner.o cache.o entry.o irq.o init.o mm.o panic.o
-COPYOBJS += rtc.o timer.o
+COPYOBJS += rtc.o timer.o perfcntr.o
 COPYOBJS += init_flags_default.o init_romdisk_default.o
 COPYOBJS += mmu.o itlb.o
 COPYOBJS += exec.o execasm.o stack.o gdb_stub.o thdswitch.o arch_exports.o

--- a/kernel/arch/dreamcast/kernel/perfcntr.c
+++ b/kernel/arch/dreamcast/kernel/perfcntr.c
@@ -1,0 +1,53 @@
+/* KallistiOS ##version##
+
+   perfcntr.c
+   Copyright (c)2003 Andy Barajas
+*/
+
+#include <arch/perfcntr.h>
+
+/* Quick access macros */
+#define PMCR_CTRL(o)  ( *((volatile uint16*)(0xff000084) + (o << 1)) )
+#define PMCTR_HIGH(o) ( *((volatile uint32*)(0xff100004) + (o << 1)) )
+#define PMCTR_LOW(o)  ( *((volatile uint32*)(0xff100008) + (o << 1)) )
+
+#define PMCR_CLR        0x2000
+#define PMCR_PMST       0x4000
+#define PMCR_PMENABLE   0x8000
+#define PMCR_RUN        0xc000
+#define PMCR_PMM_MASK   0x003f
+
+#define PMCR_CLOCK_TYPE_SHIFT 8
+
+/* Get a counter's current configuration */
+uint16 perf_cntr_get_config(int which) {
+    return PMCR_CTRL(which);
+}
+
+/* Start a performance counter */
+int perf_cntr_start(int which, int mode, int count_type) {
+    perf_cntr_clear(which);
+    PMCR_CTRL(which) = PMCR_RUN | mode | (count_type << PMCR_CLOCK_TYPE_SHIFT);
+    
+    return 0;
+}
+
+/* Stop a performance counter */
+int perf_cntr_stop(int which) {
+    PMCR_CTRL(which) &= ~(PMCR_PMM_MASK | PMCR_PMENABLE);
+
+    return 0;
+}
+
+/* Clears a performance counter.  Has to stop it first. */
+int perf_cntr_clear(int which) {
+    perf_cntr_stop(which);
+    PMCR_CTRL(which) |= PMCR_CLR;
+
+    return 0;
+}
+
+/* Returns the count value of a counter */
+uint64 perf_cntr_count(int which) {
+    return (uint64)(PMCTR_HIGH(which) & 0xffff) << 32 | PMCTR_LOW(which);
+}

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -204,6 +204,33 @@ uint64 timer_us_gettime64(void) {
     return usec;
 }
 
+void timer_ns_enable(void) {
+    perf_cntr_start(PRFC0, PMCR_ELAPSED_TIME_MODE, PMCR_COUNT_CPU_CYCLES);
+}
+
+void timer_ns_disable(void) {
+    const uint16 config = perf_cntr_get_config(PRFC0);
+
+    /* If timer is running, disable it */
+    if((config & PMCR_ELAPSED_TIME_MODE)) {
+        perf_cntr_clear(PRFC0);
+    }
+}
+
+uint64 timer_ns_gettime64(void) {
+    const uint16 config = perf_cntr_get_config(PRFC0);
+
+    /* If timer is running */
+    if((config & PMCR_ELAPSED_TIME_MODE)) {
+        uint64 cycles = perf_cntr_count(PRFC0);
+        return cycles * PMCR_NS_PER_CYCLE;
+    }
+    else {
+        uint64 micro_secs = timer_us_gettime64();
+        return micro_secs * 1000;
+    }
+}
+
 /* Primary kernel timer. What we'll do here is handle actual timer IRQs
    internally, and call the callback only after the appropriate number of
    millis has passed. For the DC you can't have timers spaced out more
@@ -313,80 +340,3 @@ void timer_shutdown(void) {
     timer_disable_ints(TMU1);
     timer_disable_ints(TMU2);
 }
-
-/* Quick access macros */
-#define PMCR_CTRL(o)  ( *((volatile uint16*)(0xff000084) + (o << 1)) )
-#define PMCTR_HIGH(o) ( *((volatile uint32*)(0xff100004) + (o << 1)) )
-#define PMCTR_LOW(o)  ( *((volatile uint32*)(0xff100008) + (o << 1)) )
-
-#define PMCR_CLR        0x2000
-#define PMCR_PMST       0x4000
-#define PMCR_PMENABLE   0x8000
-#define PMCR_RUN        0xc000
-#define PMCR_PMM_MASK   0x003f
-
-#define PMCR_CLOCK_TYPE_SHIFT 8
-
-/* 5ns per count in 1 cycle = 1 count mode(PMCR_COUNT_CPU_CYCLES) */
-#define NS_PER_CYCLE      5
-
-/* Get a counter's current configuration */
-uint16 perf_cntr_get_config(int which) {
-    return PMCR_CTRL(which);
-}
-
-/* Start a performance counter */
-int perf_cntr_start(int which, int mode, int count_type) {
-    perf_cntr_clear(which);
-    PMCR_CTRL(which) = PMCR_RUN | mode | (count_type << PMCR_CLOCK_TYPE_SHIFT);
-    
-    return 0;
-}
-
-/* Stop a performance counter */
-int perf_cntr_stop(int which) {
-    PMCR_CTRL(which) &= ~(PMCR_PMM_MASK | PMCR_PMENABLE);
-
-    return 0;
-}
-
-/* Clears a performance counter.  Has to stop it first. */
-int perf_cntr_clear(int which) {
-    perf_cntr_stop(which);
-    PMCR_CTRL(which) |= PMCR_CLR;
-
-    return 0;
-}
-
-/* Returns the count value of a counter */
-inline uint64 perf_cntr_count(int which) {
-    return (uint64)(PMCTR_HIGH(which) & 0xffff) << 32 | PMCTR_LOW(which);
-}
-
-void timer_ns_enable(void) {
-    perf_cntr_start(PRFC0, PMCR_ELAPSED_TIME_MODE, PMCR_COUNT_CPU_CYCLES);
-}
-
-void timer_ns_disable(void) {
-    uint16 config = PMCR_CTRL(PRFC0);
-
-    /* If timer is running, disable it */
-    if((config & PMCR_ELAPSED_TIME_MODE)) {
-        perf_cntr_clear(PRFC0);
-    }
-}
-
-inline uint64 timer_ns_gettime64(void) {
-    uint16 config = PMCR_CTRL(PRFC0);
-
-    /* If timer is running */
-    if((config & PMCR_ELAPSED_TIME_MODE)) {
-        uint64 cycles = perf_cntr_count(PRFC0);
-        return cycles * NS_PER_CYCLE;
-    }
-    else {
-        uint64 micro_secs = timer_us_gettime64();
-        return micro_secs * 1000;
-    }
-}
-

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -219,10 +219,20 @@ void timer_ns_gettime(uint32 *secs, uint32 *nsecs) {
     const uint16 config = perf_cntr_get_config(PRFC0);
     
     /* If nanosecond timer is running */
-    if((config & PMCR_ELAPSED_TIME_MODE)) {
+    if(1/*(config & PMCR_ELAPSED_TIME_MODE)*/) {
         /* Perform both modulo and division simultaneously */ 
-        const lldiv_t result = lldiv(timer_ns_gettime64(), 1000000000);
-        
+    #if 1
+        const uint64 time = timer_ns_gettime64();
+        struct {
+            uint32 quot;
+            uint32 rem;
+        } result = {
+            time / 1000000000,
+            time % 1000000000
+        };
+        #else 
+        //const lldiv_t result = lldiv(timer_ns_gettime64(), 1000000000);
+        #endif
         if(secs) 
             *secs = (uint32)result.quot;
         if(nsecs)
@@ -240,13 +250,13 @@ uint64 timer_ns_gettime64(void) {
     const uint16 config = perf_cntr_get_config(PRFC0);
 
     /* If timer is running */
-    if((config & PMCR_ELAPSED_TIME_MODE)) {
-        uint64 cycles = perf_cntr_count(PRFC0);
+    if(1/*(config & PMCR_ELAPSED_TIME_MODE)*/) {
+        const uint64 cycles = perf_cntr_count(PRFC0);
         return cycles * PMCR_NS_PER_CYCLE;
     }
     else {
-        uint64 micro_secs = timer_us_gettime64();
-        return micro_secs * 1000;
+        const uint64 milli_secs = timer_ms_gettime64();
+        return milli_secs * 1000000;
     }
 }
 

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <arch/arch.h>
 #include <arch/timer.h>
+#include <arch/perfcntr.h>
 #include <arch/irq.h>
 
 /* Quick access macros */
@@ -148,7 +149,7 @@ static void timer_ms_handler(irq_t source, irq_context_t *context) {
     timer_ms_counter++;
 }
 
-void timer_ms_enable() {
+void timer_ms_enable(void) {
     irq_set_handler(EXC_TMU2_TUNI2, timer_ms_handler);
     timer_prime(TMU2, 1, 1);
     timer_ms_countdown = timer_count(TMU2);
@@ -156,7 +157,7 @@ void timer_ms_enable() {
     timer_start(TMU2);
 }
 
-void timer_ms_disable() {
+void timer_ms_disable(void) {
     timer_stop(TMU2);
     timer_disable_ints(TMU2);
 }
@@ -177,7 +178,7 @@ void timer_ms_gettime(uint32 *secs, uint32 *msecs) {
     }
 }
 
-uint64 timer_ms_gettime64() {
+uint64 timer_ms_gettime64(void) {
     uint32 s, ms;
     uint64 msec;
 
@@ -187,7 +188,7 @@ uint64 timer_ms_gettime64() {
     return msec;
 }
 
-uint64 timer_us_gettime64() {
+uint64 timer_us_gettime64(void) {
     uint32 cnt, scnt;
     uint64 usec;
     uint64 used;
@@ -239,7 +240,7 @@ static void tp_handler(irq_t src, irq_context_t * cxt) {
 }
 
 /* Enable / Disable primary kernel timer */
-static void timer_primary_init() {
+static void timer_primary_init(void) {
     /* Clear out our vars */
     tp_callback = NULL;
 
@@ -248,7 +249,7 @@ static void timer_primary_init() {
     timer_clear(TMU0);
 }
 
-static void timer_primary_shutdown() {
+static void timer_primary_shutdown(void) {
     timer_stop(TMU0);
     timer_disable_ints(TMU0);
     irq_set_handler(EXC_TMU0_TUNI0, NULL);
@@ -287,9 +288,8 @@ void timer_primary_wakeup(uint32 millis) {
     }
 }
 
-
 /* Init */
-int timer_init() {
+int timer_init(void) {
     /* Disable all timers */
     TIMER8(TSTR) = 0;
 
@@ -303,7 +303,7 @@ int timer_init() {
 }
 
 /* Shutdown */
-void timer_shutdown() {
+void timer_shutdown(void) {
     /* Shutdown primary timer stuff */
     timer_primary_shutdown();
 
@@ -363,11 +363,11 @@ inline uint64 perf_cntr_count(int which) {
     return (uint64)(PMCTR_HIGH(which) & 0xffff) << 32 | PMCTR_LOW(which);
 }
 
-void timer_ns_enable() {
+void timer_ns_enable(void) {
     perf_cntr_start(PRFC0, PMCR_ELAPSED_TIME_MODE, PMCR_COUNT_CPU_CYCLES);
 }
 
-void timer_ns_disable() {
+void timer_ns_disable(void) {
     uint16 config = PMCR_CTRL(PRFC0);
 
     /* If timer is running, disable it */
@@ -376,7 +376,7 @@ void timer_ns_disable() {
     }
 }
 
-inline uint64 timer_ns_gettime64() {
+inline uint64 timer_ns_gettime64(void) {
     uint16 config = PMCR_CTRL(PRFC0);
 
     /* If timer is running */

--- a/kernel/libc/c11/timespec_get.c
+++ b/kernel/libc/c11/timespec_get.c
@@ -10,11 +10,11 @@
 
 int timespec_get(struct timespec *ts, int base) {
     if(base == TIME_UTC && ts) {
-        uint32 s, ms;
+        uint32 s, ns;
 
-        timer_ms_gettime(&s, &ms);
+        timer_ns_gettime(&s, &ns);
         ts->tv_sec = rtc_boot_time() + s;
-        ts->tv_nsec = ms * 1000 * 1000;
+        ts->tv_nsec = ns;
 
         return base;
     }

--- a/kernel/libc/newlib/newlib_gettimeofday.c
+++ b/kernel/libc/newlib/newlib_gettimeofday.c
@@ -13,16 +13,16 @@
 
 /* This is kind of approximate and works only with "localtime" */
 int _gettimeofday_r(void * re, struct timeval *tv, struct timezone *tz) {
-    uint32  m, s;
+    uint32  u, s;
 
     (void)re;
     (void)tz;
 
     assert(tv != NULL);
 
-    timer_ms_gettime(&s, &m);
+    timer_us_gettime(&s, &u);
     tv->tv_sec = rtc_boot_time() + s;
-    tv->tv_usec = m * 1000;
+    tv->tv_usec = u;
 
     return 0;
 }

--- a/utils/dc-chain/config.mk.legacy.sample
+++ b/utils/dc-chain/config.mk.legacy.sample
@@ -132,6 +132,18 @@ thread_model=kos
 # This may be useful only if you plan to debug the toolchain itself.
 install_mode=install-strip
 
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types. 
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance. 
+#newlib_opt_space=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config.mk.stable.sample
+++ b/utils/dc-chain/config.mk.stable.sample
@@ -132,6 +132,18 @@ thread_model=kos
 # This may be useful only if you plan to debug the toolchain itself.
 install_mode=install-strip
 
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types. 
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance. 
+#newlib_opt_space=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config.mk.testing.sample
+++ b/utils/dc-chain/config.mk.testing.sample
@@ -132,6 +132,18 @@ thread_model=kos
 # This may be useful only if you plan to debug the toolchain itself.
 install_mode=install-strip
 
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types. 
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance. 
+#newlib_opt_space=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -137,3 +137,15 @@ ifeq (kos,$(thread_model))
     $(error kos thread model is unsupported when KOS patches are disabled)
   endif
 endif
+
+ifdef newlib_c99_formats
+  ifneq (0,$(newlib_c99_formats))
+    newlib_extra_configure_args += --enable-newlib-io-c99-formats
+  endif
+endif
+
+ifdef newlib_opt_space
+  ifneq (0,$(newlib_opt_space))
+    newlib_extra_configure_args += --enable-target-optspace
+  endif
+endif

--- a/utils/dc-chain/scripts/newlib.mk
+++ b/utils/dc-chain/scripts/newlib.mk
@@ -17,6 +17,7 @@ $(build_newlib): logdir
 	    --target=$(target) \
 	    --prefix=$(prefix) \
 	    $(extra_configure_args) \
+	    $(newlib_extra_configure_args) \
 	    CC_FOR_TARGET="$(SH_CC_FOR_TARGET)" \
 	    $(to_log)
 	$(MAKE) $(makejobs) -C $(build) DESTDIR=$(DESTDIR) $(to_log)


### PR DESCRIPTION
Newlib supports additional configuration options which may be desirable for Dreamcast targets. I have added support for two of these, which I think will be useful to have when configuring the toolchains.

**1. Support for Additional C99 Format Specifiers**
C99 actually supports a myriad of extra formatting options for printf and friends, beyond what we've had available to us. For example, C99 supports formatters for types such as size_t, ptrdiff_t, and intmax_t plus sized integers like uint16_t, uint32_t, etc. It also has support for a few more things like printing floats as hexadecimal values. I actually personally use these in my own codebase and am always annoyed at DC being the only configuration where I don't have them.

Here's an example I just wrote to illustrate:
```
#include <inttypes.h>

size_t size = 1234; ptrdiff_t ptrdiff = 0xdeadbabe; uint16_t half = 37;
printf("SOME C99 FORMATTERS: %zu %tu %"PRIu16" %A\n", size, ptrdiff, half, -124.00012131);
```
Output before enabling C99 formatters: `SOME C99 FORMATTERS: zu tu llu A`
Output after enabling C99 formatters: `SOME C99 FORMATTERS: 1234 3735927486 37 -0X1.F0002P+6`

**2. Small Space Optimizations**
This tells Newlib to configure itself to be built with `-Os`, favoring small size. Since this is our whole standard library, this may actually be useful for people who are writing bootloaders or for people who are just not relying heavily on the standard library and would rather conserve space with it. 

