### PR TITLE
Formatting Fixes and Markdown Normalization in dc-chain Directory

### DIFF
--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -273,9 +273,9 @@ Below you will find some generic instructions; you may find some specific
 instructions in the `./doc` directory for your environment.
 
 In the dc-chain directory, run (for **BSD**, please use `gmake` instead):
-
-		make
-
+```
+make
+```
 This will build the ARM & SH4 toolchains. If you wish to only build the SH4
 toolchain and just use the prebuilt KOS sound driver run:
     make build-sh4
@@ -289,9 +289,9 @@ If anything goes wrong, check the output in `logs/`.
 
 For the `sh-elf` toolchain, if you want to use the **GNU Debugger** (`gdb`),
 you can make it by entering:
-
-	make gdb
-
+```
+make gdb
+```
 This will install `gdb` in the `sh-elf` toolchain. `gdb` is used with
 `dcload/dc-tool` programs, which are part of **KallistiOS** too, in order to do
 remote debugging of your **Dreamcast** programs. Please read the `dcload`
@@ -300,9 +300,9 @@ documentation to learn more on this point.
 ### Removing all useless files
 
 After the toolchain compilation, you can cleanup everything by entering:
-
-	make clean
-
+```
+make clean
+```
 This will save a lot of space by removing all unnecessary files.
 
 ## Final note

--- a/utils/dc-chain/doc/bsd/README.md
+++ b/utils/dc-chain/doc/bsd/README.md
@@ -18,9 +18,9 @@ do this before continuing reading the document.
 All the operations in this document should be executed with the `root` user. If 
 you don't want to connect with the `root` user, another option is to install
 the `sudo` command by entering:
-
-	pkg install sudo
-
+```
+pkg install sudo
+```
 In that case, you will need to add the `sudo` command before entering all the
 commands specified below.
 
@@ -32,9 +32,9 @@ build the whole toolchains.
 ### Installation of required packages ###
 
 The packages below need to be installed:
-
-	pkg install gcc gmake binutils texinfo bash libjpeg-turbo png libelf
-
+```
+pkg install gcc gmake binutils texinfo bash libjpeg-turbo png libelf
+```
 In **BSD** systems, the `make` is **NOT** the same as the **GNU Make** tool.
 Everything in the package needs `gmake`, you can't use `make` in **BSD**
 systems.
@@ -45,9 +45,9 @@ needs `bash`, that's why it needs to be installed.
 ### Installation of additional packages ###
 
 These additional packages are required too:
-
-	pkg install git subversion python2
-
+```
+pkg install git subversion python2
+```
 **Git** is needed right now, as **Subversion Client** and **Python 2** will be
 needed only when building `kos-ports`. But it's better to install these now.
 
@@ -55,21 +55,21 @@ By the way you can check the installation success by entering something like
 `git --version`. This should returns something like `git version X.Y.Z`.
 
 A cool text editor should be useful too:
-
-	pkg install nano
-
+```
+pkg install nano
+```
 Of course, this step is optional, you can use `vi` or something else if you
 want.
 
 ## Preparing the environment installation ##
 
 Enter the following to prepare **KallistiOS** and the toolchains:
-
-	mkdir -p /opt/toolchains/dc/
-	cd /opt/toolchains/dc/
-	git clone git://git.code.sf.net/p/cadcdev/kallistios kos
-	git clone git://git.code.sf.net/p/cadcdev/kos-ports
-
+```
+mkdir -p /opt/toolchains/dc/
+cd /opt/toolchains/dc/
+git clone git://git.code.sf.net/p/cadcdev/kallistios kos
+git clone git://git.code.sf.net/p/cadcdev/kos-ports
+```
 Everything is ready, now it's time to make the toolchains.
 
 ## Compilation ##
@@ -86,35 +86,35 @@ the main `README.md` file at the root for more information.
 To make the toolchains, do the following:
 
 1. Run `bash`, if not already done:
-
-		bash
-
+	```
+	bash
+	```
 2. Navigate to the `dc-chain` directory by entering:
 
 		cd /opt/toolchains/dc/kos/utils/dc-chain/
 	
 3. Enter the following to start downloading and building toolchain:
-
-		gmake
-
+	```
+	gmake
+	```
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 
 ### Making the GNU Debugger (gdb) ###
 
 If you want to install the **GNU Debugger** (`gdb`), just enter:
-
-	gmake gdb
-
+```	
+gmake gdb
+```
 This will install `sh-elf-gdb` and can be used to debug programs through
 `dc-load/dc-tool`.
 
 ### Removing all useless files ###
 
 After everything is done, you can cleanup all temporary files by entering:
-
-	gmake clean
-
+```
+gmake clean
+```
 ## Next steps ##
 
 After following this guide, the toolchains should be ready.

--- a/utils/dc-chain/doc/cygwin/README.md
+++ b/utils/dc-chain/doc/cygwin/README.md
@@ -81,11 +81,12 @@ whole environment to build the toolchains.
    file).
    
 2. Enter the following to prepare **KallistiOS**:
-
-		mkdir -p /opt/toolchains/dc/
-		cd /opt/toolchains/dc/
-		git clone git://git.code.sf.net/p/cadcdev/kallistios kos
-		git clone git://git.code.sf.net/p/cadcdev/kos-ports
+	```
+	mkdir -p /opt/toolchains/dc/
+	cd /opt/toolchains/dc/
+	git clone git://git.code.sf.net/p/cadcdev/kallistios kos
+	git clone git://git.code.sf.net/p/cadcdev/kos-ports
+	```
 
 Everything is ready, now it's time to make the toolchains.
 
@@ -105,31 +106,31 @@ To make the toolchains, do the following:
 1. Start the **Cygwin Terminal** if not already done.
 
 2. Navigate to the `dc-chain` directory by entering:
-
-		cd /opt/toolchains/dc/kos/utils/dc-chain/
-	
+	```
+	cd /opt/toolchains/dc/kos/utils/dc-chain/
+	```
 3. Enter the following to start downloading and building toolchain:
-
-		make
-
+	```
+	make
+	```
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 
 ### Making the GNU Debugger (gdb) ###
 
 If you want to install the **GNU Debugger** (`gdb`), just enter:
-
-	make gdb
-
+```
+make gdb
+```
 This will install `sh-elf-gdb` and can be used to debug programs through
 `dc-load/dc-tool`.
 
 ### Removing all useless files ###
 
 After everything is done, you can cleanup all temporary files by entering:
-
-	make clean
-
+```
+make clean
+```
 ## Next steps ##
 
 After following this guide, the toolchains should be ready.

--- a/utils/dc-chain/doc/linux/alpine.md
+++ b/utils/dc-chain/doc/linux/alpine.md
@@ -28,23 +28,23 @@ build the whole toolchains.
 ### Installation of required packages ###
 
 The packages below need to be installed:
-
-	apk --update add build-base patch bash texinfo libjpeg-turbo-dev libpng-dev	curl wget
-	
+```
+apk --update add build-base patch bash texinfo libjpeg-turbo-dev libpng-dev	curl wget
+```	
 At this time of writing, the `libelf-dev` package was missing from the main
 repository, so you have to execute the following to install it:
-
-	apk --update add libelf-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.9/main
-
+```
+apk --update add libelf-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.9/main
+```
 This may not be necessary depending if the `apk` repository was updated. Please
 keep in mind that you have to install the `libelf-dev` package.
 
 ### Installation of additional packages ###
 
 These additional packages are required too:
-
-	apk --update add git python subversion
-
+```
+apk --update add git python subversion
+```
 **Git** is needed right now, as **Subversion Client** and **Python 2** will be
 needed only when building `kos-ports`. But it's better to install these now.
 
@@ -54,12 +54,12 @@ By the way you can check the installation success by entering something like
 ## Preparing the environment installation ##
 
 Enter the following to prepare **KallistiOS** and the toolchains:
-
-	mkdir -p /opt/toolchains/dc/
-	cd /opt/toolchains/dc/
-	git clone git://git.code.sf.net/p/cadcdev/kallistios kos
-	git clone git://git.code.sf.net/p/cadcdev/kos-ports
-
+```
+mkdir -p /opt/toolchains/dc/
+cd /opt/toolchains/dc/
+git clone git://git.code.sf.net/p/cadcdev/kallistios kos
+git clone git://git.code.sf.net/p/cadcdev/kos-ports
+```
 Everything is ready, now it's time to make the toolchains.
 
 ## Compilation ##
@@ -76,31 +76,31 @@ the main `README.md` file at the root for more information.
 To make the toolchains, do the following:
 
 1. Navigate to the `dc-chain` directory by entering:
-
-		cd /opt/toolchains/dc/kos/utils/dc-chain/
-	
+	```
+	cd /opt/toolchains/dc/kos/utils/dc-chain/
+	```
 2. Enter the following to start downloading and building toolchain:
-
-		make
-
+	```
+	make
+	```
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 
 ### Making the GNU Debugger (gdb) ###
 
 If you want to install the **GNU Debugger** (`gdb`), just enter:
-
-	make gdb
-
+```
+make gdb
+```
 This will install `sh-elf-gdb` and can be used to debug programs through
 `dc-load/dc-tool`.
 
 ### Removing all useless files ###
 
 After everything is done, you can cleanup all temporary files by entering:
-
-	./cleanup.sh
-
+```
+./cleanup.sh
+```
 ## Next steps ##
 
 After following this guide, the toolchains should be ready.

--- a/utils/dc-chain/doc/linux/debian.md
+++ b/utils/dc-chain/doc/linux/debian.md
@@ -27,24 +27,25 @@ build the whole toolchains.
 ### Update of your local installation ###
 
 The first thing to do is to update your local installation:
-
-	apt-get update
-	apt-get upgrade -y	
-
+```
+apt-get update
+apt-get upgrade -y	
+```
 This should update all the packages of the **Debian** environment.
 
 ### Installation of required packages ###
 
 The packages below need to be installed:
-
-	apt-get install build-essential texinfo libjpeg-dev libpng-dev libelf-dev
+```
+apt-get install build-essential texinfo libjpeg-dev libpng-dev libelf-dev
+```
 
 ### Installation of additional packages ###
 
 These additional packages are required too:
-
-	apt-get install git subversion python
-
+```
+apt-get install git subversion python
+```
 **Git** is needed right now, as **Subversion Client** and **Python 2** will be
 needed only when building `kos-ports`. But it's better to install these now.
 
@@ -54,12 +55,12 @@ By the way you can check the installation success by entering something like
 ## Preparing the environment installation ##
 
 Enter the following to prepare **KallistiOS** and the toolchains:
-
-	mkdir -p /opt/toolchains/dc/
-	cd /opt/toolchains/dc/
-	git clone git://git.code.sf.net/p/cadcdev/kallistios kos
-	git clone git://git.code.sf.net/p/cadcdev/kos-ports
-
+```
+mkdir -p /opt/toolchains/dc/
+cd /opt/toolchains/dc/
+git clone git://git.code.sf.net/p/cadcdev/kallistios kos
+git clone git://git.code.sf.net/p/cadcdev/kos-ports
+```
 Everything is ready, now it's time to make the toolchains.
 
 ## Compilation ##
@@ -76,31 +77,31 @@ the main `README.md` file at the root for more information.
 To make the toolchains, do the following:
 
 1. Navigate to the `dc-chain` directory by entering:
-
-		cd /opt/toolchains/dc/kos/utils/dc-chain/
-	
+	```
+	cd /opt/toolchains/dc/kos/utils/dc-chain/
+	```
 2. Enter the following to start downloading and building toolchain:
-
-		make
-
+	```
+	make
+	```
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 
 ### Making the GNU Debugger (gdb) ###
 
 If you want to install the **GNU Debugger** (`gdb`), just enter:
-
-	make gdb
-
+```
+make gdb
+```
 This will install `sh-elf-gdb` and can be used to debug programs through
 `dc-load/dc-tool`.
 
 ### Removing all useless files ###
 
 After everything is done, you can cleanup all temporary files by entering:
-
-	make clean
-
+```
+make clean
+```
 ## Next steps ##
 
 After following this guide, the toolchains should be ready.

--- a/utils/dc-chain/doc/macos/README.md
+++ b/utils/dc-chain/doc/macos/README.md
@@ -43,9 +43,9 @@ Please note, you can ignore these instructions below if you already have
 1. Open a **Terminal**.
 
 2. Then input:
-
-		xcode-select --install
-
+	```
+	xcode-select --install
+	```
 3. When the window opens, click on the `Install` button, then click on the
    `Accept` button.
 
@@ -64,30 +64,30 @@ here to fill this gap:
 1. Open a **Terminal** window.
 
 2. Execute the following:
-
-		/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-
+	```
+	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	```
 **Homebrew** is now installed. You can check if it's working by entering
 `brew --version`.
 
 ### Installation of required packages ###
 
 The packages below need to be installed:
-
-	brew install libjpeg libpng libelf
-
+```
+brew install libjpeg libpng libelf
+```
 All the other required packages have already been installed, i.e. `git`, `svn`
 or `python`.
 
 ## Preparing the environment installation ##
 
 Enter the following to prepare **KallistiOS** and the toolchains:
-
-	mkdir -p /opt/toolchains/dc/
-	cd /opt/toolchains/dc/
-	git clone git://git.code.sf.net/p/cadcdev/kallistios kos
-	git clone git://git.code.sf.net/p/cadcdev/kos-ports
-
+```
+mkdir -p /opt/toolchains/dc/
+cd /opt/toolchains/dc/
+git clone git://git.code.sf.net/p/cadcdev/kallistios kos
+git clone git://git.code.sf.net/p/cadcdev/kos-ports
+```
 Everything is ready, now it's time to make the toolchains.
 
 ## Compilation ##
@@ -104,31 +104,31 @@ the main `README.md` file at the root for more information.
 To make the toolchains, do the following:
 
 1. Navigate to the `dc-chain` directory by entering:
-
-		cd /opt/toolchains/dc/kos/utils/dc-chain/
-	
+	```
+	cd /opt/toolchains/dc/kos/utils/dc-chain/
+	```
 2. Enter the following to start downloading and building toolchain:
-
-		make
-
+	```
+	make
+	```
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 
 ### Making the GNU Debugger (gdb) ###
 
 If you want to install the **GNU Debugger** (`gdb`), just enter:
-
-	make gdb
-
+```
+make gdb
+```
 This will install `sh-elf-gdb` and can be used to debug programs through
 `dc-load/dc-tool`.
 
 ### Removing all useless files ###
 
 After everything is done, you can cleanup all temporary files by entering:
-
-	./cleanup.sh
-
+```
+./cleanup.sh
+```
 ## Next steps ##
 
 After following this guide, the toolchains should be ready.

--- a/utils/dc-chain/doc/macos/README.md
+++ b/utils/dc-chain/doc/macos/README.md
@@ -127,7 +127,7 @@ This will install `sh-elf-gdb` and can be used to debug programs through
 
 After everything is done, you can cleanup all temporary files by entering:
 ```
-./cleanup.sh
+make clean
 ```
 ## Next steps ##
 

--- a/utils/dc-chain/doc/mingw/README.md
+++ b/utils/dc-chain/doc/mingw/README.md
@@ -19,9 +19,9 @@ can be:
 1. Open the **MSYS Shell**.
 
 2. Enter the following:
-		
-		command -v pacman
-
+    ```
+    command -v pacman
+    ```  
 3. Check the output:
 
 	* If the output is blank: You are using the legacy **MinGW/MSYS**

--- a/utils/dc-chain/doc/mingw/mingw-w64.md
+++ b/utils/dc-chain/doc/mingw/mingw-w64.md
@@ -51,34 +51,34 @@ whole environment to build the toolchains.
 ### Update of your local installation ###
 
 The first thing to do after installing is to update your local installation:
-
-	pacman -Syuu
-
+```
+pacman -Syuu
+```
 At the end of the process, a similar message to this one should be appear:
-
-	warning: terminate MSYS2 without returning to shell and check for updates again
-	warning: for example close your terminal window instead of calling exit
-
+```
+warning: terminate MSYS2 without returning to shell and check for updates again
+warning: for example close your terminal window instead of calling exit
+```
 It means only the `pacman` runtime has been updated. Close the terminal as 
 requested. Restart the **MSYS2 Shell** and run the same command again:
-
-	pacman -Syuu
-
+```
+pacman -Syuu
+```
 This should update all the packages of the **MinGW-w64/MSYS2** environment.
 
 ### Installation of required packages ###
 
 The packages below need to be installed to build the toolchains, so open the
 **MSYS2 Shell** and input:
-
-	pacman -Sy --needed base-devel mingw-w64-i686-toolchains mingw-w64-i686-libpng mingw-w64-i686-libjpeg mingw-w64-i686-libelf
-
+```
+pacman -Sy --needed base-devel mingw-w64-i686-toolchains mingw-w64-i686-libpng mingw-w64-i686-libjpeg mingw-w64-i686-libelf
+```
 ### Installation of additional packages ###
 
 Additional packages are needed:
-
-	pacman -Sy git subversion python2
-
+```
+pacman -Sy git subversion python2
+```
 **Git** is needed right now, as **Subversion Client** and **Python 2** will be
 needed only when building `kos-ports`. But it's better to install these now.
 
@@ -115,31 +115,31 @@ To make the toolchains, do the following:
 
 1. Start the **MSYS2 Shell** if not already done.
 2. Navigate to the `dc-chain` directory by entering:
-
-		cd /opt/toolchains/dc/kos/utils/dc-chain/
-	
+	```
+	cd /opt/toolchains/dc/kos/utils/dc-chain/
+	```
 3. Enter the following to start downloading and building toolchain:
-
-		make
-
+	```
+	make
+	```
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 
 ### Making the GNU Debugger (gdb) ###
 
 If you want to install the **GNU Debugger** (`gdb`), just enter:
-
-	make gdb
-
+```
+make gdb
+```
 This will install `sh-elf-gdb` and can be used to debug programs through
 `dc-load/dc-tool`.
 
 ### Removing all useless files ###
 
 After everything is done, you can cleanup all temporary files by entering:
-
-	make clean
-
+```
+make clean 
+```
 ## Fixing up Newlib for SH-4 ##
 
 The `ln` command in the **MinGW-w64/MSYS2** environment is not effective, as
@@ -151,9 +151,9 @@ This is the purpose of the provided `fixup-sh4-newlib.sh` script.
 
 Before executing it, just edit it to be sure if the `$toolchains_base` variable
 is correctly set. Then execute it by just entering:
-
-	./packages/fixup-sh4-newlib.sh
-
+```
+./packages/fixup-sh4-newlib.sh
+```
 ## Next steps ##
 
 After following this guide, the toolchains should be ready.

--- a/utils/dc-chain/doc/mingw/mingw.md
+++ b/utils/dc-chain/doc/mingw/mingw.md
@@ -181,8 +181,8 @@ To make the toolchains, do the following:
 1. Start the **MSYS Shell** if not already done.
 2. Navigate to the `dc-chain` directory by entering:
    ```
-	cd /opt/toolchains/dc/kos/utils/dc-chain/
-	```
+   cd /opt/toolchains/dc/kos/utils/dc-chain/
+   ```
 3. Enter the following to start downloading and building toolchain:
    ```
 	make

--- a/utils/dc-chain/doc/mingw/mingw.md
+++ b/utils/dc-chain/doc/mingw/mingw.md
@@ -121,12 +121,12 @@ of the `/etc/fstab` file (i.e. `${MINGW_ROOT}\msys\1.0\etc\fstab`).
    file).
    
 2. Enter the following to prepare **KallistiOS**:
-
-		mkdir -p /opt/toolchains/dc/
-		cd /opt/toolchains/dc/
-		git clone git://git.code.sf.net/p/cadcdev/kallistios kos
-		git clone git://git.code.sf.net/p/cadcdev/kos-ports
-
+   ```
+	mkdir -p /opt/toolchains/dc/
+	cd /opt/toolchains/dc/
+	git clone git://git.code.sf.net/p/cadcdev/kallistios kos
+	git clone git://git.code.sf.net/p/cadcdev/kos-ports
+   ```
 Everything is ready, now it's time to make the toolchains.
 
 ## About making toolchains static binaries ##
@@ -135,9 +135,9 @@ By default, all the binaries of the toolchains (e.g. `sh-elf-gcc`...) are
 dynamically linked, and that's the way that meant to be. The drawback is,
 if you want to use the toolchains outside the **MinGW/MSYS** environment and
 the binaries are dynamically linked, you'll have some error messages like:
-
-	The file libintl-8.dll is missing from your computer.
-
+```
+The file libintl-8.dll is missing from your computer.
+```
 This happens if you just double-click on any `sh-elf` binaries (e.g.
 `sh-elf-gcc`), even with `arm-eabi` binaries.
 
@@ -180,31 +180,31 @@ To make the toolchains, do the following:
 
 1. Start the **MSYS Shell** if not already done.
 2. Navigate to the `dc-chain` directory by entering:
-
-		cd /opt/toolchains/dc/kos/utils/dc-chain/
-	
+   ```
+	cd /opt/toolchains/dc/kos/utils/dc-chain/
+	```
 3. Enter the following to start downloading and building toolchain:
-
-		make
-
+   ```
+	make
+   ```
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 
 ### Making the GNU Debugger (gdb) ###
 
 If you want to install the **GNU Debugger** (`gdb`), just enter:
-
-	make gdb
-
+```
+make gdb
+```
 This will install `sh-elf-gdb` and can be used to debug programs through
 `dc-load/dc-tool`.
 
 ### Removing all useless files ###
 
 After everything is done, you can cleanup all temporary files by entering:
-
-	make clean
-
+```
+make clean
+```
 ## Removing the MSYS heap patch ##
 
 After your toolchains is ready, please don't forget to replace the patched
@@ -225,9 +225,9 @@ This is the purpose of the provided `fixup-sh4-newlib.sh` script.
 
 Before executing it, just edit it to be sure if the `$toolchains_base` variable
 is correctly set. Then execute it by just entering:
-
-	./packages/fixup-sh4-newlib.sh
-
+```
+./packages/fixup-sh4-newlib.sh
+```
 ## Next steps ##
 
 After following this guide, the toolchains should be ready.

--- a/utils/dc-chain/patches/README.md
+++ b/utils/dc-chain/patches/README.md
@@ -22,14 +22,14 @@ when using the **dc-chain** `Makefile`.
   default (accident?) prior to 3.4.
 
 Generic `newlib` fixups (applied directly after `newlib` is installed):
-
-	cp $(kos_base)/include/pthread.h $(newlib_inc)                       # KOS pthread.h is modified
-	cp $(kos_base)/include/sys/_pthread.h $(newlib_inc)/sys              # to define _POSIX_THREADS
-	cp $(kos_base)/include/sys/sched.h $(newlib_inc)/sys                 # pthreads to kthreads mapping
-	ln -nsf $(kos_base)/include/kos $(newlib_inc)                        # so KOS includes are available as kos/file.h
-	ln -nsf $(kos_base)/kernel/arch/dreamcast/include/arch $(newlib_inc) # kos/thread.h requires arch/arch.h
-	ln -nsf $(kos_base)/kernel/arch/dreamcast/include/dc   $(newlib_inc) # arch/arch.h requires dc/video.h
-
+```
+cp $(kos_base)/include/pthread.h $(newlib_inc)                       # KOS pthread.h is modified
+cp $(kos_base)/include/sys/_pthread.h $(newlib_inc)/sys              # to define _POSIX_THREADS
+cp $(kos_base)/include/sys/sched.h $(newlib_inc)/sys                 # pthreads to kthreads mapping
+ln -nsf $(kos_base)/include/kos $(newlib_inc)                        # so KOS includes are available as kos/file.h
+ln -nsf $(kos_base)/kernel/arch/dreamcast/include/arch $(newlib_inc) # kos/thread.h requires arch/arch.h
+ln -nsf $(kos_base)/kernel/arch/dreamcast/include/dc   $(newlib_inc) # arch/arch.h requires dc/video.h
+```
 **Note:** For the **MinGW/MSYS** environment, these `newlib` fixups should be
 manually applied. See the `mingw` directory for details. For all the others
 platforms, these fixups are applied automatically from the `Makefile`.


### PR DESCRIPTION
This PR primarily aims to correct a formatting issue located on line 277 of KallistiOS/utils/dc-chain/README.md and to remove a leftover ./cleanup.sh from the macOS documentation.

However, rather than submitting a PR for these minor corrections alone, I decided to do a little bit more. I have also normalized the formatting across all other Markdown files within the dc-chain directory to ensure consistency and enhance readability.