### PR TITLE
Remaining instances of empty arguments() replaced with (void)

### DIFF
--- a/addons/include/navi/flash.h
+++ b/addons/include/navi/flash.h
@@ -25,7 +25,7 @@
     \return                 0 if a compatible flashrom is detected, <0 if the
                             normal Dreamcast BIOS is detected.
 */
-int nvflash_detect();
+int nvflash_detect(void);
 
 /** \brief  Erase a single block of flashrom.
     \param  addr            The block of the flashrom to erase.
@@ -45,6 +45,6 @@ int nvflash_write_block(uint32 addr, void * data, uint32 len);
 /** \brief  Erase the whole flashrom.
     \return                 0 on success, <0 on error.
 */
-int nvflash_erase_all();
+int nvflash_erase_all(void);
 
 #endif  /* __NAVI_FLASH_H */

--- a/addons/include/navi/ide.h
+++ b/addons/include/navi/ide.h
@@ -40,14 +40,14 @@ int ide_write(uint32 linear, uint32 numsects, void *bufptr);
 /** \brief  Retrieve the number of sectors from the hard disk.
     \returns                The total number of linear sectors.
 */
-uint32 ide_num_sectors();
+uint32 ide_num_sectors(void);
 
 /** \brief  Initialize Navi IDE.
     \return                 0 on success (no error conditions defined).
 */
-int ide_init();
+int ide_init(void);
 
 /** \brief  Shutdown Navi IDE. */
-void ide_shutdown();
+void ide_shutdown(void);
 
 #endif  /* __NAVI_IDE_H */

--- a/addons/libnavi/navi_flash.c
+++ b/addons/libnavi/navi_flash.c
@@ -73,7 +73,7 @@
 static vuint8   * const flashport = (vuint8 *)0xa0000000;
 
 /* We'll do this before sending a command */
-static void send_unlock() {
+static void send_unlock(void) {
     flashport[ADDR_UNLOCK_1] = CMD_UNLOCK_DATA_1;
     flashport[ADDR_UNLOCK_2] = CMD_UNLOCK_DATA_2;
 }
@@ -175,7 +175,7 @@ int nvflash_erase_block(uint32 addr) {
 }
 
 /* Erase the whole flash chip */
-int nvflash_erase_all() {
+int nvflash_erase_all(void) {
     send_cmd(CMD_SECTOR_ERASE_UNLOCK_DATA);
     send_cmd(CMD_ERASE_ALL);
 
@@ -193,7 +193,7 @@ int nvflash_erase_all() {
 }
 
 /* Return 0 if we successfully detect a compatible device */
-int nvflash_detect() {
+int nvflash_detect(void) {
     uint16      mfr_id, dev_id;
 
     if(nvflash_read(0) == 0xff && nvflash_read(2) == 0x28) {

--- a/addons/libnavi/navi_ide.c
+++ b/addons/libnavi/navi_ide.c
@@ -72,7 +72,7 @@ uint16 ide_inp(int port, int size) {
 
 /* These are to synchronize us with the controller so we don't do something
    it's not ready for */
-static void wait_controller() {
+static void wait_controller(void) {
     int timeout = 1000;
 
     while((inp(0x1f7) & 0x80) && timeout) {
@@ -86,7 +86,7 @@ static void wait_controller() {
     }
 }
 
-static void wait_data() {
+static void wait_data(void) {
     int timeout = 1000;
 
     while(!(inp(0x1f7) & 0x08) && timeout) {
@@ -236,12 +236,12 @@ int ide_write(uint32 linear, uint32 numsects, void *bufptr) {
 }
 
 /* Get the available space */
-uint32 ide_num_sectors() {
+uint32 ide_num_sectors(void) {
     return hd_cyls * hd_heads * hd_sects;
 }
 
 /* Initialize the device */
-int ide_init() {
+int ide_init(void) {
     int dd_off;
 
     dbglog(DBG_INFO, "ide_init: initializing\n");
@@ -273,7 +273,7 @@ int ide_init() {
     return 0;
 }
 
-void ide_shutdown() {
+void ide_shutdown(void) {
 }
 
 

--- a/examples/dreamcast/2ndmix/2ndmix.c
+++ b/examples/dreamcast/2ndmix/2ndmix.c
@@ -103,7 +103,7 @@ int *star_x = NULL, *star_y, *star_z;
 
 pvr_poly_hdr_t stars_header;
 
-void stars_init() {
+void stars_init(void) {
     int i;
     pvr_poly_cxt_t tmp;
 
@@ -145,7 +145,7 @@ void poly_pnt(int x, int y, float z, float size, int color) {
     pvr_prim(&vert, sizeof(vert));
 }
 
-void stars_one_frame() {
+void stars_one_frame(void) {
     int i, x1, y1, xn, yn, zn, c;
 
     /* Send polygon header to the TA using store queues */
@@ -320,7 +320,7 @@ void draw_cube(int which) {
 
 /* Draw six cubes arranged in a circle */
 int zooming = 1;
-void cube_one_frame() {
+void cube_one_frame(void) {
     int i, j;
 
     rotang = (rotang + 1) % 512;
@@ -348,7 +348,7 @@ void cube_one_frame() {
 int cubes_have_header = 0;
 pvr_poly_hdr_t cubes_header;
 
-void cubes_one_frame() {
+void cubes_one_frame(void) {
     pvr_poly_cxt_t tmp;
 
     if(!cubes_have_header) {
@@ -589,7 +589,7 @@ void font_draw_string(int x1, int y1, float color, char *str) {
     }
 }
 
-void font_next_screen() {
+void font_next_screen(void) {
     int width;
     int y, y1, x;
 
@@ -625,7 +625,7 @@ void font_next_screen() {
 
 #if 0
 /* Debug code to draw the font texture */
-void blit_font_texture() {
+void blit_font_texture(void) {
     vertex_ot_t vert;
 
     vert.flags = TA_VERTEX_NORMAL;
@@ -666,7 +666,7 @@ void blit_font_texture() {
 
 pvr_poly_hdr_t  font_header;
 
-void font_one_frame() {
+void font_one_frame(void) {
     int     done, y, actrows;
 
     actrows = 0;
@@ -725,7 +725,7 @@ void font_one_frame() {
     }
 }
 
-void font_init() {
+void font_init(void) {
     int x, y, c;
     uint8 pcxpall[768];
     volatile uint16 *vtex;
@@ -787,7 +787,7 @@ void font_init() {
 /********************************************************************/
 
 int framecnt = 0;
-void draw_one_frame() {
+void draw_one_frame(void) {
     /* Begin opaque polygons */
     pvr_wait_ready();
     pvr_scene_begin();

--- a/examples/dreamcast/basic/asserthnd/asserthnd.c
+++ b/examples/dreamcast/basic/asserthnd/asserthnd.c
@@ -35,14 +35,14 @@ assuming you compiled your program with -g:
 
 */
 
-void func2() {
+void func2(void) {
     int a = 5;
 
     assert_msg(a != 5, "This is a test message!");
     assert(a != 5);
 }
 
-void func1() {
+void func1(void) {
     func2();
 }
 

--- a/examples/dreamcast/basic/stacktrace/stacktrace.c
+++ b/examples/dreamcast/basic/stacktrace/stacktrace.c
@@ -6,7 +6,7 @@
 
 #include <kos.h>
 
-void func() {
+void func(void) {
     arch_stk_trace(0);
 }
 

--- a/examples/dreamcast/conio/adventure/porthelper.h
+++ b/examples/dreamcast/conio/adventure/porthelper.h
@@ -25,6 +25,6 @@
 
 #undef getchar
 #undef putchar
-int getchar();
+int getchar(void);
 
 #endif  /* __PORTHELPER_H */

--- a/examples/dreamcast/kgl/basic/scissor/scissor.c
+++ b/examples/dreamcast/kgl/basic/scissor/scissor.c
@@ -149,7 +149,7 @@ static void draw_gl(float rot, float x, float y) {
     glPopMatrix();
 }
 
-static void draw_ortho_scene() {
+static void draw_ortho_scene(void) {
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
     glOrtho(0, 640, 0, 480, -1, 1);
@@ -169,7 +169,7 @@ static void draw_ortho_scene() {
     rect(512, 0, 512, 512);
 }
 
-static void draw_perspective_scene() {
+static void draw_perspective_scene(void) {
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     gluPerspective(45.0f, 320.0f / 240.0f, 0.1f, 100.0f);

--- a/examples/dreamcast/kgl/basic/txrenv/gltest.c
+++ b/examples/dreamcast/kgl/basic/txrenv/gltest.c
@@ -55,7 +55,7 @@ void glDrawQuads(float x, float y, float w, float h, int count,
     glEnd();
 }
 
-void RenderCallback() {
+void RenderCallback(void) {
     if(BLEND)
         glEnable(GL_BLEND);
 
@@ -72,7 +72,7 @@ void RenderCallback() {
     glutSwapBuffers();
 }
 
-int InputCallback() {
+int InputCallback(void) {
     maple_device_t *cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
 
     if(cont) {

--- a/examples/dreamcast/kgl/basic/vq/vq-example.c
+++ b/examples/dreamcast/kgl/basic/vq/vq-example.c
@@ -30,7 +30,7 @@ extern unsigned char fruit[];
 extern unsigned char fruit_end[];
 
 /* Load a texture with glCompressedTexImage2D */
-static int loadtxr() {
+static int loadtxr(void) {
 
     glGenTextures(1, texture);
     glBindTexture(GL_TEXTURE_2D, texture[0]);

--- a/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
+++ b/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
@@ -25,7 +25,7 @@ int polycnt;
 int phase = PHASE_HALVE;
 float avgfps = -1;
 
-void running_stats() {
+void running_stats(void) {
     pvr_stats_t stats;
     pvr_get_stats(&stats);
 
@@ -35,7 +35,7 @@ void running_stats() {
         avgfps = (avgfps + stats.frame_rate) / 2.0f;
 }
 
-void stats() {
+void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
@@ -44,7 +44,7 @@ void stats() {
 }
 
 
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -62,7 +62,7 @@ int check_start() {
 
 pvr_poly_hdr_t hdr;
 
-void setup() {
+void setup(void) {
     glKosInit();
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
@@ -71,7 +71,7 @@ void setup() {
     glLoadIdentity();
 }
 
-void do_frame() {
+void do_frame(void) {
     int x, y, z;
     int size;
     int i;
@@ -106,7 +106,7 @@ void switch_tests(int ppf) {
     polycnt = ppf;
 }
 
-void check_switch() {
+void check_switch(void) {
     time_t now;
 
     now = time(NULL);

--- a/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
+++ b/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
@@ -25,7 +25,7 @@ int polycnt;
 int phase = PHASE_HALVE;
 float avgfps = -1;
 
-void running_stats() {
+void running_stats(void) {
     pvr_stats_t stats;
     pvr_get_stats(&stats);
 
@@ -35,7 +35,7 @@ void running_stats() {
         avgfps = (avgfps + stats.frame_rate) / 2.0f;
 }
 
-void stats() {
+void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
@@ -44,7 +44,7 @@ void stats() {
 }
 
 
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -62,7 +62,7 @@ int check_start() {
 
 pvr_poly_hdr_t hdr;
 
-void setup() {
+void setup(void) {
     glKosInit();
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
@@ -71,7 +71,7 @@ void setup() {
     glLoadIdentity();
 }
 
-void do_frame() {
+void do_frame(void) {
     int x, y, z;
     int size;
     int i;
@@ -105,7 +105,7 @@ void switch_tests(int ppf) {
     polycnt = ppf;
 }
 
-void check_switch() {
+void check_switch(void) {
     time_t now;
 
     now = time(NULL);

--- a/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
+++ b/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
@@ -25,7 +25,7 @@ int polycnt;
 int phase = PHASE_HALVE;
 float avgfps = -1;
 
-void running_stats() {
+void running_stats(void) {
     pvr_stats_t stats;
     pvr_get_stats(&stats);
 
@@ -35,7 +35,7 @@ void running_stats() {
         avgfps = (avgfps + stats.frame_rate) / 2.0f;
 }
 
-void stats() {
+void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
@@ -44,7 +44,7 @@ void stats() {
 }
 
 
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -62,7 +62,7 @@ int check_start() {
 
 pvr_poly_hdr_t hdr;
 
-void setup() {
+void setup(void) {
     glKosInit();
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
@@ -71,7 +71,7 @@ void setup() {
     glLoadIdentity();
 }
 
-void do_frame() {
+void do_frame(void) {
     int x, y, z;
     int size;
     int i;
@@ -108,7 +108,7 @@ void switch_tests(int ppf) {
     polycnt = ppf;
 }
 
-void check_switch() {
+void check_switch(void) {
     time_t now;
 
     now = time(NULL);

--- a/examples/dreamcast/kgl/demos/blur/radial_blur.c
+++ b/examples/dreamcast/kgl/demos/blur/radial_blur.c
@@ -238,7 +238,7 @@ void DrawGL(GLuint texID) {
 #define INCREASE_RADIAL_BLUR 4
 #define DECREASE_RADIAL_BLUR 5
 
-int InputCallback() {
+int InputCallback(void) {
     maple_device_t *cont;
     cont_state_t *state;
 

--- a/examples/dreamcast/kgl/demos/mipmap/gl-mipmap.c
+++ b/examples/dreamcast/kgl/demos/mipmap/gl-mipmap.c
@@ -31,7 +31,7 @@ extern GLuint glTextureLoadPVR(char *fname, unsigned char isMipMapped, unsigned 
 #define INP_EXIT        5
 
 /* Simple Input Callback with a return value */
-int InputCallback() {
+int InputCallback(void) {
     maple_device_t *cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
 
     if(cont) {
@@ -60,7 +60,7 @@ int InputCallback() {
 }
 
 /* Very Basic Open GL Initialization for 2D rendering */
-void RenderInit() {
+void RenderInit(void) {
     glKosInit(); /* GL Will Initialize the PVR */
 
     glShadeModel(GL_SMOOTH);

--- a/examples/dreamcast/kgl/demos/specular/specular.c
+++ b/examples/dreamcast/kgl/demos/specular/specular.c
@@ -142,7 +142,7 @@ void draw_gl_cube(float x, float y, float z, uint32 color) {
 
 #define LGAP 13
 
-void draw_gl() {
+void draw_gl(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, z);
@@ -220,7 +220,7 @@ void draw_gl() {
     glPopMatrix();
 }
 
-void draw_gl2() {
+void draw_gl2(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, -z);
@@ -299,7 +299,7 @@ void draw_gl2() {
 }
 
 
-void draw_gl3() {
+void draw_gl3(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, -15);
@@ -378,7 +378,7 @@ void draw_gl3() {
 }
 
 
-void draw_gl4() {
+void draw_gl4(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, 15);
@@ -456,7 +456,7 @@ void draw_gl4() {
     glPopMatrix();
 }
 
-void draw_gl5() {
+void draw_gl5(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, -25);
@@ -535,7 +535,7 @@ void draw_gl5() {
 }
 
 
-void draw_gl6() {
+void draw_gl6(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, 25);
@@ -614,7 +614,7 @@ void draw_gl6() {
 }
 
 
-void draw_gl7() {
+void draw_gl7(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, -35);
@@ -693,7 +693,7 @@ void draw_gl7() {
 }
 
 
-void draw_gl8() {
+void draw_gl8(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, 35);
@@ -772,7 +772,7 @@ void draw_gl8() {
 }
 
 
-void draw_gl9() {
+void draw_gl9(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, -45);
@@ -851,7 +851,7 @@ void draw_gl9() {
 }
 
 
-void draw_gl10() {
+void draw_gl10(void) {
     glPushMatrix();
 
     glTranslatef(0, 0.0f, 45);
@@ -929,7 +929,7 @@ void draw_gl10() {
     glPopMatrix();
 }
 
-void GPU_Stats() {
+void GPU_Stats(void) {
     pvr_stats_t stats;
     pvr_get_stats(&stats);
 
@@ -957,7 +957,7 @@ extern uint8 romdisk[];
 KOS_INIT_ROMDISK(romdisk);
 
 static unsigned char LE[8] = {0, 1, 0, 0, 0, 0, 0, 0};
-int InputCb() {
+int InputCb(void) {
     maple_device_t *cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
 
     if(cont) {

--- a/examples/dreamcast/kgl/demos/specular/timer.c
+++ b/examples/dreamcast/kgl/demos/specular/timer.c
@@ -11,7 +11,7 @@ static uint32 s, ms;
 static uint64 msec;
 
 /* Get current hardware timing using arch/timer.h */
-unsigned int GetTime() {
+unsigned int GetTime(void) {
     timer_ms_gettime(&s, &ms);
     msec = (((uint64)s) * ((uint64)1000)) + ((uint64)ms);
     return (unsigned int)msec;

--- a/examples/dreamcast/kgl/demos/specular/timer.h
+++ b/examples/dreamcast/kgl/demos/specular/timer.h
@@ -13,6 +13,6 @@
 #include <arch/timer.h>
 
 /* Get current hardware timing using arch/timer.h */
-unsigned int GetTime();
+unsigned int GetTime(void);
 
 #endif

--- a/examples/dreamcast/libdream/cdfs/cdfs.c
+++ b/examples/dreamcast/libdream/cdfs/cdfs.c
@@ -4,7 +4,7 @@
 #include <kos.h>
 
 char buffer[2048];
-void cdfs_test() {
+void cdfs_test(void) {
     file_t fd;
     file_t d;
     dirent_t *de;

--- a/examples/dreamcast/libdream/keyboard/keyboard.c
+++ b/examples/dreamcast/libdream/keyboard/keyboard.c
@@ -1,6 +1,6 @@
 #include <kos.h>
 
-void kb_test() {
+void kb_test(void) {
     maple_device_t *cont, *kbd;
     cont_state_t *state;
     int k, x = 20, y = 20 + 24;

--- a/examples/dreamcast/libdream/lcd/lcd.c
+++ b/examples/dreamcast/libdream/lcd/lcd.c
@@ -11,7 +11,7 @@
 
 /* This is really more complicated than it needs to be in this particular
    case, but it's nice and verbose. */
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -49,7 +49,7 @@ void lcd_gs_pixel(int x, int y, int amt) {
     for(i = 0; i < amt; i++)
         lcd_disp[i][(y * 48 + x) / 8] |= 0x80 >> (x & 7);
 }
-void lcd_gs_setup() {
+void lcd_gs_setup(void) {
     char **xpm = graphic_xpm + 12;  /* Skip header */
     int x, y;
 
@@ -93,7 +93,7 @@ void lcd_gs_setup() {
 }
 
 /* This performs the actual magic */
-void lcd_test() {
+void lcd_test(void) {
     int frame = 0;
 
     lcd_gs_setup();

--- a/examples/dreamcast/libdream/mouse/mouse.c
+++ b/examples/dreamcast/libdream/mouse/mouse.c
@@ -1,6 +1,6 @@
 #include <kos.h>
 
-void mouse_test() {
+void mouse_test(void) {
     maple_device_t *cont, *mouse;
     cont_state_t *cstate;
     mouse_state_t *mstate;

--- a/examples/dreamcast/libdream/spu/spu.c
+++ b/examples/dreamcast/libdream/spu/spu.c
@@ -31,7 +31,7 @@ void copy_s3m(char *song, int len) {
         ;
 }
 
-void wait_start() {
+void wait_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 

--- a/examples/dreamcast/libdream/ta/ta.c
+++ b/examples/dreamcast/libdream/ta/ta.c
@@ -5,7 +5,7 @@
 
 /* This is really more complicated than it needs to be in this particular
    case, but it's nice and verbose. */
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -56,7 +56,7 @@ polyplace_t polys[12] = {
 };
 
 /* Does one frame of polygon movement */
-void move_polys() {
+void move_polys(void) {
     int i;
     polyplace_t *p;
 
@@ -110,7 +110,7 @@ void draw_one_poly(polyplace_t *p) {
 
 uint32 color = 0;
 int dcolor = 5;
-void draw_frame() {
+void draw_frame(void) {
     pvr_poly_cxt_t  cxt;
     pvr_poly_hdr_t  poly;
     int i;

--- a/examples/dreamcast/libdream/vmu/vmu.c
+++ b/examples/dreamcast/libdream/vmu/vmu.c
@@ -63,7 +63,7 @@ void draw_icondata(maple_device_t *addr, uint16 block) {
 }
 
 /* The full read test */
-void vmu_read_test() {
+void vmu_read_test(void) {
     int i, n, drawn = 0;
     maple_device_t *addr = maple_enum_type(0, MAPLE_FUNC_MEMCARD);
     uint8 *ent;

--- a/examples/dreamcast/network/httpd/httpd.c
+++ b/examples/dreamcast/network/httpd/httpd.c
@@ -34,12 +34,12 @@ http_state_list_t states;
 #define st_foreach(var) TAILQ_FOREACH(var, &states, list)
 mutex_t list_mutex = MUTEX_INITIALIZER;
 
-int st_init() {
+int st_init(void) {
     TAILQ_INIT(&states);
     return 0;
 }
 
-http_state_t * st_create() {
+http_state_t * st_create(void) {
     http_state_t * ns;
 
     ns = calloc(1, sizeof(http_state_t));

--- a/examples/dreamcast/parallax/bubbles/bubbles.c
+++ b/examples/dreamcast/parallax/bubbles/bubbles.c
@@ -88,7 +88,7 @@ static void sphere(float radius, int slices, int stacks) {
 
 #define SPHERE_CNT 12
 static float r = 0;
-static void sphere_frame_opaque() {
+static void sphere_frame_opaque(void) {
     int i;
 
     vid_border_color(255, 0, 0);
@@ -140,7 +140,7 @@ static void sphere_frame_opaque() {
     phase += 2 * M_PI / 240.0f;
 }
 
-static void sphere_frame_trans() {
+static void sphere_frame_trans(void) {
     int i;
 
     vid_border_color(255, 0, 0);
@@ -173,7 +173,7 @@ static void sphere_frame_trans() {
     phase += 2 * M_PI / 240.0f;
 }
 
-void do_sphere_test() {
+void do_sphere_test(void) {
     maple_device_t *cont;
     cont_state_t *state;
     int     mode = 0;

--- a/examples/dreamcast/parallax/delay_cube/delay_cube.c
+++ b/examples/dreamcast/parallax/delay_cube/delay_cube.c
@@ -41,7 +41,7 @@ each frame.
 // just like cubes. :)
 vector_t cube[6 * 6 * 6];
 int cubepnts = 6 * 6 * 6;
-void makecube() {
+void makecube(void) {
     int x, y, z;
 
     for(x = -3; x < 3; x++) {

--- a/examples/dreamcast/parallax/rotocube/rotocube.c
+++ b/examples/dreamcast/parallax/rotocube/rotocube.c
@@ -52,7 +52,7 @@ void drawpnt(float x, float y, float z, float a, float r, float g, float b) {
 }
 
 // Draws the full cube at the current position.
-void drawcube() {
+void drawcube(void) {
     uint32 color = 0xff808080;
     plx_dr_state_t dr;
 

--- a/examples/dreamcast/parallax/serpent_dma/perfmeter.c
+++ b/examples/dreamcast/parallax/serpent_dma/perfmeter.c
@@ -14,7 +14,7 @@
 plx_font_t * font;
 plx_fcxt_t * fcxt;
 
-void pm_init() {
+void pm_init(void) {
     font = plx_font_load("/rd/font.txf");
     fcxt = plx_fcxt_create(font, PVR_LIST_TR_POLY);
 }
@@ -34,7 +34,7 @@ void pm_drawbar(float pct, float posx, float posy, float posz,
     plx_vert_inp(PLX_VERT_EOS, posx + len, posy, posz, c2);
 }
 
-void pm_draw() {
+void pm_draw(void) {
     char str[64];
     float pct;
     float posx = 64, posy = 96, posz = 4500;

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -149,7 +149,7 @@ static void draw_sphere(sphere_t *s, int list) {
 
 #define SPHERE_CNT 32
 static float r = 0;
-static void sphere_frame() {
+static void sphere_frame(void) {
     int i;
     //uint64 start;
     static sphere_t big_sphere = { 1.2f, 20, 20, NULL };
@@ -219,7 +219,7 @@ static void sphere_frame() {
     pvr_scene_finish();
 }
 
-void do_sphere_test() {
+void do_sphere_test(void) {
     pvr_set_bg_color(0.2f, 0.0f, 0.4f);
 
     pvr_poly_cxt_col(&cxt[0], PVR_LIST_OP_POLY);

--- a/examples/dreamcast/png/example.c
+++ b/examples/dreamcast/png/example.c
@@ -22,13 +22,13 @@ pvr_ptr_t back_tex;
 char *data;
 
 /* init background */
-void back_init() {
+void back_init(void) {
     back_tex = pvr_mem_malloc(512 * 512 * 2);
     png_to_texture("/rd/background.png", back_tex, PNG_NO_ALPHA);
 }
 
 /* init font */
-void font_init() {
+void font_init(void) {
     int i, x, y, c;
     unsigned short * temp_tex;
 
@@ -56,7 +56,7 @@ void font_init() {
     pvr_txr_load_ex(temp_tex, font_tex, 256, 256, PVR_TXRLOAD_16BPP);
 }
 
-void text_init() {
+void text_init(void) {
     int length = zlib_getlength("/rd/text.gz");
     gzFile f;
 

--- a/examples/dreamcast/pvr/bumpmap/bump.c
+++ b/examples/dreamcast/pvr/bumpmap/bump.c
@@ -83,7 +83,7 @@ static pvr_ptr_t load_kmg(const char fn[]) {
     return rv;
 }
 
-static void setup() {
+static void setup(void) {
     pvr_sprite_cxt_t cxt;
 
     /* Load the textures. */
@@ -131,7 +131,7 @@ static void setup() {
     sprites[0].cuv = sprites[1].cuv = PVR_PACK_16BIT_UV(1.0f, 0.0f);
 }
 
-static void switch_textured() {
+static void switch_textured(void) {
     pvr_sprite_cxt_t cxt;
 
     if(!textured)
@@ -149,7 +149,7 @@ static void switch_textured() {
     textured = !textured;
 }
 
-static int check_start() {
+static int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
     static int taken = 0;
@@ -184,7 +184,7 @@ static int check_start() {
     return 0;
 }
 
-static void do_frame() {
+static void do_frame(void) {
     shdr[0].oargb = pvr_pack_bump(bumpiness, F_PI / 4.0f, 5.0f * F_PI / 6.0f);
     shdr[0].argb = 0;
 

--- a/examples/dreamcast/pvr/cheap_shadow/shadow.c
+++ b/examples/dreamcast/pvr/cheap_shadow/shadow.c
@@ -27,7 +27,7 @@ static float shadow = 0.5f;
 
 #define CLAMP(low, high, value) (value < low ? low : (value > high ? high : value))
 
-void setup() {
+void setup(void) {
     pvr_poly_cxt_t cxt;
     int i;
     float x, y, z;
@@ -81,7 +81,7 @@ void setup() {
     }
 }
 
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
     static int taken = 0;
@@ -132,7 +132,7 @@ int check_start() {
     return 0;
 }
 
-void do_frame() {
+void do_frame(void) {
     pvr_modifier_vol_t mod;
     int i;
 

--- a/examples/dreamcast/pvr/modifier_volume/modifier.c
+++ b/examples/dreamcast/pvr/modifier_volume/modifier.c
@@ -23,7 +23,7 @@ static pvr_mod_hdr_t mhdr, mhdr2;
 static float mx = 320.0f, my = 240.0f;
 static pvr_list_t list = PVR_LIST_OP_POLY;
 
-void setup() {
+void setup(void) {
     pvr_poly_cxt_t cxt;
     int i;
     float x, y, z;
@@ -75,7 +75,7 @@ void setup() {
     }
 }
 
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
     static int taken = 0;
@@ -117,7 +117,7 @@ int check_start() {
     return 0;
 }
 
-void do_frame() {
+void do_frame(void) {
     pvr_modifier_vol_t mod;
     int i;
 

--- a/examples/dreamcast/pvr/modifier_volume_tex/modifier.c
+++ b/examples/dreamcast/pvr/modifier_volume_tex/modifier.c
@@ -29,7 +29,7 @@ static float mx = 320.0f, my = 240.0f;
 static pvr_list_t list = PVR_LIST_OP_POLY;
 static pvr_ptr_t txr1, txr2;
 
-void setup() {
+void setup(void) {
     pvr_poly_cxt_t cxt;
     int i;
     float x, y, z;
@@ -138,7 +138,7 @@ void setup() {
     }
 }
 
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -169,7 +169,7 @@ int check_start() {
     return 0;
 }
 
-void do_frame() {
+void do_frame(void) {
     pvr_modifier_vol_t mod;
     int i;
 

--- a/examples/dreamcast/pvr/plasma/plasma.c
+++ b/examples/dreamcast/pvr/plasma/plasma.c
@@ -58,7 +58,7 @@ pvr_ptr_t txr[2];
 uint16 * txr_buf[2];
 int txr_cur;
 
-void plasma_init() {
+void plasma_init(void) {
     int i;
 
     xang = yang = 0;
@@ -71,7 +71,7 @@ void plasma_init() {
     }
 }
 
-void plasma_drawtex() {
+void plasma_drawtex(void) {
     uint16  *vrout = (uint16 *)(txr_buf[txr_cur]);
     int x, y, p, q, r;
 
@@ -105,7 +105,7 @@ void plasma_drawtex() {
     // pvr_txr_load_dma(txr_buf[txr_cur], txr[txr_cur], 64*64*2, 1, NULL, 0);
 }
 
-int check_start() {
+int check_start(void) {
     MAPLE_FOREACH_BEGIN(MAPLE_FUNC_CONTROLLER, cont_state_t, st)
 
     if(st->buttons & CONT_START)
@@ -115,7 +115,7 @@ int check_start() {
     return 0;
 }
 
-void pvr_setup() {
+void pvr_setup(void) {
     pvr_poly_cxt_t cxt;
     int i;
 
@@ -134,7 +134,7 @@ void pvr_setup() {
     txr_cur = 0;
 }
 
-void do_frame() {
+void do_frame(void) {
     pvr_vertex_t vert;
     float r, g, b;
 

--- a/examples/dreamcast/pvr/pvrmark/pvrmark.c
+++ b/examples/dreamcast/pvr/pvrmark/pvrmark.c
@@ -19,7 +19,7 @@ int polycnt;
 int phase = PHASE_HALVE;
 float avgfps = -1;
 
-void running_stats() {
+void running_stats(void) {
     pvr_stats_t stats;
     pvr_get_stats(&stats);
 
@@ -29,7 +29,7 @@ void running_stats() {
         avgfps = (avgfps + stats.frame_rate) / 2.0f;
 }
 
-void stats() {
+void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
@@ -38,7 +38,7 @@ void stats() {
 }
 
 
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -58,7 +58,7 @@ int check_start() {
 
 pvr_poly_hdr_t hdr;
 
-void setup() {
+void setup(void) {
     pvr_poly_cxt_t cxt;
 
     pvr_init(&pvr_params);
@@ -69,7 +69,7 @@ void setup() {
     pvr_poly_compile(&hdr, &cxt);
 }
 
-void do_frame() {
+void do_frame(void) {
     pvr_vertex_t vert;
     int x, y, z;
     int size;
@@ -120,7 +120,7 @@ void switch_tests(int ppf) {
     polycnt = ppf;
 }
 
-void check_switch() {
+void check_switch(void) {
     time_t now;
 
     now = time(NULL);

--- a/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
+++ b/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
@@ -19,7 +19,7 @@ int polycnt;
 int phase = PHASE_HALVE;
 float avgfps = -1;
 
-void running_stats() {
+void running_stats(void) {
     pvr_stats_t stats;
     pvr_get_stats(&stats);
 
@@ -29,7 +29,7 @@ void running_stats() {
         avgfps = (avgfps + stats.frame_rate) / 2.0f;
 }
 
-void stats() {
+void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
@@ -38,7 +38,7 @@ void stats() {
 }
 
 
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -58,7 +58,7 @@ int check_start() {
 
 pvr_poly_hdr_t hdr;
 
-void setup() {
+void setup(void) {
     pvr_poly_cxt_t cxt;
 
     pvr_init(&pvr_params);
@@ -69,7 +69,7 @@ void setup() {
     pvr_poly_compile(&hdr, &cxt);
 }
 
-void do_frame() {
+void do_frame(void) {
     pvr_vertex_t vert;
     int x, y, z;
     int i, col;
@@ -122,7 +122,7 @@ void switch_tests(int ppf) {
     polycnt = ppf;
 }
 
-void check_switch() {
+void check_switch(void) {
     time_t now;
 
     now = time(NULL);

--- a/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
+++ b/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
@@ -19,7 +19,7 @@ int polycnt;
 int phase = PHASE_HALVE;
 float avgfps = -1;
 
-void running_stats() {
+void running_stats(void) {
     pvr_stats_t stats;
     pvr_get_stats(&stats);
 
@@ -29,7 +29,7 @@ void running_stats() {
         avgfps = (avgfps + stats.frame_rate) / 2.0f;
 }
 
-void stats() {
+void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
@@ -38,7 +38,7 @@ void stats() {
 }
 
 
-int check_start() {
+int check_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -58,7 +58,7 @@ int check_start() {
 
 pvr_poly_hdr_t hdr;
 
-void setup() {
+void setup(void) {
     pvr_poly_cxt_t cxt;
 
     pvr_init(&pvr_params);
@@ -70,7 +70,7 @@ void setup() {
 }
 
 int oldseed = 0xdeadbeef;
-void do_frame() {
+void do_frame(void) {
     pvr_vertex_t * vert;
     int x, y, z;
     int i, col;
@@ -144,7 +144,7 @@ void switch_tests(int ppf) {
     polycnt = ppf;
 }
 
-void check_switch() {
+void check_switch(void) {
     time_t now;
 
     now = time(NULL);

--- a/examples/dreamcast/pvr/texture_render/texture_render.c
+++ b/examples/dreamcast/pvr/texture_render/texture_render.c
@@ -28,7 +28,7 @@ polyplace_t polys[6] = {
 };
 
 /* Does one frame of polygon movement */
-void move_polys() {
+void move_polys(void) {
     int i;
     polyplace_t *p;
 
@@ -115,7 +115,7 @@ int to_texture = 1;
 pvr_ptr_t d_texture;
 uint32 tx_x = 1024, tx_y = 512;
 
-void draw_frame() {
+void draw_frame(void) {
     pvr_poly_cxt_t  cxt;
     pvr_poly_hdr_t  poly;
     int i;
@@ -151,7 +151,7 @@ void draw_frame() {
         move_polys();
 }
 
-void draw_textured() {
+void draw_textured(void) {
     pvr_poly_cxt_t cxt;
     pvr_poly_hdr_t hdr;
     int i;

--- a/examples/dreamcast/sd/speedtest/sd-speedtest.c
+++ b/examples/dreamcast/sd/speedtest/sd-speedtest.c
@@ -29,7 +29,7 @@ KOS_INIT_FLAGS(INIT_DEFAULT);
 
 static uint8_t tbuf[1024 * 512] __attribute__((aligned(32)));
 
-static void __attribute__((__noreturn__)) wait_exit() {
+static void __attribute__((__noreturn__)) wait_exit(void) {
     maple_device_t *dev;
     cont_state_t *state;
 

--- a/examples/dreamcast/sound/ghettoplay-vorbis/bkg.c
+++ b/examples/dreamcast/sound/ghettoplay-vorbis/bkg.c
@@ -12,7 +12,7 @@ static pvr_ptr_t chktexture;
 static float horizon = 340.0f;
 
 /* Make a nice (now familiar =) XOR pattern texture */
-void bkg_setup() {
+void bkg_setup(void) {
     int x, y;
     uint16 *texture;
 
@@ -29,7 +29,7 @@ void bkg_setup() {
 }
 
 /* Draws the floor polygon */
-static void draw_floor_poly() {
+static void draw_floor_poly(void) {
     pvr_vertex_t vert;
     float u2 = 0.374f, j = 0.0f;
 
@@ -82,7 +82,7 @@ static void draw_floor_poly() {
 }
 
 /* Draws the "wall" polygon */
-static void draw_wall_poly() {
+static void draw_wall_poly(void) {
     pvr_vertex_t    vertc;
 
     vertc.flags = PVR_CMD_VERTEX;
@@ -113,7 +113,7 @@ static void draw_wall_poly() {
     pvr_prim(&vertc, sizeof(vertc));
 }
 
-void bkg_render() {
+void bkg_render(void) {
     pvr_poly_cxt_t cxt;
     pvr_poly_hdr_t poly;
 

--- a/examples/dreamcast/sound/ghettoplay-vorbis/ghettoplay.c
+++ b/examples/dreamcast/sound/ghettoplay-vorbis/ghettoplay.c
@@ -21,7 +21,7 @@
 
 long bitrate;
 
-int check_start() {
+int check_start(void) {
     MAPLE_FOREACH_BEGIN(MAPLE_FUNC_CONTROLLER, cont_state_t, st)
 
     if(st->buttons & CONT_START) {
@@ -38,7 +38,7 @@ int check_start() {
 static int mx = 320, my = 240;
 static int lmx[5] = {320, 320, 320, 320, 320},
                     lmy[5] = {240, 240, 240, 240, 240};
-void mouse_render() {
+void mouse_render(void) {
     int i;
     int atall = 0;
 
@@ -82,7 +82,7 @@ void mouse_render() {
 #include "vmu_play.h"
 #include "vmu_ghettoplay.h"
 static int cycle = 0, phase = 1;
-void vmu_lcd_update() {
+void vmu_lcd_update(void) {
     switch(cycle) {
         case 0: {   /* Getto/Play/GettoPlay */
             if(phase == 1) {

--- a/examples/dreamcast/sound/ghettoplay-vorbis/gp.h
+++ b/examples/dreamcast/sound/ghettoplay-vorbis/gp.h
@@ -9,13 +9,13 @@
 #define mcos(angle) fcos((angle) * 2 * M_PI / 256)
 
 /* bkg.c */
-void bkg_setup();
-void bkg_render();
+void bkg_setup(void);
+void bkg_render(void);
 
 /* texture.c */
 extern pvr_ptr_t        util_texture;
 extern pvr_poly_hdr_t       util_txr_hdr;
-void setup_util_texture();
+void setup_util_texture(void);
 
 /* 3dutils.c */
 void rotate(int zang, int xang, int yang, float *x, float *y, float *z);
@@ -27,6 +27,6 @@ void draw_poly_box(float x1, float y1, float x2, float y2, float z,
                    float a2, float r2, float g2, float b2);
 
 /* songmenu.c */
-void song_menu_render();
+void song_menu_render(void);
 
 #endif  /* __GP_H */

--- a/examples/dreamcast/sound/ghettoplay-vorbis/songmenu.c
+++ b/examples/dreamcast/sound/ghettoplay-vorbis/songmenu.c
@@ -80,7 +80,7 @@ static void snd_hook(int strm, void * obj, int freq, int chn, void ** buf, int *
 
 #include <plx/dr.h>
 #include <plx/prim.h>
-static void draw_wave() {
+static void draw_wave(void) {
     int idx, cnt;
     float x, p, y, z = 80.0f;
 
@@ -164,7 +164,7 @@ static void *load_song_list(void * p) {
 }
 
 /* Draws the song listing */
-static void draw_listing() {
+static void draw_listing(void) {
     float y = 92.0f;
     int i, esel;
 
@@ -240,14 +240,14 @@ static void start(char *fn) {
     }
 }
 
-static void stop() {
+static void stop(void) {
     if(sndoggvorbis_isplaying()) {
         sndoggvorbis_stop();
     }
 }
 
 /* Handle controller input */
-void check_controller() {
+void check_controller(void) {
     static int up_moved = 0, down_moved = 0, a_pressed = 0, y_pressed = 0;
     maple_device_t *cont;
     cont_state_t *state;
@@ -413,12 +413,12 @@ void check_controller() {
 }
 
 /* Check maple bus inputs */
-void check_inputs() {
+void check_inputs(void) {
     check_controller();
 }
 
 /* Main rendering of the song menu */
-void song_menu_render() {
+void song_menu_render(void) {
 
     if(!filtinitted) {
         snd_stream_filter_add(0, snd_hook, NULL);

--- a/examples/dreamcast/sound/ghettoplay-vorbis/texture.c
+++ b/examples/dreamcast/sound/ghettoplay-vorbis/texture.c
@@ -9,7 +9,7 @@
 #include "mouse1.h"
 pvr_ptr_t util_texture;
 pvr_poly_hdr_t util_txr_hdr;
-void setup_util_texture() {
+void setup_util_texture(void) {
     uint16  *vram;
     int x, y;
     pvr_poly_cxt_t  cxt;

--- a/examples/dreamcast/vmu/vmu_game/vmu_game.c
+++ b/examples/dreamcast/vmu/vmu_game/vmu_game.c
@@ -13,7 +13,7 @@
 extern uint8 romdisk[];
 KOS_INIT_ROMDISK(romdisk);
 
-void draw_findings() {
+void draw_findings(void) {
     file_t      d;
     int     y = 88;
 
@@ -28,7 +28,7 @@ void draw_findings() {
 }
 
 int dev_checked = 0;
-void new_vmu() {
+void new_vmu(void) {
     maple_device_t * dev;
 
     dev = maple_enum_dev(0, 1);
@@ -49,7 +49,7 @@ void new_vmu() {
     }
 }
 
-int wait_start() {
+int wait_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -71,7 +71,7 @@ int wait_start() {
 }
 
 /* Here's the actual meat of it */
-void write_game_entry() {
+void write_game_entry(void) {
     file_t f;
     int data_size;
     uint8 *data;

--- a/examples/dreamcast/vmu/vmu_pkg/vmu.c
+++ b/examples/dreamcast/vmu/vmu_pkg/vmu.c
@@ -11,7 +11,7 @@
 #include <kos.h>
 #include <kos/string.h>
 
-void draw_dir() {
+void draw_dir(void) {
     file_t      d;
     int     y = 88;
     dirent_t    *de;
@@ -35,7 +35,7 @@ void draw_dir() {
 }
 
 int dev_checked = 0;
-void new_vmu() {
+void new_vmu(void) {
     maple_device_t * dev;
 
     dev = maple_enum_dev(0, 1);
@@ -56,7 +56,7 @@ void new_vmu() {
     }
 }
 
-int wait_start() {
+int wait_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -78,7 +78,7 @@ int wait_start() {
 }
 
 /* Here's the actual meat of it */
-void write_entry() {
+void write_entry(void) {
     vmu_pkg_t   pkg;
     uint8       data[4096], *pkg_out;
     int     pkg_size;

--- a/include/kos/fs_pty.h
+++ b/include/kos/fs_pty.h
@@ -51,8 +51,8 @@ __BEGIN_DECLS
 int fs_pty_create(char * buffer, int maxbuflen, file_t * master_out, file_t * slave_out);
 
 /** \cond */
-int fs_pty_init();
-int fs_pty_shutdown();
+int fs_pty_init(void);
+int fs_pty_shutdown(void);
 /** \endcond */
 
 __END_DECLS

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -319,7 +319,7 @@ void kbd_set_queue(int active) __attribute__((deprecated));
                             keyboards.
     \see                    kbd_queue_pop()
 */
-int kbd_get_key() __attribute__((deprecated));
+int kbd_get_key(void) __attribute__((deprecated));
 
 /** \brief  Pop a key off a specific keyboard's queue.
 

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1705,7 +1705,7 @@ int pvr_list_flush(pvr_list_t list);
     \retval 0               On success.
     \retval -1              On error (no scene started).
 */
-int pvr_scene_finish();
+int pvr_scene_finish(void);
 
 /** \brief  Block the caller until the PVR system is ready for another frame to
             be submitted.
@@ -1721,7 +1721,7 @@ int pvr_scene_finish();
     \retval 0               On success. A new scene can be started now.
     \retval -1              On error. Something is probably very wrong...
 */
-int pvr_wait_ready();
+int pvr_wait_ready(void);
 
 /** \brief  Check if the PVR system is ready for another frame to be submitted.
 
@@ -1730,7 +1730,7 @@ int pvr_wait_ready();
                             scene.
     \retval -1              If the PVR is not ready for a new scene yet.
 */
-int pvr_check_ready();
+int pvr_check_ready(void);
 
 
 /* Primitive handling ************************************************/

--- a/kernel/libc/newlib/verify_newlib.c
+++ b/kernel/libc/newlib/verify_newlib.c
@@ -10,6 +10,6 @@
 // will get linked in by crtbegin and ensure that the user is using a
 // patched Newlib (otherwise a link error will occur).
 extern int __newlib_kos_patch;
-void __verify_newlib_patch() {
+void __verify_newlib_patch(void) {
     (void)__newlib_kos_patch;
 }


### PR DESCRIPTION
This continues the work started in #168 but applies it also to examples, addons, and the few in the kernel that were missed the first time around.

The only ones left were in the conio examples where they also use K&R style argument declaration, so figured I'd just leave that alone entirely.