### PR TITLE
Help prevent duplicate paths and flags upon multiple sourcing of environ.sh

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -57,15 +57,19 @@ export KOS_CC_PREFIX="sh-elf"
 export DC_ARM_BASE="/opt/toolchains/dc/arm-eabi"
 export DC_ARM_PREFIX="arm-eabi"
 
-# Expand PATH (comment out if you don't want this done here)
-export PATH="${PATH}:${KOS_CC_BASE}/bin:/opt/toolchains/dc/bin"
+# Expand PATH if not already set (comment out if you don't want this done here)
+if [[ ":$PATH:" != *":${KOS_CC_BASE}/bin:/opt/toolchains/dc/bin"* ]]; then
+  export PATH="${PATH}:${KOS_CC_BASE}/bin:/opt/toolchains/dc/bin"
+fi
 
 # reset some options because there's no reason for them to persist across
 # multiple sourcing of this
+export KOS_INC_PATHS=""
 export KOS_CFLAGS=""
 export KOS_CPPFLAGS=""
 export KOS_LDFLAGS=""
 export KOS_AFLAGS=""
+export DC_ARM_LDFLAGS=""
 
 # Setup some default CFLAGS for compilation. The things that will go here
 # are user specifyable, like optimization level and whether you want stack

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -12,8 +12,10 @@ export KOS_ARCH_DIR="${KOS_BASE}/kernel/arch/${KOS_ARCH}"
 # Pull in the arch environ file
 . ${KOS_BASE}/environ_${KOS_ARCH}.sh
 
-# Add the gnu wrappers dir to the path
-export PATH="${PATH}:${KOS_BASE}/utils/gnu_wrappers"
+# Add the gnu wrappers dir to the path if they are not already
+if [[ ":$PATH:" != *":${KOS_BASE}/utils/gnu_wrappers"* ]]; then
+  export PATH="${PATH}:${KOS_BASE}/utils/gnu_wrappers"
+fi
 
 # Our includes
 export KOS_INC_PATHS="${KOS_INC_PATHS} -I${KOS_BASE}/include \

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -12,7 +12,7 @@ export KOS_ARCH_DIR="${KOS_BASE}/kernel/arch/${KOS_ARCH}"
 # Pull in the arch environ file
 . ${KOS_BASE}/environ_${KOS_ARCH}.sh
 
-# Add the gnu wrappers dir to the path if they are not already
+# Add the gnu wrappers dir to the path if it is not already
 if [[ ":$PATH:" != *":${KOS_BASE}/utils/gnu_wrappers"* ]]; then
   export PATH="${PATH}:${KOS_BASE}/utils/gnu_wrappers"
 fi


### PR DESCRIPTION
As things currently stand, when environ.sh is sourced multiple times, the $PATH environment variable as well as the $KOS_INC_PATHS and $DC_ARM_LDFLAGS variables become duplicated, for example:

```
echo $DC_ARM_LDFLAGS
 -Wl,-Ttext=0x00000000,-N -nostartfiles -nostdlib -e reset -Wl,-Ttext=0x00000000,-N -nostartfiles -nostdlib -e reset -Wl,-Ttext=0x00000000,-N -nostartfiles -nostdlib -e reset -Wl,-Ttext=0x00000000,-N -nostartfiles -nostdlib -e reset
```

This PR helps prevent these issues. Note that if you source a different environ.sh file with a different $PATH setting you may still get multiple entries as the previous one doesn't get cleared.