### PR TITLE
Set Doxygen main page to updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ KOS is an unofficial development environment for the SEGA Dreamcast game console
 
 KOS was developed from scratch over the internet by a group of free software developers and has no relation to the official Sega Katana or Microsoft Windows CE Dreamcast development kits. This has allowed it to fuel a thriving Dreamcast homebrew scene, powering many commercial releases for the platform over the years. It supports a signficiant portion of the Dreamcast's hardware capabilities and a wide variety of peripherals, accessories, and add-ons for the console, including custom hardware modifications that have been created by the scene. 
 
-Despite the console's age, KOS offers an extremely modern, programmer-friendly development environment, supporting C17 and C++20, with the majority of their standard libraries fully supported and additional support for many POSIX APIs. Additionally, KOS-ports offers a rich set of add-on libraries such as SDL, OpenGL, and Lua for the platform. 
+Despite the console's age, KOS offers an extremely modern, programmer-friendly development environment, supporting portions of C23 and C++23, with the majority of their standard libraries fully supported and additional support for many POSIX APIs. Additionally, KOS-ports offers a rich set of add-on libraries such as SDL, OpenGL, and Lua for the platform.
 
 ## Features
 ##### Core Functionality
-* Concurrency with Kernel Threads, C11 Threads, pthreads
+* Concurrency with Kernel Threads, C11 Threads, C++11 `std::thread`, Pthreads
 * Virtual filesystem abstraction 
 * IPv4/IPv6 Network stack
 * Dynamically loading libraries/modules
@@ -47,7 +47,7 @@ Despite the console's age, KOS offers an extremely modern, programmer-friendly d
 * Custom BIOS Flashroms
 
 ## Getting Started 
-A beginner's guide to development for the Sega Dreamcast along with detailed instructions for installing KOS and the required toolchains can be found on the  [Dreamcast Wiki](https://dreamcast.wiki/Getting_Started_with_Dreamcast_development). Additional documentation can be found in the docs folder. 
+A beginner's guide to development for the Sega Dreamcast along with detailed instructions for installing KOS and the required toolchains can be found on the [Dreamcast Wiki](https://dreamcast.wiki/Getting_Started_with_Dreamcast_development). Additional documentation can be found in the docs folder. 
 
 ## Examples 
 Once you've set up the environment and are ready to begin developing, a good place to start learning is the examples directory, which provides demos for the various KOS APIs and for interacting with the Dreamcast's hardware. Examples include:
@@ -79,5 +79,5 @@ Once you've set up the environment and are ready to begin developing, a good pla
 [DCEmulation Forums](http://dcemulation.org/phpBB/viewforum.php?f=29): Goldmine of Dreamcast development information and history  
 [Dreamcast Wiki](http://dreamcast.wiki): Large collection of tutorials and articles for beginners  
 [Simulant Discord Chat](https://discord.gg/bpDZHT78PA): Home to the official Discord channel of KOS  
-IRC Channel: irc.libera.chat #dreamcastdev 
+IRC Channel: irc.libera.chat `#dreamcastdev`
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -54,7 +54,7 @@ PROJECT_NUMBER         = "##version##"
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          =
+PROJECT_BRIEF          = Independent SDK for the Sega Dreamcast
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
@@ -909,7 +909,8 @@ WARN_LOGFILE           =
 
 INPUT                  = $(KOS_BASE)/include \
                          $(KOS_BASE)/kernel/arch/$(KOS_ARCH)/include \
-                         $(KOS_BASE)/addons/include
+                         $(KOS_BASE)/addons/include \
+                         $(KOS_BASE)/README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1078,7 +1079,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = $(KOS_BASE)/README.md
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common
@@ -1600,7 +1601,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # When both GENERATE_TREEVIEW and DISABLE_INDEX are set to YES, then the
 # FULL_SIDEBAR option determines if the side bar is limited to only the treeview
@@ -1612,7 +1613,7 @@ GENERATE_TREEVIEW      = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-FULL_SIDEBAR           = NO
+FULL_SIDEBAR           = YES
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.


### PR DESCRIPTION
- Doxygen's main page is now generated from the main README.md file for the GitHub index page
- Also updated the page a tiny bit