### PR TITLE
Various corrections from static analysis

### DIFF
--- a/addons/libkosext2fs/fs_ext2.c
+++ b/addons/libkosext2fs/fs_ext2.c
@@ -740,6 +740,7 @@ static int int_rename(fs_ext2_fs_t *fs, const char *fn1, const char *fn2,
                 if(dinode)
                     ext2_inode_put(dinode);
 
+                free(cp);
                 return -EINVAL;
             }
 
@@ -754,6 +755,7 @@ static int int_rename(fs_ext2_fs_t *fs, const char *fn1, const char *fn2,
                 if(dinode)
                     ext2_inode_put(dinode);
 
+                free(cp);
                 return -EINVAL;
             }
 
@@ -771,6 +773,7 @@ static int int_rename(fs_ext2_fs_t *fs, const char *fn1, const char *fn2,
                 if(dinode)
                     ext2_inode_put(dinode);
 
+                free(cp);
                 return irv;
             }
         }
@@ -823,8 +826,10 @@ static int int_rename(fs_ext2_fs_t *fs, const char *fn1, const char *fn2,
     /* If the thing we moved was a directory, we need to fix its '..' entry and
        update the reference counts of the inodes involved. */
     if(!isfile) {
-        if((ext2_dir_redir_entry(fs->fs, finode, "..", dpinode_num, NULL)))
+        if((ext2_dir_redir_entry(fs->fs, finode, "..", dpinode_num, NULL))) {
+            free(cp);
             return -EIO;
+        }
 
         --pinode->i_links_count;
         ++dpinode->i_links_count;
@@ -911,6 +916,7 @@ static int fs_ext2_rename(vfs_handler_t *vfs, const char *fn1,
     /* Find the inode of the entry we want to move. */
     if(!(inode = ext2_inode_get(fs->fs, dent->inode, &irv))) {
         mutex_unlock(&ext2_mutex);
+        free(cp);
         errno = EIO;
         return -1;
     }

--- a/include/assert.h
+++ b/include/assert.h
@@ -96,6 +96,7 @@ typedef void (*assert_handler_t)(const char * file, int line, const char * expr,
 /** \brief  Set an assertion handler to call on a failed assertion.
 
     The default assertion handler simply will print a message and call abort().
+    NULL is a valid value and will cause nothing to happen on an assert.
 
     \return                 The old assertion handler so it may be restored
                             later if appropriate.

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -55,8 +55,8 @@ int fs_romdisk_shutdown(void);
                             freed when it is unmounted
     \retval 0               On success
     \retval -1              If fs_romdisk_init not called
-	\retval -2              If img is invalid
-	\retval -3              If a malloc fails
+    \retval -2              If img is invalid
+    \retval -3              If a malloc fails
 */
 int fs_romdisk_mount(const char * mountpoint, const uint8 *img, int own_buffer);
 

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -54,7 +54,9 @@ int fs_romdisk_shutdown(void);
                             free it if appropriate. If non-zero, img will be
                             freed when it is unmounted
     \retval 0               On success
-    \retval -1              On error
+    \retval -1              If fs_romdisk_init not called
+	\retval -2              If img is invalid
+	\retval -3              If a malloc fails
 */
 int fs_romdisk_mount(const char * mountpoint, const uint8 *img, int own_buffer);
 

--- a/include/kos/net.h
+++ b/include/kos/net.h
@@ -259,7 +259,8 @@ void net_arp_shutdown(void);
     \param  timestamp       The entry's timestamp. Set to 0 for a permanent
                             entry, otherwise set to the current number of
                             milliseconds since boot (i.e, timer_ms_gettime64()).
-    \retval 0               On success (no error conditions defined).
+    \retval 0               On success.
+    \retval -1              Error allocating memory.
 */
 int net_arp_insert(netif_t *nif, const uint8 mac[6], const uint8 ip[4],
                    uint64 timestamp);
@@ -280,6 +281,7 @@ int net_arp_insert(netif_t *nif, const uint8 mac[6], const uint8 ip[4],
     \retval 0               On success.
     \retval -1              A query is outstanding for that address.
     \retval -2              Address not found, query generated.
+    \retval -3              Error allocating memory.
 */
 int net_arp_lookup(netif_t *nif, const uint8 ip_in[4], uint8 mac_out[6],
                    const ip_hdr_t *pkt, const uint8 *data, int data_size);

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -68,6 +68,11 @@ __BEGIN_DECLS
 */
 #define PRIO_DEFAULT 10
 
+/** \brief  Initial Thread ID (tid).
+    TIDs are created starting from this value.
+*/
+#define TID_FIRST 1
+
 /* Pre-define list/queue types */
 struct kthread;
 
@@ -524,8 +529,11 @@ int thd_join(kthread_t * thd, void **value_ptr);
 
     \param  thd             The joinable thread to detach.
 
-    \return                 0 on success or less than 0 if the thread is
-                            non-existant or already detached.
+    \retval 0               On success.
+    \retval -1              NULL was passed in.
+    \retval -2              Thread not found.
+    \retval -3              Thread already detatched.
+
     \see    thd_join()
 */
 int thd_detach(kthread_t *thd);
@@ -560,8 +568,8 @@ int thd_pslist_queue(int (*pf)(const char *fmt, ...));
     This is normally done for you by default when KOS starts. This will also
     initialize all the various synchronization primitives.
 
-    \retval -1              If threads are already initialized.
     \retval 0               On success.
+    \retval -1              If threads are already initialized.
 */
 int thd_init(void);
 

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -412,6 +412,8 @@ void thd_sleep(int ms);
     \param  prio            The priority value to assign to the thread.
 
     \retval 0               On success.
+    \retval -1              thd is NULL.
+    \retval -2              prio requested was out of range.
 */
 int thd_set_prio(kthread_t *thd, prio_t prio);
 

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -68,11 +68,6 @@ __BEGIN_DECLS
 */
 #define PRIO_DEFAULT 10
 
-/** \brief  Initial Thread ID (tid).
-    TIDs are created starting from this value.
-*/
-#define TID_FIRST 1
-
 /* Pre-define list/queue types */
 struct kthread;
 
@@ -531,11 +526,8 @@ int thd_join(kthread_t * thd, void **value_ptr);
 
     \param  thd             The joinable thread to detach.
 
-    \retval 0               On success.
-    \retval -1              NULL was passed in.
-    \retval -2              Thread not found.
-    \retval -3              Thread already detatched.
-
+    \return                 0 on success or less than 0 if the thread is
+                            non-existant or already detached.
     \see    thd_join()
 */
 int thd_detach(kthread_t *thd);
@@ -570,8 +562,8 @@ int thd_pslist_queue(int (*pf)(const char *fmt, ...));
     This is normally done for you by default when KOS starts. This will also
     initialize all the various synchronization primitives.
 
-    \retval 0               On success.
     \retval -1              If threads are already initialized.
+    \retval 0               On success.
 */
 int thd_init(void);
 

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -129,6 +129,7 @@ static vmu_fh_t *vmu_open_vmu_dir(void) {
 #endif
 
     dh = malloc(sizeof(vmu_dh_t));
+    if(dh == NULL) return NULL;
     memset(dh, 0, sizeof(vmu_dh_t));
     dh->strtype = VMU_DIR;
     dh->dirblocks = malloc(num * sizeof(vmu_dir_t));
@@ -165,6 +166,9 @@ static vmu_fh_t *vmu_open_dir(maple_device_t * dev) {
 
     /* Allocate a handle for the dir blocks */
     dh = malloc(sizeof(vmu_dh_t));
+
+    if(dh == NULL) return NULL;
+
     dh->strtype = VMU_DIR;
     dh->dirblocks = dirents;
     dh->rootdir = 0;
@@ -185,6 +189,8 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
     /* Malloc a new fh struct */
     fd = malloc(sizeof(vmu_fh_t));
 
+    if(fd == NULL) return NULL;
+
     /* Fill in the filehandle struct */
     fd->strtype = VMU_FILE;
     fd->mode = mode;
@@ -203,10 +209,8 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
 
         if(rv < 0) {
             if(realmode == O_RDWR || realmode == O_WRONLY) {
-                /* In some modes failure is ok -- just setup a blank first block. */
-                data = malloc(512);
-                datasize = 512;
-                memset(data, 0, 512);
+                /* In some modes failure is ok -- flag to setup a blank first block. */
+                datasize = -1;
             }
             else {
                 free(fd);
@@ -215,8 +219,17 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
         }
     }
     else {
-        /* We're writing with truncate... just setup a blank first block. */
+        /* We're writing with truncate... flag to setup a blank first block. */
+        datasize = -1;
+    }
+
+    /* We were flagged to set up a blank first block */
+    if(datasize == -1) {
         data = malloc(512);
+        if(data == NULL) {
+            free(fd);
+            return NULL;
+        }
         datasize = 512;
         memset(data, 0, 512);
     }
@@ -226,6 +239,7 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
 
     if(fd->filesize == 0) {
         dbglog(DBG_WARNING, "VMUFS: can't open zero-length file %s\n", path);
+        free(fd->data);
         free(fd);
         return NULL;
     }

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -128,8 +128,8 @@ static vmu_fh_t *vmu_open_vmu_dir(void) {
     dbglog(DBG_KDEBUG, "# of memcards found: %d\n", num);
 #endif
 
-    dh = malloc(sizeof(vmu_dh_t));
-    if(dh == NULL) return NULL;
+    if(!(dh = malloc(sizeof(vmu_dh_t))))
+        return NULL;
     memset(dh, 0, sizeof(vmu_dh_t));
     dh->strtype = VMU_DIR;
     dh->dirblocks = malloc(num * sizeof(vmu_dir_t));
@@ -165,8 +165,8 @@ static vmu_fh_t *vmu_open_dir(maple_device_t * dev) {
         return NULL;
 
     /* Allocate a handle for the dir blocks */
-    dh = malloc(sizeof(vmu_dh_t));
-    if(dh == NULL) return NULL;
+    if(!(dh = malloc(sizeof(vmu_dh_t))))
+        return NULL;
     dh->strtype = VMU_DIR;
     dh->dirblocks = dirents;
     dh->rootdir = 0;
@@ -185,8 +185,8 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
     int     datasize;
 
     /* Malloc a new fh struct */
-    fd = malloc(sizeof(vmu_fh_t));
-    if(fd == NULL) return NULL;
+    if(!(fd = malloc(sizeof(vmu_fh_t))))
+        return NULL;
 
     /* Fill in the filehandle struct */
     fd->strtype = VMU_FILE;

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -166,9 +166,7 @@ static vmu_fh_t *vmu_open_dir(maple_device_t * dev) {
 
     /* Allocate a handle for the dir blocks */
     dh = malloc(sizeof(vmu_dh_t));
-
     if(dh == NULL) return NULL;
-
     dh->strtype = VMU_DIR;
     dh->dirblocks = dirents;
     dh->rootdir = 0;
@@ -188,7 +186,6 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
 
     /* Malloc a new fh struct */
     fd = malloc(sizeof(vmu_fh_t));
-
     if(fd == NULL) return NULL;
 
     /* Fill in the filehandle struct */

--- a/kernel/arch/dreamcast/fs/vmufs.c
+++ b/kernel/arch/dreamcast/fs/vmufs.c
@@ -543,12 +543,18 @@ static int vmufs_setup(maple_device_t * dev, vmu_root_t * root, vmu_dir_t ** dir
         if(!*fat) {
             dbglog(DBG_ERROR, "vmufs_setup: can't alloc %d bytes for FAT on device %c%c\n",
                    *fatsize, dev->port + 'A', dev->unit + '0');
+            if(dir)
+                free(*dir);
             goto dead;
         }
 
         /* Read it */
-        if(vmufs_fat_read(dev, root, *fat) < 0)
+        if(vmufs_fat_read(dev, root, *fat) < 0) {
+            free(*fat);
+            if(dir)
+                free(*dir);
             goto dead;
+        }
     }
 
     /* Ok, everything's cool */

--- a/kernel/arch/dreamcast/include/arch/mmu.h
+++ b/kernel/arch/dreamcast/include/arch/mmu.h
@@ -201,7 +201,7 @@ void mmu_use_table(mmucontext_t *context);
     own, that means you will only ever have one of these, if any.
 
     \param  asid            The address space ID of this process.
-    \return                 The newly created context.
+    \return                 The newly created context or NULL on fail.
 */
 mmucontext_t *mmu_context_create(int asid);
 
@@ -271,7 +271,7 @@ void mmu_page_map(mmucontext_t *context, int virtpage, int physpage,
     \param  srcaddr         Source, in the mapped memory space.
     \param  srccnt          The number of bytes to copy.
     \param  buffer          The kernel buffer to copy into (should be in P1).
-    \return                 The number of bytes copied.
+    \return                 The number of bytes copied (failure causes arch_panic).
 */
 int mmu_copyin(mmucontext_t *context, uint32 srcaddr, uint32 srccnt,
                void *buffer);
@@ -285,6 +285,7 @@ int mmu_copyin(mmucontext_t *context, uint32 srcaddr, uint32 srccnt,
     \param  context2        The destination's context.
     \param  iov2            The scatter/gather array to copy to.
     \param  iovcnt2         The number of entries in iov2.
+    \return                 The number of bytes copied (failure causes arch_panic).
 */
 int mmu_copyv(mmucontext_t *context1, struct iovec *iov1, int iovcnt1,
               mmucontext_t *context2, struct iovec *iov2, int iovcnt2);

--- a/kernel/arch/dreamcast/kernel/mmu.c
+++ b/kernel/arch/dreamcast/kernel/mmu.c
@@ -139,7 +139,8 @@ mmucontext_t *mmu_context_create(int asid) {
 
     cont = (mmucontext_t*)malloc(sizeof(mmucontext_t));
 
-    if(cont == NULL) return NULL;
+    if(cont == NULL)
+        return NULL;
 
     cont->asid = asid;
 

--- a/kernel/arch/dreamcast/kernel/mmu.c
+++ b/kernel/arch/dreamcast/kernel/mmu.c
@@ -138,6 +138,9 @@ mmucontext_t *mmu_context_create(int asid) {
     int     i;
 
     cont = (mmucontext_t*)malloc(sizeof(mmucontext_t));
+
+    if(cont == NULL) return NULL;
+
     cont->asid = asid;
 
     for(i = 0; i < MMU_PAGES; i++)

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
-#include <errno.h>
 
 #include <sys/queue.h>
 #include <kos/fs.h>
@@ -147,7 +146,6 @@ sfxhnd_t snd_sfx_load(const char *fn) {
 
         if(tmp == NULL) {
             fs_close(fd);
-            errno = ENOMEM;
             return SFXHND_INVALID;
         }
 
@@ -165,7 +163,7 @@ sfxhnd_t snd_sfx_load(const char *fn) {
     if(t == NULL) {
         if(ownmem)
             free(tmp);
-        errno = ENOMEM;
+
         return SFXHND_INVALID;
     }
 
@@ -205,7 +203,7 @@ sfxhnd_t snd_sfx_load(const char *fn) {
             free(t);
             if(ownmem)
                 free(tmp);
-            errno = ENOMEM;
+
             return SFXHND_INVALID;
         }
 

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -57,13 +57,7 @@ extern char *realpath(const char *, char[PATH_MAX]);
 
 /* Internal file commands for root dir reading */
 static fs_hnd_t * fs_root_opendir(void) {
-    fs_hnd_t    *hnd;
-
-    hnd = malloc(sizeof(fs_hnd_t));
-    hnd->handler = NULL;
-    hnd->hnd = 0;
-    hnd->refcnt = 0;
-    return hnd;
+    return calloc(1, sizeof(fs_hnd_t));
 }
 
 /* Not thread-safe right now */

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -185,7 +185,7 @@ int fs_pty_create(char * buffer, int maxbuflen, file_t * master_out, file_t * sl
 }
 
 /* Autoclean totally unreferenced PTYs (zero refcnt). */
-/* XXX This is a kinda nasty piece of code... two goto's!! */
+/* XXX This is a kinda nasty piece of code... goto!! */
 static void pty_destroy_unused(void) {
     ptyhalf_t * c, * n;
     int old;
@@ -202,40 +202,35 @@ again:
         n = LIST_NEXT(c, list);
 
         /* Don't mess with the kernel console or locked items */
-        if(c->id == 0 || mutex_is_locked(&c->mutex))
-            goto next;
+        if((c->id != 0) && (!mutex_is_locked(&c->mutex))) {
 
-        /* Not in use? */
-        if(c->refcnt <= 0) {
-            /* Check to see if the other end is also free */
-            if(c->other->refcnt > 0)
-                goto next;
+            /* Make sure neither is in use */
+            if((c->refcnt <= 0) && (c->other->refcnt <= 0)) {
 
-            /* Free all our structs */
-            cond_destroy(&c->ready_read);
-            cond_destroy(&c->ready_write);
-            mutex_destroy(&c->mutex);
+                /* Free all our structs */
+                cond_destroy(&c->ready_read);
+                cond_destroy(&c->ready_write);
+                mutex_destroy(&c->mutex);
 
-            /* Remove us from the list */
-            LIST_REMOVE(c, list);
+                /* Remove us from the list */
+                LIST_REMOVE(c, list);
 
-            /* Now to deal with our partner... */
-            cond_destroy(&c->other->ready_read);
-            cond_destroy(&c->other->ready_write);
-            mutex_destroy(&c->other->mutex);
+                /* Now to deal with our partner... */
+                cond_destroy(&c->other->ready_read);
+                cond_destroy(&c->other->ready_write);
+                mutex_destroy(&c->other->mutex);
 
-            /* Remove it from the list */
-            LIST_REMOVE(c->other, list);
+                /* Remove it from the list */
+                LIST_REMOVE(c->other, list);
 
-            /* Free the structs */
-            free(c->other);
-            free(c);
+                /* Free the structs */
+                free(c->other);
+                free(c);
 
-            /* Need to restart */
-            goto again;
+                /* Need to restart */
+                goto again;
+            }
         }
-
-    next:
         c = n;
     }
 
@@ -294,6 +289,14 @@ static void * pty_open_dir(const char * fn, int mode) {
 
     /* Now return that as our handle item */
     fdobj = malloc(sizeof(pipefd_t));
+
+    if(fdobj == NULL) {
+        free(dl->items);
+        free(dl);
+        errno = ENOMEM;
+        goto done;  /* return */
+    }
+
     memset(fdobj, 0, sizeof(pipefd_t));
     fdobj->d.d = dl;
     fdobj->type = PF_DIR;
@@ -354,13 +357,19 @@ static void * pty_open_file(const char * fn, int mode) {
             ph = ph->other;
     }
 
+    fdobj = malloc(sizeof(pipefd_t));
+
+    if(fdobj == NULL) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    memset(fdobj, 0, sizeof(pipefd_t));
+
     /* Now add a refcnt and return it */
     mutex_lock(&ph->mutex);
     ph->refcnt++;
     mutex_unlock(&ph->mutex);
 
-    fdobj = malloc(sizeof(pipefd_t));
-    memset(fdobj, 0, sizeof(pipefd_t));
     fdobj->d.p = ph;
     fdobj->type = PF_PTY;
     fdobj->mode = mode;

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -148,7 +148,7 @@ static rd_file_t * ramdisk_find_path(rd_dir_t * parent, const char * fn, int dir
     if(fn[0] != 0) {
         f = ramdisk_find(parent, fn, strlen(fn));
 
-        if((!dir && f->type == STAT_TYPE_DIR) || (dir && f->type != STAT_TYPE_DIR))
+        if((f == NULL) || (!dir && f->type == STAT_TYPE_DIR) || (dir && f->type != STAT_TYPE_DIR))
             return NULL;
     }
     else {
@@ -204,7 +204,14 @@ static rd_file_t * ramdisk_create_file(rd_dir_t * parent, const char * fn, int d
 
     /* Now add a file to the parent */
     f = (rd_file_t *)malloc(sizeof(rd_file_t));
+    if(f == NULL) return NULL;
+
     f->name = strdup(p);
+    if(f->name == NULL) {
+        free(f);
+        return NULL;
+    }
+
     f->size = 0;
     f->type = dir ? STAT_TYPE_DIR : STAT_TYPE_FILE;
     f->openfor = OPENFOR_NOTHING;
@@ -217,6 +224,12 @@ static rd_file_t * ramdisk_create_file(rd_dir_t * parent, const char * fn, int d
     else {
         f->data = malloc(sizeof(rd_dir_t));
         f->datasize = 0;
+    }
+
+    if(f->data == NULL) {
+        free(f->name);
+        free(f);
+        return NULL;
     }
 
     LIST_INSERT_HEAD(pdir, f, dirlist);
@@ -835,15 +848,29 @@ int fs_ramdisk_detach(const char * fn, void ** obj, size_t * size) {
 int fs_ramdisk_init(void) {
     /* Create an empty root dir */
     rootdir = (rd_dir_t *)malloc(sizeof(rd_dir_t));
-    LIST_INIT(rootdir);
+    if(rootdir == NULL) return -1;
+
     root = (rd_file_t *)malloc(sizeof(rd_file_t));
+    if(root == NULL) {
+        free(rootdir);
+        return -1;
+    }
+
     root->name = strdup("/");
+    if(root->name == NULL) {
+        free(root);
+        free(rootdir);
+        return -1;
+    }
+
     root->size = 0;
     root->type = STAT_TYPE_DIR;
     root->openfor = OPENFOR_NOTHING;
     root->usage = 0;
     root->data = rootdir;
     root->datasize = 0;
+
+    LIST_INIT(rootdir);
 
     /* Reset fd's */
     memset(fh, 0, sizeof(fh));

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -847,8 +847,8 @@ int fs_ramdisk_detach(const char * fn, void ** obj, size_t * size) {
 /* Initialize the file system */
 int fs_ramdisk_init(void) {
     /* Create an empty root dir */
-    rootdir = (rd_dir_t *)malloc(sizeof(rd_dir_t));
-    if(rootdir == NULL) return -1;
+    if(!(rootdir = (rd_dir_t *)malloc(sizeof(rd_dir_t))))
+        return -1;
 
     root = (rd_file_t *)malloc(sizeof(rd_file_t));
     if(root == NULL) {

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -203,8 +203,8 @@ static rd_file_t * ramdisk_create_file(rd_dir_t * parent, const char * fn, int d
         return NULL;
 
     /* Now add a file to the parent */
-    f = (rd_file_t *)malloc(sizeof(rd_file_t));
-    if(f == NULL) return NULL;
+    if(!(f = (rd_file_t *)malloc(sizeof(rd_file_t))))
+        return NULL;
 
     f->name = strdup(p);
     if(f->name == NULL) {

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -604,7 +604,7 @@ int fs_romdisk_mount(const char * mountpoint, const uint8 *img, int own_buffer) 
 
     if(strncmp((char *)img, "-rom1fs-", 8)) {
         dbglog(DBG_ERROR, "Rom disk image at %p is not a ROMFS image\n", img);
-        return -1;
+        return -2;
     }
     else {
         dbglog(DBG_DEBUG, "fs_romdisk: mounting image at %p at %s\n", img, mountpoint);
@@ -612,6 +612,11 @@ int fs_romdisk_mount(const char * mountpoint, const uint8 *img, int own_buffer) 
 
     /* Create a mount struct */
     mnt = (rd_image_t *)malloc(sizeof(rd_image_t));
+
+    if(mnt == NULL) {
+        errno=ENOMEM;
+        return -3;
+    }
     mnt->own_buffer = own_buffer;
     mnt->image = img;
     mnt->hdr = hdr;
@@ -620,6 +625,12 @@ int fs_romdisk_mount(const char * mountpoint, const uint8 *img, int own_buffer) 
 
     /* Make a VFS struct */
     vfsh = (vfs_handler_t *)malloc(sizeof(vfs_handler_t));
+
+    if(vfsh == NULL) {
+        free(mnt);
+        errno=ENOMEM;
+        return -3;
+    }
     memcpy(vfsh, &vh, sizeof(vfs_handler_t));
     strcpy(vfsh->nmmgr.pathname, mountpoint);
     vfsh->privdata = (void *)mnt;

--- a/kernel/libc/koslib/assert.c
+++ b/kernel/libc/koslib/assert.c
@@ -17,8 +17,8 @@
 #endif
 
 /* The default assert handler */
-static void assert_handler_default(const char *file, int line, const char *expr,
-                                   const char *msg, const char *func) {
+static void __noreturn assert_handler_default(const char *file, int line,
+                            const char *expr, const char *msg, const char *func) {
     dbglog(DBG_CRITICAL, "\n*** ASSERTION FAILURE ***\n");
 
     if(msg == NULL)

--- a/kernel/net/net_arp.c
+++ b/kernel/net/net_arp.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <stdio.h>
+#include <errno.h>
 #include <kos/net.h>
 #include <kos/thread.h>
 #include <arch/timer.h>
@@ -141,6 +142,12 @@ int net_arp_insert(netif_t *nif, const uint8 mac[6], const uint8 ip[4],
 
     /* It's not there, add an entry */
     cur = (netarp_t *)malloc(sizeof(netarp_t));
+
+    if(cur == NULL) {
+        errno = ENOMEM;
+        return -1;
+    }
+
     memcpy(cur->mac, mac, 6);
     memcpy(cur->ip, ip, 4);
     cur->timestamp = timestamp;
@@ -186,6 +193,11 @@ int net_arp_lookup(netif_t *nif, const uint8 ip_in[4], uint8 mac_out[6],
 
     /* It's not there... Add an incomplete ARP entry */
     cur = (netarp_t *)malloc(sizeof(netarp_t));
+
+    if(cur == NULL) {
+        errno = ENOMEM;
+        return -3;
+    }
     memset(cur, 0, sizeof(netarp_t));
     memcpy(cur->ip, ip_in, 4);
     cur->timestamp = timer_ms_gettime64();

--- a/kernel/net/net_arp.c
+++ b/kernel/net/net_arp.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <malloc.h>
 #include <stdio.h>
-#include <errno.h>
 #include <kos/net.h>
 #include <kos/thread.h>
 #include <arch/timer.h>
@@ -143,10 +142,8 @@ int net_arp_insert(netif_t *nif, const uint8 mac[6], const uint8 ip[4],
     /* It's not there, add an entry */
     cur = (netarp_t *)malloc(sizeof(netarp_t));
 
-    if(cur == NULL) {
-        errno = ENOMEM;
+    if(cur == NULL)
         return -1;
-    }
 
     memcpy(cur->mac, mac, 6);
     memcpy(cur->ip, ip, 4);
@@ -194,10 +191,9 @@ int net_arp_lookup(netif_t *nif, const uint8 ip_in[4], uint8 mac_out[6],
     /* It's not there... Add an incomplete ARP entry */
     cur = (netarp_t *)malloc(sizeof(netarp_t));
 
-    if(cur == NULL) {
-        errno = ENOMEM;
+    if(cur == NULL)
         return -3;
-    }
+
     memset(cur, 0, sizeof(netarp_t));
     memcpy(cur->ip, ip_in, 4);
     cur->timestamp = timer_ms_gettime64();

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -2099,7 +2099,7 @@ static short net_tcp_poll(net_socket_t *hnd, short events) {
 
         case TCP_STATE_TIME_WAIT:
         case TCP_STATE_CLOSING:
-            rv = POLLRDNORM;
+            rv |= POLLRDNORM;
             break;
 
         case TCP_STATE_SYN_RECEIVED:

--- a/kernel/net/net_udp.c
+++ b/kernel/net/net_udp.c
@@ -597,6 +597,7 @@ static int net_udp_socket(net_socket_t *hnd, int domain, int type, int proto) {
         proto = IPPROTO_UDP;
     }
     else if(proto != IPPROTO_UDP && proto != IPPROTO_UDPLITE) {
+        free(udpsock);
         errno = EPROTONOSUPPORT;
         return -1;
     }

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -492,6 +492,12 @@ int thd_destroy(kthread_t *thd) {
 
 /* Set a thread's priority */
 int thd_set_prio(kthread_t *thd, prio_t prio) {
+    if(thd == NULL)
+        return -1;
+
+    if((prio < 0) || (prio > PRIO_MAX))
+        return -2;
+
     /* Set the new priority */
     thd->prio = prio;
     return 0;

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -154,11 +154,12 @@ int thd_pslist_queue(int (*pf)(const char *fmt, ...)) {
 /* Highest thread id (used when assigning next thread id) */
 static tid_t tid_highest;
 
-/* Return the next available thread id (assumes wraparound will not run
-   into old processes). */
+/* Return the next available thread id. Asserts at wraparound. */
 static tid_t thd_next_free(void) {
-    int id;
+    tid_t id;
     id = tid_highest++;
+    /* Assert on wraparounds */
+    assert(id >= TID_FIRST);
     return id;
 }
 
@@ -357,76 +358,77 @@ kthread_t *thd_create_ex(kthread_attr_t *attr, void * (*routine)(void *param),
     /* Get a new thread id */
     tid = thd_next_free();
 
-    if(tid >= 0) {
-        /* Create a new thread structure */
-        nt = malloc(sizeof(kthread_t));
+    /* Create a new thread structure */
+    nt = malloc(sizeof(kthread_t));
 
-        if(nt != NULL) {
-            /* Clear out potentially unused stuff */
-            memset(nt, 0, sizeof(kthread_t));
+    if(nt != NULL) {
+        /* Clear out potentially unused stuff */
+        memset(nt, 0, sizeof(kthread_t));
 
-            /* Create a new thread stack */
-            if(!real_attr.stack_ptr) {
-                nt->stack = (uint32*)malloc(real_attr.stack_size);
+        /* Create a new thread stack */
+        if(!real_attr.stack_ptr) {
+            nt->stack = (uint32*)malloc(real_attr.stack_size);
 
-                if(!nt->stack) {
-                    free(nt);
-                    irq_restore(oldirq);
-                    return NULL;
-                }
+            if(!nt->stack) {
+                free(nt);
+                irq_restore(oldirq);
+                errno = ENOMEM;
+                return NULL;
             }
-            else {
-                nt->stack = (uint32*)real_attr.stack_ptr;
-            }
-
-            nt->stack_size = real_attr.stack_size;
-
-            /* Populate the context */
-            params[0] = (uint32)routine;
-            params[1] = (uint32)param;
-            params[2] = 0;
-            params[3] = 0;
-            irq_create_context(&nt->context,
-                               ((uint32)nt->stack) + nt->stack_size,
-                               (uint32)thd_birth, params, 0);
-
-            nt->tid = tid;
-            nt->prio = real_attr.prio;
-            nt->flags = THD_DEFAULTS;
-            nt->state = STATE_READY;
-
-            if(!real_attr.label) {
-                strcpy(nt->label, "[un-named kernel thread]");
-            }
-            else {
-                strncpy(nt->label, real_attr.label, 255);
-                nt->label[255] = 0;
-            }
-
-            if(thd_current)
-                strcpy(nt->pwd, thd_current->pwd);
-            else
-                strcpy(nt->pwd, "/");
-
-            _REENT_INIT_PTR((&(nt->thd_reent)));
-
-            /* Should we detach the thread? */
-            if(real_attr.create_detached)
-                nt->flags |= THD_DETACHED;
-
-            /* Initialize thread-local storage. */
-            LIST_INIT(&nt->tls_list);
-
-            /* Insert it into the thread list */
-            LIST_INSERT_HEAD(&thd_list, nt, t_list);
-
-            /* Add it to our count */
-            ++thd_count;
-
-            /* Schedule it */
-            thd_add_to_runnable(nt, 0);
         }
+        else {
+            nt->stack = (uint32*)real_attr.stack_ptr;
+        }
+
+        nt->stack_size = real_attr.stack_size;
+
+        /* Populate the context */
+        params[0] = (uint32)routine;
+        params[1] = (uint32)param;
+        params[2] = 0;
+        params[3] = 0;
+        irq_create_context(&nt->context,
+                           ((uint32)nt->stack) + nt->stack_size,
+                           (uint32)thd_birth, params, 0);
+
+        nt->tid = tid;
+        nt->prio = real_attr.prio;
+        nt->flags = THD_DEFAULTS;
+        nt->state = STATE_READY;
+
+        if(!real_attr.label) {
+            strcpy(nt->label, "[un-named kernel thread]");
+        }
+        else {
+            strncpy(nt->label, real_attr.label, 255);
+            nt->label[255] = 0;
+        }
+
+        if(thd_current)
+            strcpy(nt->pwd, thd_current->pwd);
+        else
+            strcpy(nt->pwd, "/");
+
+        _REENT_INIT_PTR((&(nt->thd_reent)));
+
+        /* Should we detach the thread? */
+        if(real_attr.create_detached)
+            nt->flags |= THD_DETACHED;
+
+        /* Initialize thread-local storage. */
+        LIST_INIT(&nt->tls_list);
+
+        /* Insert it into the thread list */
+        LIST_INSERT_HEAD(&thd_list, nt, t_list);
+
+        /* Add it to our count */
+        ++thd_count;
+
+        /* Schedule it */
+        thd_add_to_runnable(nt, 0);
     }
+    else /* nt == NULL */
+        errno = ENOMEM;
 
     irq_restore(oldirq);
     return nt;
@@ -882,7 +884,7 @@ int thd_init(void) {
     thd_mode = THD_MODE_PREEMPT;
 
     /* Initialize handle counters */
-    tid_highest = 1;
+    tid_highest = TID_FIRST;
 
     /* Initialize the thread list */
     LIST_INIT(&thd_list);


### PR DESCRIPTION
I've tried to separate each into it's own commit under this to make it easier to pick and choose/test and verify. All of these were minor issues found via cppcheck or gcc's static analysis system. Possible memory leaks, overwriting values, null derefs, etc. Along the way expanded a few comments and such.

Post-Draft: I reverted some of the commits, which unfortunately makes it a bit trickier to read, and tried to scale back some of the bigger changes. 

Most of the changes are *just* freeing or doing null checks. Some details on the rest:

fs_vmu and fs_pty: The changes adjust the execution flow to facilitate the failure condition cleanup.

net_tcp:  The change prevents the flags that need to be set by TCP_STATE_CLOSE_WAIT from being overwritten.

assert: While this should be inherited from the panic, it isn't guaranteed to.

fs_romdisk: The error return codes have been updated to distinguish different reasons for failure.