### PR TITLE
Updates to GAPS and BBA init sequences

### DIFF
--- a/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
+++ b/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
@@ -22,39 +22,68 @@
 __BEGIN_DECLS
 
 /** \defgroup bba_regs  RTL8139C Register Definitions
+
+    The default assumption is that these are all RW at any aligned size unless 
+    otherwise noted. ex (RW 32bit, RO 16/8) indicates read/write at 32bit and 
+    read-only at 16 or 8bits.
+
     @{
 */
-#define RT_IDR0             0x00    /**< \brief MAC address */
-#define RT_MAR0             0x08    /**< \brief Multicast filter 0 */
-#define RT_MAR4             0x0c    /**< \brief Multicast filter 4 */
-#define RT_TXSTATUS0        0x10    /**< \brief Transmit status (4 32bit regs) */
-#define RT_TXADDR0          0x20    /**< \brief Tx descriptors (also 4 32bit) */
-#define RT_RXBUF            0x30    /**< \brief Receive buffer start address */
-#define RT_RXEARLYCNT       0x34    /**< \brief Early Rx byte count */
-#define RT_RXEARLYSTATUS    0x36    /**< \brief Early Rx status */
+#define RT_IDR0             0x00    /**< \brief MAC address 0 (RW 32bit, RO 16/8) */
+#define RT_IDR1             0x01    /**< \brief MAC address 1 (Read-only) */
+#define RT_IDR2             0x02    /**< \brief MAC address 2 (Read-only) */
+#define RT_IDR3             0x03    /**< \brief MAC address 3 (Read-only) */
+#define RT_IDR4             0x04    /**< \brief MAC address 4 (RW 32bit, RO 16/8) */
+#define RT_IDR5             0x05    /**< \brief MAC address 5 (Read-only) */
+#define RT_RES06            0x06    /**< \brief Reserved */
+#define RT_RES07            0x07    /**< \brief Reserved */
+#define RT_MAR0             0x08    /**< \brief Multicast filter 0 (RW 32bit, RO 16/8) */
+#define RT_MAR1             0x09    /**< \brief Multicast filter 1 (Read-only) */
+#define RT_MAR2             0x0A    /**< \brief Multicast filter 2 (Read-only) */
+#define RT_MAR3             0x0B    /**< \brief Multicast filter 3 (Read-only) */
+#define RT_MAR4             0x0C    /**< \brief Multicast filter 4 (RW 32bit, RO 16/8) */
+#define RT_MAR5             0x0D    /**< \brief Multicast filter 5 (Read-only) */
+#define RT_MAR6             0x0E    /**< \brief Multicast filter 6 (Read-only) */
+#define RT_MAR7             0x0F    /**< \brief Multicast filter 7 (Read-only) */
+#define RT_TXSTATUS0        0x10    /**< \brief Transmit status 0 (32bit only) */
+#define RT_TXSTATUS1        0x14    /**< \brief Transmit status 1 (32bit only) */
+#define RT_TXSTATUS2        0x18    /**< \brief Transmit status 2 (32bit only) */
+#define RT_TXSTATUS3        0x1C    /**< \brief Transmit status 3 (32bit only) */
+#define RT_TXADDR0          0x20    /**< \brief Tx descriptor 0 (32bit only) */
+#define RT_TXADDR1          0x24    /**< \brief Tx descriptor 1 (32bit only) */
+#define RT_TXADDR2          0x28    /**< \brief Tx descriptor 2 (32bit only) */
+#define RT_TXADDR3          0x2C    /**< \brief Tx descriptor 3 (32bit only) */
+#define RT_RXBUF            0x30    /**< \brief Receive buffer start address (32bit only) */
+#define RT_RXEARLYCNT       0x34    /**< \brief Early Rx byte count (RO 16bit) */
+#define RT_RXEARLYSTATUS    0x36    /**< \brief Early Rx status (RO) */
 #define RT_CHIPCMD          0x37    /**< \brief Command register */
-#define RT_RXBUFTAIL        0x38    /**< \brief Current address of packet read (queue tail) */
-#define RT_RXBUFHEAD        0x3A    /**< \brief Current buffer address (queue head) */
-#define RT_INTRMASK         0x3C    /**< \brief Interrupt mask */
-#define RT_INTRSTATUS       0x3E    /**< \brief Interrupt status */
-#define RT_TXCONFIG         0x40    /**< \brief Tx config */
-#define RT_RXCONFIG         0x44    /**< \brief Rx config */
-#define RT_TIMER            0x48    /**< \brief A general purpose counter */
-#define RT_RXMISSED         0x4C    /**< \brief 24 bits valid, write clears */
+#define RT_RXBUFTAIL        0x38    /**< \brief Current address of packet read (queue tail) (16bit only) */
+#define RT_RXBUFHEAD        0x3A    /**< \brief Current buffer address (queue head) (RO 16bit) */
+#define RT_INTRMASK         0x3C    /**< \brief Interrupt mask (16bit only) */
+#define RT_INTRSTATUS       0x3E    /**< \brief Interrupt status (16bit only) */
+#define RT_TXCONFIG         0x40    /**< \brief Tx config (32bit only) */
+#define RT_RXCONFIG         0x44    /**< \brief Rx config (32bit only) */
+#define RT_TIMER            0x48    /**< \brief A general purpose counter, any write clears (32bit only) */
+#define RT_RXMISSED         0x4C    /**< \brief 24 bits valid, write clears (32bit only) */
 #define RT_CFG9346          0x50    /**< \brief 93C46 command register */
 #define RT_CONFIG0          0x51    /**< \brief Configuration reg 0 */
 #define RT_CONFIG1          0x52    /**< \brief Configuration reg 1 */
-#define RT_TIMERINT         0x54    /**< \brief Timer interrupt register (32 bits) */
+#define RT_RES53            0x53    /**< \brief Reserved */
+#define RT_TIMERINT         0x54    /**< \brief Timer interrupt register (32bit only) */
 #define RT_MEDIASTATUS      0x58    /**< \brief Media status register */
 #define RT_CONFIG3          0x59    /**< \brief Config register 3 */
 #define RT_CONFIG4          0x5A    /**< \brief Config register 4 */
-#define RT_MULTIINTR        0x5C    /**< \brief Multiple interrupt select */
-#define RT_MII_TSAD         0x60    /**< \brief Transmit status of all descriptors (16 bits) */
-#define RT_MII_BMCR         0x62    /**< \brief Basic Mode Control Register (16 bits) */
-#define RT_MII_BMSR         0x64    /**< \brief Basic Mode Status Register (16 bits) */
-#define RT_AS_ADVERT        0x66    /**< \brief Auto-negotiation advertisement reg (16 bits) */
-#define RT_AS_LPAR          0x68    /**< \brief Auto-negotiation link partner reg (16 bits) */
-#define RT_AS_EXPANSION     0x6A    /**< \brief Auto-negotiation expansion reg (16 bits) */
+#define RT_RES5B            0x5B    /**< \brief Reserved */
+#define RT_MULTIINTR        0x5C    /**< \brief Multiple interrupt select (32bit only) */
+#define RT_RERID            0x5E    /**< \brief PCI Revision ID (10h) (Read-only) */
+#define RT_RES5F            0x5F    /**< \brief Reserved */
+#define RT_MII_TSAD         0x60    /**< \brief Transmit status of all descriptors (RO 16bit) */
+#define RT_MII_BMCR         0x62    /**< \brief Basic Mode Control Register (16bit only) */
+#define RT_MII_BMSR         0x64    /**< \brief Basic Mode Status Register (RO 16bit) */
+#define RT_AS_ADVERT        0x66    /**< \brief Auto-negotiation advertisement reg (16bit only) */
+#define RT_AS_LPAR          0x68    /**< \brief Auto-negotiation link partner reg (RO 16bit) */
+#define RT_AS_EXPANSION     0x6A    /**< \brief Auto-negotiation expansion reg (RO 16bit) */
+
 #define RT_CONFIG5          0xD8    /**< \brief Config register 5 */
 /** @} */
 

--- a/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
+++ b/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
@@ -25,7 +25,8 @@ __BEGIN_DECLS
     @{
 */
 #define RT_IDR0             0x00    /**< \brief MAC address */
-#define RT_MAR0             0x08    /**< \brief Multicast filter */
+#define RT_MAR0             0x08    /**< \brief Multicast filter 0 */
+#define RT_MAR4             0x0c    /**< \brief Multicast filter 4 */
 #define RT_TXSTATUS0        0x10    /**< \brief Transmit status (4 32bit regs) */
 #define RT_TXADDR0          0x20    /**< \brief Tx descriptors (also 4 32bit) */
 #define RT_RXBUF            0x30    /**< \brief Receive buffer start address */
@@ -54,14 +55,21 @@ __BEGIN_DECLS
 #define RT_AS_ADVERT        0x66    /**< \brief Auto-negotiation advertisement reg (16 bits) */
 #define RT_AS_LPAR          0x68    /**< \brief Auto-negotiation link partner reg (16 bits) */
 #define RT_AS_EXPANSION     0x6A    /**< \brief Auto-negotiation expansion reg (16 bits) */
+#define RT_CONFIG5          0xD8    /**< \brief Config register 5 */
 /** @} */
 
 /** \defgroup bba_miicb RTL8139C MII (media independent interface) control bits
     @{
 */
-#define RT_MII_AN_START     0x0200  /**< \brief Start auto-negotiation */
-#define RT_MII_AN_ENABLE    0x1000  /**< \brief Enable auto-negotiation */
-#define RT_MII_RESET        0x8000  /**< \brief Reset the MII chip */
+#define RT_MII_RESET       0x8000  /**< \brief Reset the MII chip */
+#define RT_MII_RES4000     0x4000  /**< \brief Reserved */
+#define RT_MII_SPD_SET     0x2000  /**< \brief 1 for 100 0 for 10. Ignored if AN enabled. */
+#define RT_MII_AN_ENABLE   0x1000  /**< \brief Enable auto-negotiation */
+#define RT_MII_RES0800     0x0800  /**< \brief Reserved */
+#define RT_MII_RES0400     0x0400  /**< \brief Reserved */
+#define RT_MII_AN_START    0x0200  /**< \brief Start auto-negotiation */
+#define RT_MII_DUPLEX      0x0100  /**< \brief 1 for full 0 for half. Ignored if AN enabled. */
+
 /** @} */
 
 /** \defgroup bba_miisb RTL8139C MII (media independent interface) status bits
@@ -131,6 +139,54 @@ __BEGIN_DECLS
 #define RT_RX_CRC_ERR       0x00000004  /**< \brief CRC error */
 #define RT_RX_FRAME_ALIGN   0x00000002  /**< \brief Frame alignment error */
 #define RT_RX_STATUS_OK     0x00000001  /**< \brief Status ok: a good packet was received */
+/** @} */
+
+/** \defgroup bba_config1bits RTL8139C Config Register 1 bits
+
+    From RTL8139C(L) datasheet v1.4
+
+    @{
+*/
+#define RT_CONFIG1_LED1     0x80 /**< \brief XXX DC bba has no LED, maybe repurposed. */
+#define RT_CONFIG1_LED0     0x40 /**< \brief XXX DC bba has no LED, maybe repurposed. */
+#define RT_CONFIG1_DVRLOAD  0x20 /**< \brief Sets the Driver as loaded. */
+#define RT_CONFIG1_LWACT    0x10 /**< \brief LWAKE active mode. Default 0. */
+#define RT_CONFIG1_MEMMAP   0x08 /**< \brief Registers mapped to PCI mem space. Read Only */
+#define RT_CONFIG1_IOMAP    0x04 /**< \brief Registers mapped to PCI I/O space. Read Only */
+#define RT_CONFIG1_VPD      0x02 /**< \brief Enable Vital Product Data. */
+#define RT_CONFIG1_PMEn     0x01 /**< \brief Power Management Enable */
+/** @} */
+
+/** \defgroup bba_config4bits RTL8139C Config Register 4 bits
+
+    From RTL8139C(L) datasheet v1.4. Only RT_CONFIG4_RxFIFIOAC is used.
+
+    @{
+*/
+#define RT_CONFIG4_RxFIFIOAC 0x80 /**< \brief Auto-clear the Rx FIFO overflow. */
+#define RT_CONFIG4_AnaOff    0x40 /**< \brief Turn off analog power. Default 0. */
+#define RT_CONFIG4_LongWF    0x20 /**< \brief Long Wake-up Frames. */
+#define RT_CONFIG4_LWPME     0x10 /**< \brief LWake vs PMEB. */
+#define RT_CONFIG4_RES08     0x08 /**< \brief Reserved. */
+#define RT_CONFIG4_LWPTN     0x04 /**< \brief LWAKE Pattern. */
+#define RT_CONFIG4_RES02     0x02 /**< \brief Reserved. */
+#define RT_CONFIG4_PBWake    0x01 /**< \brief Disable pre-Boot Wakeup. */
+/** @} */
+
+/** \defgroup bba_config5bits RTL8139C Config Register 5 bits
+
+    From RTL8139C(L) datasheet v1.4. Only RT_CONFIG5_LDPS is used.
+
+    @{
+*/
+#define RT_CONFIG5_RES80    0x80 /**< \brief Reserved. */
+#define RT_CONFIG5_BWF      0x40 /**< \brief Enable Broadcast Wakeup Frame. Default 0. */
+#define RT_CONFIG5_MWF      0x20 /**< \brief Enable Multicast Wakeup Frame. Default 0. */
+#define RT_CONFIG5_UWF      0x10 /**< \brief Enable Unicast Wakeup Frame. Default 0. */
+#define RT_CONFIG5_FIFOAddr 0x08 /**< \brief Set FIFO address pointer. For testing only. */
+#define RT_CONFIG5_LDPS     0x04 /**< \brief Disable Link Down Power Saving mode. */
+#define RT_CONFIG5_LANW     0x02 /**< \brief Enable LANWake signal. */
+#define RT_CONFIG5_PME_STS  0x01 /**< \brief Allow PCI reset to set PME_Status bit. */
 /** @} */
 
 /** \brief  Retrieve the MAC Address of the attached BBA.


### PR DESCRIPTION
This is a partial update of the BBA driver, specifically for the GAPS and initialization sequences as well as the documentation of the registers. It's based primarily on all the work done by Moopthehedgehog and provided to the dcload-ip fork here: https://github.com/sizious/dcload-ip/pull/4 as well as by referencing the RTL8139 datasheet. I'm not entirely sure what the best way to note that would be other than just here, as Moopthehedgehog explicitly wanted to decline copyright ( see the note: https://github.com/sizious/dcload-ip/blob/master/target-src/dcload/dhcp.h )

Tested with the basic examples and didn't see any *new* issues caused by this. I figured it would be useful to import these updates piecemeal to make testing clearer, rather than rewrite the whole thing all at once.