### PR TITLE
Remove Co-Op threading mode

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -165,6 +165,9 @@ KallistiOS version 2.1.0 -----------------------------------------------
       registered with atexit() are called [Colton Pawielski == CP]
 - *** Cleaned up + documented RTC driver, added support for setting time [FG]
 - DC  Cleaned up the register access in video to match pvr [DH]
+- DC  Fixed various shutdown functions to be safer to call in an interrupt [DH]
+- DC  Cleaned up asic functions and corrected potential bugs [DH]
+- DC  Deprecated coop threading mode. Always use preemptive mode [DH]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/examples/dreamcast/hello/hello.c
+++ b/examples/dreamcast/hello/hello.c
@@ -14,9 +14,8 @@ extern uint8 romdisk[];
    you need to set any flags you want here. Here are some possibilities:
 
    INIT_NONE        -- don't do any auto init
-   INIT_IRQ     -- Enable IRQs
-   INIT_THD_PREEMPT -- Enable pre-emptive threading
-   INIT_NET     -- Enable networking (including sockets)
+   INIT_IRQ         -- Enable IRQs
+   INIT_NET         -- Enable networking (including sockets)
    INIT_MALLOCSTATS -- Enable a call to malloc_stats() right before shutdown
 
    You can OR any or all of those together. If you want to start out with

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -227,6 +227,7 @@ typedef struct kthread_attr {
     @{
 */
 #define THD_MODE_NONE       -1  /**< \brief Threads not running */
+#define THD_MODE_COOP       0   /**< \brief Cooperative mode (deprecated) */
 #define THD_MODE_PREEMPT    1   /**< \brief Preemptive threading mode */
 /** @} */
 

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -23,10 +23,7 @@ __BEGIN_DECLS
     \brief  Threading support.
 
     This file contains the interface to the threading system of KOS. Timer
-    interrupts are used to reschedule threads within the system while in
-    preemptive mode. There is also some support for a cooperative threading
-    mode (where each thread must manually give up its timeslice to swap out
-    threads).
+    interrupts are used to reschedule threads within the system.
 
     The thread scheduler itself is a relatively simplistic priority scheduler.
     There is no provision for priorities to erode over time, so keep that in
@@ -224,14 +221,12 @@ typedef struct kthread_attr {
 
 /** \defgroup thd_modes             Threading system modes
 
-    The threading system will always be in one of the following modes. This
-    represents the type of scheduling done by the system (or the special case of
-    threads not having been initialized yet).
+    The threading system will always be in one of the following modes. This 
+    represents either pre-emptive scheduling or an un-initialized state.
 
     @{
 */
 #define THD_MODE_NONE       -1  /**< \brief Threads not running */
-#define THD_MODE_COOP       0   /**< \brief Cooperative threading mode */
 #define THD_MODE_PREEMPT    1   /**< \brief Preemptive threading mode */
 /** @} */
 
@@ -360,8 +355,8 @@ void thd_exit(void *rv) __noreturn;
 /** \brief  Force a thread reschedule.
 
     This function is the thread scheduler, and is generally called from a timer
-    interrupt, at least in preemptive mode. You will most likely never have a
-    reason to call this function directly.
+    interrupt. You will most likely never have a reason to call this function 
+    directly.
 
     For most cases, you'll want to set front_of_line to zero, but read the
     comments in kernel/thread/thread.c for more info, especially if you need to
@@ -485,22 +480,6 @@ int * thd_get_errno(kthread_t *thd);
 */
 struct _reent * thd_get_reent(kthread_t *thd);
 
-/** \brief  Change threading modes.
-
-    This function changes the current threading mode of the system.
-
-    \param  mode            One of the \ref thd_modes values.
-
-    \return                 The old mode of the threading system.
-*/
-int thd_set_mode(int mode);
-
-/** \brief  Fetch the current threading mode.
-
-    \return                 The current mode of the threading system.
-*/
-int thd_get_mode(void);
-
 /** \brief  Wait for a thread to exit.
 
     This function "joins" a joinable thread. This means effectively that the
@@ -560,12 +539,10 @@ int thd_pslist_queue(int (*pf)(const char *fmt, ...));
     This is normally done for you by default when KOS starts. This will also
     initialize all the various synchronization primitives.
 
-    \param  mode            One of the \ref thd_modes values.
-
     \retval -1              If threads are already initialized.
     \retval 0               On success.
 */
-int thd_init(int mode);
+int thd_init(void);
 
 /** \brief  Shutdown the threading system.
 

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -480,6 +480,26 @@ int * thd_get_errno(kthread_t *thd);
 */
 struct _reent * thd_get_reent(kthread_t *thd);
 
+/** \brief  Change threading modes.
+
+    This function changes the current threading mode of the system.
+    With preemptive threading being the only mode, this is now 
+    deprecated.
+
+    \param  mode            One of the \ref thd_modes values.
+    \return                 The old mode of the threading system.
+*/
+int thd_set_mode(int mode) __attribute__((deprecated));
+
+/** \brief  Fetch the current threading mode.
+
+    With preemptive threading being the only mode, this is now 
+    deprecated.
+
+    \return                 The current mode of the threading system.
+*/
+int thd_get_mode(void) __attribute__((deprecated));
+
 /** \brief  Wait for a thread to exit.
 
     This function "joins" a joinable thread. This means effectively that the

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -187,8 +187,9 @@ extern void * __kos_romdisk;
     These are the flags you can specify with KOS_INIT_FLAGS().
     @{
 */
-/** \brief  Default init flags (IRQs on). */
-#define INIT_DEFAULT      INIT_IRQ
+/** \brief  Default init flags (IRQs on, preemption enabled). */
+#define INIT_DEFAULT \
+    (INIT_IRQ | INIT_THD_PREEMPT)
 
 #define INIT_NONE           0x0000  /**< \brief Don't init optional things */
 #define INIT_IRQ            0x0001  /**< \brief Enable IRQs at startup */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -187,12 +187,12 @@ extern void * __kos_romdisk;
     These are the flags you can specify with KOS_INIT_FLAGS().
     @{
 */
-/** \brief  Default init flags (IRQs on, preemption enabled). */
-#define INIT_DEFAULT \
-    (INIT_IRQ | INIT_THD_PREEMPT)
+/** \brief  Default init flags (IRQs on). */
+#define INIT_DEFAULT      INIT_IRQ
 
 #define INIT_NONE           0x0000  /**< \brief Don't init optional things */
 #define INIT_IRQ            0x0001  /**< \brief Enable IRQs at startup */
+/* Preemptive mode is the only mode now. Keeping define for compatability. */
 #define INIT_THD_PREEMPT    0x0002  /**< \brief Enable thread preemption */
 #define INIT_NET            0x0004  /**< \brief Enable built-in networking */
 #define INIT_MALLOCSTATS    0x0008  /**< \brief Enable malloc statistics */

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -105,9 +105,9 @@ int  __attribute__((weak)) arch_auto_init(void) {
 
     /* Threads */
     if(__kos_init_flags & INIT_THD_PREEMPT)
-        thd_init(THD_MODE_PREEMPT);
-    else
-        thd_init(THD_MODE_COOP);
+        dbglog(DBG_WARNING, "INIT_THD_PREEMPT is deprecated. KOS is always \
+            in pre-emptive threading mode\n");
+    thd_init();
 
     nmmgr_init();
 

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -104,9 +104,10 @@ int  __attribute__((weak)) arch_auto_init(void) {
     rtc_init();
 
     /* Threads */
-    if(__kos_init_flags & INIT_THD_PREEMPT)
-        dbglog(DBG_WARNING, "INIT_THD_PREEMPT is deprecated. KOS is always \
-            in pre-emptive threading mode\n");
+    if(!(__kos_init_flags & INIT_THD_PREEMPT))
+        dbglog(DBG_WARNING, "Cooperative threading mode is deprecated. KOS is \
+        always in pre-emptive threading mode. \n");
+
     thd_init();
 
     nmmgr_init();

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -155,7 +155,6 @@ thd_get_current
 thd_get_pwd
 thd_set_pwd
 thd_get_errno
-thd_set_mode
 thd_block_now
 
 # Libraries

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -155,6 +155,7 @@ thd_get_current
 thd_get_pwd
 thd_set_pwd
 thd_get_errno
+thd_set_mode
 thd_block_now
 
 # Libraries

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -920,7 +920,7 @@ int thd_init(void) {
     /* Schedule our first wakeup */
     timer_primary_wakeup(1000 / HZ);
 
-    printf("thd: pre-emption enabled, HZ=%d\n", HZ);
+    dbglog(DBG_INFO, "thd: pre-emption enabled, HZ=%d\n", HZ);
 
     return 0;
 }

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -813,6 +813,19 @@ struct _reent * thd_get_reent(kthread_t *thd) {
 
 /*****************************************************************************/
 
+/* Change threading modes */
+int thd_set_mode(int mode) {
+
+    dbglog(DBG_WARNING, "thd_set_mode has no effect. Cooperative threading \
+        mode is deprecated. KOS is always in pre-emptive threading mode. \n");
+
+    return mode;
+}
+
+int thd_get_mode(void) {
+    return thd_mode;
+}
+
 /* Delete a TLS key. Note that currently this doesn't prevent you from reusing
    the key after deletion. This seems ok, as the pthreads standard states that
    using the key after deletion results in "undefined behavior".


### PR DESCRIPTION
As discussed in #163 this seeks to just remove coop mode as an option in KOS. There were very few places where it was referenced or worked against, with the presumption most everywhere being that the system is in pre-emptive mode. It may make sense to change the internal names for thd_mode to something like 'initted' used in other function, as the only purpose it has currently is to note if threading has been enabled and hasn't been shutdown yet.

There *may* also be some other places where conditional considerations were being made about the threading mode without explicitly calling out the mode (nothing was using get_mode) I tried looking around some and couldn't find any. 

I left a stub warning in case someone does pass INIT_THD_PREEMPT they get a warning, so that should be good enough to provide notice. To my knowledge there's not a good way to mark a define as deprecated. I would suppose that we leave that kos_flags bit reserved for now and if we implement more to go above it before reclaiming it (we've got plenty of bits spare).