### PR TITLE
Added toolchain support for additional Newlib config options

### DIFF
--- a/utils/dc-chain/config.mk.legacy.sample
+++ b/utils/dc-chain/config.mk.legacy.sample
@@ -132,6 +132,18 @@ thread_model=kos
 # This may be useful only if you plan to debug the toolchain itself.
 install_mode=install-strip
 
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types.
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance.
+#newlib_opt_space=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config.mk.stable.sample
+++ b/utils/dc-chain/config.mk.stable.sample
@@ -132,6 +132,18 @@ thread_model=kos
 # This may be useful only if you plan to debug the toolchain itself.
 install_mode=install-strip
 
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types.
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance.
+#newlib_opt_space=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config.mk.testing.sample
+++ b/utils/dc-chain/config.mk.testing.sample
@@ -132,6 +132,18 @@ thread_model=kos
 # This may be useful only if you plan to debug the toolchain itself.
 install_mode=install-strip
 
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types.
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance.
+#newlib_opt_space=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -137,3 +137,15 @@ ifeq (kos,$(thread_model))
     $(error kos thread model is unsupported when KOS patches are disabled)
   endif
 endif
+
+ifdef newlib_c99_formats
+  ifneq (0,$(newlib_c99_formats))
+    newlib_extra_configure_args += --enable-newlib-io-c99-formats
+  endif
+endif
+
+ifdef newlib_opt_space
+  ifneq (0,$(newlib_opt_space))
+    newlib_extra_configure_args += --enable-target-optspace
+  endif
+endif

--- a/utils/dc-chain/scripts/newlib.mk
+++ b/utils/dc-chain/scripts/newlib.mk
@@ -17,6 +17,7 @@ $(build_newlib): logdir
 	    --target=$(target) \
 	    --prefix=$(prefix) \
 	    $(extra_configure_args) \
+	    $(newlib_extra_configure_args) \
 	    CC_FOR_TARGET="$(SH_CC_FOR_TARGET)" \
 	    $(to_log)
 	$(MAKE) $(makejobs) -C $(build) DESTDIR=$(DESTDIR) $(to_log)


### PR DESCRIPTION
Newlib supports additional configuration options which may be desirable for Dreamcast targets. I have added support for two of these, which I think will be useful to have when configuring the toolchains.

**1. Support for Additional C99 Format Specifiers**
C99 actually supports a myriad of extra formatting options for printf and friends, beyond what we've had available to us. For example, C99 supports formatters for types such as size_t, ptrdiff_t, and intmax_t plus sized integers like uint16_t, uint32_t, etc. It also has support for a few more things like printing floats as hexadecimal values. I actually personally use these in my own codebase and am always annoyed at DC being the only configuration where I don't have them.

Here's an example I just wrote to illustrate:
```
#include <inttypes.h>

size_t size = 1234; ptrdiff_t ptrdiff = 3735927486; uint16_t half = 37;
printf("SOME C99 FORMATTERS: %zu %tu %"PRIu16" %A\n", size, ptrdiff, half, -124.00012131);
```
Output before enabling C99 formatters: `SOME C99 FORMATTERS: zu tu llu A`
Output after enabling C99 formatters: `SOME C99 FORMATTERS: 1234 3735927486 37 -0X1.F0002P+6`

**2. Small Space Optimizations**
This tells Newlib to configure itself to be built with -Os, favoring small size. Since this is our whole standard library, this may actually be useful for people who are writing bootloaders or for people who are just not relying heavily on the standard library and would rather conserve space with it.