### PR TITLE
Unbounded indexing fix in isp_settings example

### DIFF
--- a/examples/dreamcast/network/isp-settings/isp-settings.c
+++ b/examples/dreamcast/network/isp-settings/isp-settings.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
                 "Static",
             };
             /* Check that cfg.method is set to a known value */
-            if(cfg.method<(sizeof(methods) / sizeof(methods[0])))
+            if(cfg.method < (sizeof(methods) / sizeof(methods[0])))
                 printf("Method:   %s\n", methods[cfg.method]);
             else
                 printf("Method:   unknown(%i)\n", cfg.method);


### PR DESCRIPTION
In testing using the isp_settings example, I found that my main Dreamcast had the unusual value of 18 set for methods. This caused the example to try printing from an out of bounds place and died.

My change checks the size of the pretty names array and doesn't try to use it if the actual value is out of bounds.