### PR TITLE
dc-chain: download source archives from mirrors

### DIFF
--- a/utils/dc-chain/download.sh
+++ b/utils/dc-chain/download.sh
@@ -97,7 +97,7 @@ fi
 if [ ! -f ${CONFIG_GUESS} ]; then
   WEB_DOWNLOAD_OUTPUT_SWITCH="-O"
   if [ ! -z "${IS_CURL}" ] && [ "${IS_CURL}" != "0" ]; then
-    WEB_DOWNLOADER="$(echo ${WEB_DOWNLOADER} | cut -c-9)"
+    WEB_DOWNLOADER="$(echo "${WEB_DOWNLOADER}" | sed '-es/-O//')"
     WEB_DOWNLOAD_OUTPUT_SWITCH="-o"
   fi
 

--- a/utils/dc-chain/scripts/common.sh
+++ b/utils/dc-chain/scripts/common.sh
@@ -80,7 +80,7 @@ setup_download_var ARM_GCC
 
 
 # export GNU_MIRROR_URL=mirrors.kernel.org/gnu
-export GNU_MIRROR_URL=ftp.gnu.org
+export GNU_MIRROR_URL=ftpmirror.gnu.org
 export SH_BINUTILS_TARBALL_URL=$GNU_MIRROR_URL/gnu/binutils/binutils-$SH_BINUTILS_VER.tar.$SH_BINUTILS_TARBALL_TYPE
 export SH_GCC_TARBALL_URL=$GNU_MIRROR_URL/gnu/gcc/gcc-$SH_GCC_VER/gcc-$SH_GCC_VER.tar.$SH_GCC_TARBALL_TYPE
 export NEWLIB_TARBALL_URL=sourceware.org/pub/newlib/newlib-$NEWLIB_VER.tar.$NEWLIB_TARBALL_TYPE

--- a/utils/dc-chain/scripts/gdb.mk
+++ b/utils/dc-chain/scripts/gdb.mk
@@ -7,7 +7,7 @@
 
 gdb_name = gdb-$(gdb_ver)
 gdb_file = $(gdb_name).tar.$(gdb_tarball_type)
-gdb_url  = $(download_protocol)://ftp.gnu.org/gnu/gdb/$(gdb_file)
+gdb_url  = $(download_protocol)://ftpmirror.gnu.org/gnu/gdb/$(gdb_file)
 
 stamp_gdb_unpack = gdb_unpack.stamp
 stamp_gdb_patch = gdb_patch.stamp

--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -108,7 +108,7 @@ endif
 
 # Web downloaders command-lines
 wget_cmd=wget -c
-curl_cmd=curl -C - -O
+curl_cmd=curl --fail --location -C - -O
 
 # Determine if we want to apply fixup sh4 newlib
 do_auto_fixup_sh4_newlib := 1


### PR DESCRIPTION
Use the GNU mirror hostname to download source archives. In principle, this should give better performance, though they still seems slow to me. Since the mirror works by HTTP redirects, we need to update the curl download command to automatically follow the redirect.