### PR TITLE
vmu: Add VMU framebuffer API

### DIFF
--- a/kernel/arch/dreamcast/include/dc/vmu_fb.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_fb.h
@@ -1,0 +1,132 @@
+/* KallistiOS ##version##
+
+   dc/vmu_fb.h
+   Copyright (C) 2023 Paul Cercueil
+
+*/
+
+/** \file   dc/vmu_fb.h
+    \brief  VMU framebuffer.
+
+    This file provides an API that can be used to compose a 48x32 image that can
+    then be displayed on the VMUs connected to the system.
+*/
+
+#include <dc/maple.h>
+
+/** \brief  VMU framebuffer.
+
+    This object contains a 48x32 monochrome framebuffer. It can be painted to,
+    or displayed one the VMUs connected to the system, using the API below.
+
+    \headerfile dc/vmu_fb.h
+ */
+typedef struct {
+    uint32_t data[48];
+} vmufb_t;
+
+/** \brief  VMU framebuffer font meta-data.
+
+    \headerfile dc/vmu_fb.h
+ */
+typedef struct {
+    unsigned int w;         /**< \brief Character width in pixels */
+    unsigned int h;         /**< \brief Character height in pixels */
+    unsigned int stride;    /**< \brief Size of one character in bytes */
+    const char *fontdata;   /**< \brief Pointer to the font data */
+} vmufb_font_t;
+
+/** \brief  Render into the VMU framebuffer
+
+    This function will paint the provided pixel data into the VMU framebuffer,
+    into the rectangle provided by the x, y, w and h values.
+
+    \param  fb              A pointer to the vmufb_t to paint to.
+    \param  x               The horizontal position of the top-left corner of
+                            the drawing area, in pixels
+    \param  y               The vertical position of the top-left corner of the
+                            drawing area, in pixels
+    \param  w               The width of the drawing area, in pixels
+    \param  h               The height of the drawing area, in pixels
+    \param  data            A pointer to the pixel data that will be painted
+                            into the drawing area.
+ */
+void vmufb_paint_area(vmufb_t *fb,
+                      unsigned int x, unsigned int y,
+                      unsigned int w, unsigned int h,
+                      const char *data);
+
+/** \brief  Clear a specific area of the VMU framebuffer
+
+    This function clears the area of the VMU framebuffer designated by the
+    x, y, w and h values.
+
+    \param  fb              A pointer to the vmufb_t to paint to.
+    \param  x               The horizontal position of the top-left corner of
+                            the drawing area, in pixels
+    \param  y               The vertical position of the top-left corner of the
+                            drawing area, in pixels
+    \param  w               The width of the drawing area, in pixels
+    \param  h               The height of the drawing area, in pixels
+ */
+void vmufb_clear_area(vmufb_t *fb,
+                      unsigned int x, unsigned int y,
+                      unsigned int w, unsigned int h);
+
+/** \brief  Clear the VMU framebuffer
+
+    This function clears the whole VMU framebuffer.
+
+    \param  fb              A pointer to the vmufb_t to paint to.
+ */
+void vmufb_clear(vmufb_t *fb);
+
+/** \brief  Present the VMU framebuffer to a VMU
+
+    This function presents the previously rendered VMU framebuffer to the
+    VMU identified by the dev argument.
+
+    \param  fb              A pointer to the vmufb_t to paint to.
+    \param  dev             The maple device of the VMU to present to
+ */
+void vmufb_present(const vmufb_t *fb, maple_device_t *dev);
+
+/** \brief  Render a string into the VMU framebuffer
+
+    This function uses the provided font to render text into the VMU
+    framebuffer.
+
+    \param  fb              A pointer to the vmufb_t to paint to.
+    \param  font            A pointer to the vmufb_font_t that will be used for
+                            painting the text
+    \param  x               The horizontal position of the top-left corner of
+                            the drawing area, in pixels
+    \param  y               The vertical position of the top-left corner of the
+                            drawing area, in pixels
+    \param  w               The width of the drawing area, in pixels
+    \param  h               The height of the drawing area, in pixels
+    \param  line_spacing    Specify the number of empty lines that should
+                            separate two lines of text
+    \param  str             The text to render
+ */
+void vmufb_print_string_into(vmufb_t *fb,
+			     const vmufb_font_t *font,
+			     unsigned int x, unsigned int y,
+			     unsigned int w, unsigned int h,
+			     unsigned int line_spacing,
+			     const char *str);
+
+/** \brief  Render a string into the VMU framebuffer
+
+    Simplified version of vmufb_print_string_into(). This is the same as calling
+    vmufb_print_string_into with x=0, y=0, w=48, h=32, line_spacing=0.
+
+    \param  fb              A pointer to the vmufb_t to paint to.
+    \param  font            A pointer to the vmufb_font_t that will be used for
+                            painting the text
+    \param  str             The text to render
+ */
+static __inline__ void
+vmufb_print_string(vmufb_t *fb, const vmufb_font_t *font, const char *str) {
+    vmufb_print_string_into(fb, font, 0, 0, 48, 32, 0, str);
+}

--- a/kernel/arch/dreamcast/util/Makefile
+++ b/kernel/arch/dreamcast/util/Makefile
@@ -4,7 +4,7 @@
 # Copyright (C) 2001 Megan Potter
 #
 
-OBJS = vmu_pkg.o screenshot.o minifont.o
+OBJS = vmu_fb.o vmu_pkg.o screenshot.o minifont.o
 SUBDIRS =
 
 ifneq ($(KOS_SUBARCH), naomi)

--- a/kernel/arch/dreamcast/util/vmu_fb.c
+++ b/kernel/arch/dreamcast/util/vmu_fb.c
@@ -1,0 +1,142 @@
+/* KallistiOS ##version##
+
+   util/vmu_fb.c
+   Copyright (C) 2023 Paul Cercueil
+
+*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <dc/maple/vmu.h>
+#include <dc/vmu_fb.h>
+
+#define GENMASK(h, l) \
+    (((unsigned int)-1 << (l)) & ((unsigned int)-1 >> (31 - (h))))
+
+static uint64_t extract_bits(const uint8_t *data,
+                             unsigned int offt, unsigned int w) {
+    uint32_t tmp, lsb, nb_bits;
+    uint64_t bits = 0;
+
+    /* This algorithm will extract "w" bits starting from bit "offt", and
+       place them right-adjusted in "bits".
+
+       Since we manipulate 8 bits at a time, and neither "w" nor "offt" are
+       required to be byte-aligned, we need to compute a mask of valid bits
+       for each byte that is processed. */
+    while (w) {
+        tmp = data[offt / 8];
+
+        if (8 - (offt & 0x7) > w)
+            lsb = 8 - (offt & 0x7) - w;
+        else
+            lsb = 0;
+
+        nb_bits = 8 - (offt & 0x7) - lsb;
+        bits <<= nb_bits;
+
+        tmp &= GENMASK(7 - (offt & 0x7), lsb);
+
+        bits |= tmp >> lsb;
+
+        offt += nb_bits;
+        w -= nb_bits;
+    }
+
+    return bits;
+}
+
+static void insert_bits(uint8_t *data,
+                        unsigned int offt, unsigned int w, uint64_t bits) {
+    uint32_t tmp, lsb, nb_bits, mask;
+
+    while (w) {
+        tmp = data[offt / 8];
+
+        if (8 - (offt & 0x7) > w)
+            lsb = 8 - (offt & 0x7) - w;
+        else
+            lsb = 0;
+
+        nb_bits = 8 - (offt & 0x7) - lsb;
+        mask = GENMASK(7 - (offt & 0x7), lsb);
+        tmp &= ~mask;
+
+        tmp |= ((bits >> (w - nb_bits)) << lsb) & mask;
+
+        data[offt / 8] = tmp;
+
+        offt += nb_bits;
+        w -= nb_bits;
+    }
+}
+
+void vmufb_paint_area(vmufb_t *fb,
+                      unsigned int x, unsigned int y,
+                      unsigned int w, unsigned int h,
+                      const char *data) {
+    unsigned int i;
+    uint64_t bits;
+
+    for (i = 0; i < h; i++) {
+        bits = extract_bits((const uint8_t *)data, i * w, w);
+        insert_bits((uint8_t *)fb->data, (y + i) * 48 + x, w, bits);
+    }
+}
+
+void vmufb_clear(vmufb_t *fb) {
+    memset(fb->data, 0, sizeof(fb->data));
+}
+
+void vmufb_clear_area(vmufb_t *fb,
+                      unsigned int x, unsigned int y,
+                      unsigned int w, unsigned int h) {
+    uint32_t tmp[48] = {};
+
+    vmufb_paint_area(fb, x, y, w, h, (const char *) tmp);
+}
+
+void vmufb_present(const vmufb_t *fb, maple_device_t *dev) {
+    if (dev->info.connector_direction == 0) /* 0: UP - rotated like most controllers */
+        vmu_draw_lcd_rotated(dev, fb->data);
+    else /* 1: DOWN - not rotated, like lightgun */
+        vmu_draw_lcd(dev, fb->data);
+}
+
+void vmufb_print_string_into(vmufb_t *fb,
+                             const vmufb_font_t *font,
+                             unsigned int x, unsigned int y,
+                             unsigned int w, unsigned int h,
+                             unsigned int line_spacing,
+                             const char *str) {
+    unsigned int xorig = x, yorig = y;
+
+    for (; *str; str++) {
+        switch (*str) {
+        case '\n':
+            x = xorig;
+            y += line_spacing + font->h;
+            continue;
+        default:
+            break;
+        }
+
+        if (x > xorig + w - font->w) {
+            /* We run out of horizontal space - put character on new line */
+            x = xorig;
+            y += line_spacing + font->h;
+        }
+
+        if (y > yorig + h - font->h) {
+            /* We ran out of space */
+            break;
+        }
+
+        vmufb_paint_area(fb, x, y, font->w, font->h,
+                         &font->fontdata[*str * font->stride]);
+
+        x += font->w;
+    }
+}


### PR DESCRIPTION
This API can be used to render and present dynamic images to the VMUs connected to the system. It also supports rendering text using a user-provided font.