### PR TITLE
RTC cleanup, documentation, setting date/time

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -163,6 +163,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Add support for compiling with LTO [Paul Cercueil == PC]
 - DC  Fixed calling newlib's exit after returning from main so functions
       registered with atexit() are called [Colton Pawielski == CP]
+- *** Cleaned up + documented RTC driver, added support for setting time [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/kernel/arch/dreamcast/include/arch/rtc.h
+++ b/kernel/arch/dreamcast/include/arch/rtc.h
@@ -83,7 +83,7 @@ time_t rtc_unix_secs(void);
 */
 int rtc_set_unix_secs(time_t time);
 
-/** \brief   Get the time somce the sytem was booted.
+/** \brief   Get the time since the sytem was booted.
     \ingroup rtc
 
     This function retrieves the cached RTC value from when KallistiOS was started. As

--- a/kernel/arch/dreamcast/include/arch/rtc.h
+++ b/kernel/arch/dreamcast/include/arch/rtc.h
@@ -92,7 +92,7 @@ __BEGIN_DECLS
 
 /** \brief Timestamp write enable
 
-    \ref{RTC_CTRL_ADDR} value to be written in order to unlock
+    #RTC_CTRL_ADDR value to be written in order to unlock
     writing to the timestamp registers.
 */
 #define RTC_CTRL_WRITE_EN         (1 << 0)

--- a/kernel/arch/dreamcast/include/arch/rtc.h
+++ b/kernel/arch/dreamcast/include/arch/rtc.h
@@ -28,7 +28,7 @@ __BEGIN_DECLS
 #include <time.h>
 
 /** \defgroup rtc Real-Time Clock
-    \brief Real-Time Clock Management 
+    \brief Real-Time Clock (RTC) Management
 
     Provides an API for fetching and managing the date/time using
     the Dreamcast's real-time clock. All timestamps are in standard
@@ -54,6 +54,48 @@ __BEGIN_DECLS
     Y2K and the last timestamp it can represent before rolling over is 
     February 06 2086 06:28:15. 
 */
+
+/** \defgroup rtc_regs Registers
+    \brief    RTC registers
+    \ingroup  rtc
+
+    All registers are located on the G2 BUS and must be read and
+    written to as full 32-byte values.
+@{*/
+
+/** \brief High 16-bit timestamp value
+
+    32-bit register containing the upper 16-bits of
+    the 32-bit timestamp in seconds. Only the lower 16-bits
+    are valid.
+
+    \note Writing to this register will lock the timestamp registers.
+ */
+#define RTC_TIMESTAMP_HIGH_ADDR   0xa0710000
+
+/** \brief Low 16-bit timestamp value
+
+    32-bit register containing the lower 16-bits of
+    the 32-bit timestamp in seconds. Only the lower 16-bits
+    are valid.
+ */
+#define RTC_TIMESTAMP_LOW_ADDR    0xa0710004
+
+/** \brief Timestamp control register
+
+    All fields are reserved except for #RTC_CTRL_WRITE_EN,
+    which is write-only.
+ */
+#define RTC_CTRL_ADDR             0xa0710008
+/**
+@} */
+
+/** \brief Timestamp write enable
+
+    \ref{RTC_CTRL_ADDR} value to be written in order to unlock
+    writing to the timestamp registers.
+*/
+#define RTC_CTRL_WRITE_EN         (1 << 0)
 
 /** \brief   Get the current date/time.
     \ingroup rtc

--- a/kernel/arch/dreamcast/include/arch/rtc.h
+++ b/kernel/arch/dreamcast/include/arch/rtc.h
@@ -2,11 +2,13 @@
 
    arch/dreamcast/include/rtc.h
    (c)2000-2001 Megan Potter
+   (c)2023 Falco Girgis
 
 */
 
-/** \file   arch/rtc.h
-    \brief  Low-level real time clock functionality.
+/** \file    arch/rtc.h
+    \brief   Low-level real time clock functionality.
+    \ingroup rtc
 
     This file contains functions for interacting with the real time clock in the
     Dreamcast. Generally, you should prefer interacting with the higher level
@@ -23,29 +25,78 @@ __BEGIN_DECLS
 
 #include <time.h>
 
-/** \brief  Get the current date/time.
+/** \defgroup rtc Real-Time Clock
+    \brief Real-Time Clock Management 
+
+    Provides an API for fetching and managing the date/time using
+    the Dreamcast's real-time clock. All timestamps are in standard
+    Unix format, with an epoch of January 1, 1970. Due to the fact
+    that there is no time zone data on the RTC, all times are expected
+    to be in the local time zone.
+
+    \note
+    The RTC that is used by the DC is located on the AICA rather than SH4, 
+    presumably for power-efficiency reasons. Because of this, accessing 
+    it requires a trip over the G2 BUS, which is notoriously slow.
+
+    \note 
+    For reading the current date/time, you should favor the standard C,
+    C++, or POSIX functions, as they are platform-indpendent and are 
+    calculating current time based on a cached boot time plus a delta
+    that is maintained by the timer subsystem, rather than actually
+    having to requery the RTC over the G2 BUS, so they are faster.
+
+    \warning
+    Internally, the RTC's date/time is maintained using a 32-bit counter 
+    with an epoch of January 1, 1950 00:00. Because of this, the Dreamcast's
+    Y2K and the last timestamp it can represent before rolling over is 
+    February 06 2086 06:28:15. 
+*/
+
+/** \brief   Get the current date/time.
+    \ingroup rtc
 
     This function retrieves the current RTC value as a standard UNIX timestamp
     (with an epoch of January 1, 1970 00:00). This is assumed to be in the
     timezone of the user (as the RTC does not support timezones).
 
     \return                 The current UNIX-style timestamp (local time).
+
+    \sa rtc_set_unix_secs(), rtc_boot_time()
 */
-time_t rtc_unix_secs();
+time_t rtc_unix_secs(void);
 
-/** \brief  Get the time that the sytem was booted.
+/** \brief   Get the current date/time.
+    \ingroup rtc
 
-    This function retrieves the RTC value from when KallistiOS was started. As
+    This function sets the current RTC value as a standard UNIX timestamp
+    (with an epoch of January 1, 1970 00:00). This is assumed to be in the
+    timezone of the user (as the RTC does not support timezones).
+
+    \param time             Unix timestamp to set the current time to
+
+    \return                 0 for success or -1 for failure
+
+    \sa rtc_unix_secs()
+*/
+int rtc_set_unix_secs(time_t time);
+
+/** \brief   Get the time that the sytem was booted.
+    \ingroup rtc
+
+    This function retrieves the cached RTC value from when KallistiOS was started. As
     with rtc_unix_secs(), this is a UNIX-style timestamp in local time.
 
     \return                 The boot time as a UNIX-style timestamp.
+
+    \sa rtc_boot_time()
 */
-time_t rtc_boot_time();
+time_t rtc_boot_time(void);
 
 /* \cond */
-/* Init / Shutdown */
-int rtc_init();
-void rtc_shutdown();
+/* Internally called Init / Shutdown */
+int rtc_init(void);
+void rtc_shutdown(void);
 /* \endcond */
 
 __END_DECLS

--- a/kernel/arch/dreamcast/include/arch/rtc.h
+++ b/kernel/arch/dreamcast/include/arch/rtc.h
@@ -1,20 +1,22 @@
 /* KallistiOS ##version##
 
    arch/dreamcast/include/rtc.h
-   (c)2000-2001 Megan Potter
-   (c)2023 Falco Girgis
+   Copyright (C) 2000-2001 Megan Potter
+   Copyright (C) 2023 Falco Girgis
 
 */
 
 /** \file    arch/rtc.h
-    \brief   Low-level real time clock functionality.
+    \brief   Low-level real-time clock functionality.
     \ingroup rtc
 
-    This file contains functions for interacting with the real time clock in the
+    This file contains functions for interacting with the real-time clock in the
     Dreamcast. Generally, you should prefer interacting with the higher level
-    standard C functions, like time(), rather than these.
+    standard C functions, like time(), rather than these when simply needing
+    to fetch the current system time.
 
     \author Megan Potter
+    \author Falco Girgis
 */
 
 #ifndef __ARCH_RTC_H
@@ -81,7 +83,7 @@ time_t rtc_unix_secs(void);
 */
 int rtc_set_unix_secs(time_t time);
 
-/** \brief   Get the time that the sytem was booted.
+/** \brief   Get the time somce the sytem was booted.
     \ingroup rtc
 
     This function retrieves the cached RTC value from when KallistiOS was started. As
@@ -89,7 +91,7 @@ int rtc_set_unix_secs(time_t time);
 
     \return                 The boot time as a UNIX-style timestamp.
 
-    \sa rtc_boot_time()
+    \sa rtc_unix_secs()
 */
 time_t rtc_boot_time(void);
 

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -3,7 +3,7 @@
    rtc.c
    Copyright (C) 2001 Megan Potter
    Copyright (C) 2023 Falco Girgis
-   Copyright (C) 2023 SWAT
+   Copyright (C) 2023 Ruslan Rostovtsev
    Copyright (C) 2023 Megavolt85
 */
 

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -97,7 +97,7 @@ int rtc_set_unix_secs(time_t secs) {
 
     /* Signify failure if the fetched time never matched the
        time we attempted to set. */
-    if(i == 3)
+    if(i == RTC_RETRY_COUNT)
         result = -1;
 
     /* We have to update the boot time now as well, subtracting

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -76,7 +76,7 @@ int rtc_set_unix_secs(time_t secs) {
     const uint32_t adjusted = secs + RTC_UNIX_EPOCH_DELTA;
 
     /* Enable writing by setting LSB of control */
-    g2_write_32(RTC_CTRL_ADDR, 0x1);
+    g2_write_32(RTC_CTRL_ADDR, RTC_CTRL_WRITE_EN);
 
     /* Try 3 times to ensure we didn't write a value then have 
        the clock increment itself before the next. */

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -7,7 +7,7 @@
    Copyright (C) 2023 Megavolt85
 */
 
-/* Real Time Clock support
+/* Real-Time Clock (RTC) support
 
    The functions in here return various info about the real-world time and
    date stored in the machine. The general process here is to retrieve
@@ -28,9 +28,6 @@
 #include <arch/timer.h>
 #include <dc/g2bus.h>
 
-#define RTC_CONTROL_ADDR        0xa0710008  /* SFR with write-enable bit */
-#define RTC_SECONDS_HIGH_ADDR   0xa0710000  /* Upper 16 bits of timestamp */
-#define RTC_SECONDS_LOW_ADDR    0xa0710004  /* Lower 16 bits of timestamp */
 #define RTC_UNIX_EPOCH_DELTA    631152000   /* Twenty years in seconds */
 #define RTC_RETRY_COUNT         3           /* # of times to repeat on bad access */
 
@@ -49,14 +46,14 @@ time_t rtc_unix_secs(void) {
 
     for(;;) {
         for(i = 0; i < RTC_RETRY_COUNT; i++) {
-            rtcnew = ((g2_read_32(RTC_SECONDS_HIGH_ADDR) & 0xffff) << 16) | 
-                      (g2_read_32(RTC_SECONDS_LOW_ADDR) & 0xffff);
+            rtcnew = ((g2_read_32(RTC_TIMESTAMP_HIGH_ADDR) & 0xffff) << 16) |
+                      (g2_read_32(RTC_TIMESTAMP_LOW_ADDR) & 0xffff);
 
             if(rtcnew != rtcold)
                 break;
         }
 
-        if(i < 3)
+        if(i < RTC_RETRY_COUNT)
             rtcold = rtcnew;
         else
             break;
@@ -79,19 +76,18 @@ int rtc_set_unix_secs(time_t secs) {
     const uint32_t adjusted = secs + RTC_UNIX_EPOCH_DELTA;
 
     /* Enable writing by setting LSB of control */
-    g2_write_32(RTC_CONTROL_ADDR, 0x1);
+    g2_write_32(RTC_CTRL_ADDR, 0x1);
 
     /* Try 3 times to ensure we didn't write a value then have 
        the clock increment itself before the next. */
     for(i = 0; i < RTC_RETRY_COUNT; i++) { 
         /* Write the least-significant 16-bits first, because 
            writing to the high 16-bits will lock RTC writes. */
-        g2_write_32(RTC_SECONDS_LOW_ADDR, (adjusted) & 0xffff);
-        g2_write_32(RTC_SECONDS_HIGH_ADDR, (adjusted >> 16) & 0xffff);
+        g2_write_32(RTC_TIMESTAMP_LOW_ADDR, (adjusted) & 0xffff);
+        g2_write_32(RTC_TIMESTAMP_HIGH_ADDR, (adjusted >> 16) & 0xffff);
 
         /* Read the time back again, to ensure it was written properly. */
-        rtcnew = ((g2_read_32(RTC_SECONDS_HIGH_ADDR) & 0xffff) << 16) | 
-                  (g2_read_32(RTC_SECONDS_LOW_ADDR) & 0xffff);
+        rtcnew = rtc_unix_secs() + RTC_UNIX_EPOCH_DELTA;
 
         if(rtcnew == adjusted)
             break;

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -2,6 +2,7 @@
 
    rtc.c
    (c)2001 Megan Potter
+   (c)2023 Falco Girgis
 */
 
 /* Real Time Clock support
@@ -22,13 +23,20 @@
  */
 
 #include <arch/rtc.h>
+#include <arch/timer.h>
 #include <dc/g2bus.h>
+
+#define RTC_CONTROL_ADDR        0xa0710008  /* SFR with write-enable bit */
+#define RTC_SECONDS_HIGH_ADDR   0xa0710000  /* Upper 16 bits of timestamp */
+#define RTC_SECONDS_LOW_ADDR    0xa0710004  /* Lower 16 bits of timestamp */
+#define RTC_UNIX_EPOCH_DELTA    631152000   /* Twenty years in seconds */
+#define RTC_RETRY_COUNT         3           /* # of times to repeat on bad access */
 
 /* The boot time; we'll save this in rtc_init() */
 static time_t boot_time = 0;
 
 /* Returns the date/time value as a UNIX epoch time stamp */
-time_t rtc_unix_secs() {
+time_t rtc_unix_secs(void) {
     uint32 rtcold, rtcnew;
     int i;
 
@@ -38,8 +46,9 @@ time_t rtc_unix_secs() {
     rtcold = 0;
 
     for(;;) {
-        for(i = 0; i < 3; i++) {
-            rtcnew = ((g2_read_32(0xa0710000) & 0xffff) << 16) | (g2_read_32(0xa0710004) & 0xffff);
+        for(i = 0; i < RTC_RETRY_COUNT; i++) {
+            rtcnew = ((g2_read_32(RTC_SECONDS_HIGH_ADDR) & 0xffff) << 16) | 
+                      (g2_read_32(RTC_SECONDS_LOW_ADDR) & 0xffff);
 
             if(rtcnew != rtcold)
                 break;
@@ -52,23 +61,66 @@ time_t rtc_unix_secs() {
     }
 
     /* Subtract out 20 years */
-    rtcnew = rtcnew - 631152000;
+    rtcnew = rtcnew - RTC_UNIX_EPOCH_DELTA;
 
     return rtcnew;
 }
 
+/* Sets the date/time value from a UNIX epoch time stamp, 
+   returning 0 for success or -1 for failure. */
+int rtc_set_unix_secs(time_t secs) {
+    int result = 0;
+    uint32_t rtcnew;
+    int i;
+
+    /* Adjust by 20 years to get to the expected RTC time. */
+    const uint32_t adjusted = secs + RTC_UNIX_EPOCH_DELTA;
+
+    /* Enable writing by setting LSB of control */
+    g2_write_32(RTC_CONTROL_ADDR, 0x1);
+
+    /* Try 3 times to ensure we didn't write a value then have 
+       the clock increment itself before the next. */
+    for(i = 0; i < RTC_RETRY_COUNT; i++) { 
+        /* Write the least-significant 16-bits first, because 
+           writing to the high 16-bits will lock RTC writes. */
+        g2_write_32(RTC_SECONDS_LOW_ADDR, (adjusted) & 0xffff);
+        g2_write_32(RTC_SECONDS_HIGH_ADDR, (adjusted >> 16) & 0xffff);
+
+        /* Read the time back again, to ensure it was written properly. */
+        rtcnew = ((g2_read_32(RTC_SECONDS_HIGH_ADDR) & 0xffff) << 16) | 
+                  (g2_read_32(RTC_SECONDS_LOW_ADDR) & 0xffff);
+
+        if(rtcnew == adjusted)
+            break;
+    }
+
+    /* Signify failure if the fetched time never matched the
+       time we attempted to set. */
+    if(i == 3)
+        result = -1;
+
+    /* We have to update the boot time now as well, subtracting
+       the amount of time that has elapsed since boot from the 
+       new time we've just set. */
+    uint32 s, ms;
+    timer_ms_gettime(&s, &ms);
+    boot_time = rtcnew - RTC_UNIX_EPOCH_DELTA - s;
+
+    return result;
+}
 
 /* Returns the date/time that the system was booted as a UNIX epoch time
    stamp. Adding this to the value from timer_ms_gettime() will
-   produce a current timestamp. */
-time_t rtc_boot_time() {
+   produce a current timestamp without needing the trip over the G2 BUS. */
+time_t rtc_boot_time(void) {
     return boot_time;
 }
 
-int rtc_init() {
+int rtc_init(void) {
     boot_time = rtc_unix_secs();
     return 0;
 }
 
-void rtc_shutdown() {
+void rtc_shutdown(void) {
 }

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -1,8 +1,10 @@
 /* KallistiOS ##version##
 
    rtc.c
-   (c)2001 Megan Potter
-   (c)2023 Falco Girgis
+   Copyright (C) 2001 Megan Potter
+   Copyright (C) 2023 Falco Girgis
+   Copyright (C) 2023 SWAT
+   Copyright (C) 2023 Metavolt85
 */
 
 /* Real Time Clock support

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -4,7 +4,7 @@
    Copyright (C) 2001 Megan Potter
    Copyright (C) 2023 Falco Girgis
    Copyright (C) 2023 SWAT
-   Copyright (C) 2023 Metavolt85
+   Copyright (C) 2023 Megavolt85
 */
 
 /* Real Time Clock support


### PR DESCRIPTION
I have been referencing the RTC a bunch with the date/time work for Newlib and now the NS timer stuff with the perf counters that I'm working on... I noticed the docs could be fleshed out better and there was no way to SET the date/time. 

- Improved Doxygen documentation for RTC, adding more information on it and a new module
- Added support for setting the date/time
- Removed magic numbers
- Added a #define for configuring retry attempts for read/write failures
- Added explicit `(void)` argument lists for type checking parameters properly in plain C
- Tested on my own DC, ensuring that the cached boot time was updated properly as well and that standard C date/time functions behave properly with change