### PR TITLE
Correct a number of whitespace issue.

### DIFF
--- a/include/kos/nmmgr.h
+++ b/include/kos/nmmgr.h
@@ -128,7 +128,7 @@ int nmmgr_handler_remove(nmmgr_handler_t *hnd);
 /** \cond */
 /* Name manager init */
 int nmmgr_init(void);
-void    nmmgr_shutdown(void);
+void nmmgr_shutdown(void);
 /** \endcond */
 
 __END_DECLS

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -34,13 +34,13 @@ static spinlock_t mutex = SPINLOCK_INITIALIZER;
 
 #define plain_dclsc(...) ({ \
         int old = 0, rv; \
-        if (!irq_inside_int()) { \
+        if(!irq_inside_int()) { \
             old = irq_disable(); \
         } \
-        while ((*(vuint32 *)0xa05f688c) & 0x20) \
+        while((*(vuint32 *)0xa05f688c) & 0x20) \
             ; \
         rv = dcloadsyscall(__VA_ARGS__); \
-        if (!irq_inside_int()) \
+        if(!irq_inside_int()) \
             irq_restore(old); \
         rv; \
     })
@@ -51,7 +51,7 @@ static void * lwip_dclsc = 0;
 
 #define dclsc(...) ({ \
         int rv; \
-        if (lwip_dclsc) \
+        if(lwip_dclsc) \
             rv = (*(int (*)()) lwip_dclsc)(__VA_ARGS__); \
         else \
             rv = plain_dclsc(__VA_ARGS__); \
@@ -534,7 +534,7 @@ int fs_dcload_init(void) {
     if((dcload_type == DCLOAD_TYPE_IP) && (__kos_init_flags & INIT_NET)) {
         dbglog(DBG_INFO, "dc-load console+kosnet, will switch to internal ethernet\n");
         return -1;
-        /* if (old_printk) {
+        /* if(old_printk) {
             dbgio_set_printk(old_printk);
             old_printk = 0;
         }

--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -685,7 +685,7 @@ static ssize_t iso_read(void * h, void *buf, size_t bytes) {
            here commented out in case we could find a better use
            for it later than speed (i.e., preventing thread context
            switches). */
-        /* if (thissect == 2048 && toread >= 2048) {
+        /* if(thissect == 2048 && toread >= 2048) {
             // Round it off to an even sector count
             thissect = toread / 2048;
             toread = thissect * 2048;
@@ -694,7 +694,7 @@ static ssize_t iso_read(void * h, void *buf, size_t bytes) {
                 thissect);
 
             // Do the read
-            if (cdrom_read_sectors(outbuf,
+            if(cdrom_read_sectors(outbuf,
                 fh[fd].first_extent + fh[fd].ptr/2048 + 150,
                 thissect) < 0)
             {

--- a/kernel/arch/dreamcast/fs/vmufs.c
+++ b/kernel/arch/dreamcast/fs/vmufs.c
@@ -754,7 +754,7 @@ int vmufs_write(maple_device_t * dev, const char * fn, void * inbuf, int insize,
 
     /* Write out the data and update our structs */
     if((st = vmufs_file_write(dev, &root, fat, dir, &nd, inbuf, insize / 512)) < 0) {
-        if (st == -2)
+        if(st == -2)
             rv = -7;
         else
             rv = -4;

--- a/kernel/arch/dreamcast/hardware/biosfont.c
+++ b/kernel/arch/dreamcast/hardware/biosfont.c
@@ -176,7 +176,7 @@ uint16 *bfont_draw_one_row(uint16 *b, uint16 word, uint8 opaque, uint32 fg, uint
     uint16 write16 = 0x0000;
     uint16 oldcolor = *b;
 
-    if ((bpp == 4)||(bpp == 8)) {
+    if((bpp == 4)||(bpp == 8)) {
         /* For 4 or 8bpp we have to go 2 or 4 pixels at a time to properly write out in all cases. */
         uint8 bMask = (bpp==4) ? 0xf : 0xff;
         uint8 pix = 16/bpp;
@@ -217,21 +217,21 @@ unsigned char bfont_draw_ex(uint8 *buffer, uint32 bufwidth, uint32 fg, uint32 bg
     uint8 y;
 
     /* If they're requesting a wide char and in the wrong format, kick this out */
-    if (wide && (bfont_code_mode == BFONT_CODE_ISO8859_1)) {
+    if(wide && (bfont_code_mode == BFONT_CODE_ISO8859_1)) {
         dbglog(DBG_ERROR, "bfont_draw_ex: can't draw wide in bfont mode %d\n", bfont_code_mode);
         return 0;
     }
 
     /* Just making sure we can draw the character we want to */
-    if (bufwidth < (uint32)(BFONT_THIN_WIDTH*(wide+1))) {
+    if(bufwidth < (uint32)(BFONT_THIN_WIDTH*(wide+1))) {
         dbglog(DBG_ERROR, "bfont_draw_ex: buffer is too small to draw into\n");
         return 0;
     }
 
     /* Translate the character */
-    if (bfont_code_mode == BFONT_CODE_RAW)
+    if(bfont_code_mode == BFONT_CODE_RAW)
         ch = get_font_address() + c;
-    else if (wide && ((bfont_code_mode == BFONT_CODE_EUC) || (bfont_code_mode == BFONT_CODE_SJIS)))
+    else if(wide && ((bfont_code_mode == BFONT_CODE_EUC) || (bfont_code_mode == BFONT_CODE_SJIS)))
         ch = bfont_find_char_jp(c);
     else {
         if(iskana)
@@ -260,7 +260,7 @@ unsigned char bfont_draw_ex(uint8 *buffer, uint32 bufwidth, uint32 fg, uint32 bg
     }
 
     /* Return the horizontal distance covered in bytes */
-    if (wide)
+    if(wide)
         return (BFONT_WIDE_WIDTH*bpp)/8;
     else
         return (BFONT_THIN_WIDTH*bpp)/8;

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -106,7 +106,7 @@ int cdrom_set_sector_size(int size) {
 int cdrom_exec_cmd(int cmd, void *param) {
     int status[4] = {0};
     int f, n;
-    
+
     mutex_lock(&_g1_ata_mutex);
 
     /* Make sure to select the GD-ROM drive. */
@@ -122,8 +122,9 @@ int cdrom_exec_cmd(int cmd, void *param) {
         if(n == PROCESSING)
             thd_pass();
     }
-    while(n == PROCESSING);
-    
+    while(n == PROCESSING)
+        ;
+
     mutex_unlock(&_g1_ata_mutex);
 
     if(n == COMPLETED)
@@ -278,7 +279,7 @@ int cdrom_reinit_ex(int sector_part, int cdxa, int sector_size) {
 
     r = cdrom_change_datatype(sector_part, cdxa, sector_size);
     mutex_unlock(&_g1_ata_mutex);
-    
+
     return r;
 }
 
@@ -324,7 +325,7 @@ int cdrom_read_sectors_ex(void *buffer, int sector, int cnt, int mode) {
     */
     if(mode == CDROM_READ_DMA)
         rv = cdrom_exec_cmd(CMD_DMAREAD, &params);
-    else if (mode == CDROM_READ_PIO)
+    else if(mode == CDROM_READ_PIO)
         rv = cdrom_exec_cmd(CMD_PIOREAD, &params);
 
     mutex_unlock(&_g1_ata_mutex);

--- a/kernel/arch/dreamcast/hardware/maple/dreameye.c
+++ b/kernel/arch/dreamcast/hardware/maple/dreameye.c
@@ -126,7 +126,7 @@ int dreameye_get_image_count(maple_device_t *dev, int block) {
         /* Wait for the Dreameye to accept it */
         if(genwait_wait(&dev->frame, "dreameye_get_image_count", 500,
                         NULL) < 0) {
-            if(dev->frame.state != MAPLE_FRAME_VACANT)  {
+            if(dev->frame.state != MAPLE_FRAME_VACANT) {
                 /* Something went wrong... */
                 dev->frame.state = MAPLE_FRAME_VACANT;
                 dbglog(DBG_ERROR, "dreameye_get_image_count: timeout to unit "
@@ -239,7 +239,7 @@ static int dreameye_get_transfer_count(maple_device_t *dev, uint8 img) {
     /* Wait for the Dreameye to accept it */
     if(genwait_wait(&dev->frame, "dreameye_get_transfer_count", 500,
                     NULL) < 0) {
-        if(dev->frame.state != MAPLE_FRAME_VACANT)  {
+        if(dev->frame.state != MAPLE_FRAME_VACANT) {
             /* Something went wrong... */
             dev->frame.state = MAPLE_FRAME_VACANT;
             dbglog(DBG_ERROR, "dreameye_get_transfer_count: timeout to unit "

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -467,55 +467,55 @@ static void kbd_check_poll(maple_frame_t *frm) {
     for(i = 0; i < MAX_PRESSED_KEYS; i++) {
 
         /* Once we get to a 'none', the rest will be 'none' */
-		if (cond->keys[i] == KBD_KEY_NONE){
-			/* This could be used to indicate how many keys are pressed by setting it to ~i or i+1
-				or similar. This could be useful, but would make it a weird exception. */
-			/* If the first key in the key array is none, there are no non-modifer keys pressed at all. */
-			if (i==0)state->matrix[KBD_KEY_NONE] = KEY_STATE_PRESSED;
-			break;
-		}
+        if(cond->keys[i] == KBD_KEY_NONE) {
+            /* This could be used to indicate how many keys are pressed by setting it to ~i or i+1 
+                or similar. This could be useful, but would make it a weird exception. */
+            /* If the first key in the key array is none, there are no non-modifer keys pressed at all. */
+            if(i==0) state->matrix[KBD_KEY_NONE] = KEY_STATE_PRESSED;
+            break;
+        }
         /* Between None and A are error indicators. This would be a good place to do... something. If an error occurs the whole array will be error.*/
-		else if (cond->keys[i]>KBD_KEY_NONE && cond->keys[i]<KBD_KEY_A) {
+        else if(cond->keys[i]>KBD_KEY_NONE && cond->keys[i]<KBD_KEY_A) {
             state->matrix[cond->keys[i]] = KEY_STATE_PRESSED;
             break;
         }
         /* The rest of the keys are treated normally */
         else {
             /* If the key hadn't been pressed. */
-			if (state->matrix[cond->keys[i]] == KEY_STATE_NONE){
-				state->matrix[cond->keys[i]] = KEY_STATE_PRESSED;
-				kbd_enqueue(state, cond->keys[i], mods);
-				state->kbd_repeat_key = cond->keys[i];
-				state->kbd_repeat_timer = timer_ms_gettime64() + kbd_repeat_start;
-			}
-			/* If the key was already being pressed and was our one allowed repeating key, then... */
-			else if (state->matrix[cond->keys[i]] == KEY_STATE_WAS_PRESSED){
-				state->matrix[cond->keys[i]] = KEY_STATE_PRESSED;
-				if (state->kbd_repeat_key == cond->keys[i]){
-					uint64 time = timer_ms_gettime64();
-					/* We have passed the prescribed amount of time, and will repeat the key */
-					if(time >= (state->kbd_repeat_timer)){
-						kbd_enqueue(state, cond->keys[i], mods);
-						state->kbd_repeat_timer = time + kbd_repeat_interval;
-					}
-				}
-			}
-			else assert_msg(0, "invalid key matrix array detected");
+            if(state->matrix[cond->keys[i]] == KEY_STATE_NONE) {
+                state->matrix[cond->keys[i]] = KEY_STATE_PRESSED;
+                kbd_enqueue(state, cond->keys[i], mods);
+                state->kbd_repeat_key = cond->keys[i];
+                state->kbd_repeat_timer = timer_ms_gettime64() + kbd_repeat_start;
+            }
+            /* If the key was already being pressed and was our one allowed repeating key, then... */
+            else if(state->matrix[cond->keys[i]] == KEY_STATE_WAS_PRESSED) {
+                state->matrix[cond->keys[i]] = KEY_STATE_PRESSED;
+                if(state->kbd_repeat_key == cond->keys[i]) {
+                    uint64 time = timer_ms_gettime64();
+                    /* We have passed the prescribed amount of time, and will repeat the key */
+                    if(time >= (state->kbd_repeat_timer)) {
+                        kbd_enqueue(state, cond->keys[i], mods);
+                        state->kbd_repeat_timer = time + kbd_repeat_interval;
+                    }
+                }
+            }
+            else assert_msg(0, "invalid key matrix array detected");
         }
     }
 
     /* Now normalize the key matrix */
     /* If it was determined no keys are pressed, wipe the matrix */
-	if (state->matrix[KBD_KEY_NONE] == KEY_STATE_PRESSED)
+    if(state->matrix[KBD_KEY_NONE] == KEY_STATE_PRESSED)
         memset (state->matrix, KEY_STATE_NONE, MAX_KBD_KEYS);
     /* Otherwise, walk through the whole matrix */
     else    {
         for(i = 0; i < MAX_KBD_KEYS; i++) {
-            if (state->matrix[i] == KEY_STATE_NONE) continue;
+            if(state->matrix[i] == KEY_STATE_NONE) continue;
 
-           else if (state->matrix[i] == KEY_STATE_WAS_PRESSED) state->matrix[i] = KEY_STATE_NONE;
+            else if(state->matrix[i] == KEY_STATE_WAS_PRESSED) state->matrix[i] = KEY_STATE_NONE;
 
-            else if (state->matrix[i] == KEY_STATE_PRESSED)	state->matrix[i] = KEY_STATE_WAS_PRESSED;
+            else if(state->matrix[i] == KEY_STATE_PRESSED) state->matrix[i] = KEY_STATE_WAS_PRESSED;
             else assert_msg(0, "invalid key matrix array detected");
         }
     }
@@ -588,8 +588,8 @@ static int kbd_attach(maple_driver_t *drv, maple_device_t *dev) {
     /* Retrieve the region data */
     state->region = dev->info.function_data[d] & 0xFF;
 
-    if (state->region > KBD_NUM_KEYMAPS)
-        /* Unrecognized keyboards will appear as US keyboards... */
+    /* Unrecognized keyboards will appear as US keyboards... */
+    if(state->region > KBD_NUM_KEYMAPS)
         state->region = KBD_REGION_US;
 
     /* Make sure all the queue variables are set up properly... */

--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -14,7 +14,7 @@
 /* Be warned, not all purus are created equal, in fact, most of
    them act different for just about everything you feed to them. */
 
-static void purupuru_rumble_cb(maple_frame_t *frame)    {
+static void purupuru_rumble_cb(maple_frame_t *frame) {
     /* Unlock the frame */
     maple_frame_unlock(frame);
 
@@ -46,7 +46,7 @@ int purupuru_rumble_raw(maple_device_t *dev, uint32 effect) {
 
     /* Wait for the purupuru to accept it */
     if(genwait_wait(&dev->frame, "purupuru_rumble_raw", 500, NULL) < 0) {
-        if(dev->frame.state != MAPLE_FRAME_VACANT)  {
+        if(dev->frame.state != MAPLE_FRAME_VACANT) {
             /* Something went wrong.... */
             dev->frame.state = MAPLE_FRAME_VACANT;
             dbglog(DBG_ERROR, "purupuru_rumble_raw: timeout to unit %c%c\n",
@@ -87,7 +87,7 @@ int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect) {
 
     /* Wait for the purupuru to accept it */
     if(genwait_wait(&dev->frame, "purupuru_rumble", 500, NULL) < 0) {
-        if(dev->frame.state != MAPLE_FRAME_VACANT)  {
+        if(dev->frame.state != MAPLE_FRAME_VACANT) {
             /* Something went wrong.... */
             dev->frame.state = MAPLE_FRAME_VACANT;
             dbglog(DBG_ERROR, "purupuru_rumble: timeout to unit %c%c\n",

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -155,7 +155,7 @@ int vmu_beep_raw(maple_device_t * dev, uint32 beep) {
 
     /* Wait for the timer to accept it */
     if(genwait_wait(&dev->frame, "vmu_beep_raw", 500, NULL) < 0) {
-        if(dev->frame.state != MAPLE_FRAME_VACANT)  {
+        if(dev->frame.state != MAPLE_FRAME_VACANT) {
             /* Something went wrong.... */
             dev->frame.state = MAPLE_FRAME_VACANT;
             dbglog(DBG_ERROR, "vmu_beep_raw: timeout to unit %c%c, beep: %lu\n",

--- a/kernel/arch/dreamcast/hardware/modem/mintr.c
+++ b/kernel/arch/dreamcast/hardware/modem/mintr.c
@@ -609,7 +609,7 @@ void modemIntShutdown(void) {
 #define dspSetClear8(addr, mask, clear)\
     {\
         data = dspRead8(addr);\
-        if (!(clear))\
+        if(!(clear))\
             data |= mask;\
         else\
             data &= ~mask;\

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -423,9 +423,9 @@ static void g2_read_block_8(uint8 *dst, uint8 *src, int len) {
     G2_LOCK(old1, old2);
 
     /* This is in case dst is not multiple of 4, which never happens here */
-    /*     while ( (((uint32)dst)&3) ) { */
+    /*     while( (((uint32)dst)&3) ) { */
     /*       *dst++ = *src++; */
-    /*       if (!--len) */
+    /*       if(!--len) */
     /*  return; */
     /*     } */
 
@@ -637,7 +637,7 @@ static int bba_tx(const uint8 * pkt, int len, int wait)
     /*
        int i;
 
-    printf("Transmitting packet:\r\n"); for (i=0; i<len; i++) { printf("%02x ", pkt[i]); if (i
+    printf("Transmitting packet:\r\n"); for(i=0; i<len; i++) { printf("%02x ", pkt[i]); if(i
        && !(i % 16)) printf("\r\n"); } printf("\r\n");
     */
 
@@ -783,7 +783,7 @@ static void bba_rx(void) {
             break;
         }
 
-        /*     if ( ( ( g2_read_16(NIC(RT_RXBUFHEAD)) - ring_offset ) & (RX_BUFFER_LEN-1)) < */
+        /*     if( ( ( g2_read_16(NIC(RT_RXBUFHEAD)) - ring_offset ) & (RX_BUFFER_LEN-1)) < */
         /*   ( (rx_size+4+3) & (RX_BUFFER_LEN-3-1) )) { */
         /*       //dbglog(DBG_KDEBUG, "bba: oops\n"); */
         /*       break; */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_fog_tables.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_fog_tables.h
@@ -179,7 +179,7 @@ int main () {
     float value, f = 0.0F;
     int i = 0;
     printf("static float exp_table[FOG_EXP_TABLE_SIZE] = {\n\t");
-    for ( ; i < FOG_EXP_TABLE_SIZE ; i++, f += FOG_INCR) {
+    for( ; i < FOG_EXP_TABLE_SIZE ; i++, f += FOG_INCR) {
         value = (float) exp(-f);
         printf("%01.8f, %s", value, ((i+1)%4)?" ":"\n\t");
     }

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
@@ -350,7 +350,7 @@ int public_pvr_mALLOPt(int p, int v) {
         INTERNAL_SIZE_T* mzp = (INTERNAL_SIZE_T*)(charp);                           \
         unsigned long mctmp = (nbytes)/sizeof(INTERNAL_SIZE_T);                     \
         long mcn;                                                                   \
-        if (mctmp < 8) mcn = 0; else { mcn = (mctmp-1)/8; mctmp %= 8; }             \
+        if(mctmp < 8) mcn = 0; else { mcn = (mctmp-1)/8; mctmp %= 8; }             \
         switch (mctmp) {                                                            \
             case 0: for(;;) { *mzp++ = 0;                                             \
                 case 7:           *mzp++ = 0;                                             \
@@ -612,7 +612,7 @@ nextchunk-> +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /*  Same, except also perform argument check */
 
 #define checked_request2size(req, sz)                             \
-    if (REQUEST_OUT_OF_RANGE(req)) {                                \
+    if(REQUEST_OUT_OF_RANGE(req)) {                                \
         MALLOC_FAILURE_ACTION;                                        \
         return 0;                                                     \
     }                                                               \
@@ -1221,7 +1221,7 @@ static void do_check_inuse_chunk(p) mchunkptr p;
       Since more things can be checked with free chunks than inuse ones,
       if an inuse chunk borders them and debug is on, it's worth doing them.
     */
-    if(!prev_inuse(p))  {
+    if(!prev_inuse(p)) {
         /* Note that we cannot even look at prev unless it is not inuse */
         mchunkptr prv = prev_chunk(p);
         assert(next_chunk(prv) == p);
@@ -2095,7 +2095,7 @@ Void_t* mALLOc(bytes) size_t bytes;
                 unlink(victim, bck, fwd);
 
                 /* Exhaust */
-                if(remainder_size < MINSIZE)  {
+                if(remainder_size < MINSIZE) {
                     set_inuse_bit_at_offset(victim, size);
                     check_malloced_chunk(victim, nb);
                     return chunk2mem(victim);
@@ -3446,13 +3446,13 @@ void pvr_int_mem_reset(void) {
     void *ptr = 0;
     static void *sbrk_top = 0;
 
-    if (size > 0)
+    if(size > 0)
     {
-      if (size < MINIMUM_MORECORE_SIZE)
+      if(size < MINIMUM_MORECORE_SIZE)
          size = MINIMUM_MORECORE_SIZE;
-      if (CurrentExecutionLevel() == kTaskLevel)
+      if(CurrentExecutionLevel() == kTaskLevel)
          ptr = PoolAllocateResident(size + RM_PAGE_SIZE, 0);
-      if (ptr == 0)
+      if(ptr == 0)
       {
         return (void *) MORECORE_FAILURE;
       }
@@ -3463,7 +3463,7 @@ void pvr_int_mem_reset(void) {
       sbrk_top = (char *) ptr + size;
       return ptr;
     }
-    else if (size < 0)
+    else if(size < 0)
     {
       // we don't currently support shrink behavior
       return (void *) MORECORE_FAILURE;
@@ -3481,8 +3481,8 @@ void pvr_int_mem_reset(void) {
   {
     void **ptr;
 
-    for (ptr = our_os_pools; ptr < &our_os_pools[MAX_POOL_ENTRIES]; ptr++)
-      if (*ptr)
+    for(ptr = our_os_pools; ptr < &our_os_pools[MAX_POOL_ENTRIES]; ptr++)
+      if(*ptr)
       {
          PoolDeallocate(*ptr);
          *ptr = 0;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.h
@@ -998,12 +998,12 @@ struct mallinfo public_pvr_mALLINFo();
   struct Node* build_list() {
     struct Node** pool;
     int n = read_number_of_nodes_needed();
-    if (n <= 0) return 0;
+    if(n <= 0) return 0;
     pool = (struct Node**)(independent_calloc(n, sizeof(struct Node), 0);
-    if (pool == 0) die();
+    if(pool == 0) die();
     // organize into a linked list...
     struct Node* first = pool[0];
-    for (i = 0; i < n-1; ++i)
+    for(i = 0; i < n-1; ++i)
       pool[i]->next = pool[i+1];
     free(pool);     // Can now free the array (or not, if it is needed later)
     return first;
@@ -1058,7 +1058,7 @@ Void_t** public_pvr_iCALLOc();
     int msglen = strlen(msg);
     size_t sizes[3] = { sizeof(struct Head), msglen, sizeof(struct Foot) };
     void* chunks[3];
-    if (independent_comalloc(3, sizes, chunks) == 0)
+    if(independent_comalloc(3, sizes, chunks) == 0)
       die();
     struct Head* head = (struct Head*)(chunks[0]);
     char*        body = (char*)(chunks[1]);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
@@ -355,7 +355,7 @@ void pvr_sprite_compile(pvr_sprite_hdr_t *dst, pvr_sprite_cxt_t *src) {
     dst->mode2 |= (src->gen.color_clamp << PVR_TA_PM2_CLAMP_SHIFT) & PVR_TA_PM2_CLAMP_MASK;
     dst->mode2 |= (src->gen.alpha << PVR_TA_PM2_ALPHA_SHIFT) & PVR_TA_PM2_ALPHA_MASK;
 
-    if(src->txr.enable == PVR_TEXTURE_DISABLE)  {
+    if(src->txr.enable == PVR_TEXTURE_DISABLE) {
         dst->mode3 = 0;
     }
     else    {

--- a/kernel/arch/dreamcast/hardware/scif-spi.c
+++ b/kernel/arch/dreamcast/hardware/scif-spi.c
@@ -126,9 +126,12 @@ static void slow_rw_delay(void) {
     timer_clear(TMU1);
     timer_start(TMU1);
 
-    while(!timer_clear(TMU1)) ;
-    while(!timer_clear(TMU1)) ;
-    while(!timer_clear(TMU1)) ;
+    while(!timer_clear(TMU1))
+        ;
+    while(!timer_clear(TMU1))
+        ;
+    while(!timer_clear(TMU1))
+        ;
     timer_stop(TMU1);
 }
 

--- a/kernel/arch/dreamcast/hardware/scif.c
+++ b/kernel/arch/dreamcast/hardware/scif.c
@@ -224,7 +224,7 @@ int scif_init(void) {
         scsmr2 = 2;
         scbrr2 = (50000000 / (512 * serial_baud)) - 1;
     }
-    else if (serial_baud) {
+    else if(serial_baud) {
         scsmr2 = 3;
         scbrr2 = (50000000 / (2048 * serial_baud)) - 1;
     }

--- a/kernel/arch/dreamcast/include/arch/rtc.h
+++ b/kernel/arch/dreamcast/include/arch/rtc.h
@@ -41,7 +41,7 @@ __BEGIN_DECLS
     presumably for power-efficiency reasons. Because of this, accessing 
     it requires a trip over the G2 BUS, which is notoriously slow.
 
-    \note 
+    \note
     For reading the current date/time, you should favor the standard C,
     C++, or POSIX functions, as they are platform-indpendent and are 
     calculating current time based on a cached boot time plus a delta
@@ -52,7 +52,7 @@ __BEGIN_DECLS
     Internally, the RTC's date/time is maintained using a 32-bit counter 
     with an epoch of January 1, 1950 00:00. Because of this, the Dreamcast's
     Y2K and the last timestamp it can represent before rolling over is 
-    February 06 2086 06:28:15. 
+    February 06 2086 06:28:15.
 */
 
 /** \defgroup rtc_regs Registers

--- a/kernel/arch/dreamcast/include/arch/spinlock.h
+++ b/kernel/arch/dreamcast/include/arch/spinlock.h
@@ -70,11 +70,11 @@ typedef volatile int spinlock_t;
                                  : "=r" (__gotlock) \
                                  : "r" (__lock) \
                                  : "t", "memory"); \
-            if (!__gotlock) \
+            if(!__gotlock) \
                 thd_pass(); \
             else break; \
         } \
-    } while (0)
+    } while(0)
 
 /** \brief  Free a lock.
 
@@ -85,7 +85,7 @@ typedef volatile int spinlock_t;
 */
 #define spinlock_unlock(A) do { \
         *(A) = 0; \
-    } while (0)
+    } while(0)
 
 /** \brief  Determine if a lock is locked.
 

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -228,7 +228,7 @@ void timer_shutdown(void);
 /** \defgroup   perf_counters Performance Counters
     The performance counter API exposes the SH4's hardware profiling registers, 
     which consist of two different sets of independently operable 64-bit 
-    counters.  
+    counters.
 */
 
 /** \brief  SH4 Performance Counter.

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -757,7 +757,7 @@ void maple_wait_scan(void);
    like this:
 
    MAPLE_FOREACH_BEGIN(MAPLE_FUNC_CONTROLLER, cont_state_t, st)
-    if (st->buttons & CONT_START)
+    if(st->buttons & CONT_START)
         return -1;
    MAPLE_FOREACH_END()
 
@@ -786,7 +786,7 @@ void maple_wait_scan(void);
         int __i; \
         \
         __i = 0; \
-        while ( (__dev = maple_enum_type(__i, TYPE)) ) { \
+        while( (__dev = maple_enum_type(__i, TYPE)) ) { \
             VAR = (VARTYPE *)maple_dev_status(__dev); \
             do {
 

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -112,7 +112,7 @@ typedef struct {
 /* \cond */
 /* Init / Shutdown */
 int cont_init(void);
-void    cont_shutdown(void);
+void cont_shutdown(void);
 /* \endcond */
 
 /** \brief  Controller automatic callback type.
@@ -134,7 +134,7 @@ typedef void (*cont_btn_callback_t)(uint8 addr, uint32 btns);
     \param  btns            The buttons bitmask to match.
     \param  cb              The callback to call when the buttons are pressed.
 */
-void    cont_btn_callback(uint8 addr, uint32 btns, cont_btn_callback_t cb);
+void cont_btn_callback(uint8 addr, uint32 btns, cont_btn_callback_t cb);
 
 /** \defgroup   controller_caps Controller capability bits.
 

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -202,7 +202,7 @@ __BEGIN_DECLS
 #define MAX_PRESSED_KEYS 6
 
 /** \brief Maximum number of keys a DC keyboard can have.
-	This is a hardware constant. The define prevents the magic number '256' from appearing.
+    This is a hardware constant. The define prevents the magic number '256' from appearing.
 **/
 #define MAX_KBD_KEYS 256
 
@@ -276,7 +276,7 @@ typedef struct kbd_state {
     int queue_tail;                     /**< \brief Key queue tail. */
     int queue_head;                     /**< \brief Key queue head. */
     int queue_len;                      /**< \brief Current length of queue. */
-    
+
     uint8 kbd_repeat_key;           /**< \brief Key that is repeating. */
     uint64 kbd_repeat_timer;        /**< \brief Time that the next repeat will trigger. */
 } kbd_state_t;

--- a/kernel/arch/dreamcast/include/dc/maple/mouse.h
+++ b/kernel/arch/dreamcast/include/dc/maple/mouse.h
@@ -85,7 +85,7 @@ typedef struct {
 /* \cond */
 /* Init / Shutdown */
 int mouse_init(void);
-void    mouse_shutdown(void);
+void mouse_shutdown(void);
 /* \endcond */
 
 __END_DECLS

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1649,7 +1649,7 @@ typedef uint32 pvr_dr_state_t;
         (vtx_buf_ptr) = 0; \
         QACR0 = ((((uint32)PVR_TA_INPUT) >> 26) << 2) & 0x1c; \
         QACR1 = ((((uint32)PVR_TA_INPUT) >> 26) << 2) & 0x1c; \
-    } while (0)
+    } while(0)
 
 /** \brief  Obtain the target address for Direct Rendering.
 

--- a/kernel/arch/dreamcast/include/dc/video.h
+++ b/kernel/arch/dreamcast/include/dc/video.h
@@ -203,7 +203,7 @@ void vid_set_start(uint32 base);
     This function sets the displayed framebuffer to the specified buffer and
     sets the vram_s and vram_l pointers to point at the next framebuffer, to
     allow for tearing-free framebuffer-direct drawing. The specified buffer 
-	is masked against (vid_mode->fb_count - 1) in order to loop around.
+    is masked against (vid_mode->fb_count - 1) in order to loop around.
 
     \param  fb              The framebuffer to display (or -1 for the next one).
 */

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -149,7 +149,7 @@ dpurge_loop:
 	rts
 	nop
 
-! This routine prefetch to operand cache the specified data range. 
+! This routine prefetch to operand cache the specified data range.
 ! r4 is starting address
 ! r5 is count
 _dcache_pref_range:

--- a/kernel/arch/dreamcast/kernel/exec.c
+++ b/kernel/arch/dreamcast/kernel/exec.c
@@ -59,7 +59,7 @@ void arch_exec_at(const void *image, uint32 length, uint32 address) {
     icache_flush_range((uint32)buffer, tcount * 4);
 
     /* printf("Finished trampoline:\n");
-    for (i=0; i<tcount; i++) {
+    for(i=0; i<tcount; i++) {
         printf("%08x: %08x\n", (uint32)(buffer + i), buffer[i]);
     } */
 

--- a/kernel/arch/dreamcast/kernel/make_banner.sh
+++ b/kernel/arch/dreamcast/kernel/make_banner.sh
@@ -42,7 +42,7 @@ printf '\\n"\n' >> banner.h
 
 printf '"  ' >> banner.h
 tmp=`$KOS_CC --version | head -n 1`
-printf "$tmp" >> banner.h 
+printf "$tmp" >> banner.h
 printf '\\n"\n' >> banner.h
 printf ';\n' >> banner.h
 

--- a/kernel/arch/dreamcast/kernel/mmu.c
+++ b/kernel/arch/dreamcast/kernel/mmu.c
@@ -477,7 +477,7 @@ int mmu_copyv(mmucontext_t *context1, struct iovec *iov1, int iovcnt1,
             run = dstcnt;
 
         /* Do the segment copy */
-        /* if (!sproket) {
+        /* if(!sproket) {
             dbgio_printf("Copying %08lx -> %08lx (%08lx -> %08lx), %d bytes\n",
                 srcptr, dstptr, src, dst, run);
             dbgio_flush();
@@ -642,7 +642,7 @@ void mmu_gen_tlb_miss(const char *what, irq_t source, irq_context_t *context) {
     }
 
     /* Make sure we don't overwrite the last TLB entry */
-    /* if (GET_URC() == last_urc) {
+    /* if(GET_URC() == last_urc) {
         last_urc++;
         SET_URC(last_urc);
     } else {

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -81,7 +81,7 @@ int rtc_set_unix_secs(time_t secs) {
 
     /* Try 3 times to ensure we didn't write a value then have 
        the clock increment itself before the next. */
-    for(i = 0; i < RTC_RETRY_COUNT; i++) { 
+    for(i = 0; i < RTC_RETRY_COUNT; i++) {
         /* Write the least-significant 16-bits first, because 
            writing to the high 16-bits will lock RTC writes. */
         g2_write_32(RTC_TIMESTAMP_LOW_ADDR, (adjusted) & 0xffff);

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -339,7 +339,7 @@ uint16 perf_cntr_get_config(int which) {
 int perf_cntr_start(int which, int mode, int count_type) {
     perf_cntr_clear(which);
     PMCR_CTRL(which) = PMCR_RUN | mode | (count_type << PMCR_CLOCK_TYPE_SHIFT);
-    
+
     return 0;
 }
 

--- a/kernel/arch/dreamcast/sound/arm/crt0.s
+++ b/kernel/arch/dreamcast/sound/arm/crt0.s
@@ -68,7 +68,7 @@ fiq_timer:
 	str	r9,[r8]
 	
 	# Request a new timer interrupt. We'll calculate the number
-	# put in here based on the "jps" (jiffies per second). 
+	# put in here based on the "jps" (jiffies per second).
 	ldr	r8, timer_control
 	mov	r9,#256-(44100/4410)
 #	ldr	r9,jps

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -68,12 +68,12 @@ void snd_sfx_unload_all(void) {
 /* Unload a single sample */
 void snd_sfx_unload(sfxhnd_t idx) {
     snd_effect_t * t = (snd_effect_t *)idx;
-    
+
     if(idx == SFXHND_INVALID) {
         dbglog(DBG_WARNING, "snd_sfx: can't unload an invalid SFXHND\n");
         return;
     }
-    
+
     snd_mem_free(t->locl);
 
     if(t->stereo)
@@ -154,7 +154,7 @@ sfxhnd_t snd_sfx_load(const char *fn) {
 
     t = malloc(sizeof(snd_effect_t));
     memset(t, 0, sizeof(snd_effect_t));
-    
+
     /* Common characteristics not impacted by stream type */
     t->rate = hz;
     t->stereo = stereo - 1;
@@ -242,7 +242,7 @@ sfxhnd_t snd_sfx_load(const char *fn) {
     if(ownmem)
         free(tmp);
 
-    if(t != SFXHND_INVALID) 
+    if(t != SFXHND_INVALID)
         LIST_INSERT_HEAD(&snd_effects, t, list);
 
     return (sfxhnd_t)t;
@@ -270,12 +270,12 @@ int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan) {
     chan->loopend = size;
     chan->freq = t->rate;
     chan->vol = vol;
-    
-    if(!t->stereo) {        
+
+    if(!t->stereo) {
         chan->pan = pan;
         snd_sh4_to_aica(tmp, cmd->size);
     }
-    else {        
+    else {
         chan->pan = 0;
 
         snd_sh4_to_aica_stop();

--- a/kernel/arch/dreamcast/util/fb_console.c
+++ b/kernel/arch/dreamcast/util/fb_console.c
@@ -34,7 +34,7 @@ static int fb_init(void) {
     bfont_set_encoding(BFONT_CODE_ISO8859_1);
 
     /* Init based on current video mode, defaulting to 640x480x16bpp. */
-    if (vid_mode == 0)
+    if(vid_mode == 0)
         dbgio_fb_set_target(NULL, 640, 480, 32, 32);
     else
         dbgio_fb_set_target(NULL, vid_mode->width, vid_mode->height, 32, 32);

--- a/kernel/arch/dreamcast/util/fb_console_naomi.c
+++ b/kernel/arch/dreamcast/util/fb_console_naomi.c
@@ -36,7 +36,7 @@ static int fb_detected(void) {
 
 static int fb_init(void) {
     /* Init based on current video mode, defaulting to 640x480x16bpp. */
-    if (vid_mode == 0)
+    if(vid_mode == 0)
         dbgio_fb_set_target(NULL, 640, 480, 32, 32);
     else
         dbgio_fb_set_target(NULL, vid_mode->width, vid_mode->height, 32, 32);

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -374,7 +374,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
 
 #define DO_ONE(symname, outp) \
     sym = find_sym(ELF_SYM_PREFIX symname, symtab, symtabsize); \
-    if (sym < 0) { \
+    if(sym < 0) { \
         dbglog(DBG_ERROR, "elf_load: ELF contains no %s()\n", symname); \
         goto error3; \
     } \

--- a/kernel/fs/fs_utils.c
+++ b/kernel/fs/fs_utils.c
@@ -166,7 +166,7 @@ ssize_t fs_path_append(char *dst, const char *src, size_t len) {
     /* If dst ends with '/' and src starts with '/', ignore '/' from dst */
     if(dlen > 0 && dst[dlen - 1] == '/' && src[0] == '/')
         --dlen;
-        
+
     /* Concatenate the src string on the dst, copying the NUL terminator while
        we are at it. */
     memcpy(dst + dlen, src, slen + 1);

--- a/kernel/libc/koslib/gethostbyname.c
+++ b/kernel/libc/koslib/gethostbyname.c
@@ -75,7 +75,8 @@ static int fill_hostent(const char *name, struct addrinfo *ai) {
     he.h_aliases[0] = NULL;
 
     /* Figure out how many addresses we have in the addrinfo chain. */
-    for(i = ai; i; i = i->ai_next, ++addrs) ;
+    for(i = ai; i; i = i->ai_next, ++addrs)
+        ;
 
     if(!(he.h_addr_list = (char **)malloc((addrs + 1) * sizeof(char *))))
         return NO_RECOVERY;

--- a/kernel/libc/koslib/malloc.c
+++ b/kernel/libc/koslib/malloc.c
@@ -1154,12 +1154,12 @@ extern "C" {
       struct Node* build_list() {
         struct Node** pool;
         int n = read_number_of_nodes_needed();
-        if (n <= 0) return 0;
+        if(n <= 0) return 0;
         pool = (struct Node**)(independent_calloc(n, sizeof(struct Node), 0);
-        if (pool == 0) die();
+        if(pool == 0) die();
         // organize into a linked list...
         struct Node* first = pool[0];
-        for (i = 0; i < n-1; ++i)
+        for(i = 0; i < n-1; ++i)
           pool[i]->next = pool[i+1];
         free(pool);     // Can now free the array (or not, if it is needed later)
         return first;
@@ -1214,7 +1214,7 @@ extern "C" {
         int msglen = strlen(msg);
         size_t sizes[3] = { sizeof(struct Head), msglen, sizeof(struct Foot) };
         void* chunks[3];
-        if (independent_comalloc(3, sizes, chunks) == 0)
+        if(independent_comalloc(3, sizes, chunks) == 0)
           die();
         struct Head* head = (struct Head*)(chunks[0]);
         char*        body = (char*)(chunks[1]);
@@ -2451,7 +2451,7 @@ int public_mALLOPt(int p, int v) {
         INTERNAL_SIZE_T* mzp = (INTERNAL_SIZE_T*)(charp);                           \
         CHUNK_SIZE_T  mctmp = (nbytes)/sizeof(INTERNAL_SIZE_T);                     \
         long mcn;                                                                   \
-        if (mctmp < 8) mcn = 0; else { mcn = (mctmp-1)/8; mctmp %= 8; }             \
+        if(mctmp < 8) mcn = 0; else { mcn = (mctmp-1)/8; mctmp %= 8; }             \
         switch (mctmp) {                                                            \
             case 0: for(;;) { *mzp++ = 0;                                             \
                 case 7:           *mzp++ = 0;                                             \
@@ -2470,7 +2470,7 @@ int public_mALLOPt(int p, int v) {
         INTERNAL_SIZE_T* mcdst = (INTERNAL_SIZE_T*) dest;                           \
         CHUNK_SIZE_T  mctmp = (nbytes)/sizeof(INTERNAL_SIZE_T);                     \
         long mcn;                                                                   \
-        if (mctmp < 8) mcn = 0; else { mcn = (mctmp-1)/8; mctmp %= 8; }             \
+        if(mctmp < 8) mcn = 0; else { mcn = (mctmp-1)/8; mctmp %= 8; }             \
         switch (mctmp) {                                                            \
             case 0: for(;;) { *mcdst++ = *mcsrc++;                                    \
                 case 7:           *mcdst++ = *mcsrc++;                                    \
@@ -2680,7 +2680,7 @@ nextchunk-> +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /*  Same, except also perform argument check */
 
 #define checked_request2size(req, sz)                             \
-    if (REQUEST_OUT_OF_RANGE(req)) {                                \
+    if(REQUEST_OUT_OF_RANGE(req)) {                                \
         MALLOC_FAILURE_ACTION;                                        \
         return 0;                                                     \
     }                                                               \
@@ -3354,7 +3354,7 @@ static void do_check_inuse_chunk(p) mchunkptr p;
       Since more things can be checked with free chunks than inuse ones,
       if an inuse chunk borders them and debug is on, it's worth doing them.
     */
-    if(!prev_inuse(p))  {
+    if(!prev_inuse(p)) {
         /* Note that we cannot even look at prev unless it is not inuse */
         mchunkptr prv = prev_chunk(p);
         assert(next_chunk(prv) == p);
@@ -4286,7 +4286,7 @@ Void_t* mALLOc(bytes) size_t bytes;
                 unlink(victim, bck, fwd);
 
                 /* Exhaust */
-                if(remainder_size < MINSIZE)  {
+                if(remainder_size < MINSIZE) {
                     set_inuse_bit_at_offset(victim, size);
                     check_malloced_chunk(victim, nb);
                     return chunk2mem(victim);
@@ -5454,13 +5454,13 @@ int value;
     void *ptr = 0;
     static void *sbrk_top = 0;
 
-    if (size > 0)
+    if(size > 0)
     {
-      if (size < MINIMUM_MORECORE_SIZE)
+      if(size < MINIMUM_MORECORE_SIZE)
          size = MINIMUM_MORECORE_SIZE;
-      if (CurrentExecutionLevel() == kTaskLevel)
+      if(CurrentExecutionLevel() == kTaskLevel)
          ptr = PoolAllocateResident(size + RM_PAGE_SIZE, 0);
-      if (ptr == 0)
+      if(ptr == 0)
       {
         return (void *) MORECORE_FAILURE;
       }
@@ -5471,7 +5471,7 @@ int value;
       sbrk_top = (char *) ptr + size;
       return ptr;
     }
-    else if (size < 0)
+    else if(size < 0)
     {
       // we don't currently support shrink behavior
       return (void *) MORECORE_FAILURE;
@@ -5489,8 +5489,8 @@ int value;
   {
     void **ptr;
 
-    for (ptr = our_os_pools; ptr < &our_os_pools[MAX_POOL_ENTRIES]; ptr++)
-      if (*ptr)
+    for(ptr = our_os_pools; ptr < &our_os_pools[MAX_POOL_ENTRIES]; ptr++)
+      if(*ptr)
       {
          PoolDeallocate(*ptr);
          *ptr = 0;

--- a/kernel/libc/koslib/realpath.c
+++ b/kernel/libc/koslib/realpath.c
@@ -70,7 +70,7 @@ realpath(const char *path, char resolved[PATH_MAX]) {
         left_len = strlcpy(left, path + 1, sizeof(left));
     }
     else {
-        /* if (getcwd(resolved, PATH_MAX) == NULL) {
+        /* if(getcwd(resolved, PATH_MAX) == NULL) {
             strlcpy(resolved, ".", PATH_MAX);
             return (NULL);
         } */

--- a/kernel/net/net_arp.c
+++ b/kernel/net/net_arp.c
@@ -242,7 +242,7 @@ int net_arp_revlookup(netif_t *nif, uint8 ip_out[4], const uint8 mac_in[6]) {
 }
 
 /* Send an ARP reply packet on the specified network adapter */
-static int net_arp_send(netif_t *nif, arp_pkt_t *pkt)   {
+static int net_arp_send(netif_t *nif, arp_pkt_t *pkt) {
     arp_pkt_t pkt_out;
     eth_hdr_t eth_hdr;
     uint8 buf[sizeof(arp_pkt_t) + sizeof(eth_hdr_t)];

--- a/kernel/net/net_core.c
+++ b/kernel/net/net_core.c
@@ -99,7 +99,7 @@ struct netif_list * net_get_if_list(void) {
 /* Init/shutdown */
 
 /* Set default */
-netif_t *net_set_default(netif_t *n)    {
+netif_t *net_set_default(netif_t *n) {
     netif_t *olddev = net_default_dev;
 
     net_default_dev = n;

--- a/kernel/thread/rwsem.c
+++ b/kernel/thread/rwsem.c
@@ -266,7 +266,7 @@ int rwsem_read_trylock(rw_semaphore_t *s) {
     int old, rv;
 
     old = irq_disable();
-    
+
     if(s->initialized != 1 && s->initialized != 2) {
         rv = -1;
         errno = EINVAL;

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -850,7 +850,7 @@ int kthread_key_delete(kthread_key_t key) {
     }
 
     /* Make sure we can actually use free below. */
-    if(!malloc_irq_safe())  {
+    if(!malloc_irq_safe()) {
         irq_restore(old);
         errno = EPERM;
         return -1;

--- a/kernel/thread/tls.c
+++ b/kernel/thread/tls.c
@@ -73,7 +73,7 @@ int kthread_key_create(kthread_key_t *key, void (*destructor)(void *)) {
     kthread_tls_dest_t *dest;
 
     if(irq_inside_int() &&
-       (spinlock_is_locked(&mutex) || !malloc_irq_safe()))  {
+       (spinlock_is_locked(&mutex) || !malloc_irq_safe())) {
         errno = EPERM;
         return -1;
     }


### PR DESCRIPTION
Correcting a number of whitespace issues including ones pointed out by @andressbarajas in #168 .

There are a few different ones being corrected:
1) Tabs to whitespace (seems I was the cause of most of those 5 years back).
2) Remove extra space between if/for/else/while and opening parens, closing parens and opening braces, between function prototype returns and their names, and at the end of lines.
3) Moving the ';' from empty loops to the following line (this was the majority across the codebase).
