### PR TITLE
Allow overriding stack size / early init function

### DIFF
--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -182,6 +182,14 @@ extern void * __kos_romdisk;
 /** \brief  State that you don't want a romdisk. */
 #define KOS_INIT_ROMDISK_NONE   NULL
 
+/** \brief  Register a single function to be called very early in the boot
+ *          process, before the BSS section is cleared.
+ *
+    \param  func            The function to register. The prototype should be:
+                            void func(void)
+*/
+#define KOS_INIT_EARLY(func) void (*__kos_init_early_fn)(void) = (func)
+
 /** \defgroup arch_initflags        Available flags for initialization
 
     These are the flags you can specify with KOS_INIT_FLAGS().

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -32,6 +32,8 @@ extern void _init(void);
 extern void _fini(void);
 extern void __verify_newlib_patch();
 
+void (*__kos_init_early_fn)(void) __attribute__((weak)) = NULL;
+
 int main(int argc, char **argv);
 uint32 _fs_dclsocket_get_ip(void);
 
@@ -229,6 +231,10 @@ void arch_main(void) {
 
     /* Ensure that UBC is not enabled from a previous session */
     ubc_disable_all();
+
+    /* Handle optional callback provided by KOS_INIT_EARLY() */
+    if (__kos_init_early_fn)
+	    __kos_init_early_fn();
 
     /* Clear out the BSS area */
     memset(bss_start, 0, bss_end - bss_start);

--- a/kernel/arch/dreamcast/kernel/stack.c
+++ b/kernel/arch/dreamcast/kernel/stack.c
@@ -15,6 +15,13 @@
 #include <kos/dbgio.h>
 #include <arch/arch.h>
 #include <arch/stack.h>
+#include <stdint.h>
+
+static uintptr_t arch_stack_16m_dft = 0x8d000000;
+static uintptr_t arch_stack_32m_dft = 0x8e000000;
+
+extern uintptr_t arch_stack_16m __attribute__((weak,alias("arch_stack_16m_dft")));
+extern uintptr_t arch_stack_32m __attribute__((weak,alias("arch_stack_32m_dft")));
 
 /* Do a stack trace from the current function; leave off the first n frames
    (i.e., in assert()). */

--- a/utils/dc-chain/patches/gcc-13.1.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-13.1.0-kos.diff
@@ -28,7 +28,7 @@ diff --color -ruN gcc-13.1.0/gcc/configure gcc-13.1.0-kos/gcc/configure
 diff --color -ruN gcc-13.1.0/libgcc/config/sh/crt1.S gcc-13.1.0-kos/libgcc/config/sh/crt1.S
 --- gcc-13.1.0/libgcc/config/sh/crt1.S	2023-04-26 02:09:43.000000000 -0500
 +++ gcc-13.1.0-kos/libgcc/config/sh/crt1.S	2023-04-29 12:46:39.571346358 -0500
-@@ -1,724 +1,230 @@
+@@ -1,724 +1,233 @@
 -/* Copyright (C) 2000-2023 Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
 +! KallistiOS ##version##
@@ -249,6 +249,7 @@ diff --color -ruN gcc-13.1.0/libgcc/config/sh/crt1.S gcc-13.1.0-kos/libgcc/confi
 +	mov.l	old_stack_addr,r0
 +	mov.l	r15,@r0
 +	mov.l   new_stack_16m,r15
++	mov.l	@r15,r15
 +
 +	! Check if 0xadffffff is a mirror of 0xacffffff, or if unique
 +	! If unique, then memory is 32MB instead of 16MB, and we must
@@ -259,6 +260,7 @@ diff --color -ruN gcc-13.1.0/libgcc/config/sh/crt1.S gcc-13.1.0-kos/libgcc/confi
 +	mov	#0xba,r1
 +	mov.b	r1,@-r2			! Store 0xba to 0xacffffff
 +	mov.l	new_stack_32m,r1
++	mov.l	@r1,r1
 +	or	r0,r1
 +	mov	#0xab,r0
 +	mov.b	r0,@-r1			! Store 0xab in 0xadffffff
@@ -267,6 +269,7 @@ diff --color -ruN gcc-13.1.0/libgcc/config/sh/crt1.S gcc-13.1.0-kos/libgcc/confi
 +	cmp/eq	r0,r1			! Check if values match
 +	bt	memchk_done		! If so, mirror - we're done, move on
 +	mov.l	new_stack_32m,r15	! If not, unique - set higher stack
++	mov.l	@r15,r15
 +memchk_done:
 +	mov.l	mem_top_addr,r0
 +	mov.l	r15,@r0			! Save address of top of memory
@@ -943,9 +946,9 @@ diff --color -ruN gcc-13.1.0/libgcc/config/sh/crt1.S gcc-13.1.0-kos/libgcc/confi
 +mem_top_addr:
 +	.long	__arch_mem_top
 +new_stack_16m:
-+	.long	0x8d000000
++	.long	_arch_stack_16m
 +new_stack_32m:
-+	.long	0x8e000000
++	.long	_arch_stack_32m
 +p2_mask:
 +	.long	0xa0000000
 +setup_cache_addr:

--- a/utils/dc-chain/patches/gcc-4.7.4-kos.diff
+++ b/utils/dc-chain/patches/gcc-4.7.4-kos.diff
@@ -66,7 +66,7 @@ diff --color -ruN gcc-4.7.4/gcc/doc/gcc.texi gcc-4.7.4-kos/gcc/doc/gcc.texi
 diff --color -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/sh/crt1.S
 --- gcc-4.7.4/libgcc/config/sh/crt1.S	2011-11-02 09:33:56.000000000 -0500
 +++ gcc-4.7.4-kos/libgcc/config/sh/crt1.S	2023-04-29 12:35:49.271313212 -0500
-@@ -1,1369 +1,230 @@
+@@ -1,1369 +1,233 @@
 -/* Copyright (C) 2000, 2001, 2003, 2004, 2005, 2006, 2009, 2011
 -   Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
@@ -929,6 +929,7 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/
 +	mov.l	old_stack_addr,r0
 +	mov.l	r15,@r0
 +	mov.l   new_stack_16m,r15
++	mov.l	@r15,r15
 +
 +	! Check if 0xadffffff is a mirror of 0xacffffff, or if unique
 +	! If unique, then memory is 32MB instead of 16MB, and we must
@@ -939,6 +940,7 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/
 +	mov	#0xba,r1
 +	mov.b	r1,@-r2			! Store 0xba to 0xacffffff
 +	mov.l	new_stack_32m,r1
++	mov.l	@r1,r1
 +	or	r0,r1
 +	mov	#0xab,r0
 +	mov.b	r0,@-r1			! Store 0xab in 0xadffffff
@@ -947,6 +949,7 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/
 +	cmp/eq	r0,r1			! Check if values match
 +	bt	memchk_done		! If so, mirror - we're done, move on
 +	mov.l	new_stack_32m,r15	! If not, unique - set higher stack
++	mov.l	@r15,r15
 +memchk_done:
 +	mov.l	mem_top_addr,r0
 +	mov.l	r15,@r0			! Save address of top of memory
@@ -1626,9 +1629,9 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/
 +mem_top_addr:
 +	.long	__arch_mem_top
 +new_stack_16m:
-+	.long	0x8d000000
++	.long	_arch_stack_16m
 +new_stack_32m:
-+	.long	0x8e000000
++	.long	_arch_stack_32m
 +p2_mask:
 +	.long	0xa0000000
 +setup_cache_addr:

--- a/utils/dc-chain/patches/gcc-9.3.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-9.3.0-kos.diff
@@ -28,7 +28,7 @@ diff --color -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
 diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.S
 --- gcc-9.3.0/libgcc/config/sh/crt1.S	2020-03-12 06:07:23.000000000 -0500
 +++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2023-04-29 12:41:39.015442403 -0500
-@@ -1,724 +1,230 @@
+@@ -1,724 +1,233 @@
 -/* Copyright (C) 2000-2019 Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
 +! KallistiOS ##version##
@@ -249,6 +249,7 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/
 +	mov.l	old_stack_addr,r0
 +	mov.l	r15,@r0
 +	mov.l   new_stack_16m,r15
++	mov.l	@r15,r15
 +
 +	! Check if 0xadffffff is a mirror of 0xacffffff, or if unique
 +	! If unique, then memory is 32MB instead of 16MB, and we must
@@ -259,6 +260,7 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/
 +	mov	#0xba,r1
 +	mov.b	r1,@-r2			! Store 0xba to 0xacffffff
 +	mov.l	new_stack_32m,r1
++	mov.l	@r1,r1
 +	or	r0,r1
 +	mov	#0xab,r0
 +	mov.b	r0,@-r1			! Store 0xab in 0xadffffff
@@ -267,6 +269,7 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/
 +	cmp/eq	r0,r1			! Check if values match
 +	bt	memchk_done		! If so, mirror - we're done, move on
 +	mov.l	new_stack_32m,r15	! If not, unique - set higher stack
++	mov.l	@r15,r15
 +memchk_done:
 +	mov.l	mem_top_addr,r0
 +	mov.l	r15,@r0			! Save address of top of memory
@@ -943,9 +946,9 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/
 +mem_top_addr:
 +	.long	__arch_mem_top
 +new_stack_16m:
-+	.long	0x8d000000
++	.long	_arch_stack_16m
 +new_stack_32m:
-+	.long	0x8e000000
++	.long	_arch_stack_32m
 +p2_mask:
 +	.long	0xa0000000
 +setup_cache_addr:


### PR DESCRIPTION
Update the GCC-13 patch to allow setting a different stack size.

Add a `early_init` weak function. If provided, the function will be called. This is used in my case to copy data appended to the raw binary to its final location in RAM; the advantage vs. romdisks, is that the data appended to the raw binary will eventually be reused by the .bss section and the heap.