### PR TITLE
Moved Noreturn_ attribute to front of thrd_exit().

### DIFF
--- a/include/threads.h
+++ b/include/threads.h
@@ -369,7 +369,7 @@ extern int thrd_equal(thrd_t thr0, thrd_t thr1);
     \param  res             The return value of the thread.
     \note                   This function will not return.
 */
-extern _Noreturn void thrd_exit(int res);
+_Noreturn extern void thrd_exit(int res);
 
 /** \brief  Join a running thread.
 


### PR DESCRIPTION
Apparently C++17 and onward requires standard attributes to be at the beginning of function declarations. This was in the middle, so it wasn't building with newer C++ standards.

Curiously enough the source file was already correct, so now we're consistent (not that it matters, though, source was C, not C++).

See the actual standard (if you hate yourself): https://eel.is/c++draft/class.mem#general
See a few other posts about it:
https://stackoverflow.com/questions/74457085/nodiscard-attribute-different-compilation-result-for-gcc-and-clang
https://github.com/jarro2783/cxxopts/issues/353

Did a quick recursive grep, don't see that particular `Noreturn_` attribute used elsewhere, but there could very well be other attributes on functions in the wrong order which should be changed to appease newfangled C++.