### PR TITLE
Ensure the dcload dbgio name gets re-written after being nulled

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -501,7 +501,7 @@ int dcload_type = DCLOAD_TYPE_NONE;
 void fs_dcload_init_console(void) {
     /* Setup our dbgio handler */
     memcpy(&dbgio_dcload, &dbgio_null, sizeof(dbgio_dcload));
-	dbgio_dcload.name = dbgio_dcload_name;
+    dbgio_dcload.name = dbgio_dcload_name;
     dbgio_dcload.detected = fs_dcload_detected;
     dbgio_dcload.write_buffer = dcload_write_buffer;
     // dbgio_dcload.read = dcload_read_cons;

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -493,6 +493,7 @@ int fs_dcload_detected(void) {
 }
 
 static int *dcload_wrkmem = NULL;
+static const char * dbgio_dcload_name = "fs_dcload";
 int dcload_type = DCLOAD_TYPE_NONE;
 
 /* Call this before arch_init_all (or any call to dbgio_*) to use dcload's
@@ -500,6 +501,7 @@ int dcload_type = DCLOAD_TYPE_NONE;
 void fs_dcload_init_console(void) {
     /* Setup our dbgio handler */
     memcpy(&dbgio_dcload, &dbgio_null, sizeof(dbgio_dcload));
+	dbgio_dcload.name = dbgio_dcload_name;
     dbgio_dcload.detected = fs_dcload_detected;
     dbgio_dcload.write_buffer = dcload_write_buffer;
     // dbgio_dcload.read = dcload_read_cons;


### PR DESCRIPTION
There is likely a better way to go about this and I'll gladly take suggestions (maybe just offset the memcpy to not overwrite the whole struct, or copy each of the null handler functions over). But I spent wayyy too long trying to figure out why I was using the null dbgio driver (pulling the name with `dbgio_dev_get()`) and how anything was coming across dcload with it.