### PR TITLE
Separate out initialization flags from <arch/arch.h>

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -177,6 +177,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Update bfont example for Dreamcast-specific characters [DH]
 - DC  Add example for VMU speaker use [DH && FG]
 - DC  Add example for rumble accessory use [DH]
+- *** Split init flags from <arch/arch.h> into <kos/init.h> [LS]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/examples/dreamcast/basic/memtest32/main.c
+++ b/examples/dreamcast/basic/memtest32/main.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include <kos/init.h>
 #include <arch/arch.h>
 
 #include "memtest.h"
@@ -40,8 +41,8 @@
 #define BASE_ADDRESS  (volatile datum *) (0x8c000000 + SAFE_AREA)
 
 /* Define the number of bytes to be tested. KallistiOS provides the
- * macros HW_MEM_16 and HW_MEM_32 in <arch/arch.h> which describe 
- * the number of bytes available in standard supported console 
+ * macros HW_MEM_16 and HW_MEM_32 in <arch/arch.h> which describe
+ * the number of bytes available in standard supported console
  * configurations (16777216 and 33554432, respectively). */
 #define NUM_BYTES_32  (HW_MEM_32 - SAFE_AREA - STACK_SIZE)
 #define NUM_BYTES_16  (HW_MEM_16 - SAFE_AREA - STACK_SIZE)

--- a/examples/dreamcast/cpp/out_of_memory/Makefile
+++ b/examples/dreamcast/cpp/out_of_memory/Makefile
@@ -1,7 +1,7 @@
 #
 # C++ out-of-memory demonstration
 # (c)2023 Falco Girgis
-#   
+#
 
 TARGET = out_of_memory.elf
 OBJS = out_of_memory.o
@@ -13,13 +13,13 @@ all: rm-elf $(TARGET)
 include $(KOS_BASE)/Makefile.rules
 
 clean: rm-elf
-	-rm -f $(OBJS) 
+	-rm -f $(OBJS)
 
 rm-elf:
-	-rm -f $(TARGET) 
+	-rm -f $(TARGET)
 
 $(TARGET): $(OBJS)
-	kos-c++ -o $(TARGET) $(OBJS) -lm
+	kos-c++ -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)
@@ -27,4 +27,3 @@ run: $(TARGET)
 dist: $(TARGET)
 	-rm -f $(OBJS)
 	$(KOS_STRIP) $(TARGET)
-

--- a/examples/dreamcast/cpp/out_of_memory/out_of_memory.cc
+++ b/examples/dreamcast/cpp/out_of_memory/out_of_memory.cc
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <malloc.h>
 
-#include <arch/arch.h>
+#include <kos/init.h>
 
 KOS_INIT_FLAGS(INIT_MALLOCSTATS);
 
@@ -12,7 +12,7 @@ void new_handler_cb() {
 
     malloc_stats();
 
-    // Unregister ourself as the new handler, so that next 
+    // Unregister ourself as the new handler, so that next
     // iteration will hit the exception handler.
     std::set_new_handler(NULL);
 }
@@ -34,22 +34,22 @@ int main(int argc, char **argv) {
 
         } catch(std::bad_alloc const&) {
 
-            if(!failed_once) { 
+            if(!failed_once) {
                 // std::bad_alloc is thrown when a call to new fails
-                std::cout << "Caught std::bad_alloc! Current size: " 
-                          << static_cast<double>(bytes.capacity()) 
-                                / 1024.0 / 1024.0 << "MB" 
+                std::cout << "Caught std::bad_alloc! Current size: "
+                          << static_cast<double>(bytes.capacity())
+                                / 1024.0 / 1024.0 << "MB"
                           << std::endl;
-                          
-                // Remember, std::vector typically requests RAM in 
+
+                // Remember, std::vector typically requests RAM in
                 // powers-of-two, so the actual requested allocation
                 // was probably 2x the size of the vector.
-                
+
                 // Lets force the vector to shrink to free up some
                 // space and ensure we can continue to allocate.
-                
+
                 malloc_stats();
-                
+
                 bytes.resize(0);
                 bytes.shrink_to_fit();
 

--- a/examples/dreamcast/kgl/basic/elements/gl-elements.c
+++ b/examples/dreamcast/kgl/basic/elements/gl-elements.c
@@ -1,4 +1,4 @@
-/* 
+/*
    KallistiOS 2.0.0
 
    gl-elements.c
@@ -15,7 +15,7 @@
 #include <GL/glu.h>
 #include <GL/glut.h>
 
-#include <arch/arch.h>
+#include <kos/init.h>
 
 /* Load a PVR texture - located in pvr-texture.c */
 extern GLuint glTextureLoadPVR(char *fname, unsigned char isMipMapped, unsigned char glMipMap);
@@ -107,4 +107,3 @@ int main(int argc, char **argv) {
 
     return 0;
 }
-

--- a/examples/dreamcast/kgl/basic/zclip_arrays/gl-arrays.c
+++ b/examples/dreamcast/kgl/basic/zclip_arrays/gl-arrays.c
@@ -1,4 +1,4 @@
-/* 
+/*
    KallistiOS 2.0.0
 
    gl-arrays.c
@@ -15,7 +15,7 @@
 #include <GL/glu.h>
 #include <GL/glut.h>
 
-#include <arch/arch.h>
+#include <kos/init.h>
 
 /* Load a PVR texture - located in pvr-texture.c */
 extern GLuint glTextureLoadPVR(char *fname, unsigned char isMipMapped, unsigned char glMipMap);
@@ -34,21 +34,21 @@ static void SetVertex3tc(Vertex3tc * vertex, GLfloat x, GLfloat y, GLfloat z,
 {
     vertex->position[0] = x;
     vertex->position[1] = y;
-    vertex->position[2] = z;  
+    vertex->position[2] = z;
     vertex->texCoord[0] = u;
-    vertex->texCoord[1] = v; 
-    vertex->color = color;    
+    vertex->texCoord[1] = v;
+    vertex->color = color;
 }
 static void buildDemoArray()
 {
     vertex = malloc( sizeof( Vertex3tc ) * 6 );
-    
+
     SetVertex3tc(&vertex[0], -100.0f, -10.0f, -100.0f, 0, 0, 0xFFFF0000);
     SetVertex3tc(&vertex[1], 100.0f, -10.0f, -100.0f, 1, 0, 0xFF00FF00);
     SetVertex3tc(&vertex[2], -100.0f, -10.0f, 100.0f, 0, 1, 0xFF0000FF);
     SetVertex3tc(&vertex[3], 100.0f, -10.0f, 100.0f, 1, 1, 0xFFFFFF00);
     SetVertex3tc(&vertex[4], -100.0f, -10.0f, 300.0f, 0, 0, 0xFFFF0000);
-    SetVertex3tc(&vertex[5], 100.0f, -10.0f, 300.0f, 1, 0, 0xFF00FF00);       
+    SetVertex3tc(&vertex[5], 100.0f, -10.0f, 300.0f, 1, 0, 0xFF00FF00);
 }
 
 static GLfloat rx = 1.0f;
@@ -56,7 +56,7 @@ static GLfloat rx = 1.0f;
 /* Example using Open GL Vertex Array Submission. */
 void RenderCallback(GLuint texID) {
     glEnable(GL_KOS_NEARZ_CLIPPING);
-    
+
     /* Rotate the matrix to make sure transforms and clipping are working */
     glLoadIdentity();
     glRotatef(rx++, 0, 1, 0);
@@ -64,17 +64,17 @@ void RenderCallback(GLuint texID) {
     /* Enable 2D Texturing and bind the Texture */
     glEnable(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, texID);
-    
+
     /* Enable Vertex, Color and Texture Coord Arrays */
     glEnableClientState(GL_VERTEX_ARRAY);
     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
     glEnableClientState(GL_COLOR_ARRAY);
-    
+
     /* Bind Vertex Array Data, Using Strided Vertices */
     glColorPointer(1, GL_UNSIGNED_INT, sizeof(Vertex3tc), &vertex[0].color);
     glTexCoordPointer(2, GL_FLOAT, sizeof(Vertex3tc), vertex[0].texCoord);
-    glVertexPointer(3, GL_FLOAT, sizeof(Vertex3tc), vertex[0].position);    
-    
+    glVertexPointer(3, GL_FLOAT, sizeof(Vertex3tc), vertex[0].position);
+
     /* Render the Submitted Vertex Data */
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 6);
 
@@ -101,9 +101,9 @@ int main(int argc, char **argv) {
 
     /* Load a PVR texture to OpenGL */
     GLuint texID = glTextureLoadPVR("/rd/wp001vq.pvr", 0, 0);
-    
+
     buildDemoArray();
-    
+
     while(1) {
         /* Draw the "scene" */
         RenderCallback(texID);
@@ -114,4 +114,3 @@ int main(int argc, char **argv) {
 
     return 0;
 }
-

--- a/examples/dreamcast/network/httpd/simhost.c
+++ b/examples/dreamcast/network/httpd/simhost.c
@@ -3,7 +3,7 @@
 #include <dc/biosfont.h>
 #include <dc/maple.h>
 #include <dc/maple/controller.h>
-#include <arch/arch.h>
+#include <kos/init.h>
 
 extern uint8 romdisk[];
 KOS_INIT_ROMDISK(romdisk);

--- a/examples/dreamcast/pvr/bumpmap/bump.c
+++ b/examples/dreamcast/pvr/bumpmap/bump.c
@@ -17,7 +17,7 @@
 #include <dc/fmath.h>
 #include <dc/maple/controller.h>
 
-#include <arch/arch.h>
+#include <kos/init.h>
 
 #include <kmg/kmg.h>
 

--- a/examples/dreamcast/pvr/modifier_volume_tex/modifier.c
+++ b/examples/dreamcast/pvr/modifier_volume_tex/modifier.c
@@ -14,7 +14,7 @@
 #include <dc/maple.h>
 #include <dc/maple/controller.h>
 
-#include <arch/arch.h>
+#include <kos/init.h>
 
 #include <pcx/pcx.h>
 #include <kmg/kmg.h>

--- a/examples/dreamcast/rumble/rumble.c
+++ b/examples/dreamcast/rumble/rumble.c
@@ -9,13 +9,13 @@
 /*
     This example allows you to send raw commands to the rumble accessory (aka purupuru).
 
-    This is a recreation of an original posted by SinisterTengu in 2004 here: 
-    https://dcemulation.org/phpBB/viewtopic.php?p=490067#p490067 . Unfortunately, 
-    that one is lost, but I had based my vmu_beep testing on it, and the principle is 
-    the same. In each, a single 32-bit value is sent to the device which defines the 
+    This is a recreation of an original posted by SinisterTengu in 2004 here:
+    https://dcemulation.org/phpBB/viewtopic.php?p=490067#p490067 . Unfortunately,
+    that one is lost, but I had based my vmu_beep testing on it, and the principle is
+    the same. In each, a single 32-bit value is sent to the device which defines the
     features of the rumbling.
 
-    TODO: This should be updated at some point to display and work from the macros in 
+    TODO: This should be updated at some point to display and work from the macros in
     dc/maple/purupuru.h that define the characteristics of the raw 32-bit value.
 
  */
@@ -23,9 +23,12 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include <kos/init.h>
+
 #include <dc/maple.h>
 #include <dc/maple/controller.h>
 #include <dc/maple/purupuru.h>
+
 #include <plx/font.h>
 
 extern uint8_t romdisk[];
@@ -40,7 +43,7 @@ void wait_for_dev_attach(maple_device_t **dev_ptr, unsigned int func) {
     point_t w = {40.0f, 200.0f, 10.0f, 0.0f};
 
     /* If we already have it, and it's still valid, leave */
-    /* dev->valid is set to 0 by the driver if the device 
+    /* dev->valid is set to 0 by the driver if the device
        is detatched, but dev will stay not-null */
     if((dev != NULL) && (dev->valid != 0)) return;
 
@@ -91,7 +94,7 @@ int main(int argc, char *argv[]) {
     /* Loop until Start is pressed */
     while(!(rel_buttons & CONT_START)) {
 
-        /* Before drawing the screen, trap into these functions to be 
+        /* Before drawing the screen, trap into these functions to be
            sure that there's at least one controller and one rumbler */
         wait_for_dev_attach(&contdev, MAPLE_FUNC_CONTROLLER);
         wait_for_dev_attach(&purudev, MAPLE_FUNC_PURUPURU);

--- a/examples/dreamcast/sd/speedtest/sd-speedtest.c
+++ b/examples/dreamcast/sd/speedtest/sd-speedtest.c
@@ -19,8 +19,8 @@
 #include <dc/maple/controller.h>
 
 #include <arch/timer.h>
-#include <arch/arch.h>
 
+#include <kos/init.h>
 #include <kos/dbgio.h>
 #include <kos/blockdev.h>
 

--- a/examples/dreamcast/sound/hello-opus/opustest.c
+++ b/examples/dreamcast/sound/hello-opus/opustest.c
@@ -14,7 +14,7 @@
 #include <dc/maple/controller.h>
 #include <dc/sound/stream.h>
 
-#include <arch/arch.h>
+#include <kos/init.h>
 
 #include <opusplay/opusplay.h>
 

--- a/examples/dreamcast/vmu/vmu_beep/beep.c
+++ b/examples/dreamcast/vmu/vmu_beep/beep.c
@@ -24,13 +24,16 @@
     Enjoy, and let me know about some interesting sounds.
  */
 
+#include <stdio.h>
+#include <stdint.h>
+
+#include <kos/init.h>
+
 #include <dc/maple.h>
 #include <dc/maple/controller.h>
 #include <dc/maple/vmu.h>
-#include <plx/font.h>
 
-#include <stdio.h>
-#include <stdint.h>
+#include <plx/font.h>
 
 extern uint8_t romdisk[];
 KOS_INIT_FLAGS(INIT_DEFAULT);
@@ -157,7 +160,7 @@ int main(int argc, char *argv[]) {
 
         /* Store current button states + buttons which have been released. */
         state = (cont_state_t *)maple_dev_status(dev);
-        rel_buttons = (old_buttons ^ state->buttons);	
+        rel_buttons = (old_buttons ^ state->buttons);
 
         if((state->buttons & CONT_DPAD_LEFT) && (rel_buttons & CONT_DPAD_LEFT)) {
             if(i > 0) i--;

--- a/examples/dreamcast/vmu/vmu_beep/beep.c
+++ b/examples/dreamcast/vmu/vmu_beep/beep.c
@@ -33,6 +33,8 @@
 #include <dc/maple/controller.h>
 #include <dc/maple/vmu.h>
 
+#include <arch/arch.h>
+
 #include <plx/font.h>
 
 extern uint8_t romdisk[];

--- a/examples/dreamcast/vmu/vmu_lcd/lcd.c
+++ b/examples/dreamcast/vmu/vmu_lcd/lcd.c
@@ -27,6 +27,8 @@
 #include <dc/maple/vmu.h>
 #include <dc/vmu_fb.h>
 
+#include <arch/arch.h>
+
 /* 4x6 font from the Linux kernel:
    https://github.com/torvalds/linux/blob/master/lib/fonts/font_mini_4x6.c
 

--- a/examples/dreamcast/vmu/vmu_lcd/lcd.c
+++ b/examples/dreamcast/vmu/vmu_lcd/lcd.c
@@ -10,26 +10,28 @@
     VMU's LCD display. It does so by rendering to a virtual
     framebuffer and then presenting it, which sends the updated
     framebuffer to the VMU over the maple protocol which displays
-    it. 
+    it.
 
-    This demo also shows off rendering dynamic text using an 
+    This demo also shows off rendering dynamic text using an
     embedded font.
  */
+
+#include <stdio.h>
+#include <math.h>
+#include <stdint.h>
+
+#include <kos/init.h>
 
 #include <dc/maple.h>
 #include <dc/maple/controller.h>
 #include <dc/maple/vmu.h>
 #include <dc/vmu_fb.h>
 
-#include <stdio.h>
-#include <math.h>
-#include <stdint.h>
-
 /* 4x6 font from the Linux kernel:
    https://github.com/torvalds/linux/blob/master/lib/fonts/font_mini_4x6.c
- 
-   Modified locally to pack the data better. 
- 
+
+   Modified locally to pack the data better.
+
    Created by Kenneth Albanowski.
    No rights reserved, released to the public domain.
  */

--- a/include/kos.h
+++ b/include/kos.h
@@ -56,6 +56,7 @@ __BEGIN_DECLS
 #include <kos/elf.h>
 #include <kos/fs_socket.h>
 #include <kos/string.h>
+#include <kos/init.h>
 
 #include <arch/arch.h>
 #include <arch/cache.h>

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -1,0 +1,88 @@
+/* KallistiOS ##version##
+
+   include/kos/init.h
+   Copyright (C) 2001 Megan Potter
+   Copyright (C) 2023 Lawrence Sebald
+
+*/
+
+/** \file   kos/init.h
+    \brief  Initialization-related flags and macros.
+
+    This file provides initialization-related flags and macros that can be used
+    to set up various subsystems of KOS on startup. Only flags that are
+    architecture-independent are specified here, however this file also includes
+    the architecture-specific file to bring in those flags as well.
+
+    \author Lawrence Sebald
+    \author Megan Potter
+    \see    arch/init_flags.h
+*/
+
+#ifndef __KOS_INIT_H
+#define __KOS_INIT_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+#include <arch/types.h>
+#include <arch/init_flags.h>
+
+/** \brief  Use this macro to determine the level of initialization you'd like
+            in your program by default.
+
+    The defaults will be fine for most things, and will be used if you do not
+    specify any init flags yourself.
+
+    \param  flags           Parts of KOS to init.
+    \see    kos_initflags
+    \see    dreamcast_initflags
+*/
+#define KOS_INIT_FLAGS(flags)   uint32 __kos_init_flags = (flags)
+
+/** \brief  The init flags. Do not modify this directly! */
+extern uint32 __kos_init_flags;
+
+/** \brief  Define a romdisk for your program, if you'd like one.
+    \param  rd                  Pointer to the romdisk image in your code.
+*/
+#define KOS_INIT_ROMDISK(rd)    void * __kos_romdisk = (rd)
+
+/** \brief  Built-in romdisk. Do not modify this directly! */
+extern void * __kos_romdisk;
+
+/** \brief  State that you don't want a romdisk. */
+#define KOS_INIT_ROMDISK_NONE   NULL
+
+/** \brief  Register a single function to be called very early in the boot
+            process, before the BSS section is cleared.
+
+    \param  func            The function to register. The prototype should be
+                            void func(void)
+*/
+#define KOS_INIT_EARLY(func) void (*__kos_init_early_fn)(void) = (func)
+
+/** \defgroup kos_initflags     Available flags for initialization
+
+    These are the architecture-independent flags that can be specified with
+    KOS_INIT_FLAGS.
+
+    \see    dreamcast_initflags
+    @{
+*/
+/** \brief  Default init flags (IRQs on, preemption enabled). */
+#define INIT_DEFAULT \
+    (INIT_IRQ | INIT_THD_PREEMPT)
+
+#define INIT_NONE           0x0000  /**< \brief Don't init optional things */
+#define INIT_IRQ            0x0001  /**< \brief Enable IRQs at startup */
+/* Preemptive mode is the only mode now. Keeping define for compatability. */
+#define INIT_THD_PREEMPT    0x0002  /**< \brief Enable thread preemption */
+#define INIT_NET            0x0004  /**< \brief Enable built-in networking */
+#define INIT_MALLOCSTATS    0x0008  /**< \brief Enable malloc statistics */
+#define INIT_QUIET          0x0010  /**< \brief Disable dbgio */
+/** @} */
+
+__END_DECLS
+
+#endif /* !__KOS_INIT_H */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -159,58 +159,9 @@ int mm_init(void);
 */
 void * mm_sbrk(unsigned long increment);
 
-/** \brief  Use this macro to determine the level of initialization you'd like
-            in your program by default.
-
-    The defaults line will be fine for most things.
-
-    \param  flags           Parts of KOS to init.
-*/
-#define KOS_INIT_FLAGS(flags)   uint32 __kos_init_flags = (flags)
-
-/** \brief  The init flags. Do not modify this directly! */
-extern uint32 __kos_init_flags;
-
-/** \brief  Define a romdisk for your program, if you'd like one.
-    \param  rd              Pointer to the romdisk image in your code.
-*/
-#define KOS_INIT_ROMDISK(rd)    void * __kos_romdisk = (rd)
-
-/** \brief  Built-in romdisk. Do not modify this directly! */
-extern void * __kos_romdisk;
-
-/** \brief  State that you don't want a romdisk. */
-#define KOS_INIT_ROMDISK_NONE   NULL
-
-/** \brief  Register a single function to be called very early in the boot
-            process, before the BSS section is cleared.
-
-    \param  func            The function to register. The prototype should be
-                            void func(void)
-*/
-#define KOS_INIT_EARLY(func) void (*__kos_init_early_fn)(void) = (func)
-
-/** \defgroup arch_initflags        Available flags for initialization
-
-    These are the flags you can specify with KOS_INIT_FLAGS().
-    @{
-*/
-/** \brief  Default init flags (IRQs on, preemption enabled). */
-#define INIT_DEFAULT \
-    (INIT_IRQ | INIT_THD_PREEMPT)
-
-#define INIT_NONE           0x0000  /**< \brief Don't init optional things */
-#define INIT_IRQ            0x0001  /**< \brief Enable IRQs at startup */
-/* Preemptive mode is the only mode now. Keeping define for compatability. */
-#define INIT_THD_PREEMPT    0x0002  /**< \brief Enable thread preemption */
-#define INIT_NET            0x0004  /**< \brief Enable built-in networking */
-#define INIT_MALLOCSTATS    0x0008  /**< \brief Enable malloc statistics */
-#define INIT_QUIET          0x0010  /**< \brief Disable dbgio */
-
-/* DC-specific stuff */
-#define INIT_OCRAM          0x10000 /**< \brief Use half of the dcache as RAM */
-#define INIT_NO_DCLOAD      0x20000 /**< \brief Disable dcload */
-/** @} */
+/* Bring in the init flags for compatibility with old code that expects them
+   here. */
+#include <kos/init.h>
 
 /* Dreamcast-specific arch init things */
 /** \brief  Jump back to the bootloader.

--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -1,0 +1,41 @@
+/* KallistiOS ##version##
+
+   arch/dreamcast/include/arch/init_flags.h
+   Copyright (C) 2001 Megan Potter
+   Copyright (C) 2023 Lawrence Sebald
+
+*/
+
+/** \file   arch/init_flags.h
+    \brief  Dreamcast-specific initialization-related flags and macros.
+
+    This file provides initialization-related flags that are specific to the
+    Dreamcast architecture.
+
+    \author Lawrence Sebald
+    \author Megan Potter
+    \see    kos/init.h
+*/
+
+#ifndef __ARCH_INIT_FLAGS_H
+#define __ARCH_INIT_FLAGS_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+/** \defgroup dreamcast_initflags   Dreamcast-specific initialization flags.
+
+    These are the Dreamcast-specific flags that can be specified with
+    KOS_INIT_FLAGS.
+
+    \see    kos_initflags
+    @{
+*/
+#define INIT_OCRAM          0x10000 /**< \brief Use half of the dcache as RAM */
+#define INIT_NO_DCLOAD      0x20000 /**< \brief Disable dcload */
+
+/** @} */
+
+__END_DECLS
+
+#endif /* !__ARCH_INIT_FLAGS_H */


### PR DESCRIPTION
Closes #232.

- Split initialization flags and macros from the `<arch/arch.h>` header file into two new header files: `<kos/init.h>` (for arch-independent parts), and `<arch/init_flags.h>` (for arch-dependent parts).
- Update examples to include the new header for this functionality, rather than `<arch/arch.h>`