### PR TITLE
Suppress warning about deprecated functions in exports.

### DIFF
--- a/utils/genexports/genexports.sh
+++ b/utils/genexports/genexports.sh
@@ -35,6 +35,7 @@ for i in $includes; do
 done
 
 # Now write out the sym table
+echo '#pragma GCC diagnostic ignored "-Wdeprecated-declarations"' >> $outpfile
 echo "export_sym_t ${outpsym}[] = {" >> $outpfile
 for i in $names; do
 	echo "	{ \"$i\", (unsigned long)(&$i) }," >> $outpfile
@@ -42,4 +43,3 @@ done
 
 echo "	{ 0, 0 }" >> $outpfile
 echo "};" >> $outpfile
-


### PR DESCRIPTION
When compiling KOS , I'm seeing the following warnings:

```
$KOS_BASE/utils/genexports/genexports.sh ../exports-pristine.txt arch_exports.c arch_symtab
kos-cc  -c arch_exports.c -o arch_exports.o
arch_exports.c:64:9: warning: ‘kbd_get_key’ is deprecated [-Wdeprecated-declarations]
   64 |         { "kbd_get_key", (unsigned long)(&kbd_get_key) },
      |         ^
In file included from $KOS_BASE/include/kos.h:90,
                 from arch_exports.c:7:
$KOS_BASE/kernel/arch/dreamcast/include/dc/maple/keyboard.h:322:5: note: declared here
  322 | int kbd_get_key() __attribute__((deprecated));
      |     ^~~~~~~~~~~
arch_exports.c:65:9: warning: ‘kbd_set_queue’ is deprecated [-Wdeprecated-declarations]
   65 |         { "kbd_set_queue", (unsigned long)(&kbd_set_queue) },
      |         ^
$KOS_BASE/kernel/arch/dreamcast/include/dc/maple/keyboard.h:302:6: note: declared here
  302 | void kbd_set_queue(int active) __attribute__((deprecated));
      |      ^~~~~~~~~~~~~

kos-cc  -c kernel_exports.c -o kernel_exports.o
kernel_exports.c:25:9: warning: ‘cond_create’ is deprecated: Use cond_init or COND_INTIALIZER. [-Wdeprecated-declarations]
   25 |         { "cond_create", (unsigned long)(&cond_create) },
      |         ^
In file included from $KOS_BASE/include/sys/sched.h:30,
                 from /opt/toolchains/dc/sh-elf-13.1.0-kos/sh-elf/include/sys/_pthreadtypes.h:23,
                 from /opt/toolchains/dc/sh-elf-13.1.0-kos/sh-elf/include/sys/types.h:221,
                 from /opt/toolchains/dc/sh-elf-13.1.0-kos/sh-elf/include/sys/unistd.h:12,
                 from /opt/toolchains/dc/sh-elf-13.1.0-kos/sh-elf/include/unistd.h:4,
                 from $KOS_BASE/include/kos/dbglog.h:24,
                 from $KOS_BASE/include/sys/stdio.h:30,
                 from /opt/toolchains/dc/sh-elf-13.1.0-kos/sh-elf/include/stdio.h:85,
                 from $KOS_BASE/include/kos.h:31,
                 from kernel_exports.c:7:
$KOS_BASE/include/kos/cond.h:83:12: note: declared here
   83 | condvar_t *cond_create() __depr("Use cond_init or COND_INTIALIZER.");
      |            ^~~~~~~~~~~
kernel_exports.c:128:9: warning: ‘mutex_create’ is deprecated: Use mutex_init or an initializer. [-Wdeprecated-declarations]
  128 |         { "mutex_create", (unsigned long)(&mutex_create) },
      |         ^
In file included from $KOS_BASE/include/kos/cond.h:52:
$KOS_BASE/include/kos/mutex.h:110:10: note: declared here
  110 | mutex_t *mutex_create(void) __depr("Use mutex_init or an initializer.");
      |          ^~~~~~~~~~~~
kernel_exports.c:150:9: warning: ‘sem_create’ is deprecated: Use sem_init or SEM_INITAILZER. [-Wdeprecated-declarations]
  150 |         { "sem_create", (unsigned long)(&sem_create) },
      |         ^
In file included from $KOS_BASE/include/sys/sched.h:29:
$KOS_BASE/include/kos/sem.h:62:14: note: declared here
   62 | semaphore_t *sem_create(int value) __depr("Use sem_init or SEM_INITAILZER.");
      |         
```

Obviously, this is intended behavior with no need for a warning, so in order to suppress it, I modified genexports.sh to add a pragma directive to the generated exports C files to force GCC to ignore -Wdeprecated-declarations for the symbol tables containing the deprecated declarations. I chose this way of doing it because it was most localized to any actual warnings needing suppression, and least likely to suppress any warnings we'd want to keep, but I could have done it other ways like in Makefiles, too, so let me know if there's a better way of doing it. 