### PR TITLE
Fix compilation of .S files

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -37,7 +37,7 @@ endif
 	kos-as $< -o $@
 
 %.o: %.S
-	kos-cc $< -o $@
+	kos-cc -c $< -o $@
 
 subdirs: $(patsubst %, _dir_%, $(SUBDIRS))
 


### PR DESCRIPTION
The change from kos-as to kos-cc was missing the -c parameter to compile object files. Fixes #195