### PR TITLE
Relocate dc-chain patch stamps to source directory

### DIFF
--- a/utils/dc-chain/scripts/clean.mk
+++ b/utils/dc-chain/scripts/clean.mk
@@ -7,12 +7,13 @@
 
 clean: clean-archives clean-downloads clean-builds clean_patches_stamp
 
+clean-keep-archives: clean-downloads clean-builds clean_patches_stamp
+
 clean_patches_stamp:
 	-@tmpdir=.tmp; \
 	if ! test -d "$${tmpdir}"; then \
 		mkdir "$${tmpdir}"; \
 	fi; \
-	mv patch-*.stamp $${tmpdir} 2>/dev/null; \
 	mv $(stamp_gdb_download) $${tmpdir} 2>/dev/null; \
 	mv $(stamp_gdb_patch) $${tmpdir} 2>/dev/null; \
 	rm -f *.stamp; \
@@ -30,7 +31,7 @@ clean-builds: clean_patches_stamp
 	-rm -rf build-$(gdb_name)
 
 clean-downloads: clean-gdb-sources clean-arm-sources clean-sh-sources
-	
+
 clean-gdb-sources:
 	-rm -rf $(gdb_name)
 

--- a/utils/dc-chain/scripts/patch.mk
+++ b/utils/dc-chain/scripts/patch.mk
@@ -76,7 +76,7 @@ uname_s := $(shell uname -s)
 
 # This is a common 'patch_apply' function used in all the cases
 define patch_apply
-	@stamp_file=patch-$(stamp_radical_name).stamp; \
+	@stamp_file=$(src_dir)/$(patch_target_name)_patch.stamp; \
 	patches=$$(echo "$(diff_patches)" | xargs); \
 	if ! test -f "$${stamp_file}"; then \
 		if ! test -z "$${patches}"; then \


### PR DESCRIPTION
Currently if `make clean` is run, the patch stamps located in `dc-chain/` are not deleted (and to be honest I don't really understand what's going on in `clean_patches_stamp` in `dc-chain/scripts/clean.mk`, it seems like it's set up to do the opposite of what I thought it would do?). This is a problem because if the scripts are being re-run again after, the patches won't apply, causing a build error, and the user probably won't notice why, creating quite a bit of confusion.

This PR changes the patch stamp location to be within the source directory, so when `clean-*-sources` is run, the patch stamps are also deleted, which should always be expected and is the same behavior as the download stamps.

Secondly, this creates a new target: `make clean-keep-archives` which deletes everything but the downloaded archive files, which is very useful to me when experimenting with compiler settings and patches. 

In short, this patch allows this behavior:
`make clean-downloads clean-builds clean_patches_stamp && rm -f *.stamp`
to be run using just:
`make clean-keep-archives`