### PR TITLE
Update AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ Falco Girgis: 2023
 Ruslan Rostovtsev: 2014, 2016, 2023
 Colton Pawielski: 2023
 Andy Barajas: 2023
+Paul Cercueil: 2023
 
 Files with Specific licenses:
 -----------------------------


### PR DESCRIPTION
For his contributions to KOS, its toolchains, and the Dreamcast-Scene, we hereby nominate  Paul Cercueil, aka "zcrc," as an official KOS author! 