### PR TITLE
Fixed GDB download failure in toolchain make/build scripts

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -679,7 +679,7 @@ SORT_MEMBERS_CTORS_1ST = NO
 # appear in their defined order.
 # The default value is: NO.
 
-SORT_GROUP_NAMES       = NO
+SORT_GROUP_NAMES       = YES
 
 # If the SORT_BY_SCOPE_NAME tag is set to YES, the class list will be sorted by
 # fully-qualified names, including namespaces. If set to NO, the class list will
@@ -2303,7 +2303,7 @@ EXPAND_AS_DEFINED      = __BEGIN_DECLS \
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-SKIP_FUNCTION_MACROS   = YES
+SKIP_FUNCTION_MACROS   = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to external references

--- a/examples/dreamcast/tsunami/banner/banner.cpp
+++ b/examples/dreamcast/tsunami/banner/banner.cpp
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     int done = 0, done2 = 0;
 
     cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
-                      (void (*)(unsigned char, long  unsigned int))arch_exit);
+                      (cont_btn_callback_t)arch_exit);
 
     pvr_init_defaults();
 

--- a/examples/dreamcast/tsunami/font/font.cpp
+++ b/examples/dreamcast/tsunami/font/font.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
     int done = 0;
 
     cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
-                      (void (*)(unsigned char, long  unsigned int))arch_exit);
+                      (cont_btn_callback_t)arch_exit);
 
     pvr_init_defaults();
 

--- a/examples/dreamcast/tsunami/genmenu/genmenu.cpp
+++ b/examples/dreamcast/tsunami/genmenu/genmenu.cpp
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
 
     // Guard against an untoward exit during testing.
     cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
-                      (void (*)(unsigned char, long  unsigned int))arch_exit);
+                      (cont_btn_callback_t)arch_exit);
 
     // Get 3D going
     pvr_init_defaults();

--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -11,22 +11,33 @@
 #include <string.h>
 #include <assert.h>
 
+/* Raw controller condition structure */
+typedef struct {
+    uint16_t buttons;  /* buttons bitfield */
+    uint8_t rtrig;     /* right trigger */
+    uint8_t ltrig;     /* left trigger */
+    uint8_t joyx;      /* joystick X */
+    uint8_t joyy;      /* joystick Y */
+    uint8_t joy2x;     /* second joystick X */
+    uint8_t joy2y;     /* second joystick Y */
+} cont_cond_t;
+
 static cont_btn_callback_t btn_callback = NULL;
-static uint8 btn_callback_addr = 0;
-static uint32 btn_callback_btns = 0;
+static uint8_t btn_callback_addr = 0;
+static uint32_t btn_callback_btns = 0;
 
 /* Set a controller callback for a button combo; set addr=0 for any controller */
-void cont_btn_callback(uint8 addr, uint32 btns, cont_btn_callback_t cb) {
+void cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb) {
     btn_callback_addr = addr;
     btn_callback_btns = btns;
     btn_callback = cb;
 }
 
 static void cont_reply(maple_frame_t *frm) {
-    maple_response_t    *resp;
-    uint32          *respbuf;
-    cont_cond_t     *raw;
-    cont_state_t        *cooked;
+    maple_response_t *resp;
+    uint32_t         *respbuf;
+    cont_cond_t      *raw;
+    cont_state_t     *cooked;
 
     /* Unlock the frame now (it's ok, we're in an IRQ) */
     maple_frame_unlock(frm);
@@ -37,7 +48,7 @@ static void cont_reply(maple_frame_t *frm) {
     if(resp->response != MAPLE_RESPONSE_DATATRF)
         return;
 
-    respbuf = (uint32 *)resp->data;
+    respbuf = (uint32_t *)resp->data;
 
     if(respbuf[0] != MAPLE_FUNC_CONTROLLER)
         return;
@@ -74,13 +85,13 @@ static void cont_reply(maple_frame_t *frm) {
 }
 
 static int cont_poll(maple_device_t *dev) {
-    uint32 * send_buf;
+    uint32_t *send_buf;
 
     if(maple_frame_lock(&dev->frame) < 0)
         return 0;
 
     maple_frame_init(&dev->frame);
-    send_buf = (uint32 *)dev->frame.recv_buf;
+    send_buf = (uint32_t *)dev->frame.recv_buf;
     send_buf[0] = MAPLE_FUNC_CONTROLLER;
     dev->frame.cmd = MAPLE_COMMAND_GETCOND;
     dev->frame.dst_port = dev->port;

--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -12,7 +12,7 @@
 #include <assert.h>
 
 /* Raw controller condition structure */
-typedef struct {
+typedef struct cont_cond {
     uint16_t buttons;  /* buttons bitfield */
     uint8_t rtrig;     /* right trigger */
     uint8_t ltrig;     /* left trigger */

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -2,12 +2,14 @@
 
    dc/maple/controller.h
    (C)2000-2002 Jordan DeLong, Megan Potter
+   (C)2023 Falco Girgis
 
    Thanks to Marcus Comstedt for information on the controller.
 */
 
-/** \file   dc/maple/controller.h
-    \brief  Definitions for using the controller device.
+/** \file    dc/maple/controller.h
+    \brief   Definitions for using the controller device.
+    \ingroup controller
 
     This file contains the definitions needed to access the Maple controller
     device. Obviously, this corresponds to the MAPLE_FUNC_CONTROLLER function
@@ -15,6 +17,7 @@
 
     \author Jordan DeLong
     \author Megan Potter
+    \author Falco Girgis
 */
 
 #ifndef __DC_MAPLE_CONTROLLER_H
@@ -24,119 +27,109 @@
 __BEGIN_DECLS
 
 #include <arch/types.h>
+#include <stdint.h>
 
-/** \defgroup   controller_buttons  Controller button codes
+/** \defgroup controller Controller
+    \ingroup maple
 
-    This is the set of all buttons that are valid for a maple bus controller
-    device. The names should make it obvious what the button is.
+    This module contains the public API for the controller
+    maple driver.
 
+    A standard, first-party Dreamcast controller has
+    the following button configuration:
+
+                           ___________
+                          / |  __  |  \
+       L button -----|   /  | |  | |   \  |----- R button
+                    _|__/   | |__| |    \_|__
+                   |  _      \____/   _   _ |
+    Analog Pad ----|-/ \             |X| |Y||
+                   | \_/              _   _ |
+                   |  _              |A| |B||
+                   |_| |_             ¯   ¯ |
+        D-Pad -----|_   _|                  |
+                   | |_|      /\            |
+                    \        /__\          /
+                     \    ____|________   /
+                      \  /    |       \  /
+                       \/     |        \/
+                              |
+                          Start button
+*/
+
+/** \defgroup controller_buttons  Controller Button Masks
+    \ingroup  controller
+
+    The set of bitmasks for all valid maple controller button states.
     @{
 */
-#define CONT_C          (1<<0)
-#define CONT_B          (1<<1)
-#define CONT_A          (1<<2)
-#define CONT_START      (1<<3)
-#define CONT_DPAD_UP        (1<<4)
-#define CONT_DPAD_DOWN      (1<<5)
-#define CONT_DPAD_LEFT      (1<<6)
-#define CONT_DPAD_RIGHT     (1<<7)
-#define CONT_Z          (1<<8)
-#define CONT_Y          (1<<9)
-#define CONT_X          (1<<10)
-#define CONT_D          (1<<11)
-#define CONT_DPAD2_UP       (1<<12)
-#define CONT_DPAD2_DOWN     (1<<13)
-#define CONT_DPAD2_LEFT     (1<<14)
-#define CONT_DPAD2_RIGHT    (1<<15)
+#define CONT_C              (1<<0)      /** \brief C button Mask. */
+#define CONT_B              (1<<1)      /** \brief B button Mask. */
+#define CONT_A              (1<<2)      /** \brief A button Mask. */
+#define CONT_START          (1<<3)      /** \brief Start button Mask. */
+#define CONT_DPAD_UP        (1<<4)      /** \brief Left Dpad Up button Mask. */
+#define CONT_DPAD_DOWN      (1<<5)      /** \brief Left Dpad Down button Mask. */
+#define CONT_DPAD_LEFT      (1<<6)      /** \brief Left Dpad Left button Mask. */
+#define CONT_DPAD_RIGHT     (1<<7)      /** \brief Left Dpad right button Mask. */
+#define CONT_Z              (1<<8)      /** \brief Z button Mask. */
+#define CONT_Y              (1<<9)      /** \brief Y button Mask. */
+#define CONT_X              (1<<10)     /** \brief X button Mask. */
+#define CONT_D              (1<<11)     /** \brief D button Mask. */
+#define CONT_DPAD2_UP       (1<<12)     /** \brief Right Dpad Up button Mask. */
+#define CONT_DPAD2_DOWN     (1<<13)     /** \brief Right Dpad Down button Mask. */
+#define CONT_DPAD2_LEFT     (1<<14)     /** \brief Right Dpad Left button Mask. */
+#define CONT_DPAD2_RIGHT    (1<<15)     /** \brief Right Dpad Right button Mask. */
 /** @} */
 
-/* Raw controller condition structure */
-typedef struct {
-    uint16 buttons;         /* buttons bitfield */
-    uint8 rtrig;            /* right trigger */
-    uint8 ltrig;            /* left trigger */
-    uint8 joyx;         /* joystick X */
-    uint8 joyy;         /* joystick Y */
-    uint8 joy2x;            /* second joystick X */
-    uint8 joy2y;            /* second joystick Y */
-} cont_cond_t;
-
-/* Our more civilized structure. Note that there are some fairly
-   significant differences in value interpretations here between
-   this struct and the old one:
-
-   - "buttons" is zero based: a 1-bit means the button is PRESSED.
-   - "joyx", "joyy", "joy2x", and "joy2y" are all zero based: zero
-     means they are in the center, negative values are up/left,
-     and positive values are down/right.
-
-   Note also that this is the struct you will get back if you call
-   maple_dev_status(), NOT a cont_cond_t. However, cont_get_cond() will
-   return the old compatible struct for now. */
-
-/** \brief  Controller status structure.
+/** \brief   Controller state structure.
+    \ingroup controller
 
     This structure contains information about the status of the controller
-    device and can be fetched with maple_dev_status().
+    device and can be fetched by casting the result of maple_dev_status() to
+    this structure.
 
-    A 1 bit in the buttons bitfield indicates that a button is pressed, and the
+    A 1 bit in the buttons' bitfield indicates that a button is pressed, and the
     joyx, joyy, joy2x, joy2 values are all 0 based (0 is centered).
 
     \headerfile dc/maple/controller.h
 */
-typedef struct {
-    /** \brief  Buttons bitfield.
-        \see    controller_buttons
-    */
-    uint32  buttons;
+typedef struct cont_state {
+    union {
+        /** \brief  bit-packed controller button states
+            \sa     controller_buttons
+        */
+        uint32_t buttons;
+        struct {
+            uint32_t c: 1;              /** \brief C button value. */
+            uint32_t b: 1;              /** \brief B button value. */
+            uint32_t a: 1;              /** \brief A button value. */
+            uint32_t start: 1;          /** \brief Start button value. */
+            uint32_t dpad_up: 1;        /** \brief Left Dpad Up button value. */
+            uint32_t dpad_down: 1;      /** \brief Left Dpad Down button value. */
+            uint32_t dpad_left: 1;      /** \brief Left Dpad Left button value. */
+            uint32_t dpad_right: 1;     /** \brief Left Dpad Right button value. */
+            uint32_t z: 1;              /** \brief Z button value. */
+            uint32_t y: 1;              /** \brief Y button value. */
+            uint32_t x: 1;              /** \brief X button value. */
+            uint32_t d: 1;              /** \brief D button value. */
+            uint32_t dpad2_up: 1;       /** \brief Right Dpad Up button value. */
+            uint32_t dpad2_down: 1;     /** \brief Right Dpad Down button value. */
+            uint32_t dpad2_left: 1;     /** \brief Right Dpad Left button value. */
+            uint32_t dpad2_right: 1;    /** \brief Right Dpad Right button value. */
+            uint32_t unused: 16;
+        };
+    };
 
-    /** \brief  Left trigger value. */
-    int ltrig;
-
-    /** \brief  Right trigger value. */
-    int rtrig;
-
-    /** \brief  Main joystick x-axis value. */
-    int joyx;
-
-    /** \brief  Main joystick y-axis value. */
-    int joyy;
-
-    /** \brief  Secondary joystick x-axis value (if applicable). */
-    int joy2x;
-
-    /** \brief  Secondary joystick y-axis value (if applicable). */
-    int joy2y;
+    int ltrig;    /** \brief Left trigger value. */
+    int rtrig;    /** \brief Right trigger value. */
+    int joyx;     /** \brief Main joystick x-axis value. */
+    int joyy;     /** \brief Main joystick y-axis value. */
+    int joy2x;    /** \brief Secondary joystick x-axis value (if applicable). */
+    int joy2y;    /** \brief Secondary joystick y-axis value (if applicable). */
 } cont_state_t;
 
-/* \cond */
-/* Init / Shutdown */
-int cont_init(void);
-void cont_shutdown(void);
-/* \endcond */
-
-/** \brief  Controller automatic callback type.
-
-    Functions of this type can be set with cont_btn_callback() to respond
-    automatically to the specified set of buttons being pressed. This can be
-    used, for instance, to implement the standard A+B+X+Y+Start method of ending
-    the program running.
-*/
-typedef void (*cont_btn_callback_t)(uint8 addr, uint32 btns);
-
-/** \brief  Set an automatic button press callback.
-
-    This function sets a callback function to be called when the specified
-    controller has the set of buttons given pressed.
-
-    \param  addr            The controller to listen on. This value can be
-                            obtained by using maple_addr().
-    \param  btns            The buttons bitmask to match.
-    \param  cb              The callback to call when the buttons are pressed.
-*/
-void cont_btn_callback(uint8 addr, uint32 btns, cont_btn_callback_t cb);
-
-/** \defgroup   controller_caps Controller capability bits.
+/** \defgroup controller_caps Controller capability bit masks
+    \ingroup  controller
 
     These bits will be set in the function_data for the controller's deviceinfo
     if the controller supports the corresponding feature.
@@ -166,6 +159,47 @@ void cont_btn_callback(uint8 addr, uint32 btns, cont_btn_callback_t cb);
 #define CONT_CAPABILITY_ANALOG2_X       (1<<12)
 #define CONT_CAPABILITY_ANALOG2_Y       (1<<13)
 /** @} */
+
+/* Aggregate Capability Categories */
+#define CONT_CAPABILITY_STANDARD
+#define CONT_CAPABILITY_RIGHT_DPAD
+#define CONT_CAPABILITY_RIGHT_ANALOG
+#define CONT_CAPABILITY_EXTRA_BUTTONS
+
+int cont_has_standard_capabilities(const maple_device_t *cont);
+
+int cont_has_right_dpad(const maple_device_t *cont);
+
+int cont_has_right_analog(const maple_device_t *cont);
+
+int cont_has_extra_buttons(const maple_device_t *cont);
+
+/** \brief  Controller automatic callback type.
+
+    Functions of this type can be set with cont_btn_callback() to respond
+    automatically to the specified set of buttons being pressed. This can be
+    used, for instance, to implement the standard A+B+X+Y+Start method of ending
+    the program running.
+*/
+typedef void (*cont_btn_callback_t)(uint8_t addr, uint32_t btns);
+
+/** \brief  Set an automatic button press callback.
+
+    This function sets a callback function to be called when the specified
+    controller has the set of buttons given pressed.
+
+    \param  addr            The controller to listen on. This value can be
+                            obtained by using maple_addr().
+    \param  btns            The buttons bitmask to match.
+    \param  cb              The callback to call when the buttons are pressed.
+*/
+void cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb);
+
+/* \cond */
+/* Init / Shutdown */
+int cont_init(void);
+void cont_shutdown(void);
+/* \endcond */
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -38,23 +38,22 @@ __BEGIN_DECLS
     A standard, first-party Dreamcast controller has
     the following button configuration:
 
-                           ___________
-                          / |  __  |  \
-       L button -----|   /  | |  | |   \  |----- R button
-                    _|__/   | |__| |    \_|__
-                   |  _      \____/   _   _ |
-    Analog Pad ----|-/ \             |X| |Y||
-                   | \_/              _   _ |
-                   |  _              |A| |B||
-                   |_| |_             ¯   ¯ |
-        D-Pad -----|_   _|                  |
-                   | |_|      /\            |
-                    \        /__\          /
-                     \    ____|________   /
-                      \  /    |       \  /
-                       \/     |        \/
-                              |
-                          Start button
+                            ___________
+                           / |  __  |  \
+       L trigger -----|   /  | |  | |   \  |----- R trigger
+                     _|__/   | |__| |    \_|__
+                    |  _      \____/   _   _ |
+     Joystick   ----|-/ \             |X| |Y||
+                    | \_/              _   _ |
+                    |  _              |A| |B||
+                    |_| |_             ¯   ¯ |
+         D-Pad -----|_   _|                  |
+                    | |_|       /\           |
+                     \         /__\          /
+                      \    _____|_______    /
+                       \  /     |       \  /
+                        \/      |        \/
+                           Start button
 */
 
 /** \defgroup controller_buttons  Controller Button Masks
@@ -91,7 +90,6 @@ __BEGIN_DECLS
     A 1 bit in the buttons' bitfield indicates that a button is pressed, and the
     joyx, joyy, joy2x, joy2 values are all 0 based (0 is centered).
 
-    \headerfile dc/maple/controller.h
 */
 typedef struct cont_state {
     union {
@@ -174,7 +172,8 @@ int cont_has_right_analog(const maple_device_t *cont);
 
 int cont_has_extra_buttons(const maple_device_t *cont);
 
-/** \brief  Controller automatic callback type.
+/** \brief   Controller automatic callback type.
+    \ingroup controller
 
     Functions of this type can be set with cont_btn_callback() to respond
     automatically to the specified set of buttons being pressed. This can be

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -1,8 +1,8 @@
 /* KallistiOS ##version##
 
    dc/maple/controller.h
-   (C)2000-2002 Jordan DeLong, Megan Potter
-   (C)2023 Falco Girgis
+   (C) 2000-2002 Jordan DeLong, Megan Potter
+   (C) 2023 Falco Girgis
 
    Thanks to Marcus Comstedt for information on the controller.
 */
@@ -30,7 +30,8 @@ __BEGIN_DECLS
 #include <stdint.h>
 
 /** \defgroup controller Controller
-    \ingroup maple
+    \brief    Controller Maple Device API
+    \ingroup  maple
 
     This module contains the public API for the controller
     maple driver.
@@ -38,47 +39,60 @@ __BEGIN_DECLS
     A standard, first-party Dreamcast controller has
     the following button configuration:
 
-                            ___________
-                           / |  __  |  \
-       L trigger -----|   /  | |  | |   \  |----- R trigger
-                     _|__/   | |__| |    \_|__
-                    |  _      \____/   _   _ |
-     Joystick   ----|-/ \             |X| |Y||
-                    | \_/              _   _ |
-                    |  _              |A| |B||
-                    |_| |_             ¯   ¯ |
-         D-Pad -----|_   _|                  |
-                    | |_|       /\           |
-                     \         /__\          /
-                      \    _____|_______    /
-                       \  /     |       \  /
-                        \/      |        \/
-                           Start button
+                                ___________
+                               / |  __  |  \
+           L trigger -----|   /  | |  | |   \  |----- R trigger
+                         _|__/   | |__| |    \_|__
+                        |  _      \____/   _   _ |
+         Joystick   ----|-/ \             |X| |Y||
+                        | \_/              _   _ |
+                        |  _              |A| |B||
+                        |_| |_             ¯   ¯ |
+             D-Pad -----|_   _|                  |
+                        | |_|       /\           |
+                         \         /__\          /
+                          \    _____|_______    /
+                           \  /     |       \  /
+                            \/      |        \/
+                               Start button
 */
 
-/** \defgroup controller_buttons  Controller Button Masks
+/** \defgroup controller_buttons  Button Masks
     \ingroup  controller
 
     The set of bitmasks for all valid maple controller button states.
     @{
 */
-#define CONT_C              (1<<0)      /** \brief C button Mask. */
-#define CONT_B              (1<<1)      /** \brief B button Mask. */
-#define CONT_A              (1<<2)      /** \brief A button Mask. */
-#define CONT_START          (1<<3)      /** \brief Start button Mask. */
-#define CONT_DPAD_UP        (1<<4)      /** \brief Left Dpad Up button Mask. */
-#define CONT_DPAD_DOWN      (1<<5)      /** \brief Left Dpad Down button Mask. */
-#define CONT_DPAD_LEFT      (1<<6)      /** \brief Left Dpad Left button Mask. */
-#define CONT_DPAD_RIGHT     (1<<7)      /** \brief Left Dpad right button Mask. */
-#define CONT_Z              (1<<8)      /** \brief Z button Mask. */
-#define CONT_Y              (1<<9)      /** \brief Y button Mask. */
-#define CONT_X              (1<<10)     /** \brief X button Mask. */
-#define CONT_D              (1<<11)     /** \brief D button Mask. */
-#define CONT_DPAD2_UP       (1<<12)     /** \brief Right Dpad Up button Mask. */
-#define CONT_DPAD2_DOWN     (1<<13)     /** \brief Right Dpad Down button Mask. */
-#define CONT_DPAD2_LEFT     (1<<14)     /** \brief Right Dpad Left button Mask. */
-#define CONT_DPAD2_RIGHT    (1<<15)     /** \brief Right Dpad Right button Mask. */
+#define CONT_C              (1<<0)      /**< \brief C button Mask. */
+#define CONT_B              (1<<1)      /**< \brief B button Mask. */
+#define CONT_A              (1<<2)      /**< \brief A button Mask. */
+#define CONT_START          (1<<3)      /**< \brief Start button Mask. */
+#define CONT_DPAD_UP        (1<<4)      /**< \brief Main Dpad Up button Mask. */
+#define CONT_DPAD_DOWN      (1<<5)      /**< \brief Main Dpad Down button Mask. */
+#define CONT_DPAD_LEFT      (1<<6)      /**< \brief Main Dpad Left button Mask. */
+#define CONT_DPAD_RIGHT     (1<<7)      /**< \brief Main Dpad right button Mask. */
+#define CONT_Z              (1<<8)      /**< \brief Z button Mask. */
+#define CONT_Y              (1<<9)      /**< \brief Y button Mask. */
+#define CONT_X              (1<<10)     /**< \brief X button Mask. */
+#define CONT_D              (1<<11)     /**< \brief D button Mask. */
+#define CONT_DPAD2_UP       (1<<12)     /**< \brief Secondary Dpad Up button Mask. */
+#define CONT_DPAD2_DOWN     (1<<13)     /**< \brief Secondary Dpad Down button Mask. */
+#define CONT_DPAD2_LEFT     (1<<14)     /**< \brief Secondary Dpad Left button Mask. */
+#define CONT_DPAD2_RIGHT    (1<<15)     /**< \brief Secondary Dpad Right button Mask. */
 /** @} */
+
+/** \brief   Controller buttons for standard reset action
+    \ingroup controller
+    
+    Convenience macro combining together all of the masks for buttons
+    used by most games as a reset mechanism:
+        * CONT_A
+        * CONT_B
+        * CONT_X
+        * CONT_Y
+        * CONT_START
+*/
+#define CONT_RESET_BUTTONS  (CONT_A | CONT_B | CONT_X | CONT_Y | CONT_START)
 
 /** \brief   Controller state structure.
     \ingroup controller
@@ -90,6 +104,7 @@ __BEGIN_DECLS
     A 1 bit in the buttons' bitfield indicates that a button is pressed, and the
     joyx, joyy, joy2x, joy2 values are all 0 based (0 is centered).
 
+    \sa maple_dev_status
 */
 typedef struct cont_state {
     union {
@@ -98,35 +113,35 @@ typedef struct cont_state {
         */
         uint32_t buttons;
         struct {
-            uint32_t c: 1;              /** \brief C button value. */
-            uint32_t b: 1;              /** \brief B button value. */
-            uint32_t a: 1;              /** \brief A button value. */
-            uint32_t start: 1;          /** \brief Start button value. */
-            uint32_t dpad_up: 1;        /** \brief Left Dpad Up button value. */
-            uint32_t dpad_down: 1;      /** \brief Left Dpad Down button value. */
-            uint32_t dpad_left: 1;      /** \brief Left Dpad Left button value. */
-            uint32_t dpad_right: 1;     /** \brief Left Dpad Right button value. */
-            uint32_t z: 1;              /** \brief Z button value. */
-            uint32_t y: 1;              /** \brief Y button value. */
-            uint32_t x: 1;              /** \brief X button value. */
-            uint32_t d: 1;              /** \brief D button value. */
-            uint32_t dpad2_up: 1;       /** \brief Right Dpad Up button value. */
-            uint32_t dpad2_down: 1;     /** \brief Right Dpad Down button value. */
-            uint32_t dpad2_left: 1;     /** \brief Right Dpad Left button value. */
-            uint32_t dpad2_right: 1;    /** \brief Right Dpad Right button value. */
+            uint32_t c: 1;              /**< \brief C button value. */
+            uint32_t b: 1;              /**< \brief B button value. */
+            uint32_t a: 1;              /**< \brief A button value. */
+            uint32_t start: 1;          /**< \brief Start button value. */
+            uint32_t dpad_up: 1;        /**< \brief Main Dpad Up button value. */
+            uint32_t dpad_down: 1;      /**< \brief Main Dpad Down button value. */
+            uint32_t dpad_left: 1;      /**< \brief Main Dpad Left button value. */
+            uint32_t dpad_right: 1;     /**< \brief Main Dpad Right button value. */
+            uint32_t z: 1;              /**< \brief Z button value. */
+            uint32_t y: 1;              /**< \brief Y button value. */
+            uint32_t x: 1;              /**< \brief X button value. */
+            uint32_t d: 1;              /**< \brief D button value. */
+            uint32_t dpad2_up: 1;       /**< \brief Secondary Dpad Up button value. */
+            uint32_t dpad2_down: 1;     /**< \brief Secondary Dpad Down button value. */
+            uint32_t dpad2_left: 1;     /**< \brief Secondary Dpad Left button value. */
+            uint32_t dpad2_right: 1;    /**< \brief Secondary Dpad Right button value. */
             uint32_t unused: 16;
         };
     };
 
-    int ltrig;    /** \brief Left trigger value. */
-    int rtrig;    /** \brief Right trigger value. */
-    int joyx;     /** \brief Main joystick x-axis value. */
-    int joyy;     /** \brief Main joystick y-axis value. */
-    int joy2x;    /** \brief Secondary joystick x-axis value (if applicable). */
-    int joy2y;    /** \brief Secondary joystick y-axis value (if applicable). */
+    int ltrig;    /**< \brief Left trigger value (0-255). */
+    int rtrig;    /**< \brief Right trigger value (0-255). */
+    int joyx;     /**< \brief Main joystick x-axis value. (-128 - 127) */
+    int joyy;     /**< \brief Main joystick y-axis value. */
+    int joy2x;    /**< \brief Secondary joystick x-axis value (if applicable). */
+    int joy2y;    /**< \brief Secondary joystick y-axis value (if applicable). */
 } cont_state_t;
 
-/** \defgroup controller_caps Controller capability bit masks
+/** \defgroup controller_caps Capability Masks
     \ingroup  controller
 
     These bits will be set in the function_data for the controller's deviceinfo
@@ -134,43 +149,102 @@ typedef struct cont_state {
 
     @{
 */
-#define CONT_CAPABILITY_C               (1<<24)
-#define CONT_CAPABILITY_B               (1<<25)
-#define CONT_CAPABILITY_A               (1<<26)
-#define CONT_CAPABILITY_START           (1<<27)
-#define CONT_CAPABILITY_DPAD_UP         (1<<28)
-#define CONT_CAPABILITY_DPAD_DOWN       (1<<29)
-#define CONT_CAPABILITY_DPAD_LEFT       (1<<30)
-#define CONT_CAPABILITY_DPAD_RIGHT      (1<<31)
-#define CONT_CAPABILITY_Z               (1<<16)
-#define CONT_CAPABILITY_Y               (1<<17)
-#define CONT_CAPABILITY_X               (1<<18)
-#define CONT_CAPABILITY_D               (1<<19)
-#define CONT_CAPABILITY_DPAD2_UP        (1<<20)
-#define CONT_CAPABILITY_DPAD2_DOWN      (1<<21)
-#define CONT_CAPABILITY_DPAD2_LEFT      (1<<22)
-#define CONT_CAPABILITY_DPAD2_RIGHT     (1<<23)
-#define CONT_CAPABILITY_RTRIG           (1<<8)
-#define CONT_CAPABILITY_LTRIG           (1<<9)
-#define CONT_CAPABILITY_ANALOG_X        (1<<10)
-#define CONT_CAPABILITY_ANALOG_Y        (1<<11)
-#define CONT_CAPABILITY_ANALOG2_X       (1<<12)
-#define CONT_CAPABILITY_ANALOG2_Y       (1<<13)
+#define CONT_CAPABILITY_C               (1<<24)     /**< \brief C button capability mask. */
+#define CONT_CAPABILITY_B               (1<<25)     /**< \brief B button capability mask. */
+#define CONT_CAPABILITY_A               (1<<26)     /**< \brief A button capability mask. */
+#define CONT_CAPABILITY_START           (1<<27)     /**< \brief Start button capability mask. */
+#define CONT_CAPABILITY_DPAD_UP         (1<<28)     /**< \brief First Dpad up capability mask. */
+#define CONT_CAPABILITY_DPAD_DOWN       (1<<29)     /**< \brief First Dpad down capability mask. */
+#define CONT_CAPABILITY_DPAD_LEFT       (1<<30)     /**< \brief First Dpad left capability mask. */
+#define CONT_CAPABILITY_DPAD_RIGHT      (1<<31)     /**< \brief First Dpad right capability mask. */
+#define CONT_CAPABILITY_Z               (1<<16)     /**< \brief Z button capability mask. */
+#define CONT_CAPABILITY_Y               (1<<17)     /**< \brief Y button capability mask. */
+#define CONT_CAPABILITY_X               (1<<18)     /**< \brief X button capability mask. */
+#define CONT_CAPABILITY_D               (1<<19)     /**< \brief D button capability mask. */
+#define CONT_CAPABILITY_DPAD2_UP        (1<<20)     /**< \brief Second Dpad up capability mask. */
+#define CONT_CAPABILITY_DPAD2_DOWN      (1<<21)     /**< \brief Second Dpad down capability mask. */
+#define CONT_CAPABILITY_DPAD2_LEFT      (1<<22)     /**< \brief Second Dpad left capability mask. */
+#define CONT_CAPABILITY_DPAD2_RIGHT     (1<<23)     /**< \brief Second Dpad right capability mask. */
+#define CONT_CAPABILITY_RTRIG           (1<<8)      /**< \brief Right trigger capability mask. */
+#define CONT_CAPABILITY_LTRIG           (1<<9)      /**< \brief Left trigger capability mask. */
+#define CONT_CAPABILITY_ANALOG_X        (1<<10)     /**< \brief First analog X axis capability mask. */
+#define CONT_CAPABILITY_ANALOG_Y        (1<<11)     /**< \brief First analog Y axis capability mask. */
+#define CONT_CAPABILITY_ANALOG2_X       (1<<12)     /**< \brief Second analog X axis capability mask. */
+#define CONT_CAPABILITY_ANALOG2_Y       (1<<13)     /**< \brief Second analog Y axis capability mask. */
+
+
+#define CONT_CAPABILITY_STANDARD_BUTTONS    (CONT_CAPABILITY_A | \
+                                             CONT_CAPABILITY_B | \
+                                             CONT_CAPABILITY_X | \
+                                             CONT_CAPABILITY_Y | \
+                                             CONT_CAPABILITY_START)
+
+#define CONT_CAPABILITY_DPAD                (CONT_CAPABILITY_DPAD_UP   | \
+                                             CONT_CAPABILITY_DPAD_DOWN | \
+                                             CONT_CAPABILITY_DPAD_LEFT | \
+                                             CONT_CAPABILITY_DPAD_RIGHT)
+
+#define CONT_CAPABILITY_ANALOG              (CONT_CAPABILITY_ANALOG_X | \ 
+                                             CONT_CAPABILITY_ANALOG_Y) 
+
+#define CONT_CAPABILITY_TRIGGERS            (CONT_CAPABILITY_LTRIG | \
+                                             CONT_CAPABILITY_RTRIG)
+
+#define CONT_CAPABILITY_EXTENDED_BUTTONS    (CONT_CAPABILITY_C | \
+                                             CONT_CAPABILITY_Z)
+
+#define CONT_CAPABILITY_SECONDARY_DPAD      (CONT_CAPABILITY_DPAD2_UP   | \ 
+                                             CONT_CAPABILITY_DPAD2_DOWN | \
+                                             CONT_CAPABILITY_DPAD2_LEFT | \
+                                             CONT_CAPABILITY_DPAD2_RIGHT)
+
+#define CONT_CAPABILITY_SECONDARY_ANALOG    (CONT_CAPABILITY_ANALOG2_X | \
+                                             CONT_CAPABILITY_ANALOG2_Y)
+
+#define CONT_CAPABILITY_DUAL_DPAD           (CONT_CAPABILITIES_DPAD | \
+                                             CONT_CAPABILITIES_SECONDARY_DPAD)
+
+#define CONT_CAPABILITY_DUAL_ANALOG         (CONT_CAPABILITIES_ANALOG | \
+                                             CONT_CAPABILITIES_SECONDARY_ANALOG)
+
 /** @} */
 
-/* Aggregate Capability Categories */
-#define CONT_CAPABILITY_STANDARD
-#define CONT_CAPABILITY_RIGHT_DPAD
-#define CONT_CAPABILITY_RIGHT_ANALOG
-#define CONT_CAPABILITY_EXTRA_BUTTONS
+#define CONT_TYPE_STANDARD_CONTROLLER       (CONT_CAPABILITY_STANDARD_BUTTONS | \
+                                             CONT_CAPABILITY_TRIGGERS | \
+                                             CONT_CAPABLITY_DPAD | \
+                                             CONT_CAPABILITY_ANALOG)
 
-int cont_has_standard_capabilities(const maple_device_t *cont);
+#define CONT_TYPE_DUAL_ANALOG_CONTROLLER    (CONT_CAPABILITY_STANDARD_BUTTONS | \
+                                             CONT_CAPABILITY_TRIGGERS | \
+                                             CONT_CAPABLITY_DPAD | \
+                                             CONT_CAPABILITY_DUAL_ANALOG)
 
-int cont_has_right_dpad(const maple_device_t *cont);
+#define CONT_TYPE_ASCII_PAD                 (CONT_CAPABILITY_STANDARD_BUTTONS | \
+                                             CONT_CAPABILITY_EXTENDED_BUTTONS | \
+                                             CONT_CAPABILITY_DPAD)
 
-int cont_has_right_analog(const maple_device_t *cont);
+#define CONT_TYPE_ARCADE_STICK              (CONT_CAPABILITY_STANDARD_BUTTONS | \
+                                             CONT_CAPABILITY_EXTENDED_BUTTONS | \
+                                             CONT_CAPABILITY_DPAD)
 
-int cont_has_extra_buttons(const maple_device_t *cont);
+#define CONT_TYPE_TWIN_STICK                (CONT_CAPABILITY_STANDARD_BUTTONS | \ 
+                                             CONT_CAPABILITY_EXTENDED_BUTTONS | \
+                                             CONT_CAPABILITY_DUAL_DPAD)
+
+// Require research
+#define CONT_TYPE_RACING_CONTROLLER
+#define CONT_TYPE_MARACAS
+#define CONT_TYPE_FISHING_ROD
+#define CONT_TYPE_POP_N_MUSIC
+#define CONT_TYPE_DENSHA_DE_GO
+
+struct maple_device;
+
+// Conroller has EXACTLY the given capabilties
+int cont_is_type(const struct maple_device_t *cont, uint32_t type);
+
+// Controller has at LEAST the given capabilities
+int cont_has_capabilities(const struct maple_device_t *cont, uint32_t capability_mask);
 
 /** \brief   Controller automatic callback type.
     \ingroup controller
@@ -179,16 +253,39 @@ int cont_has_extra_buttons(const maple_device_t *cont);
     automatically to the specified set of buttons being pressed. This can be
     used, for instance, to implement the standard A+B+X+Y+Start method of ending
     the program running.
+
+    \warning
+    Your callback will be invoked within a context with interrupts disabled.
+    See cont_btn_callback for more information.
+
+    \sa cont_btn_callback
 */
 typedef void (*cont_btn_callback_t)(uint8_t addr, uint32_t btns);
 
-/** \brief  Set an automatic button press callback.
+/** \brief   Set an automatic button press callback.
+    \ingroup controller
 
     This function sets a callback function to be called when the specified
     controller has the set of buttons given pressed.
 
-    \param  addr            The controller to listen on. This value can be
-                            obtained by using maple_addr().
+    \note 
+    The callback gets invoked for the given maple port; however, providing
+    an address of '0' will cause it to be invoked for any port with a 
+    device pressing the given buttons. Since you are passed back the address 
+    of this device, You are free to implement your own filtering logic within
+    your callback.
+
+    \warning
+    The provided callback function is invoked within a context which has
+    interrupts disabled. This means that you should not do any sort of complex
+    processing or make any API calls which depend on interrupts to complete,
+    such as Maple or etherent processing whichy rely on packet transmission,
+    any sleeping or threading calls, blocking on any sort of file I/O, etc. 
+    This mechanism is typically used to quickly terminate the application
+    and should be used with caution.
+
+    \param  addr            The controller to listen on (or 0 for all ports). 
+                            This value can be obtained by using maple_addr().
     \param  btns            The buttons bitmask to match.
     \param  cb              The callback to call when the buttons are pressed.
 */

--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -169,7 +169,7 @@ $(foreach package, $(packages), $(eval $(call warn_and_fallback,$(package)_downl
 # Web downloaders command-lines
 downloaders = curl wget
 wget_cmd = wget -c $(if $(2),-O $(2)) '$(1)'
-curl_cmd = curl --fail --location  -C - $(if $(2),-o $(2),-O) '$(1)' 
+curl_cmd = curl --fail --location  -C - $(if $(2),-o $(2),-O) $(1)
 
 ifneq ($(force_downloader),)
 # Check if specified downloader is in supported list


### PR DESCRIPTION
I'm writing a tutorial for setting up GDB with Qt Creator. When I tried to run the usual `make gdb` from within `utils/dc-chain`, I was met with this:

    falco@slutserv:/opt/toolchains/dc/kos/utils/dc-chain$ make gdb
    ******************************************
    Sega Dreamcast Toolchains Maker (dc-chain)
    ******************************************

    scripts/init.mk:167: gdb_download_type not defined, falling back to gdb_tarball_type 
    Using curl as download tool
    GNU/Linux build environment detected
    +++ Downloading gdb-9.2.tar.xz ...
    curl --fail --location  -C - -O 'https://ftpmirror.gnu.org/gnu/gdb/gdb-9.2.tar.xz '  
    curl: (3) URL using bad/illegal format or missing URL
    make: *** [scripts/download.mk:76: gdb-9.2.tar.xz] Error 3

The fix seems to just be removing the single quotes from teh URL variable. Works now...