### PR TITLE
Define MAX_FN_LEN to NAME_MAX for legacy code compatibility

### DIFF
--- a/include/kos/limits.h
+++ b/include/kos/limits.h
@@ -20,6 +20,11 @@
 #define NAME_MAX    256     /**< \brief Max filename length */
 #endif
 
+/* MAX_FN_LEN defined for legacy code compatibility */
+#ifndef MAX_FN_LEN
+#define MAX_FN_LEN  NAME_MAX
+#endif
+
 #ifndef PATH_MAX
 #define PATH_MAX    4096    /**< \brief Max path length */
 #endif


### PR DESCRIPTION
The renaming of `MAX_FN_LEN` to `NAME_MAX` has unnecessarily broken many old codebases which used `MAX_FN_LEN`. This PR defines `MAX_FN_LEN` to `NAME_MAX` so as to restore compatibility. I left it without Doxygen documentation as I wasn't sure it was necessary given it's deprecated. 