### PR TITLE
vmu: Add function vmu_draw_lcd_rotated()

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -173,6 +173,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Updated Objective-C examples to include more thorough testing of the
       runtime aspects of the language [Andrew Apperley == AA]
 - DC  Improve fipr() and fipr_magnitude_sqr() functions [PC]
+- DC  Add optimized bit-reverse function && vmu_draw_lcd_rotated() [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -169,7 +169,7 @@ int vmu_beep_raw(maple_device_t * dev, uint32 beep) {
 
 /* Draw a 1-bit bitmap on the LCD screen (48x32). return a -1 if
    an error occurs */
-int vmu_draw_lcd(maple_device_t * dev, void *bitmap) {
+int vmu_draw_lcd(maple_device_t * dev, const void *bitmap) {
     uint32 *    send_buf;
 
     assert(dev != NULL);

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -12,6 +12,7 @@
 #include <kos/genwait.h>
 #include <dc/maple.h>
 #include <dc/maple/vmu.h>
+#include <dc/math.h>
 #include <dc/biosfont.h>
 #include <dc/vmufs.h>
 #include <arch/timer.h>
@@ -204,6 +205,17 @@ int vmu_draw_lcd(maple_device_t * dev, const void *bitmap) {
     }
 
     return MAPLE_EOK;
+}
+
+int vmu_draw_lcd_rotated(maple_device_t *dev, const void *bitmap) {
+    uint32 bitmap_inverted[48];
+    unsigned int i;
+
+    for (i = 0; i < 48; i++) {
+        bitmap_inverted[i] = bit_reverse(((uint32 *)bitmap)[47 - i]);
+    }
+
+    return vmu_draw_lcd(dev, bitmap_inverted);
 }
 
 /* This function converts a xbm image to a 1-bit bitmap that can

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -97,7 +97,7 @@ int vmu_beep_raw(maple_device_t * dev, uint32 beep);
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
     \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
 */
-int vmu_draw_lcd(maple_device_t * dev, void *bitmap);
+int vmu_draw_lcd(maple_device_t * dev, const void *bitmap);
 
 /** \brief  Display a Xwindows XBM image on a VMU screen.
 

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -99,6 +99,25 @@ int vmu_beep_raw(maple_device_t * dev, uint32 beep);
 */
 int vmu_draw_lcd(maple_device_t * dev, const void *bitmap);
 
+/** \brief  Display a 1bpp bitmap on a VMU screen.
+
+    This function sends a raw bitmap to a VMU to display on its screen. This
+    bitmap is 1bpp, and is 48x32 in size. This function is equivalent to
+    vmu_draw_lcd, but the image is rotated 180° so that the first byte of the
+    bitmap corresponds to the top-left corner, instead of the bottom-right one.
+
+    \param  dev             The device to draw to.
+    \param  bitmap          The bitmap to show.
+    \retval MAPLE_EOK       On success.
+    \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
+    \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
+
+    \warning    This function is optimized by an assembly routine which operates
+                on 32 bits at a time. As such, the given bitmap must be 4-byte
+		aligned.
+*/
+int vmu_draw_lcd_rotated(maple_device_t * dev, const void *bitmap);
+
 /** \brief  Display a Xwindows XBM image on a VMU screen.
 
     This function takes in a Xwindows XBM, converts it to a raw bitmap, and sends 

--- a/kernel/arch/dreamcast/include/dc/math.h
+++ b/kernel/arch/dreamcast/include/dc/math.h
@@ -1,0 +1,27 @@
+/* KallistiOS ##version##
+
+   dc/math.h
+   Copyright (C) 2023 Paul Cercueil
+
+*/
+
+#ifndef __DC_MATH_H
+#define __DC_MATH_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+/**
+    \file   dc/math.h
+    \brief  Prototypes for optimized math functions written in ASM
+    \author Paul Cercueil
+*/
+
+/**
+    \brief  Returns the bit-reverse value of the argument (where MSB
+            becomes LSB and vice-versa).
+    \return the bit-reverse value of the argument.
+*/
+unsigned int bit_reverse(unsigned int value);
+
+#endif /* __DC_MATH_H */

--- a/kernel/arch/dreamcast/math/Makefile
+++ b/kernel/arch/dreamcast/math/Makefile
@@ -6,7 +6,7 @@
 
 # Dreamcast-specific math functions
 
-OBJS = fmath.o matrix.o matrix3d.o
+OBJS = fmath.o math.o matrix.o matrix3d.o
 SUBDIRS = 
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/arch/dreamcast/math/math.s
+++ b/kernel/arch/dreamcast/math/math.s
@@ -1,0 +1,18 @@
+! KallistiOS ##version##
+!
+! dc/math.s
+! Copyright (C) 2023 Paul Cercueil
+
+! Return the bit-reverse value of the first argument.
+.globl _bit_reverse
+_bit_reverse:
+	mov r4,r0
+	sett
+_1:
+	rotcr r0
+	rotcl r1
+	cmp/eq #1,r0
+	bf _1
+
+	rts
+	mov r1,r0


### PR DESCRIPTION
This function is equivalent to vmu_draw_lcd, but the image is rotated
180° so that the first byte of the bitmap corresponds to the top-left
corner, instead of the bottom-right one.