### PR TITLE
Fix libobjc building after regression in 'Allow overriding stack size / early init function' PR

### DIFF
--- a/kernel/arch/dreamcast/kernel/startup.s
+++ b/kernel/arch/dreamcast/kernel/startup.s
@@ -18,6 +18,9 @@
 .globl __arch_old_fpscr
 .globl __arch_mem_top
 
+.weak   _arch_stack_16m
+.weak   _arch_stack_32m
+
 _start:
 start:
 	! Disable interrupts (if they're enabled)
@@ -73,6 +76,7 @@ init:
 	mov.l	old_stack_addr,r0
 	mov.l	r15,@r0
 	mov.l   new_stack_16m,r15
+	mov.l	@r15,r15
 
 	! Check if 0xadffffff is a mirror of 0xacffffff, or if unique
 	! If unique, then memory is 32MB instead of 16MB, and we must
@@ -83,6 +87,7 @@ init:
 	mov	#0xba,r1
 	mov.b	r1,@-r2			! Store 0xba to 0xacffffff
 	mov.l	new_stack_32m,r1
+	mov.l	@r1,r1
 	or	r0,r1
 	mov	#0xab,r0
 	mov.b	r0,@-r1			! Store 0xab in 0xadffffff
@@ -91,6 +96,7 @@ init:
 	cmp/eq	r0,r1			! Check if values match
 	bt	memchk_done		! If so, mirror - we're done, move on
 	mov.l	new_stack_32m,r15	! If not, unique - set higher stack
+	mov.l	@r15,r15
 memchk_done:
 	mov.l	mem_top_addr,r0
 	mov.l	r15,@r0			! Save address of top of memory
@@ -205,9 +211,9 @@ __arch_mem_top:
 mem_top_addr:
 	.long	__arch_mem_top
 new_stack_16m:
-	.long	0x8d000000
+	.long	_arch_stack_16m
 new_stack_32m:
-	.long	0x8e000000
+	.long	_arch_stack_32m
 p2_mask:
 	.long	0xa0000000
 setup_cache_addr:

--- a/utils/dc-chain/patches/gcc-13.1.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-13.1.0-kos.diff
@@ -1,6 +1,6 @@
 diff --color -ruN gcc-13.1.0/gcc/config/sh/sh-c.cc gcc-13.1.0-kos/gcc/config/sh/sh-c.cc
---- gcc-13.1.0/gcc/config/sh/sh-c.cc	2023-04-26 02:09:39.000000000 -0500
-+++ gcc-13.1.0-kos/gcc/config/sh/sh-c.cc	2023-04-29 12:45:52.160038658 -0500
+--- gcc-13.1.0/gcc/config/sh/sh-c.cc	2023-05-15 22:32:33.801167700 -0500
++++ gcc-13.1.0-kos/gcc/config/sh/sh-c.cc	2023-05-15 22:32:40.133180838 -0500
 @@ -141,4 +141,11 @@
  
    cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
@@ -14,8 +14,8 @@ diff --color -ruN gcc-13.1.0/gcc/config/sh/sh-c.cc gcc-13.1.0-kos/gcc/config/sh/
 +  builtin_define ("__KOS_GCC_32MB__");
  }
 diff --color -ruN gcc-13.1.0/gcc/configure gcc-13.1.0-kos/gcc/configure
---- gcc-13.1.0/gcc/configure	2023-04-26 02:11:18.000000000 -0500
-+++ gcc-13.1.0-kos/gcc/configure	2023-04-29 12:45:52.164038684 -0500
+--- gcc-13.1.0/gcc/configure	2023-05-15 22:32:36.862174050 -0500
++++ gcc-13.1.0-kos/gcc/configure	2023-05-15 22:32:40.135180842 -0500
 @@ -13012,7 +13012,7 @@
      target_thread_file='single'
      ;;
@@ -26,9 +26,9 @@ diff --color -ruN gcc-13.1.0/gcc/configure gcc-13.1.0-kos/gcc/configure
      ;;
    *)
 diff --color -ruN gcc-13.1.0/libgcc/config/sh/crt1.S gcc-13.1.0-kos/libgcc/config/sh/crt1.S
---- gcc-13.1.0/libgcc/config/sh/crt1.S	2023-04-26 02:09:43.000000000 -0500
-+++ gcc-13.1.0-kos/libgcc/config/sh/crt1.S	2023-04-29 12:46:39.571346358 -0500
-@@ -1,724 +1,233 @@
+--- gcc-13.1.0/libgcc/config/sh/crt1.S	2023-05-15 22:32:32.834165694 -0500
++++ gcc-13.1.0-kos/libgcc/config/sh/crt1.S	2023-05-15 22:32:50.679202715 -0500
+@@ -1,724 +1,236 @@
 -/* Copyright (C) 2000-2023 Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
 +! KallistiOS ##version##
@@ -52,7 +52,9 @@ diff --color -ruN gcc-13.1.0/libgcc/config/sh/crt1.S gcc-13.1.0-kos/libgcc/confi
 +.globl __arch_mem_top
  
 -This file is part of GCC.
--
++.weak   _arch_stack_16m
++.weak   _arch_stack_32m
+ 
 -GCC is free software; you can redistribute it and/or modify it
 -under the terms of the GNU General Public License as published by the
 -Free Software Foundation; either version 3, or (at your option) any
@@ -971,7 +973,7 @@ diff --color -ruN gcc-13.1.0/libgcc/config/sh/crt1.S gcc-13.1.0-kos/libgcc/confi
 +	.word	0x092d
 diff --color -ruN gcc-13.1.0/libgcc/config/sh/fake-kos.S gcc-13.1.0-kos/libgcc/config/sh/fake-kos.S
 --- gcc-13.1.0/libgcc/config/sh/fake-kos.S	1969-12-31 18:00:00.000000000 -0600
-+++ gcc-13.1.0-kos/libgcc/config/sh/fake-kos.S	2023-04-29 12:45:52.164038684 -0500
++++ gcc-13.1.0-kos/libgcc/config/sh/fake-kos.S	2023-05-15 22:32:40.135180842 -0500
 @@ -0,0 +1,78 @@
 +! Weakly linked symbols used to get GCC to hopefully compile itself properly.
 +! These will be replaced by the real symbols in actual compiled programs.
@@ -1053,7 +1055,7 @@ diff --color -ruN gcc-13.1.0/libgcc/config/sh/fake-kos.S gcc-13.1.0-kos/libgcc/c
 +    mov     #-1, r0
 diff --color -ruN gcc-13.1.0/libgcc/config/sh/gthr-kos.h gcc-13.1.0-kos/libgcc/config/sh/gthr-kos.h
 --- gcc-13.1.0/libgcc/config/sh/gthr-kos.h	1969-12-31 18:00:00.000000000 -0600
-+++ gcc-13.1.0-kos/libgcc/config/sh/gthr-kos.h	2023-04-29 12:45:52.165038690 -0500
++++ gcc-13.1.0-kos/libgcc/config/sh/gthr-kos.h	2023-05-15 22:32:40.135180842 -0500
 @@ -0,0 +1,401 @@
 +/* Copyright (C) 2009, 2010, 2011, 2012, 2020 Lawrence Sebald */
 +
@@ -1457,8 +1459,8 @@ diff --color -ruN gcc-13.1.0/libgcc/config/sh/gthr-kos.h gcc-13.1.0-kos/libgcc/c
 +
 +#endif /* ! GCC_GTHR_KOS_H */
 diff --color -ruN gcc-13.1.0/libgcc/config/sh/t-sh gcc-13.1.0-kos/libgcc/config/sh/t-sh
---- gcc-13.1.0/libgcc/config/sh/t-sh	2023-04-26 02:09:43.000000000 -0500
-+++ gcc-13.1.0-kos/libgcc/config/sh/t-sh	2023-04-29 12:45:52.165038690 -0500
+--- gcc-13.1.0/libgcc/config/sh/t-sh	2023-05-15 22:32:32.834165694 -0500
++++ gcc-13.1.0-kos/libgcc/config/sh/t-sh	2023-05-15 22:32:40.135180842 -0500
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -1469,8 +1471,8 @@ diff --color -ruN gcc-13.1.0/libgcc/config/sh/t-sh gcc-13.1.0-kos/libgcc/config/
  	$(gcc_compile) -c $<
  
 diff --color -ruN gcc-13.1.0/libgcc/configure gcc-13.1.0-kos/libgcc/configure
---- gcc-13.1.0/libgcc/configure	2023-04-26 02:09:43.000000000 -0500
-+++ gcc-13.1.0-kos/libgcc/configure	2023-04-29 12:45:52.165038690 -0500
+--- gcc-13.1.0/libgcc/configure	2023-05-15 22:32:32.883165796 -0500
++++ gcc-13.1.0-kos/libgcc/configure	2023-05-15 22:32:40.136180844 -0500
 @@ -5699,6 +5699,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -1480,8 +1482,8 @@ diff --color -ruN gcc-13.1.0/libgcc/configure gcc-13.1.0-kos/libgcc/configure
  esac
  
 diff --color -ruN gcc-13.1.0/libobjc/configure gcc-13.1.0-kos/libobjc/configure
---- gcc-13.1.0/libobjc/configure	2023-04-26 02:11:18.000000000 -0500
-+++ gcc-13.1.0-kos/libobjc/configure	2023-04-29 12:45:52.167038703 -0500
+--- gcc-13.1.0/libobjc/configure	2023-05-15 22:32:32.887165804 -0500
++++ gcc-13.1.0-kos/libobjc/configure	2023-05-15 22:32:40.136180844 -0500
 @@ -2918,11 +2918,9 @@
  
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -1495,8 +1497,8 @@ diff --color -ruN gcc-13.1.0/libobjc/configure gcc-13.1.0-kos/libobjc/configure
    return 0;
  }
 diff --color -ruN gcc-13.1.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-13.1.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-13.1.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-04-26 02:09:43.000000000 -0500
-+++ gcc-13.1.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-04-29 12:45:52.167038703 -0500
+--- gcc-13.1.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-05-15 22:32:33.215166485 -0500
++++ gcc-13.1.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-05-15 22:32:40.137180846 -0500
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -1548,8 +1550,8 @@ diff --color -ruN gcc-13.1.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-13.1.0-k
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
 diff --color -ruN gcc-13.1.0/libstdc++-v3/configure gcc-13.1.0-kos/libstdc++-v3/configure
---- gcc-13.1.0/libstdc++-v3/configure	2023-04-26 02:09:43.000000000 -0500
-+++ gcc-13.1.0-kos/libstdc++-v3/configure	2023-04-29 12:45:52.173038742 -0500
+--- gcc-13.1.0/libstdc++-v3/configure	2023-05-15 22:32:33.632167350 -0500
++++ gcc-13.1.0-kos/libstdc++-v3/configure	2023-05-15 22:32:40.140180852 -0500
 @@ -15809,6 +15809,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/patches/gcc-4.7.4-kos.diff
+++ b/utils/dc-chain/patches/gcc-4.7.4-kos.diff
@@ -1,6 +1,6 @@
 diff --color -ruN gcc-4.7.4/gcc/config/sh/sh.h gcc-4.7.4-kos/gcc/config/sh/sh.h
---- gcc-4.7.4/gcc/config/sh/sh.h	2013-03-25 17:55:56.000000000 -0500
-+++ gcc-4.7.4-kos/gcc/config/sh/sh.h	2023-04-29 12:35:14.894104257 -0500
+--- gcc-4.7.4/gcc/config/sh/sh.h	2023-05-15 22:37:11.104742972 -0500
++++ gcc-4.7.4-kos/gcc/config/sh/sh.h	2023-05-15 22:37:14.351749707 -0500
 @@ -93,6 +93,12 @@
      builtin_define ("__FMOVD_ENABLED__"); \
    builtin_define (TARGET_LITTLE_ENDIAN \
@@ -15,8 +15,8 @@ diff --color -ruN gcc-4.7.4/gcc/config/sh/sh.h gcc-4.7.4-kos/gcc/config/sh/sh.h
  
  /* Value should be nonzero if functions must have frame pointers.
 diff --color -ruN gcc-4.7.4/gcc/configure gcc-4.7.4-kos/gcc/configure
---- gcc-4.7.4/gcc/configure	2014-02-12 10:43:47.000000000 -0600
-+++ gcc-4.7.4-kos/gcc/configure	2023-04-29 12:35:14.897104275 -0500
+--- gcc-4.7.4/gcc/configure	2023-05-15 22:37:11.074742909 -0500
++++ gcc-4.7.4-kos/gcc/configure	2023-05-15 22:37:14.352749709 -0500
 @@ -11338,7 +11338,7 @@
      target_thread_file='single'
      ;;
@@ -27,8 +27,8 @@ diff --color -ruN gcc-4.7.4/gcc/configure gcc-4.7.4-kos/gcc/configure
      ;;
    *)
 diff --color -ruN gcc-4.7.4/gcc/cp/cfns.h gcc-4.7.4-kos/gcc/cp/cfns.h
---- gcc-4.7.4/gcc/cp/cfns.h	2009-04-21 14:03:23.000000000 -0500
-+++ gcc-4.7.4-kos/gcc/cp/cfns.h	2023-04-29 12:35:14.898104281 -0500
+--- gcc-4.7.4/gcc/cp/cfns.h	2023-05-15 22:37:11.076742914 -0500
++++ gcc-4.7.4-kos/gcc/cp/cfns.h	2023-05-15 22:37:14.353749711 -0500
 @@ -53,6 +53,9 @@
  static unsigned int hash (const char *, unsigned int);
  #ifdef __GNUC__
@@ -49,8 +49,8 @@ diff --color -ruN gcc-4.7.4/gcc/cp/cfns.h gcc-4.7.4-kos/gcc/cp/cfns.h
    switch (hval)
      {
 diff --color -ruN gcc-4.7.4/gcc/doc/gcc.texi gcc-4.7.4-kos/gcc/doc/gcc.texi
---- gcc-4.7.4/gcc/doc/gcc.texi	2010-06-09 18:46:33.000000000 -0500
-+++ gcc-4.7.4-kos/gcc/doc/gcc.texi	2023-04-29 12:35:14.898104281 -0500
+--- gcc-4.7.4/gcc/doc/gcc.texi	2023-05-15 22:37:10.038740760 -0500
++++ gcc-4.7.4-kos/gcc/doc/gcc.texi	2023-05-15 22:37:14.353749711 -0500
 @@ -86,9 +86,9 @@
  @item GNU Press
  @tab Website: www.gnupress.org
@@ -64,9 +64,9 @@ diff --color -ruN gcc-4.7.4/gcc/doc/gcc.texi gcc-4.7.4-kos/gcc/doc/gcc.texi
  @tab Tel 617-542-5942
  @item Boston, MA 02110-1301 USA
 diff --color -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/sh/crt1.S
---- gcc-4.7.4/libgcc/config/sh/crt1.S	2011-11-02 09:33:56.000000000 -0500
-+++ gcc-4.7.4-kos/libgcc/config/sh/crt1.S	2023-04-29 12:35:49.271313212 -0500
-@@ -1,1369 +1,233 @@
+--- gcc-4.7.4/libgcc/config/sh/crt1.S	2023-05-15 22:37:09.929740534 -0500
++++ gcc-4.7.4-kos/libgcc/config/sh/crt1.S	2023-05-15 22:37:20.022761471 -0500
+@@ -1,1369 +1,236 @@
 -/* Copyright (C) 2000, 2001, 2003, 2004, 2005, 2006, 2009, 2011
 -   Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
@@ -219,7 +219,26 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/
 -
 -#ifdef MMU_SUPPORT
 -	! Set up the VM using the MMU and caches
--
++! KallistiOS ##version##
++!
++! startup.s
++! (c)2000-2001 Megan Potter
++!
++! This file must appear FIRST in your linking order, or your program won't
++! work correctly as a raw binary.
++!
++! This is very loosely based on Marcus' crt0.s/startup.s
++!
++
++.globl start
++.globl _start
++.globl _arch_real_exit
++.globl __arch_old_sr
++.globl __arch_old_vbr
++.globl __arch_old_stack
++.globl __arch_old_fpscr
++.globl __arch_mem_top
+ 
 -	! .vm_ep is first instruction to execute
 -	! after VM initialization
 -	pt/l	.vm_ep, tr1
@@ -758,27 +777,10 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/
 -profiling_enabled:
 -	.long 0
 -#endif
--
-+! KallistiOS ##version##
-+!
-+! startup.s
-+! (c)2000-2001 Megan Potter
-+!
-+! This file must appear FIRST in your linking order, or your program won't
-+! work correctly as a raw binary.
-+!
-+! This is very loosely based on Marcus' crt0.s/startup.s
-+!
-+
-+.globl start
-+.globl _start
-+.globl _arch_real_exit
-+.globl __arch_old_sr
-+.globl __arch_old_vbr
-+.globl __arch_old_stack
-+.globl __arch_old_fpscr
-+.globl __arch_mem_top
++.weak   _arch_stack_16m
++.weak   _arch_stack_32m
  
+-
 -	.section .text
 -	.global	start
 -	.import ___rtos_profiler_start_timer
@@ -1654,7 +1656,7 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/crt1.S gcc-4.7.4-kos/libgcc/config/
 +	.word	0x092d
 diff --color -ruN gcc-4.7.4/libgcc/config/sh/fake-kos.S gcc-4.7.4-kos/libgcc/config/sh/fake-kos.S
 --- gcc-4.7.4/libgcc/config/sh/fake-kos.S	1969-12-31 18:00:00.000000000 -0600
-+++ gcc-4.7.4-kos/libgcc/config/sh/fake-kos.S	2023-04-29 12:35:14.898104281 -0500
++++ gcc-4.7.4-kos/libgcc/config/sh/fake-kos.S	2023-05-15 22:37:14.353749711 -0500
 @@ -0,0 +1,75 @@
 +! Weakly linked symbols used to get GCC to hopefully compile itself properly.
 +! These will be replaced by the real symbols in actual compiled programs.
@@ -1734,7 +1736,7 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/fake-kos.S gcc-4.7.4-kos/libgcc/con
 \ No newline at end of file
 diff --color -ruN gcc-4.7.4/libgcc/config/sh/gthr-kos.h gcc-4.7.4-kos/libgcc/config/sh/gthr-kos.h
 --- gcc-4.7.4/libgcc/config/sh/gthr-kos.h	1969-12-31 18:00:00.000000000 -0600
-+++ gcc-4.7.4-kos/libgcc/config/sh/gthr-kos.h	2023-04-29 12:35:14.899104287 -0500
++++ gcc-4.7.4-kos/libgcc/config/sh/gthr-kos.h	2023-05-15 22:37:14.353749711 -0500
 @@ -0,0 +1,355 @@
 +/* Copyright (C) 2009, 2010, 2011, 2012 Lawrence Sebald */
 +
@@ -2092,8 +2094,8 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/gthr-kos.h gcc-4.7.4-kos/libgcc/con
 +
 +#endif /* ! GCC_GTHR_KOS_H */
 diff --color -ruN gcc-4.7.4/libgcc/config/sh/t-sh gcc-4.7.4-kos/libgcc/config/sh/t-sh
---- gcc-4.7.4/libgcc/config/sh/t-sh	2011-11-07 11:14:32.000000000 -0600
-+++ gcc-4.7.4-kos/libgcc/config/sh/t-sh	2023-04-29 12:35:14.899104287 -0500
+--- gcc-4.7.4/libgcc/config/sh/t-sh	2023-05-15 22:37:09.929740534 -0500
++++ gcc-4.7.4-kos/libgcc/config/sh/t-sh	2023-05-15 22:37:14.353749711 -0500
 @@ -24,6 +24,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -2104,8 +2106,8 @@ diff --color -ruN gcc-4.7.4/libgcc/config/sh/t-sh gcc-4.7.4-kos/libgcc/config/sh
  	$(gcc_compile) -c $<
  
 diff --color -ruN gcc-4.7.4/libgcc/configure gcc-4.7.4-kos/libgcc/configure
---- gcc-4.7.4/libgcc/configure	2012-08-06 09:34:27.000000000 -0500
-+++ gcc-4.7.4-kos/libgcc/configure	2023-04-29 12:35:14.899104287 -0500
+--- gcc-4.7.4/libgcc/configure	2023-05-15 22:37:09.912740499 -0500
++++ gcc-4.7.4-kos/libgcc/configure	2023-05-15 22:37:14.354749713 -0500
 @@ -4480,6 +4480,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -2115,8 +2117,8 @@ diff --color -ruN gcc-4.7.4/libgcc/configure gcc-4.7.4-kos/libgcc/configure
  
  # Substitute configuration variables
 diff --color -ruN gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h gcc-4.7.4-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h	2011-01-30 16:39:36.000000000 -0600
-+++ gcc-4.7.4-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-04-29 12:35:14.899104287 -0500
+--- gcc-4.7.4/libstdc++-v3/config/cpu/sh/atomicity.h	2023-05-15 22:37:11.265743306 -0500
++++ gcc-4.7.4-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-05-15 22:37:14.354749713 -0500
 @@ -80,7 +80,12 @@
  
  namespace 

--- a/utils/dc-chain/patches/gcc-9.3.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-9.3.0-kos.diff
@@ -1,6 +1,6 @@
 diff --color -ruN gcc-9.3.0/gcc/config/sh/sh-c.c gcc-9.3.0-kos/gcc/config/sh/sh-c.c
---- gcc-9.3.0/gcc/config/sh/sh-c.c	2020-03-12 06:07:21.000000000 -0500
-+++ gcc-9.3.0-kos/gcc/config/sh/sh-c.c	2023-04-29 12:41:28.765379932 -0500
+--- gcc-9.3.0/gcc/config/sh/sh-c.c	2023-05-15 22:34:42.320434318 -0500
++++ gcc-9.3.0-kos/gcc/config/sh/sh-c.c	2023-05-15 22:35:04.507480347 -0500
 @@ -141,4 +141,11 @@
  
    cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
@@ -14,8 +14,8 @@ diff --color -ruN gcc-9.3.0/gcc/config/sh/sh-c.c gcc-9.3.0-kos/gcc/config/sh/sh-
 +  builtin_define ("__KOS_GCC_32MB__");
  }
 diff --color -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
---- gcc-9.3.0/gcc/configure	2020-03-12 06:08:30.000000000 -0500
-+++ gcc-9.3.0-kos/gcc/configure	2023-04-29 12:41:28.769379957 -0500
+--- gcc-9.3.0/gcc/configure	2023-05-15 22:34:44.370438571 -0500
++++ gcc-9.3.0-kos/gcc/configure	2023-05-15 22:35:04.509480351 -0500
 @@ -11862,7 +11862,7 @@
      target_thread_file='single'
      ;;
@@ -26,9 +26,9 @@ diff --color -ruN gcc-9.3.0/gcc/configure gcc-9.3.0-kos/gcc/configure
      ;;
    *)
 diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/sh/crt1.S
---- gcc-9.3.0/libgcc/config/sh/crt1.S	2020-03-12 06:07:23.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2023-04-29 12:41:39.015442403 -0500
-@@ -1,724 +1,233 @@
+--- gcc-9.3.0/libgcc/config/sh/crt1.S	2023-05-15 22:34:41.988433629 -0500
++++ gcc-9.3.0-kos/libgcc/config/sh/crt1.S	2023-05-15 22:35:16.055504303 -0500
+@@ -1,724 +1,236 @@
 -/* Copyright (C) 2000-2019 Free Software Foundation, Inc.
 -   This file was pretty much copied from newlib.
 +! KallistiOS ##version##
@@ -52,7 +52,9 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/
 +.globl __arch_mem_top
  
 -This file is part of GCC.
--
++.weak   _arch_stack_16m
++.weak   _arch_stack_32m
+ 
 -GCC is free software; you can redistribute it and/or modify it
 -under the terms of the GNU General Public License as published by the
 -Free Software Foundation; either version 3, or (at your option) any
@@ -971,7 +973,7 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/crt1.S gcc-9.3.0-kos/libgcc/config/
 +	.word	0x092d
 diff --color -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S
 --- gcc-9.3.0/libgcc/config/sh/fake-kos.S	1969-12-31 18:00:00.000000000 -0600
-+++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2023-04-29 12:41:28.769379957 -0500
++++ gcc-9.3.0-kos/libgcc/config/sh/fake-kos.S	2023-05-15 22:35:04.510480353 -0500
 @@ -0,0 +1,78 @@
 +! Weakly linked symbols used to get GCC to hopefully compile itself properly.
 +! These will be replaced by the real symbols in actual compiled programs.
@@ -1053,7 +1055,7 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/fake-kos.S gcc-9.3.0-kos/libgcc/con
 +    mov     #-1, r0
 diff --color -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h
 --- gcc-9.3.0/libgcc/config/sh/gthr-kos.h	1969-12-31 18:00:00.000000000 -0600
-+++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2023-04-29 12:41:28.769379957 -0500
++++ gcc-9.3.0-kos/libgcc/config/sh/gthr-kos.h	2023-05-15 22:35:04.510480353 -0500
 @@ -0,0 +1,401 @@
 +/* Copyright (C) 2009, 2010, 2011, 2012, 2020 Lawrence Sebald */
 +
@@ -1457,8 +1459,8 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/gthr-kos.h gcc-9.3.0-kos/libgcc/con
 +
 +#endif /* ! GCC_GTHR_KOS_H */
 diff --color -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh/t-sh
---- gcc-9.3.0/libgcc/config/sh/t-sh	2020-03-12 06:07:23.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2023-04-29 12:41:28.769379957 -0500
+--- gcc-9.3.0/libgcc/config/sh/t-sh	2023-05-15 22:34:41.988433629 -0500
++++ gcc-9.3.0-kos/libgcc/config/sh/t-sh	2023-05-15 22:35:04.510480353 -0500
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -1469,8 +1471,8 @@ diff --color -ruN gcc-9.3.0/libgcc/config/sh/t-sh gcc-9.3.0-kos/libgcc/config/sh
  	$(gcc_compile) -c $<
  
 diff --color -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
---- gcc-9.3.0/libgcc/configure	2020-03-12 06:07:23.000000000 -0500
-+++ gcc-9.3.0-kos/libgcc/configure	2023-04-29 12:41:28.770379963 -0500
+--- gcc-9.3.0/libgcc/configure	2023-05-15 22:34:42.023433702 -0500
++++ gcc-9.3.0-kos/libgcc/configure	2023-05-15 22:35:04.510480353 -0500
 @@ -5550,6 +5550,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -1480,8 +1482,8 @@ diff --color -ruN gcc-9.3.0/libgcc/configure gcc-9.3.0-kos/libgcc/configure
  
  
 diff --color -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2020-03-12 06:07:24.000000000 -0500
-+++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-04-29 12:41:28.770379963 -0500
+--- gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-05-15 22:34:44.682439218 -0500
++++ gcc-9.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-05-15 22:35:04.510480353 -0500
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -1533,8 +1535,8 @@ diff --color -ruN gcc-9.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.3.0-kos
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
 diff --color -ruN gcc-9.3.0/libstdc++-v3/configure gcc-9.3.0-kos/libstdc++-v3/configure
---- gcc-9.3.0/libstdc++-v3/configure	2020-03-12 06:07:24.000000000 -0500
-+++ gcc-9.3.0-kos/libstdc++-v3/configure	2023-04-29 12:41:28.778380012 -0500
+--- gcc-9.3.0/libstdc++-v3/configure	2023-05-15 22:34:45.058439998 -0500
++++ gcc-9.3.0-kos/libstdc++-v3/configure	2023-05-15 22:35:04.514480362 -0500
 @@ -15629,6 +15629,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;


### PR DESCRIPTION
This PR updates startup.s with the changes that were supposed to be added in the "Allow overriding stack size / early init function" but were only added in the GCC patches directly.

Additionally, after that PR, the following errors occur:
```
undefined reference to `_arch_stack_16m'
undefined reference to `_arch_stack_32m'
```
And then libobjc fails to compile. 

It was @cepawiel 's suggestion to add the following to the `startup.s`:
```
.weak   _arch_stack_16m
.weak   _arch_stack_32m
```
Colton was unsure if this was the correct/proper way to fix the problem, but I am submitting it as a PR as this fixed the issue for me and we can discuss it here.