### PR TITLE
Added fast math flags and -fno-builtin options to environ.sh.sample

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -79,10 +79,18 @@ export KOS_AFLAGS=""
 export KOS_CFLAGS="-O2 -fomit-frame-pointer"
 # export KOS_CFLAGS="-O2 -DFRAME_POINTERS -fno-omit-frame-pointer"
 
+# Comment out this line to enable GCC to use its own builtin implementations of 
+# certain standard library functions. Under certain conditions, this can allow
+# compiler-optimized implementations to replace standard function invocations.
+# The downside of this is that it COULD interfere with Newlib or KOS implementations
+# of these functions, and it has not been tested thoroughly to ensure compatibility. 
+export KOS_CFLAGS="${KOS_CFLAGS} -fno-builtin"
+
 # Uncomment this line to enable the optimized fast-math instructions (FSSRA,
 # FSCA, and FSQRT) for calculating sin/cos, inverse square root, and square roots.
 # These can result in substantial performance gains for these kinds of operations;
 # however, they do so at the price of accuracy and are not IEEE compliant.
+# NOTE: This also requires -fno-builtin be removed from KOS_CFLAGS to take effect!
 # export KOS_CFLAGS="${KOS_CFLAGS} -ffast-math -ffp-contract=fast -mfsrra -mfsca"
 
 # Everything else is pretty much shared. If you want to configure compiler

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -79,6 +79,12 @@ export KOS_AFLAGS=""
 export KOS_CFLAGS="-O2 -fomit-frame-pointer"
 # export KOS_CFLAGS="-O2 -DFRAME_POINTERS -fno-omit-frame-pointer"
 
+# Uncomment this line to enable the optimized fast-math instructions (FSSRA,
+# FSCA, and FSQRT) for calculating sin/cos, inverse square root, and square roots.
+# These can result in substantial performance gains for these kinds of operations;
+# however, they do so at the price of accuracy and are not IEEE compliant.
+# export KOS_CFLAGS="${KOS_CFLAGS} -ffast-math -ffp-contract=fast -mfsrra -mfsca"
+
 # Everything else is pretty much shared. If you want to configure compiler
 # options or other such things, look at this file.
 . ${KOS_BASE}/environ_base.sh

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -33,7 +33,7 @@ export KOS_OBJCOPY="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-objcopy"
 export KOS_LD="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-ld"
 export KOS_RANLIB="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-gcc-ranlib"
 export KOS_STRIP="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-strip"
-export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_INC_PATHS} -D_arch_${KOS_ARCH} -D_arch_sub_${KOS_SUBARCH} -Wall -g -fno-builtin"
+export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_INC_PATHS} -D_arch_${KOS_ARCH} -D_arch_sub_${KOS_SUBARCH} -Wall -g"
 export KOS_CPPFLAGS="${KOS_CPPFLAGS} ${KOS_INC_PATHS_CPP} -fno-operator-names"
 
 # Which standards modes we want to compile for


### PR DESCRIPTION
So yet again the topic of KOS not using the fast math compiler directives for emitting fsca and fsrra has been brought up (https://dcemulation.org/phpBB/viewtopic.php?p=1060030#p1060030)... This time it looks as though an actual issue has been found: Even if the user adds the correct flags, fast math instructions will still never be emitted... Why? Because we use `-fno-builtin` universally in `environ_base.sh`. 

Nobody seems to be questioning the validity of our decision to not enable these flags by default, as they are not IEEE floating point conforming; however, I do think they have a legitimate point of frustration in that they cannot enable them even if they wanted to.

TapamN proposes to remove that flag... I just got done testing with it removed, and building KOS gives a few new warnings that weren't present before, but everything *does* seem to build and work fine... However, obviously we don't know what global impact this will have without far more testing...

So I have a proposal... I think we should do two things here to give the users a choice:
1) Add a line to `environ.sh.sample` for enabling all of the fast math optimizations with an explanation of the ramifications of doing so, with it disabled by default
2) Remove `-fno-builtin` from `environ_base.sh`, where the user isn't supposed to touch anything, and readd it to `environ.sh.sample`, where we can now give them the *choice* to disable the flag. I've added a detailed explanation, again, warning them of the potential ramifications of doing so, and it's enabled by default. 

So we basically get two new feature switches with this proposal without changing our defaults. Everybody wins?