### PR TITLE
Fix dist target for examples

### DIFF
--- a/examples/dreamcast/dreameye/basic/Makefile
+++ b/examples/dreamcast/dreameye/basic/Makefile
@@ -21,9 +21,9 @@ $(TARGET): $(OBJS)
 	$(KOS_CC) $(KOS_CFLAGS) $(KOS_LDFLAGS) -o $(TARGET) $(KOS_START) \
 	$(OBJS) $(DATAOBJS) $(OBJEXTRA) $(KOS_LIBS)
 
-run: $(TARGET).elf
-	$(KOS_LOADER) $(TARGET).elf
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
 
 dist:
 	rm -f $(OBJS)
-	$(KOS_STRIP) $(TARGET).elf
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/network/httpd/Makefile
+++ b/examples/dreamcast/network/httpd/Makefile
@@ -30,3 +30,7 @@ romdisk.o: romdisk.img
 
 run: $(TARGET)
 	dc-tool -n -x $(TARGET)
+
+dist:
+	rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)


### PR DESCRIPTION
This change fixes two issues with the `make dist` target for the examples:

1) `dreameye/basic` had extra `.elf`'s appended to the target variable on both the run and dist targets

2) `network/httpd` was missing a target for dist