### PR TITLE
Improve fipr() function

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -172,6 +172,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added Objective-C example testing/demonstrating C Runtime [FG]
 - *** Updated Objective-C examples to include more thorough testing of the
       runtime aspects of the language [Andrew Apperley == AA]
+- DC  Improve fipr() and fipr_magnitude_sqr() functions [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/kernel/arch/dreamcast/include/dc/fmath_base.h
+++ b/kernel/arch/dreamcast/include/dc/fmath_base.h
@@ -125,34 +125,34 @@ __BEGIN_DECLS
 
 /* Floating point inner product (dot product) */
 #define __fipr(x, y, z, w, a, b, c, d) ({ \
-        register float __x __asm__("fr0") = (x); \
-        register float __y __asm__("fr1") = (y); \
-        register float __z __asm__("fr2") = (z); \
-        register float __w __asm__("fr3") = (w); \
-        register float __a __asm__("fr4") = (a); \
-        register float __b __asm__("fr5") = (b); \
-        register float __c __asm__("fr6") = (c); \
-        register float __d __asm__("fr7") = (d); \
+        register float __x __asm__("fr5") = (x); \
+        register float __y __asm__("fr4") = (y); \
+        register float __z __asm__("fr7") = (z); \
+        register float __w __asm__("fr6") = (w); \
+        register float __a __asm__("fr9") = (a); \
+        register float __b __asm__("fr8") = (b); \
+        register float __c __asm__("fr11") = (c); \
+        register float __d __asm__("fr10") = (d); \
         __asm__ __volatile__( \
-                              "fipr	fv4,fv0" \
-                              : "+f" (__w) \
+                              "fipr	fv8,fv4" \
+                              : "+f" (__z) \
                               : "f" (__x), "f" (__y), "f" (__z), "f" (__w), \
                               "f" (__a), "f" (__b), "f" (__c), "f" (__d) \
                             ); \
-        __w; })
+        __z; })
 
 /* Floating point inner product w/self (square of vector magnitude) */
 #define __fipr_magnitude_sqr(x, y, z, w) ({ \
-        register float __x __asm__("fr4") = (x); \
-        register float __y __asm__("fr5") = (y); \
-        register float __z __asm__("fr6") = (z); \
-        register float __w __asm__("fr7") = (w); \
+        register float __x __asm__("fr5") = (x); \
+        register float __y __asm__("fr4") = (y); \
+        register float __z __asm__("fr7") = (z); \
+        register float __w __asm__("fr6") = (w); \
         __asm__ __volatile__( \
                               "fipr	fv4,fv4" \
-                              : "+f" (__w) \
+                              : "+f" (__z) \
                               : "f" (__x), "f" (__y), "f" (__z), "f" (__w) \
                             ); \
-        __w; })
+        __z; })
 
 /** \endcond */
 __END_DECLS


### PR DESCRIPTION
Update the __fipr() macro to use better registers.

With this change, the inner body of the fipr() function passes from being 11 opcodes long, to being just 3 opcodes long.

See it in Compiler Explorer: https://godbolt.org/z/qj3P8x4ba