### PR TITLE
Fixed missing header from rtc.c

### DIFF
--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -27,6 +27,7 @@
 #include <arch/rtc.h>
 #include <arch/timer.h>
 #include <dc/g2bus.h>
+#include <stdint.h>
 
 #define RTC_UNIX_EPOCH_DELTA    631152000   /* Twenty years in seconds */
 #define RTC_RETRY_COUNT         3           /* # of times to repeat on bad access */


### PR DESCRIPTION
- stdint.h was missing, but it only manifested on GCC-4.7.4.

SORRY, GUYS! 