### PR TITLE
Move vector.h from addons to core.

### DIFF
--- a/addons/include/kos/bspline.h
+++ b/addons/include/kos/bspline.h
@@ -24,7 +24,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <kos/vector.h>
+#include <dc/vector.h>
 
 /** \brief  Calculate and set b-spline coefficients.
 

--- a/addons/include/kos/vector.h
+++ b/addons/include/kos/vector.h
@@ -8,7 +8,8 @@
 /** \file   kos/vector.h
     \brief  Deprecated alias for <dc/vector.h>.
 
-    This file is provided for backwards compatibility. New code should include <dc/vector.h> directly.
+    This file is provided for backwards compatibility. New code should include
+    <dc/vector.h> directly.
 */
 
 #include <dc/vector.h>

--- a/addons/include/kos/vector.h
+++ b/addons/include/kos/vector.h
@@ -5,42 +5,11 @@
 
 */
 
-#ifndef __KOS_VECTOR_H
-#define __KOS_VECTOR_H
-
 /** \file   kos/vector.h
-    \brief  Primitive matrix, vector, and point types.
+    \brief  Deprecated alias for <dc/vector.h>.
 
-    This file provides a few primivite data types that are useful for 3D
-    graphics. These are used by the code in kos/bspline.h and can be useful
-    elsewhere, as well.
-
-    \author Megan Potter
+    This file is provided for backwards compatibility. New code should include <dc/vector.h> directly.
 */
 
-#include <sys/cdefs.h>
-__BEGIN_DECLS
-
-#include <arch/types.h>
-
-/** \brief  Basic 4x4 matrix type.
-    \headerfile kos/vector.h
-*/
-typedef float matrix_t[4][4];
-
-/** \brief  4-part vector type.
-    \headerfile kos/vector.h
-*/
-typedef struct vectorstr {
-    float x, y, z, w;
-} vector_t;
-
-/** \brief  4-part point type (alias to the vector_t type).
-    \headerfile kos/vector.h
-*/
-typedef vector_t point_t;
-
-__END_DECLS
-
-#endif  /* __KOS_VECTOR_H */
+#include <dc/vector.h>
 

--- a/kernel/arch/dreamcast/include/dc/matrix.h
+++ b/kernel/arch/dreamcast/include/dc/matrix.h
@@ -25,7 +25,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <kos/vector.h>
+#include <dc/vector.h>
 
 /** \brief  Copy the internal matrix to a memory one.
 

--- a/kernel/arch/dreamcast/include/dc/vector.h
+++ b/kernel/arch/dreamcast/include/dc/vector.h
@@ -1,0 +1,46 @@
+/* KallistiOS ##version##
+
+   kos/vector.h
+   Copyright (C) 2002 Megan Potter
+
+*/
+
+#ifndef __DC_VECTOR_H
+#define __DC_VECTOR_H
+
+/** \file   kos/vector.h
+    \brief  Primitive matrix, vector, and point types.
+
+    This file provides a few primivite data types that are useful for 3D
+    graphics. These are used by the code in kos/bspline.h and can be useful
+    elsewhere, as well.
+
+    \author Megan Potter
+*/
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+#include <arch/types.h>
+
+/** \brief  Basic 4x4 matrix type.
+    \headerfile kos/vector.h
+*/
+typedef float matrix_t[4][4];
+
+/** \brief  4-part vector type.
+    \headerfile kos/vector.h
+*/
+typedef struct vectorstr {
+    float x, y, z, w;
+} vector_t;
+
+/** \brief  4-part point type (alias to the vector_t type).
+    \headerfile kos/vector.h
+*/
+typedef vector_t point_t;
+
+__END_DECLS
+
+#endif  /* __DC_VECTOR_H */
+

--- a/kernel/arch/dreamcast/include/dc/vector.h
+++ b/kernel/arch/dreamcast/include/dc/vector.h
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   kos/vector.h
+   dc/vector.h
    Copyright (C) 2002 Megan Potter
 
 */
@@ -8,12 +8,11 @@
 #ifndef __DC_VECTOR_H
 #define __DC_VECTOR_H
 
-/** \file   kos/vector.h
+/** \file   dc/vector.h
     \brief  Primitive matrix, vector, and point types.
 
     This file provides a few primivite data types that are useful for 3D
-    graphics. These are used by the code in kos/bspline.h and can be useful
-    elsewhere, as well.
+    graphics.
 
     \author Megan Potter
 */
@@ -21,22 +20,20 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
-
 /** \brief  Basic 4x4 matrix type.
-    \headerfile kos/vector.h
+    \headerfile dc/vector.h
 */
 typedef float matrix_t[4][4];
 
 /** \brief  4-part vector type.
-    \headerfile kos/vector.h
+    \headerfile dc/vector.h
 */
 typedef struct vectorstr {
     float x, y, z, w;
 } vector_t;
 
 /** \brief  4-part point type (alias to the vector_t type).
-    \headerfile kos/vector.h
+    \headerfile dc/vector.h
 */
 typedef vector_t point_t;
 


### PR DESCRIPTION
The core matrix API depends on the typedefs in vector.h, which currently lives in the addons tree. This change moves these typed back to the core kernel tree so that we don't have a dependency from addons back to the kernel.