### PR TITLE
Correct exit() during an int giving mutex warnings

### DIFF
--- a/addons/libppp/ppp.c
+++ b/addons/libppp/ppp.c
@@ -684,7 +684,11 @@ int ppp_init(void) {
 int ppp_shutdown(void) {
     ppp_protocol_t *i, *next;
 
-    mutex_lock(&mutex);
+    /* If we're in an int, it's ok if we can't lock */
+    if(irq_inside_int())
+        mutex_trylock(&mutex);
+    else
+        mutex_lock(&mutex);
 
     if(!ppp_state.initted) {
         mutex_unlock(&mutex);

--- a/kernel/arch/dreamcast/hardware/network/lan_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/lan_adapter.c
@@ -430,9 +430,7 @@ static void la_stop(void) {
 /* Shut it down for good */
 static void la_hw_shutdown(void) {
     /* Power down chip */
-    thd_sleep(2);
     la_write(DLCR7, la_read(DLCR7) & ~DLCR7_NSTBY);
-    thd_sleep(2);
 
     la_started = LA_NOT_STARTED;
 

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -129,7 +129,9 @@ void irq_handle_exception(int code) {
         arch_panic("double fault");
     }
 
-    inside_int = 1;
+    /* Reveal this info about the int to inside_int for better 
+       diagnostics returns if we try to do something in the int. */
+    inside_int = ((code&0xf)<<16) | (evt&0xffff);
 
     /* If there's a global handler, call it */
     if(irq_hnd_global) {

--- a/kernel/exports/nmmgr.c
+++ b/kernel/exports/nmmgr.c
@@ -68,7 +68,11 @@ int nmmgr_handler_remove(nmmgr_handler_t *hnd) {
     nmmgr_handler_t *c;
     int rv = -1;
 
-    mutex_lock(&mutex);
+    /* If we're in an int, lets do the trylock */
+    if(irq_inside_int())
+        mutex_trylock(&mutex);
+    else
+        mutex_lock(&mutex);
 
     /* Verify that it's actually in there */
     LIST_FOREACH(c, &nmmgr_handlers, list_ent) {

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -800,8 +800,13 @@ int fs_pty_shutdown(void) {
     if(!initted)
         return 0;
 
+    /* If we're in an int, lets do the trylock */
+    if(irq_inside_int())
+        mutex_trylock(&list_mutex);
+    else
+        mutex_lock(&list_mutex);
+
     /* Go through and free all the pty entries */
-    mutex_lock(&list_mutex);
     c = LIST_FIRST(&ptys);
 
     while(c != NULL) {

--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -85,9 +85,9 @@ int mutex_lock(mutex_t *m) {
 int mutex_lock_timed(mutex_t *m, int timeout) {
     int old, rv = 0;
 
-    if(irq_inside_int()) {
-        dbglog(DBG_WARNING, "%s: called inside interrupt\n",
-               timeout ? "mutex_lock_timed" : "mutex_lock");
+    if((rv = irq_inside_int())) {
+        dbglog(DBG_WARNING, "%s: called inside an interrupt with code: %x evt: %.4x\n",
+               timeout ? "mutex_lock_timed" : "mutex_lock", ((rv>>16) & 0xf), (rv & 0xffff));
         errno = EPERM;
         return -1;
     }

--- a/kernel/thread/rwsem.c
+++ b/kernel/thread/rwsem.c
@@ -67,8 +67,10 @@ int rwsem_destroy(rw_semaphore_t *s) {
 int rwsem_read_lock_timed(rw_semaphore_t *s, int timeout) {
     int old, rv = 0;
 
-    if(irq_inside_int()) {
-        dbglog(DBG_WARNING, "rwsem_read_lock_timed: called inside interrupt\n");
+    if((rv = irq_inside_int())) {
+        dbglog(DBG_WARNING, "%s: called inside an interrupt with code: %x evt: %.4x\n",
+               timeout ? "rwsem_read_lock_timed" : "rwsem_read_lock",
+               ((rv>>16) & 0xf), (rv & 0xffff));
         errno = EPERM;
         return -1;
     }

--- a/kernel/thread/sem.c
+++ b/kernel/thread/sem.c
@@ -86,8 +86,10 @@ int sem_wait_timed(semaphore_t *sem, int timeout) {
     int old, rv = 0;
 
     /* Make sure we're not inside an interrupt */
-    if(irq_inside_int()) {
-        dbglog(DBG_WARNING, "sem_wait_timed: called inside interrupt\n");
+    if((rv = irq_inside_int())) {
+        dbglog(DBG_WARNING, "%s: called inside an interrupt with code: %x evt: %.4x\n",
+               timeout ? "sem_wait_timed" : "sem_wait",
+               ((rv>>16) & 0xf), (rv & 0xffff));
         errno = EPERM;
         return -1;
     }

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -693,9 +693,10 @@ int thd_join(kthread_t * thd, void **value_ptr) {
     if(thd == NULL)
         return -1;
 
-    if(irq_inside_int()) {
-        dbglog(DBG_WARNING, "thd_join(%p) called inside an interrupt!\n",
-               (void *)thd);
+    if((rv = irq_inside_int())) {
+        dbglog(DBG_WARNING, "thd_join(%p) called inside an interrupt with code: %x evt: %.4x\n",
+               (void *)thd,
+               ((rv>>16) & 0xf), (rv & 0xffff));
         return -1;
     }
 


### PR DESCRIPTION
It's been reported multiple times that using a callback to call exit gives warnings or can hang the system rather than properly shutting down.

This is the most common way for it to happen:
`    /* Press all buttons to exit */
    cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
                      (void (*)(unsigned char, long  unsigned int))arch_exit);`
                      
The output ends up looking like this (from running examples/libdream/320x240/:
`maple: attached devices:
  A0: Dreamcast Controller          (01000000: Controller)
vid_set_mode: 320x240 VGA


Press all buttons simultaneously to exit.
thd: pre-emption enabled, HZ=100
mutex_lock: called inside interrupt
mutex_lock: called inside interrupt
arch: exit return code 0
arch: shutting down kernel
vid_set_mode: 640x480 VGA
mutex_lock: called inside interrupt
mutex_lock: called inside interrupt
mutex_lock: called inside interrupt
mutex_lock: called inside interrupt
mutex_lock: called inside interrupt
mutex_lock: called inside interrupt
mutex_lock: called inside interrupt
`
The cause of this seems to be primarily that the function nmmgr_handler_remove was trying to mutex lock when it is called during the shutdowns of the various vfses. I've updated the function to test for being in an int and do a trylock instead.

In my testing this removed all the warnings that were being generated after the vid_set_mode output and should have no significant negative impact. I considered having the shutdowns fail and return an error if the mutex trylock fails, but none of the shutdown functions are ever tested for failure, so this would just force shutdown processes not to happen.

The two that happen prior to arch: exit still show up for me, and I couldn't quite track them down. Something is a bit wrong anyways as the "thd: pre-emption enabled, HZ=100" line does not show up until the button presses are done.

In the process of finding the above, I also enhanced the return of int_inside_irq to expose the code/evt of the interrupt, and the various objects that call it giving a warning if in an int (mutex, sem, thread, rwsem).
