### PR TITLE
Add patches and update testing configuration for GCC 13.2.0

### DIFF
--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -104,7 +104,7 @@ without problems.
 
 Working **GCC** and **Newlib** version combinations are:
 
-- GCC `13.1.0` with Newlib `4.3.0` for `sh-elf` and GCC `8.5.0` for `arm-eabi`
+- GCC `13.2.0` with Newlib `4.3.0` for `sh-elf` and GCC `8.5.0` for `arm-eabi`
   (**testing**; the most modern combination);
 - GCC `9.3.0` with Newlib `3.3.0` for `sh-elf` and GCC `8.4.0` for `arm-eabi`
   (**stable**; the most widely used, widely tested combination);

--- a/utils/dc-chain/config.mk.testing.sample
+++ b/utils/dc-chain/config.mk.testing.sample
@@ -18,7 +18,7 @@
 
 # Toolchain versions for SH
 sh_binutils_ver=2.40
-sh_gcc_ver=13.1.0
+sh_gcc_ver=13.2.0
 newlib_ver=4.3.0.20230120
 gdb_ver=13.1
 

--- a/utils/dc-chain/patches/arm-Darwin/gcc-13.2.0-kos.diff
+++ b/utils/dc-chain/patches/arm-Darwin/gcc-13.2.0-kos.diff
@@ -1,0 +1,28 @@
+diff --color -ruN gcc-13.2.0/gcc/config/host-darwin.cc gcc-13.2.0-kos/gcc/config/host-darwin.cc
+--- gcc-13.2.0/gcc/config/host-darwin.cc	2023-03-11 14:18:10
++++ gcc-13.2.0-kos/gcc/config/host-darwin.cc	2023-03-11 14:22:40
+@@ -24,6 +24,10 @@
+ #include "diagnostic-core.h"
+ #include "config/host-darwin.h"
+ #include <errno.h>
++#include "hosthooks.h"
++#include "hosthooks-def.h"
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
+ 
+ /* For Darwin (macOS only) platforms, without ASLR (PIE) enabled on the
+    binaries, the following VM addresses are expected to be available.
+diff --color -ruN gcc-13.2.0/gcc/config.host gcc-13.2.0-kos/gcc/config.host
+--- gcc-13.2.0/gcc/config.host	2023-03-11 14:18:26
++++ gcc-13.2.0-kos/gcc/config.host	2023-03-11 14:23:01
+@@ -93,8 +93,8 @@
+ case ${host} in
+   *-darwin*)
+     # Generic darwin host support.
+-    out_host_hook_obj=host-darwin.o
+-    host_xmake_file="${host_xmake_file} x-darwin"
++    # out_host_hook_obj=host-darwin.o
++    # host_xmake_file="${host_xmake_file} x-darwin"
+     ;;
+ esac
+ 

--- a/utils/dc-chain/patches/gcc-13.2.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-13.2.0-kos.diff
@@ -1,0 +1,162 @@
+diff --color -ruN gcc-13.2.0/gcc/config/sh/sh-c.cc gcc-13.2.0-kos/gcc/config/sh/sh-c.cc
+--- gcc-13.2.0/gcc/config/sh/sh-c.cc	2023-06-04 20:48:46.612552162 -0500
++++ gcc-13.2.0-kos/gcc/config/sh/sh-c.cc	2023-06-04 20:49:03.486606055 -0500
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff --color -ruN gcc-13.2.0/gcc/configure gcc-13.2.0-kos/gcc/configure
+--- gcc-13.2.0/gcc/configure	2023-06-04 20:48:49.679561957 -0500
++++ gcc-13.2.0-kos/gcc/configure	2023-06-04 20:49:03.488606061 -0500
+@@ -13012,7 +13012,7 @@
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32 | mcf)
++  single | tpf | vxworks | win32 | kos | mcf)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff --color -ruN gcc-13.2.0/libgcc/config/sh/t-sh gcc-13.2.0-kos/libgcc/config/sh/t-sh
+--- gcc-13.2.0/libgcc/config/sh/t-sh	2023-06-04 20:48:45.741549380 -0500
++++ gcc-13.2.0-kos/libgcc/config/sh/t-sh	2023-06-04 20:49:03.488606061 -0500
+@@ -23,6 +23,8 @@
+   $(LIB1ASMFUNCS_CACHE)
+ LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
+ 
++LIB2ADD = $(srcdir)/config/sh/fake-kos.S
++
+ crt1.o: $(srcdir)/config/sh/crt1.S
+ 	$(gcc_compile) -c $<
+ 
+diff --color -ruN gcc-13.2.0/libgcc/configure gcc-13.2.0-kos/libgcc/configure
+--- gcc-13.2.0/libgcc/configure	2023-06-04 20:48:45.787549527 -0500
++++ gcc-13.2.0-kos/libgcc/configure	2023-06-04 20:49:03.489606065 -0500
+@@ -5699,6 +5699,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 
+diff --color -ruN gcc-13.2.0/libobjc/configure gcc-13.2.0-kos/libobjc/configure
+--- gcc-13.2.0/libobjc/configure	2023-06-04 20:48:49.902562670 -0500
++++ gcc-13.2.0-kos/libobjc/configure	2023-06-04 20:49:03.489606065 -0500
+@@ -2918,11 +2918,9 @@
+ 
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#include <stdio.h>
+ int
+ main ()
+ {
+-printf ("hello world\n");
+   ;
+   return 0;
+ }
+diff --color -ruN gcc-13.2.0/libobjc/Makefile.in gcc-13.2.0-kos/libobjc/Makefile.in
+--- gcc-13.2.0/libobjc/Makefile.in	2023-06-04 20:48:49.901562666 -0500
++++ gcc-13.2.0-kos/libobjc/Makefile.in	2023-06-04 20:49:03.490606068 -0500
+@@ -308,14 +308,16 @@
+ $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
+ 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+ 
+-install: install-libs install-headers
++install-strip: INSTALL_STRIP_FLAG = -s
++install install-strip: install-libs install-headers
+ 
+ install-libs: installdirs
+ 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
+-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
++	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+ 	if [ "$(OBJC_BOEHM_GC)" ]; then \
+-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
+-				$(DESTDIR)$(toolexeclibdir);\
++	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
+ 	fi
+ 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
+ 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
+@@ -328,7 +330,7 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
+diff --color -ruN gcc-13.2.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-13.2.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-13.2.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:48:46.047550357 -0500
++++ gcc-13.2.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:49:03.490606068 -0500
+@@ -22,14 +22,40 @@
+ // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ // <http://www.gnu.org/licenses/>.
+ 
+-// Use the default atomicity stuff, which will use __atomic* builtins
+-// if threads are available, or the *_single functions on single-thread
+-// configurations.
+-// Actually we wouldn't need this header at all, but because of PR 53579
+-// libstdc++'s configury will not pickup the -matomic-model= option when
+-// set in the environment.  This makes it impossible to enable the proper
+-// atomic model on SH without modifying GCC itself, because libstdc++ always
+-// thinks the target doesn't do any atomics and uses the default mutex based
+-// implementation from cpu/generic/atomicity_mutex.
++/* This is generic/atomicity.h */
+ 
+ #include <ext/atomicity.h>
++#include <ext/concurrence.h>
++
++namespace 
++{
++  __gnu_cxx::__mutex&
++  get_atomic_mutex()
++  {
++    static __gnu_cxx::__mutex atomic_mutex;
++    return atomic_mutex;
++  }
++} // anonymous namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val) throw ()
++  {
++    __gnu_cxx::__scoped_lock sentry(get_atomic_mutex());
++    _Atomic_word __result;
++    __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word* __mem, int __val) throw ()
++  { __exchange_and_add(__mem, __val); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --color -ruN gcc-13.2.0/libstdc++-v3/configure gcc-13.2.0-kos/libstdc++-v3/configure
+--- gcc-13.2.0/libstdc++-v3/configure	2023-06-04 20:48:46.398551478 -0500
++++ gcc-13.2.0-kos/libstdc++-v3/configure	2023-06-04 20:49:03.493606077 -0500
+@@ -15809,6 +15809,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 


### PR DESCRIPTION
GCC 13.2.0 is scheduled to be released on July 27, 2023. The release candidate was tested and it performs as expected. 
Please review this patch in advance, but do not actually merge until the GCC 13.2.0 release announcement, when packages are uploaded. 