### PR TITLE
dc: init: Move __kos_init_early_fn to .data section

### DIFF
--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -32,7 +32,7 @@ extern void _init(void);
 extern void _fini(void);
 extern void __verify_newlib_patch();
 
-void (*__kos_init_early_fn)(void) __attribute__((weak)) = NULL;
+void (*__kos_init_early_fn)(void) __attribute__((weak,section(".data"))) = NULL;
 
 int main(int argc, char **argv);
 uint32 _fs_dclsocket_get_ip(void);


### PR DESCRIPTION
The __kos_init_early_fn pointer is initialized to NULL, which means that unless specified otherwise, it ends up in the .bss section.

However, its value is checked *before* the .bss section is cleared; which means that it might contain a garbage value, and the init code would then branch to a random address in memory.

Address this issue by forcing the value to be in the .data section.

Note that I didn't update the CHANGELOG since the last entry is the one where I add support for the early init function. But I can add one new entry if you think it's better.