### PR TITLE
Stabilize 13.2; update binutils to 2.41; revise documentation, configs, and Dockerfile

### DIFF
--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -1,88 +1,87 @@
 # Sega Dreamcast Toolchains Maker (`dc-chain`)
 
-The **Sega Dreamcast Toolchains Maker** (`dc-chain`) utility is a set of files
-made for building all the needed toolchains used in **Sega Dreamcast**
-programming under the **KallistiOS** environment. It was first released by
-*Jim Ursetto* back in 2004 and was initially adapted from *Stalin*'s build
-script v0.3. This utility is part of **KallistiOS** (**KOS**).
+The **Sega Dreamcast Toolchains Maker** (`dc-chain`) is a utility to assist in
+building the toolchains and development environment needed for **Sega Dreamcast**
+programming. Initially adapted from *Stalin*'s build script, it was first
+released by *Jim Ursetto* back in 2004, and is now included as part of
+**KallistiOS** (**KOS**).
 
-By using this utility, 2 toolchains will be built for **Dreamcast** development:
+This utility is capable of building two toolchains for **Dreamcast** development:
 
-- A `sh-elf` toolchain, which is the main toolchain as it targets the CPU of the
-  **Dreamcast**, i.e. the **Hitachi SH-4 CPU** (a.k.a. **SuperH**).
-- An `arm-eabi` toolchain, which is the toolchain used only for the **Yamaha
-  Super Intelligent Sound Processor** (**AICA**). This processor is based
-  on an **ARM7** core. Under **KallistiOS**, only the sound driver is compiled
-  with that toolchain, so you won't need to use it directly.
+- The `sh-elf` toolchain, the primary cross-compiler toolchain targetting the
+  main CPU of the Dreamcast, the **Hitachi SuperH (SH4) CPU** .
+- The `arm-eabi` toolchain, used only for the **Yamaha Super Intelligent Sound
+  Processor** (**AICA**). This processor is based on an **ARM7** core.
 
-The `dc-chain` package will build everything you need to compile **KallistiOS**
-and then finally develop for the **Sega Dreamcast** system. Please note that
-`dc-chain` optimize the both toolchains for the use of **KallistiOS** so if you
-plan to use another **Dreamcast** library (e.g. `libronin`), `dc-chain` may
-not be so useful for you, at least *out-of-the-box*.
+The main `sh-elf` toolchain is required, but KallistiOS includes a precompiled
+AICA sound driver, so building the `arm-eabi` toolchain is only necessary when
+altering the sound driver or writing custom AICA code.
+
+The `sh-elf` toolchain by default is built to target KallistiOS specifically,
+however options are included to build a "raw" toolchain to allow targeting other
+Dreamcast libraries.
 
 ## Overview
 
-Components included in the toolchains built through `dc-chain` are:
+Toolchain components built through `dc-chain` include:
 
-- **Binutils** (mainly `ld` plus other tools);
-- **GNU Compiler Collection** (`gcc`, `g++`);
-- **Newlib** (mainly `libc` plus other libraries);
-- **GNU Debugger** (`gdb`) - Optional;
+- **Binutils** (including `ld` and related tools)
+- **GNU Compiler Collection** (`gcc`, `g++`, etc.)
+- **Newlib** (a C standard library for embedded systems)
+- **GNU Debugger** (`gdb`, optional)
 
-**Binutils** and **GCC** are installed for both targets (i.e. `sh-elf` and
-`arm-eabi`) where **Newlib** and **GNU Debugger** (**GDB**) are needed only
-for the main toolchain (`sh-elf`).
+**Binutils** and **GCC** are installed for both `sh-elf` and `arm-eabi`
+toolchains, while **Newlib** and **GNU Debugger** (**GDB**) are needed only for
+the main `sh-elf` toolchain.
 
 ## Getting started
 
-Before you start, please browse the `./doc` directory and check if they are
-full instructions for building the whole toolchains for your environment.
+Before you start, please browse the `doc` directory and check for full
+instructions for building the toolchains for your environment.
 
-A big effort was put to simplify the building process as much as possible, for
-all modern environments, mainly **Linux** (including **BSD**), **macOS** and
-**Windows** (including **Cygwin**, **MinGW-w64/MSYS2** and **MinGW/MSYS**).
-Indeed, a lot of conditional instructions have been added, so it should work
-most of the time just out-of-the-box for your environment.
+A big effort was put into simplifying the building process as much as possible
+for all modern environments, including **Linux**, **FreeBSD**, **macOS** and
+**Windows** (via **Windows Subsystem for Linux**, **Cygwin**, **MinGW-w64/MSYS2**
+or **MinGW/MSYS**). Many conditional instructions have been diligently added to
+the script to allow it to seemlessly function in many environments out of the box.
 
 ### `dc-chain` utility installation
-
-`dc-chain` is part of **KallistiOS** so you should have it installed in the
-`$KOS_BASE/utils/dc-chain` directory. You don't need to have **KallistiOS**
-configured (i.e. have the `$KOS_BASE/environ.sh` file created) as building
-toolchains is a prerequisite in order to build **KallistiOS** itself.
+`dc-chain` is packaged with KallistiOS, where it can be found within the
+`$KOS_BASE/utils/dc-chain` directory. As building this toolchain is a
+prerequisite to building KallistiOS, KallistiOS does not yet need to be
+configured to proceed to building the toolchain.
 
 ### Prerequisites installation
 
-You'll need your host toolchain (i.e. the regular `gcc` plus additional tools)
-for your computer installed. Indeed, to build the cross-compilers you'll need a
-working compilation environment on your computer.
+You'll need to have a host toolchain for your computer installed (i.e. the
+regular `gcc` and related tools) in order to build the cross compiler. The
+`dc-chain` scripts are intended to be used with a `bash` shell; other shells
+*may* work, but are not guaranteed to function properly.
 
-In addition, you must have `bash` installed on your host system. Other shells
-*may* work, but are not tested and not guaranteed to work.
-
-If you need help on this step, everything is described in the `./doc` directory.
-
-Please note that you may be required to use older versions of some of the
-prerequisites in certain configurations. For instance, building GCC 4.7.4 may
-require an older version of the `flex` tool be installed. If you receive errors
-about tools you have installed, check your system's package manager for an older
-version of that tool.
+Several dependencies such as `wget`, `gettext`, `texinfo`, `gmp`, `mpfr`,
+`libmpc`, etc. are required to build the toolchain. The `doc` directory contains
+useful platform-specific instructions for installing dependencies.
 
 ## Configuration
 
-In order to allow `dc-chain` to work, you'll need to provide a `config.mk` file.
-This file will contain the settings used for making the toolchains.
+Before running `dc-chain`, you will need to set up the `config.mk` file containing
+settings for building the toolchain(s). Most users can simply use the the default
+`config.mk.stable.sample` template, which contains a stable default configuration
+to make this easy for you. Additional configuration templates for alternative
+settings are available in the `config` directory; see `config/README.md` for more
+details. Most users can skip configuration without altering any options whatsoever.
+Simply copy the `config.mk.stable.sample` file from the `config` directory to use
+this configuration:
+```
+cp config/config.mk.stable.sample config.mk
+```
 
-You may create this `config.mk` file from scratch or use a provided template
-as base.
-
-Please find below every parameter available in the `config.mk` file and more
-information about `config.mk` templates.
+Additional settings are detailed below.
 
 ### Toolchains components
 
-All component's versions of the toolchains are declared in the `config.mk` file.
+You may adjust the version numbers of components to install through declarations
+within the `config.mk` file.
 
 For the `sh-elf` toolchain, they are:
 
@@ -96,95 +95,91 @@ For the `arm-eabi` toolchain, they are:
 - `arm_binutils_ver`
 - `arm_gcc_ver`
 
-Speaking about the best versions of the components to use for the Dreamcast
-development, this is a very critical point. Indeed, **GCC** and **Newlib**
-versions are core components; they are patched to compile with **KallistiOS**.
-For **Binutils** or **GDB**, you may in theory use the latest available versions
-without problems.
+Because the **GCC** and **Newlib** builds must be patched to target KallistiOS,
+you may only select versions with patches available when building the default
+toolchain targeting KallistiOS. See the alternate configurations in the `config`
+directory for examples.
 
-Working **GCC** and **Newlib** version combinations are:
+**Note:** The `arm-eabi` GCC does not need a KallistiOS patch. The latest
+version of GCC possible for the `arm-eabi` toolchain, however, is `8.5.0`.
+Support for the **ARM7DI** core in the AICA was dropped after the GCC `8.x`
+series. If you choose to compile the optional `arm-eabi` toolchain, it is
+recommended to just pick the latest `8.5.0`.
 
-- GCC `13.2.0` with Newlib `4.3.0` for `sh-elf` and GCC `8.5.0` for `arm-eabi`
-  (**testing**; the most modern combination);
-- GCC `9.3.0` with Newlib `3.3.0` for `sh-elf` and GCC `8.4.0` for `arm-eabi`
-  (**stable**; the most widely used, widely tested combination);
-- GCC `4.7.4` with Newlib `2.0.0` for `sh-elf` and `arm-eabi` (**legacy**; the
-  oldest supported combination, previously stable [some issues may happen in C++](https://dcemulation.org/phpBB/viewtopic.php?f=29&t=104724));
+For **Binutils** or **GDB**, the latest version typically just works.
 
-To help you on this, 3 `config.mk` templates are provided with `dc-chain`:
+For advanced users, you may specify **custom dependencies for GCC** directly in
+the `config.mk` file. You must define `use_custom_dependencies=1` to use your
+custom versions of **GMP**, **MPC**, **MPFR** and **ISL** rather than the
+versions provided with GCC.
 
-- `config.mk.testing.sample` (testing);
-- `config.mk.stable.sample` (stable);
-- `config.mk.legacy.sample` (legacy).
+You may need to specify the tarball extension of the archive containing the
+package you want to download using `download_type`. This is already properly set
+for you in the provided templates, but this may be altered in case a package
+changes its extension on the servers. For example, older GCC versions like
+`4.7.4`, there is no `xz` tarball file, so this setting must be `gz`.
 
-Just copy the relevant `config.mk` sample file to `config.mk` and you are good
-to go.
+Git repositories can also be used to obtain source files. The git download method
+can be selected by specifying `git` as the `download_type`. This enables the use
+of `git_repo` and `git_branch` variables to specify the repository and branch
+respectively. If `git_branch` is omitted, the default for the repository will be
+used.
 
-**Note:** The GCC's maximum version number possible for the `arm-eabi` toolchain
-is `8.x`. Support of the **ARM7DI** chip is dropped after that GCC version. So
-don't try to update the version of the `arm-eabi-gcc` component beyond `8.x`.
+Alternative mirrors for GNU software can be selected using the `gnu_mirror`
+option detailed below.
 
-You have the possibility to **use custom dependencies for GCC** directly in the
-`config.mk` file. In that case, you have to define `use_custom_dependencies=1`.
-Doing so will use your custom versions of **GMP**, **MPC**, **MPFR** and
-**ISL** rather than the provided versions with GCC. You may also use this flag
-if you have trouble using the `contrib/download_prerequisites` script provided
-with GCC.
+### Download protocol
 
-Please note that you have the possibility to specify the tarball extensions
-you want to download using `download_type`; this may be useful if a
-package changes its extension on the servers. For example, for GCC `4.7.4`, 
-there is no `xz` tarball file, so you may change this to `gz`. In the case that
-`download_type` is not specified, `tarball_type` will be checked as a fallback to
-support legacy `config.mk` files.
+You may specify the download protocol used when downloading packages with the
+`download_protocol` variable. Available options include `http`, `https` or `ftp`
+as you want. The default is `https`.
 
-Git repositories can also be used to obtain source files. The git download method 
-can be selected by specifying `git` as the `download_type`. This enables
-the use of `git_repo` and `git_branch` variables to specify the repository
-and branch respectively. If `git_branch` is omitted, the default for the
-repository will be used.
+### Force downloader
 
-**Note:** All download URL are computed in the `scripts/download.mk` file, but
-you shouldn't update/change this as it can be overriden with the `gnu_mirror` 
-config option detailed below.
+You must have either the [Wget](https://www.gnu.org/software/wget/) or
+[cURL](https://curl.haxx.se/) file downloading utilities installed to use
+dc-chain. You may specify which to use for downloading files with the
+`force_downloader` variable. If this variable is empty or commented, the web
+downloader tool will try to detect which is available and choose cURL if both are
+available.
+
+### Override GNU Download Mirror
+
+Set `gnu_mirror` to override the default `ftpmirror.gnu.org` mirror when you have
+a prefered mirror for downloading GNU sources.
 
 ### Toolchains base
 
-`toolchains_base` indicates the root directory where toolchains will be
-installed. This should match your `environ.sh` configuration. Default is
-`/opt/toolchains/dc`.
-
-In clear, after building the toolchains, by using the default `toolchains_base`,
-you'll have two additional directories:
-
-- `/opt/toolchains/dc/arm-eabi`;
-- `/opt/toolchains/dc/sh-elf`.
-
-Of course, you may adapt the path if needed; but it's better to use the standard
-path if possible.
-
-### Erase
-
-Set the `erase` flag to `1` to remove build directories on the fly to save
-space.
+`toolchains_base` specifies the root directory where toolchains will be
+installed. The default is `/opt/toolchains/dc`. If using this default, you will
+find the `sh-elf` toolchain installed at `/opt/toolchains/dc/sh-elf` and the
+`arm-eabi` toolchain at `/opt/toolchains/dc/arm-eabi`. These are also the default
+paths for the KallistiOS configuration. It is recommended to stick with these
+paths unless you have a specific need to change them.
 
 ### Verbose
 
-Set `verbose` to `1` to display output to screen as well as `log` files. In clear
-if `verbose` is set to `0`, all the output will be stored directly in the `log`
-files.
+Set `verbose` to `1` to display verbose build output to your terminal as well as
+write to `log` files. If `verbose` is set to `0`, the verbose output will only be
+stored in the `log` files.
+
+### Erase
+
+Set the `erase` flag to `1` to remove build directories on the fly to save space.
+
+### Install mode
+
+Set this to `install` if you want to debug the toolchains themselves or keep this
+as `install-strip` if you just want to use the produced toolchains in **release**
+mode. This drastically reduces the size of the toolchains.
 
 ### Make jobs
 
-You may attempt to spawn multiple jobs with `make`. Using `make -j2` is
-recommended for speeding up the building of the toolchain. There is an option
-inside the `config.mk` to set the number of jobs for the building phases.
-Set the `makejobs` variable in the `config.mk` to whatever you would normally
-feel the need to use on the command line, and it will do the right thing.
-
-In the old times, this option may break things, so, if you run into trouble,
-you should clear this variable and try again with just one job running (i.e.
-`makejobs=`).
+You may build the toolchains using multiple CPU threads by specifying the number
+of jobs in the `makejobs` variable. The default value is `-j2`, for two threads.
+This will dramatically speed up the compilation process. Previously, this option
+could potentially break things. If you run into trouble while building the
+toolchains, you may want to try setting this value to `-j1` to rule out issues.
 
 On **MinGW/MSYS** environment, it has been confirmed that multiple jobs breaks
 the toolchain all the time, so please don't try to do that under this
@@ -193,135 +188,131 @@ apply to **MinGW-w64/MSYS2**.
 
 ### Languages
 
-Use the `pass2_languages` variable to declare the languages you want to use.
-The default is to enable **C**, **C++**, **Objective C** and **Objective C++**.
-You may remove the latter two if you don't want them.
-
-### Download protocol
-
-You may have the possibility to change the download protocol used when
-downloading the packages (i.e. from `download.sh` script file).
-
-Set the `download_protocol` variable to `http`, `https` or `ftp` as you want.
-Default is `https`.
-
-### Force downloader
-
-You may specify here `wget` or `curl`. If this variable is empty or commented,
-the web downloader tool will be auto-detected in the following order:
-
-- cURL
-- Wget
-
-You must have either [Wget](https://www.gnu.org/software/wget/) or
-[cURL](https://curl.haxx.se/) installed to use dc-chain.
+The `pass2_languages` variable specifies the the languages you wish GCC to
+support. The supported options are **C**, **C++**, **Objective-C** and
+**Objective-C++**. The default is to build support for all.
 
 ### GCC threading model
 
-With GCC `4.x` versions and up, the patches provide a `kos` thread model, so you
-should use it. If you really don't want threading support for C++, Objective C
-or Objective C++, you can set this to `single`. With GCC `3.x`, you probably
-want `posix` here; but this mode is deprecated as the GCC `3.x` branch is not
-supported anymore.
+The KallistiOS patches provide a `kos` thread model required for use with
+KallistiOS. If you don't want threading support for C++, Objective-C, or
+Objective-C++, or are building a raw toolchain, you may set this to `single`.
+KallistiOS used the `posix` thread model with GCC `3.x`, but this configuration
+is no longer supported.
 
-### Install mode
+### Automatic KOS Patching
+Set `use_kos_patches` to `0` if you want to skip applying the KOS patches to the
+downloaded sources before building. Setting this option along with
+`auto_fixup_sh4_newlib=0` will keep the generated toolchain completely raw, e.g.
+for use with `libronin` instead of `KallistiOS`.
 
-Set this to `install` if you want to debug the toolchains themselves or keep
-this to `install-strip` if you just want to use the produced toolchains in
-**release** mode. This reduces the size of the toolchains drastically.
+**Note:** If you disable this flag, the KallistiOS threading model (`kos`) will
+be unavailable. **Use this flag with care**.
+
+### Automatic fixup of SH4 Newlib
+
+Set `auto_fixup_sh4_newlib` to `0` if you want to disable the automatic fixup of
+SH4 Newlib needed by KallistiOS. Only modify this option if you know what you are
+doing. Setting this option along with `use_kos_patches=0` will keep the generated
+toolchain completely raw, e.g. for use with `libronin` instead of `KallistiOS`.
+
+**Note:** If you disable this flag, the KallistiOS threading model (`kos`) will
+be unavailable. This will be a problem if you still apply the KallistiOS patches.
+**Use this flag with care**.
+
+### C99 Format Specifier Support
+
+Set `newlib_c99_formats` to `1` if you want to build SH4 Newlib with additional
+support for the C99 format specifiers, used by printf and friends. These include
+support for `size_t`, `ptrdiff_t`, `intmax_t`, and sized integral types.
+
+### Optimize Newlib for Space
+
+Set `newlib_opt_space` to `1` to enable optimizing for space when building
+Newlib. This will build Newlib with compiler flags which favor smaller code sizes
+over faster performance.
 
 ### Standalone binaries (MinGW/MSYS only)
 
-Set `standalone_binary` to `1` if you want to build static binaries, which may
-be run outside the MinGW/MSYS environment. This flag has no effect on other
-environments.
+Set `standalone_binary` to `1` if you want to build static binaries, which may be
+run outside the MinGW/MSYS environment. This flag has no effect on other
+environments. Building static binaries is useful only if you plan to use an IDE
+on Windows. This flag exists mainly for producing
+[DreamSDK](https://dreamsdk.org).
 
-Building static binaries are useful only if you plan to use an IDE on Windows.
-This flag is here mainly for producing [DreamSDK](https://dreamsdk.org).
+### Force installation of BFD for SH
 
-### Automatic fixup SH-4 Newlib (use with care)
+Set `sh_force_libbfd_installation` to `1` if youw ant to force the installation
+of `libbfd` for the SH toolchain. This is required for MinGW/MSYS and cannot be
+disabled in that scenario. This option is available to force the installation of
+`libbfd` in other environments. However, this won't be necessary in most cases,
+as `libelf`` is used almost everywhere. Please note, `libbfd`` cannot be
+portable if you built it in another environment. Don't mess with this flag unless
+you know exactly what you are doing.
 
-Set `auto_fixup_sh4_newlib` to `0` if you want to disable the automatic fixup
-SH-4 Newlib needed by KallistiOS. Setting this option along with 
-`use_kos_patches=0` will keep the generated toolchain completely raw. 
+## Building the toolchain
 
-**Note:** If you disable this flag, the KallistiOS threading model (`kos`) will
-be unavailable. Also, this may be a problem if you still apply the KallistiOS
-patches. **Use this flag with care**.
+With prerequisites installed and a `config.mk` configuration file in place, the
+toolchains are ready to be built. Generic instructions follow below, but you may
+find more detailed platform-specific instructions in the `doc` directory.
 
-### Automatic KOS Patching (use with care)
-Set `use_kos_patches` to `0` if you want to skip applying the KOS patches
-to the downloaded sources before building. Setting this option along with 
-`auto_fixup_sh4_newlib=0` will keep the generated toolchain completely raw.
-
-**Note:** If you disable this flag, the KallistiOS threading model (`kos`) will
-be unavailable. Also, this may be a problem if you still apply the KallistiOS
-patches. **Use this flag with care**.
-
-### Override GNU Download Mirror
-Set `gnu_mirror` to override the default of `ftpmirror.gnu.org` when you have
-a prefered mirror to download GNU sources from.
-
-## Usage
-
-After installing all the prerequisites and tweaking the configuration with the
-`config.mk` file, it's time to build the toolchains.
-
-### Making the toolchain
-
-Below you will find some generic instructions; you may find some specific
-instructions in the `./doc` directory for your environment.
-
-In the dc-chain directory, run (for **BSD**, please use `gmake` instead):
+In the dc-chain directory, you may run (for **BSD**, please use `gmake` instead):
 ```
 make
 ```
-This will build the ARM & SH4 toolchains. If you wish to only build the SH4
-toolchain and just use the prebuilt KOS sound driver run:
-    make build-sh4
-
-Depending of your environment, this can take a bunch of hours. So please be
-patient!
+This will build the `sh-elf` and `arm-eabi` toolchains. If you wish to only build
+the `sh-elf` toolchain and use the pre-built KOS sound driver, run:
+```
+make build-sh4
+```
+Depending on your hardware and environment, this process may take minutes to
+several hours, so please be patient!
 
 If anything goes wrong, check the output in `logs/`.
 
-### Making the GNU Debugger (gdb)
+## Building the GNU Debugger (gdb)
 
-For the `sh-elf` toolchain, if you want to use the **GNU Debugger** (`gdb`),
-you can make it by entering:
+For the `sh-elf` toolchain, if you want to use the **GNU Debugger** (`gdb`), you
+can build it by entering:
 ```
 make gdb
 ```
-This will install `gdb` in the `sh-elf` toolchain. `gdb` is used with
-`dcload/dc-tool` programs, which are part of **KallistiOS** too, in order to do
-remote debugging of your **Dreamcast** programs. Please read the `dcload`
-documentation to learn more on this point.
+This will install `gdb` in the `sh-elf` toolchain. `gdb` is used in conjunction
+with the `dcload/dc-tool` debug link utilities to perform remote debugging of
+**Dreamcast** programs. Further details can be found in the documentation for
+`dcload/dc-tool`.
 
-### Removing all useless files
+## Cleaning up files
 
-After the toolchain compilation, you can cleanup everything by entering:
+After the toolchain compilation, you may save space by cleaning up downloaded and
+temporary generated files by entering:
 ```
 make clean
 ```
-This will save a lot of space by removing all unnecessary files.
 
-## Final note
+## Finished
 
-Please see the comments at the top of the `config.mk` file for more build
-options. For example, if something goes wrong, you may restart the compilation
-of the problematic step only rather than running the whole process again.
+Once the toolchains have been compiled, you are ready to build KallistiOS itself.
+See the KallistiOS documentation for further instructions.
+
+## Addendum
 
 Interesting targets (you can `make` any of these):
 
-- `all`: `fetch` `patch` `build` (fetch, patch and build everything, excluding `gdb`)
+- `all`: `fetch` `patch` `build` (fetch, patch and build everything, excluding
+  `gdb`)
 - `fetch`: `fetch-sh4` `fetch-arm` `fetch-gdb`
 - `patch`: `patch-gcc` `patch-newlib` `patch-kos` (should be executed once)
 - `build`: `build-sh4` `build-arm` (build everything, excluding `gdb`)
-- `build-sh4`: `build-sh4-binutils` `build-sh4-gcc` (build only `sh-elf` toolchain, excluding `gdb`)
-- `build-arm`: `build-arm-binutils` `build-arm-gcc` (build only `arm-eabi` toolchain)
+- `build-sh4`: `build-sh4-binutils` `build-sh4-gcc` (build only `sh-elf`
+  toolchain, excluding `gdb`)
+- `build-arm`: `build-arm-binutils` `build-arm-gcc` (build only `arm-eabi`
+  toolchain)
 - `build-sh4-binutils` (build only `binutils` for `sh-elf`)
 - `build-arm-binutils` (build only `binutils` for `arm-eabi`)
-- `build-sh4-gcc`: `build-sh4-gcc-pass1` `build-sh4-newlib` `build-sh4-gcc-pass2` (build only `sh-elf-gcc` and `sh-elf-g++`)
+- `build-sh4-gcc`: `build-sh4-gcc-pass1` `build-sh4-newlib` `build-sh4-gcc-pass2`
+  (build only `sh-elf-gcc` and `sh-elf-g++`)
 - `build-arm-gcc`: `build-arm-gcc-pass1` (build only `arm-eabi-gcc`)
-- `build-sh4-newlib`: `build-sh4-newlib-only` `fixup-sh4-newlib` (build only `newlib` for `sh-elf`)
+- `build-sh4-newlib`: `build-sh4-newlib-only` `fixup-sh4-newlib` (build only
+  `newlib` for `sh-elf`)
 - `gdb` (build only `sh-elf-gdb`; it's never built automatically)

--- a/utils/dc-chain/config/README.md
+++ b/utils/dc-chain/config/README.md
@@ -1,0 +1,16 @@
+The available templates include the following configurations:
+
+| filename | sh4 gcc | newlib | sh4 binutils | arm gcc | arm binutils | notes |
+|---------:|:-------:|:----------:|:------------:|:-------:|:----------------:|:------|
+| config.mk.legacy.sample | 4.7.4 | 2.0.0 | 2.34 | 4.7.4 | 2.34 | older toolchain based on GCC 4<br />former "stable" / "legacy" configuration<br /> [some issues may happen in C++](https://dcemulation.org/phpBB/viewtopic.php?f=29&t=104724) |
+| config.mk.9.3.0.sample | 9.3.0 | 3.3.0 | 2.34 | 8.4.0 | 2.34 | older toolchain based on GCC 9<br />former "stable" configuration |
+| config.mk.10.5.0.sample | 10.5.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 10 |
+| config.mk.11.4.0.sample | 11.4.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 11 |
+| config.mk.12.3.0.sample | 12.3.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 12 |
+| **config.mk.stable.sample** | **13.2.0** | **4.3.0** | **2.41** | **8.5.0** | **2.41** | **modern toolchain with GCC 13**<br />**current "stable" configuration** |
+| config.mk.testing.sample | X | X | X | X | X | most recent GCC release<br />currently none in testing |
+| config.mk.devel.sample | git | 4.3.0 | 2.41 | 8.5.0 | 2.41 | latest dev version from git<br />builds as of 2023-07-30 |
+
+The **stable** configuration is the primary, widely tested target for KallistiOS, and is the most recent toolchain configuration known to work with all example programs. The **testing** configuration contains the most recent release of GCC that builds KallistiOS and the 2ndmix example, and is without any known major issues. The **legacy** configuration contains an older version of the toolchain that may be useful in compiling older software. The alternative configurations are maintained at a low priority and are not guaranteed to build, but feel free to open a bug report if issues are encountered building one of these configurations.
+
+Please note that if you choose to install an older version of the GCC compiler, you may be required to use older versions of some of the prerequisites in certain configurations. For instance, building GCC `4.7.4` may require an older version of the `flex` tool be installed. If you receive errors about tools you have installed, check your system's package manager for an older version of that tool. Depending on availability, it may not be possible to build older versions of the toolchain on your platform. 

--- a/utils/dc-chain/config/config.mk.10.5.0.sample
+++ b/utils/dc-chain/config/config.mk.10.5.0.sample
@@ -5,22 +5,11 @@
 # Initially adapted from Stalin's build script version 0.3.
 #
 
-# Interesting targets (you can 'make' any of these):
-# all: patch build
-# patch: patch-gcc patch-newlib patch-kos
-# build: build-sh4 build-arm
-# build-sh4: build-sh4-binutils build-sh4-gcc
-# build-arm: build-arm-binutils build-arm-gcc
-# build-sh4-gcc: build-sh4-gcc-pass1 build-sh4-newlib build-sh4-gcc-pass2
-# build-arm-gcc: build-arm-gcc-pass1
-# build-sh4-newlib: build-sh4-newlib-only fixup-sh4-newlib
-# gdb
-
 # Toolchain versions for SH
-sh_binutils_ver=2.34
-sh_gcc_ver=9.3.0
-newlib_ver=3.3.0
-gdb_ver=9.2
+sh_binutils_ver=2.41
+sh_gcc_ver=10.5.0
+newlib_ver=4.3.0.20230120
+gdb_ver=13.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz
@@ -29,33 +18,29 @@ newlib_download_type=gz
 gdb_download_type=xz
 
 # Toolchain for ARM
-# The ARM version of binutils/gcc is separated out as the particular CPU
-# versions we need may not be available in newer versions of GCC.
-arm_binutils_ver=2.34
-arm_gcc_ver=8.4.0
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
+arm_binutils_ver=2.41
+arm_gcc_ver=8.5.0
 
 # Tarball extensions to download for ARM
 arm_binutils_download_type=xz
 arm_gcc_download_type=xz
 
 # GCC custom dependencies
-# Specify here if you want to use custom GMP, MPFR and MPC libraries as they are
-# required when building GCC. If you leave this variable commented, all 
-# these dependencies will be automatically downloaded by using the provided 
-# '/contrib/download_prerequisites' shell script from the GCC packages, which is
-# recommended. The ISL dependency isn't mandatory; if you don't want it, you may 
-# just comment the version numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to
-# disable the ISL library.
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
 #use_custom_dependencies=1
 
-# Internal custom GCC libraries (i.e. GMP, MPFR, MPC and ISL) versions to use
-# only if the 'use_custom_dependencies' flag is set to '1'.
-
 # GCC dependencies for SH
-sh_gmp_ver=6.1.0
-sh_mpfr_ver=3.1.4
-sh_mpc_ver=1.0.3
-sh_isl_ver=0.18
+sh_gmp_ver=6.2.1
+sh_mpfr_ver=4.1.0
+sh_mpc_ver=1.2.1
+sh_isl_ver=0.24
 
 # Tarball extensions to download for GCC dependencies for SH
 sh_gmp_download_type=bz2
@@ -75,18 +60,40 @@ arm_mpfr_download_type=bz2
 arm_mpc_download_type=gz
 arm_isl_download_type=bz2
 
+# Download protocol (http|https|ftp)
+# Specify here the protocol you want to use for downloading the packages.
+download_protocol=https
+
+# Force downloader (curl|wget)
+# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
+# web downloader tool will be auto-detected in the following order: cURL, Wget.
+# You must have either Wget or cURL installed to use dc-chain.
+#force_downloader=wget
+
+# Specify GNU Mirror override
+# The default mirror for GNU sources is `ftpmirror.gnu.org`
+# Setting this will allow overriding the default mirror which
+# may be desirable if you have a prefered mirror.
+#gnu_mirror=mirrors.kernel.org
+
 # Toolchains base
 # Indicate the root directory where toolchains will be installed
 # This should match your 'environ.sh' configuration
 toolchains_base=/opt/toolchains/dc
 
+# Verbose (1|0)
+# Display output to screen as well as log files
+verbose=1
+
 # Erase (1|0)
 # Erase build directories on the fly to save space
 erase=1
 
-# Verbose (1|0)
-# Display output to screen as well as log files
-verbose=1
+# Install mode (install-strip|install)
+# Use 'install-strip' mode for removing debugging symbols of the toolchains.
+# Use 'install' only if you want to enable debug symbols for the toolchains.
+# This may be useful only if you plan to debug the toolchain itself.
+install_mode=install-strip
 
 # Make jobs (-jn|<empty>)
 # Set this value to -jn where n is the number of jobs you want to run with make.
@@ -105,16 +112,6 @@ makejobs=-j2
 # hard drive space.
 pass2_languages=c,c++,objc,obj-c++
 
-# Download protocol (http|https|ftp)
-# Specify here the protocol you want to use for downloading the packages.
-download_protocol=https
-
-# Force downloader (curl|wget)
-# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
-# web downloader tool will be auto-detected in the following order: cURL, Wget.
-# You must have either Wget or cURL installed to use dc-chain.
-#force_downloader=wget
-
 # GCC threading model (single|kos|posix*)
 # With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
 # should use it. If you really don't want threading support for C++ (or 
@@ -123,11 +120,17 @@ download_protocol=https
 # is not anymore supported.
 thread_model=kos
 
-# Install mode (install-strip|install)
-# Use 'install-strip' mode for removing debugging symbols of the toolchains.
-# Use 'install' only if you want to enable debug symbols for the toolchains.
-# This may be useful only if you plan to debug the toolchain itself.
-install_mode=install-strip
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
+# Automatic fixup SH-4 Newlib (1|0)
+# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
+# KallistiOS. This will keep the generated toolchain completely raw. This will
+# also disable the 'kos' thread model. Don't mess with that flag unless you know
+# exactly what you are doing.
+#auto_fixup_sh4_newlib=0
 
 # C99 Format Specifier Support (1|0)
 # Define this to build SH4 Newlib with additional support for the C99 format
@@ -148,18 +151,6 @@ install_mode=install-strip
 # environment. This is NOT recommended. Use it if you know what you are doing.
 #standalone_binary=1
 
-# Automatic fixup SH-4 Newlib (1|0)
-# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
-# KallistiOS. This will keep the generated toolchain completely raw. This will
-# also disable the 'kos' thread model. Don't mess with that flag unless you know
-# exactly what you are doing.
-#auto_fixup_sh4_newlib=0
-
-# Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
-#use_kos_patches=0
-
 # Force installation of BFD for SH (1|0)
 # Uncomment this if you want to force the installation of 'libbfd' for the SH
 # toolchain. This is required for MinGW/MSYS and can't be disabled in this
@@ -169,9 +160,3 @@ install_mode=install-strip
 # portable if you built it on another environment. Don't mess with that flag
 # unless you know exactly what you are doing.
 #sh_force_libbfd_installation=1
-
-# Specify GNU Mirror override
-# The default mirror for GNU sources is `ftpmirror.gnu.org`
-# Setting this will allow overriding the default mirror which
-# may be desirable if you have a prefered mirror.
-# gnu_mirror=mirrors.kernel.org

--- a/utils/dc-chain/config/config.mk.11.4.0.sample
+++ b/utils/dc-chain/config/config.mk.11.4.0.sample
@@ -1,0 +1,162 @@
+# Sega Dreamcast Toolchains Maker (dc-chain)
+# This file is part of KallistiOS.
+#
+# Created by Jim Ursetto (2004)
+# Initially adapted from Stalin's build script version 0.3.
+#
+
+# Toolchain versions for SH
+sh_binutils_ver=2.41
+sh_gcc_ver=11.4.0
+newlib_ver=4.3.0.20230120
+gdb_ver=13.2
+
+# Tarball extensions to download for SH
+sh_binutils_download_type=xz
+sh_gcc_download_type=xz
+newlib_download_type=gz
+gdb_download_type=xz
+
+# Toolchain for ARM
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
+arm_binutils_ver=2.41
+arm_gcc_ver=8.5.0
+
+# Tarball extensions to download for ARM
+arm_binutils_download_type=xz
+arm_gcc_download_type=xz
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies for SH
+sh_gmp_ver=6.2.1
+sh_mpfr_ver=4.1.0
+sh_mpc_ver=1.2.1
+sh_isl_ver=0.24
+
+# Tarball extensions to download for GCC dependencies for SH
+sh_gmp_download_type=bz2
+sh_mpfr_download_type=bz2
+sh_mpc_download_type=gz
+sh_isl_download_type=bz2
+
+# GCC dependencies for ARM
+arm_gmp_ver=6.1.0
+arm_mpfr_ver=3.1.4
+arm_mpc_ver=1.0.3
+arm_isl_ver=0.18
+
+# Tarball extensions to download for GCC dependencies for ARM
+arm_gmp_download_type=bz2
+arm_mpfr_download_type=bz2
+arm_mpc_download_type=gz
+arm_isl_download_type=bz2
+
+# Download protocol (http|https|ftp)
+# Specify here the protocol you want to use for downloading the packages.
+download_protocol=https
+
+# Force downloader (curl|wget)
+# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
+# web downloader tool will be auto-detected in the following order: cURL, Wget.
+# You must have either Wget or cURL installed to use dc-chain.
+#force_downloader=wget
+
+# Specify GNU Mirror override
+# The default mirror for GNU sources is `ftpmirror.gnu.org`
+# Setting this will allow overriding the default mirror which
+# may be desirable if you have a prefered mirror.
+#gnu_mirror=mirrors.kernel.org
+
+# Toolchains base
+# Indicate the root directory where toolchains will be installed
+# This should match your 'environ.sh' configuration
+toolchains_base=/opt/toolchains/dc
+
+# Verbose (1|0)
+# Display output to screen as well as log files
+verbose=1
+
+# Erase (1|0)
+# Erase build directories on the fly to save space
+erase=1
+
+# Install mode (install-strip|install)
+# Use 'install-strip' mode for removing debugging symbols of the toolchains.
+# Use 'install' only if you want to enable debug symbols for the toolchains.
+# This may be useful only if you plan to debug the toolchain itself.
+install_mode=install-strip
+
+# Make jobs (-jn|<empty>)
+# Set this value to -jn where n is the number of jobs you want to run with make.
+# If you only want one job, just set this to nothing (i.e, "makejobs=").
+# Tracking down problems with multiple make jobs is much more difficult than
+# with just one running at a time. So, if you run into trouble, then you should
+# clear this variable and try again with just one job running.
+# Please note, this value may be overriden in some cases; as issues were
+# detected on some OS.
+makejobs=-j2
+
+# Languages (c|c++|objc|obj-c++)
+# Set the languages to build for pass 2 of building gcc for sh-elf. The default
+# here is to build C, C++, Objective C, and Objective C++. You may want to take
+# out the latter two if you're not worried about them and/or you're short on
+# hard drive space.
+pass2_languages=c,c++,objc,obj-c++
+
+# GCC threading model (single|kos|posix*)
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
+# should use it. If you really don't want threading support for C++ (or 
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
+# is not anymore supported.
+thread_model=kos
+
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
+# Automatic fixup SH-4 Newlib (1|0)
+# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
+# KallistiOS. This will keep the generated toolchain completely raw. This will
+# also disable the 'kos' thread model. Don't mess with that flag unless you know
+# exactly what you are doing.
+#auto_fixup_sh4_newlib=0
+
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types.
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance.
+#newlib_opt_space=1
+
+# MinGW/MSYS
+# Standalone binaries (1|0)
+# Define this if you want a standalone, no dependency binaries (i.e. static)
+# When the binaries are standalone, it can be run outside MinGW/MSYS
+# environment. This is NOT recommended. Use it if you know what you are doing.
+#standalone_binary=1
+
+# Force installation of BFD for SH (1|0)
+# Uncomment this if you want to force the installation of 'libbfd' for the SH
+# toolchain. This is required for MinGW/MSYS and can't be disabled in this
+# scenario. This option is here mainly if you want to force the installation of
+# 'libbfd' under other environments; but this won't be necessary in most cases,
+# as 'libelf' is used almost everywhere. Please note, 'libbfd' couldn't be
+# portable if you built it on another environment. Don't mess with that flag
+# unless you know exactly what you are doing.
+#sh_force_libbfd_installation=1

--- a/utils/dc-chain/config/config.mk.12.3.0.sample
+++ b/utils/dc-chain/config/config.mk.12.3.0.sample
@@ -1,0 +1,162 @@
+# Sega Dreamcast Toolchains Maker (dc-chain)
+# This file is part of KallistiOS.
+#
+# Created by Jim Ursetto (2004)
+# Initially adapted from Stalin's build script version 0.3.
+#
+
+# Toolchain versions for SH
+sh_binutils_ver=2.41
+sh_gcc_ver=12.3.0
+newlib_ver=4.3.0.20230120
+gdb_ver=13.2
+
+# Tarball extensions to download for SH
+sh_binutils_download_type=xz
+sh_gcc_download_type=xz
+newlib_download_type=gz
+gdb_download_type=xz
+
+# Toolchain for ARM
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
+arm_binutils_ver=2.41
+arm_gcc_ver=8.5.0
+
+# Tarball extensions to download for ARM
+arm_binutils_download_type=xz
+arm_gcc_download_type=xz
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies for SH
+sh_gmp_ver=6.2.1
+sh_mpfr_ver=4.1.0
+sh_mpc_ver=1.2.1
+sh_isl_ver=0.24
+
+# Tarball extensions to download for GCC dependencies for SH
+sh_gmp_download_type=bz2
+sh_mpfr_download_type=bz2
+sh_mpc_download_type=gz
+sh_isl_download_type=bz2
+
+# GCC dependencies for ARM
+arm_gmp_ver=6.1.0
+arm_mpfr_ver=3.1.4
+arm_mpc_ver=1.0.3
+arm_isl_ver=0.18
+
+# Tarball extensions to download for GCC dependencies for ARM
+arm_gmp_download_type=bz2
+arm_mpfr_download_type=bz2
+arm_mpc_download_type=gz
+arm_isl_download_type=bz2
+
+# Download protocol (http|https|ftp)
+# Specify here the protocol you want to use for downloading the packages.
+download_protocol=https
+
+# Force downloader (curl|wget)
+# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
+# web downloader tool will be auto-detected in the following order: cURL, Wget.
+# You must have either Wget or cURL installed to use dc-chain.
+#force_downloader=wget
+
+# Specify GNU Mirror override
+# The default mirror for GNU sources is `ftpmirror.gnu.org`
+# Setting this will allow overriding the default mirror which
+# may be desirable if you have a prefered mirror.
+#gnu_mirror=mirrors.kernel.org
+
+# Toolchains base
+# Indicate the root directory where toolchains will be installed
+# This should match your 'environ.sh' configuration
+toolchains_base=/opt/toolchains/dc
+
+# Verbose (1|0)
+# Display output to screen as well as log files
+verbose=1
+
+# Erase (1|0)
+# Erase build directories on the fly to save space
+erase=1
+
+# Install mode (install-strip|install)
+# Use 'install-strip' mode for removing debugging symbols of the toolchains.
+# Use 'install' only if you want to enable debug symbols for the toolchains.
+# This may be useful only if you plan to debug the toolchain itself.
+install_mode=install-strip
+
+# Make jobs (-jn|<empty>)
+# Set this value to -jn where n is the number of jobs you want to run with make.
+# If you only want one job, just set this to nothing (i.e, "makejobs=").
+# Tracking down problems with multiple make jobs is much more difficult than
+# with just one running at a time. So, if you run into trouble, then you should
+# clear this variable and try again with just one job running.
+# Please note, this value may be overriden in some cases; as issues were
+# detected on some OS.
+makejobs=-j2
+
+# Languages (c|c++|objc|obj-c++)
+# Set the languages to build for pass 2 of building gcc for sh-elf. The default
+# here is to build C, C++, Objective C, and Objective C++. You may want to take
+# out the latter two if you're not worried about them and/or you're short on
+# hard drive space.
+pass2_languages=c,c++,objc,obj-c++
+
+# GCC threading model (single|kos|posix*)
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
+# should use it. If you really don't want threading support for C++ (or 
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
+# is not anymore supported.
+thread_model=kos
+
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
+# Automatic fixup SH-4 Newlib (1|0)
+# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
+# KallistiOS. This will keep the generated toolchain completely raw. This will
+# also disable the 'kos' thread model. Don't mess with that flag unless you know
+# exactly what you are doing.
+#auto_fixup_sh4_newlib=0
+
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types.
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance.
+#newlib_opt_space=1
+
+# MinGW/MSYS
+# Standalone binaries (1|0)
+# Define this if you want a standalone, no dependency binaries (i.e. static)
+# When the binaries are standalone, it can be run outside MinGW/MSYS
+# environment. This is NOT recommended. Use it if you know what you are doing.
+#standalone_binary=1
+
+# Force installation of BFD for SH (1|0)
+# Uncomment this if you want to force the installation of 'libbfd' for the SH
+# toolchain. This is required for MinGW/MSYS and can't be disabled in this
+# scenario. This option is here mainly if you want to force the installation of
+# 'libbfd' under other environments; but this won't be necessary in most cases,
+# as 'libelf' is used almost everywhere. Please note, 'libbfd' couldn't be
+# portable if you built it on another environment. Don't mess with that flag
+# unless you know exactly what you are doing.
+#sh_force_libbfd_installation=1

--- a/utils/dc-chain/config/config.mk.9.3.0.sample
+++ b/utils/dc-chain/config/config.mk.9.3.0.sample
@@ -5,57 +5,42 @@
 # Initially adapted from Stalin's build script version 0.3.
 #
 
-# Interesting targets (you can 'make' any of these):
-# all: patch build
-# patch: patch-gcc patch-newlib patch-kos
-# build: build-sh4 build-arm
-# build-sh4: build-sh4-binutils build-sh4-gcc
-# build-arm: build-arm-binutils build-arm-gcc
-# build-sh4-gcc: build-sh4-gcc-pass1 build-sh4-newlib build-sh4-gcc-pass2
-# build-arm-gcc: build-arm-gcc-pass1
-# build-sh4-newlib: build-sh4-newlib-only fixup-sh4-newlib
-# gdb
-
 # Toolchain versions for SH
 sh_binutils_ver=2.34
-sh_gcc_ver=4.7.4
-newlib_ver=2.0.0
+sh_gcc_ver=9.3.0
+newlib_ver=3.3.0
 gdb_ver=9.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz
-sh_gcc_download_type=bz2
+sh_gcc_download_type=xz
 newlib_download_type=gz
 gdb_download_type=xz
 
 # Toolchain for ARM
-# The ARM version of binutils/gcc is separated out as the particular CPU
-# versions we need may not be available in newer versions of GCC.
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
 arm_binutils_ver=2.34
-arm_gcc_ver=4.7.4
+arm_gcc_ver=8.4.0
 
 # Tarball extensions to download for ARM
 arm_binutils_download_type=xz
-arm_gcc_download_type=bz2
+arm_gcc_download_type=xz
 
 # GCC custom dependencies
-# Specify here if you want to use custom GMP, MPFR and MPC libraries as they are
-# required when building GCC. If you leave this variable commented, all 
-# these dependencies will be automatically downloaded by using the provided 
-# '/contrib/download_prerequisites' shell script from the GCC packages, which is
-# recommended. The ISL dependency isn't mandatory; if you don't want it, you may 
-# just comment the version numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to
-# disable the ISL library.
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
 #use_custom_dependencies=1
 
-# Internal custom GCC libraries (i.e. GMP, MPFR, MPC and ISL) versions to use
-# only if the 'use_custom_dependencies' flag is set to '1'.
-
 # GCC dependencies for SH
-sh_gmp_ver=4.3.2
-sh_mpfr_ver=2.4.2
-sh_mpc_ver=0.8.1
-#sh_isl_ver=0.18
+sh_gmp_ver=6.1.0
+sh_mpfr_ver=3.1.4
+sh_mpc_ver=1.0.3
+sh_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for SH
 sh_gmp_download_type=bz2
@@ -64,10 +49,10 @@ sh_mpc_download_type=gz
 sh_isl_download_type=bz2
 
 # GCC dependencies for ARM
-arm_gmp_ver=4.3.2
-arm_mpfr_ver=2.4.2
-arm_mpc_ver=0.8.1
-#arm_isl_ver=0.18
+arm_gmp_ver=6.1.0
+arm_mpfr_ver=3.1.4
+arm_mpc_ver=1.0.3
+arm_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for ARM
 arm_gmp_download_type=bz2
@@ -75,18 +60,40 @@ arm_mpfr_download_type=bz2
 arm_mpc_download_type=gz
 arm_isl_download_type=bz2
 
+# Download protocol (http|https|ftp)
+# Specify here the protocol you want to use for downloading the packages.
+download_protocol=https
+
+# Force downloader (curl|wget)
+# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
+# web downloader tool will be auto-detected in the following order: cURL, Wget.
+# You must have either Wget or cURL installed to use dc-chain.
+#force_downloader=wget
+
+# Specify GNU Mirror override
+# The default mirror for GNU sources is `ftpmirror.gnu.org`
+# Setting this will allow overriding the default mirror which
+# may be desirable if you have a prefered mirror.
+#gnu_mirror=mirrors.kernel.org
+
 # Toolchains base
 # Indicate the root directory where toolchains will be installed
 # This should match your 'environ.sh' configuration
 toolchains_base=/opt/toolchains/dc
 
+# Verbose (1|0)
+# Display output to screen as well as log files
+verbose=1
+
 # Erase (1|0)
 # Erase build directories on the fly to save space
 erase=1
 
-# Verbose (1|0)
-# Display output to screen as well as log files
-verbose=1
+# Install mode (install-strip|install)
+# Use 'install-strip' mode for removing debugging symbols of the toolchains.
+# Use 'install' only if you want to enable debug symbols for the toolchains.
+# This may be useful only if you plan to debug the toolchain itself.
+install_mode=install-strip
 
 # Make jobs (-jn|<empty>)
 # Set this value to -jn where n is the number of jobs you want to run with make.
@@ -105,16 +112,6 @@ makejobs=-j2
 # hard drive space.
 pass2_languages=c,c++,objc,obj-c++
 
-# Download protocol (http|https|ftp)
-# Specify here the protocol you want to use for downloading the packages.
-download_protocol=https
-
-# Force downloader (curl|wget)
-# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
-# web downloader tool will be auto-detected in the following order: cURL, Wget.
-# You must have either Wget or cURL installed to use dc-chain.
-#force_downloader=wget
-
 # GCC threading model (single|kos|posix*)
 # With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
 # should use it. If you really don't want threading support for C++ (or 
@@ -123,11 +120,17 @@ download_protocol=https
 # is not anymore supported.
 thread_model=kos
 
-# Install mode (install-strip|install)
-# Use 'install-strip' mode for removing debugging symbols of the toolchains.
-# Use 'install' only if you want to enable debug symbols for the toolchains.
-# This may be useful only if you plan to debug the toolchain itself.
-install_mode=install-strip
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
+# Automatic fixup SH-4 Newlib (1|0)
+# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
+# KallistiOS. This will keep the generated toolchain completely raw. This will
+# also disable the 'kos' thread model. Don't mess with that flag unless you know
+# exactly what you are doing.
+#auto_fixup_sh4_newlib=0
 
 # C99 Format Specifier Support (1|0)
 # Define this to build SH4 Newlib with additional support for the C99 format
@@ -148,17 +151,6 @@ install_mode=install-strip
 # environment. This is NOT recommended. Use it if you know what you are doing.
 #standalone_binary=1
 
-# Automatic fixup SH-4 Newlib (1|0)
-# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
-# KallistiOS. This will also disable the 'kos' thread model. Don't mess with that 
-# flag unless you know exactly what you are doing.
-#auto_fixup_sh4_newlib=0
-
-# Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
-#use_kos_patches=0
-
 # Force installation of BFD for SH (1|0)
 # Uncomment this if you want to force the installation of 'libbfd' for the SH
 # toolchain. This is required for MinGW/MSYS and can't be disabled in this
@@ -168,9 +160,3 @@ install_mode=install-strip
 # portable if you built it on another environment. Don't mess with that flag
 # unless you know exactly what you are doing.
 #sh_force_libbfd_installation=1
-
-# Specify GNU Mirror override
-# The default mirror for GNU sources is `ftpmirror.gnu.org`
-# Setting this will allow overriding the default mirror which
-# may be desirable if you have a prefered mirror.
-# gnu_mirror=mirrors.kernel.org

--- a/utils/dc-chain/config/config.mk.devel.sample
+++ b/utils/dc-chain/config/config.mk.devel.sample
@@ -1,0 +1,172 @@
+# Sega Dreamcast Toolchains Maker (dc-chain)
+# This file is part of KallistiOS.
+#
+# Created by Jim Ursetto (2004)
+# Initially adapted from Stalin's build script version 0.3.
+#
+
+###############################################################################
+###############################################################################
+### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2023-07-30.
+###############################################################################
+###############################################################################
+
+# Toolchain versions for SH
+sh_binutils_ver=2.41
+sh_gcc_ver=devel
+newlib_ver=4.3.0.20230120
+gdb_ver=13.2
+
+# Tarball extensions to download for SH
+sh_binutils_download_type=xz
+sh_gcc_download_type=git
+sh_gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+sh_gcc_git_branch=master
+newlib_download_type=gz
+gdb_download_type=xz
+
+# Toolchain for ARM
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
+arm_binutils_ver=2.41
+arm_gcc_ver=8.5.0
+
+# Tarball extensions to download for ARM
+arm_binutils_download_type=xz
+arm_gcc_download_type=xz
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies for SH
+sh_gmp_ver=6.2.1
+sh_mpfr_ver=4.1.0
+sh_mpc_ver=1.2.1
+sh_isl_ver=0.24
+
+# Tarball extensions to download for GCC dependencies for SH
+sh_gmp_download_type=bz2
+sh_mpfr_download_type=bz2
+sh_mpc_download_type=gz
+sh_isl_download_type=bz2
+
+# GCC dependencies for ARM
+arm_gmp_ver=6.1.0
+arm_mpfr_ver=3.1.4
+arm_mpc_ver=1.0.3
+arm_isl_ver=0.18
+
+# Tarball extensions to download for GCC dependencies for ARM
+arm_gmp_download_type=bz2
+arm_mpfr_download_type=bz2
+arm_mpc_download_type=gz
+arm_isl_download_type=bz2
+
+# Download protocol (http|https|ftp)
+# Specify here the protocol you want to use for downloading the packages.
+download_protocol=https
+
+# Force downloader (curl|wget)
+# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
+# web downloader tool will be auto-detected in the following order: cURL, Wget.
+# You must have either Wget or cURL installed to use dc-chain.
+#force_downloader=wget
+
+# Specify GNU Mirror override
+# The default mirror for GNU sources is `ftpmirror.gnu.org`
+# Setting this will allow overriding the default mirror which
+# may be desirable if you have a prefered mirror.
+#gnu_mirror=mirrors.kernel.org
+
+# Toolchains base
+# Indicate the root directory where toolchains will be installed
+# This should match your 'environ.sh' configuration
+toolchains_base=/opt/toolchains/dc
+
+# Verbose (1|0)
+# Display output to screen as well as log files
+verbose=1
+
+# Erase (1|0)
+# Erase build directories on the fly to save space
+erase=1
+
+# Install mode (install-strip|install)
+# Use 'install-strip' mode for removing debugging symbols of the toolchains.
+# Use 'install' only if you want to enable debug symbols for the toolchains.
+# This may be useful only if you plan to debug the toolchain itself.
+install_mode=install-strip
+
+# Make jobs (-jn|<empty>)
+# Set this value to -jn where n is the number of jobs you want to run with make.
+# If you only want one job, just set this to nothing (i.e, "makejobs=").
+# Tracking down problems with multiple make jobs is much more difficult than
+# with just one running at a time. So, if you run into trouble, then you should
+# clear this variable and try again with just one job running.
+# Please note, this value may be overriden in some cases; as issues were
+# detected on some OS.
+makejobs=-j2
+
+# Languages (c|c++|objc|obj-c++|rust)
+# Set the languages to build for pass 2 of building gcc for sh-elf. The default
+# here is to build C, C++, Objective-C, Objective-C++, and Rust. You may want
+# to take out some languages if you're not worried about them and/or you're
+# short on hard drive space. Only C is required to build KallistiOS, but some
+# included examples use other languages.
+pass2_languages=c,c++,objc,obj-c++,rust
+
+# GCC threading model (single|kos|posix*)
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
+# should use it. If you really don't want threading support for C++ (or 
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
+# is not anymore supported.
+thread_model=kos
+
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
+# Automatic fixup SH-4 Newlib (1|0)
+# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
+# KallistiOS. This will keep the generated toolchain completely raw. This will
+# also disable the 'kos' thread model. Don't mess with that flag unless you know
+# exactly what you are doing.
+#auto_fixup_sh4_newlib=0
+
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types.
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance.
+#newlib_opt_space=1
+
+# MinGW/MSYS
+# Standalone binaries (1|0)
+# Define this if you want a standalone, no dependency binaries (i.e. static)
+# When the binaries are standalone, it can be run outside MinGW/MSYS
+# environment. This is NOT recommended. Use it if you know what you are doing.
+#standalone_binary=1
+
+# Force installation of BFD for SH (1|0)
+# Uncomment this if you want to force the installation of 'libbfd' for the SH
+# toolchain. This is required for MinGW/MSYS and can't be disabled in this
+# scenario. This option is here mainly if you want to force the installation of
+# 'libbfd' under other environments; but this won't be necessary in most cases,
+# as 'libelf' is used almost everywhere. Please note, 'libbfd' couldn't be
+# portable if you built it on another environment. Don't mess with that flag
+# unless you know exactly what you are doing.
+#sh_force_libbfd_installation=1

--- a/utils/dc-chain/config/config.mk.legacy.sample
+++ b/utils/dc-chain/config/config.mk.legacy.sample
@@ -1,0 +1,162 @@
+# Sega Dreamcast Toolchains Maker (dc-chain)
+# This file is part of KallistiOS.
+#
+# Created by Jim Ursetto (2004)
+# Initially adapted from Stalin's build script version 0.3.
+#
+
+# Toolchain versions for SH
+sh_binutils_ver=2.34
+sh_gcc_ver=4.7.4
+newlib_ver=2.0.0
+gdb_ver=9.2
+
+# Tarball extensions to download for SH
+sh_binutils_download_type=xz
+sh_gcc_download_type=bz2
+newlib_download_type=gz
+gdb_download_type=xz
+
+# Toolchain for ARM
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
+arm_binutils_ver=2.34
+arm_gcc_ver=4.7.4
+
+# Tarball extensions to download for ARM
+arm_binutils_download_type=xz
+arm_gcc_download_type=bz2
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies for SH
+sh_gmp_ver=4.3.2
+sh_mpfr_ver=2.4.2
+sh_mpc_ver=0.8.1
+#sh_isl_ver=0.18
+
+# Tarball extensions to download for GCC dependencies for SH
+sh_gmp_download_type=bz2
+sh_mpfr_download_type=bz2
+sh_mpc_download_type=gz
+sh_isl_download_type=bz2
+
+# GCC dependencies for ARM
+arm_gmp_ver=4.3.2
+arm_mpfr_ver=2.4.2
+arm_mpc_ver=0.8.1
+#arm_isl_ver=0.18
+
+# Tarball extensions to download for GCC dependencies for ARM
+arm_gmp_download_type=bz2
+arm_mpfr_download_type=bz2
+arm_mpc_download_type=gz
+arm_isl_download_type=bz2
+
+# Download protocol (http|https|ftp)
+# Specify here the protocol you want to use for downloading the packages.
+download_protocol=https
+
+# Force downloader (curl|wget)
+# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
+# web downloader tool will be auto-detected in the following order: cURL, Wget.
+# You must have either Wget or cURL installed to use dc-chain.
+#force_downloader=wget
+
+# Specify GNU Mirror override
+# The default mirror for GNU sources is `ftpmirror.gnu.org`
+# Setting this will allow overriding the default mirror which
+# may be desirable if you have a prefered mirror.
+#gnu_mirror=mirrors.kernel.org
+
+# Toolchains base
+# Indicate the root directory where toolchains will be installed
+# This should match your 'environ.sh' configuration
+toolchains_base=/opt/toolchains/dc
+
+# Verbose (1|0)
+# Display output to screen as well as log files
+verbose=1
+
+# Erase (1|0)
+# Erase build directories on the fly to save space
+erase=1
+
+# Install mode (install-strip|install)
+# Use 'install-strip' mode for removing debugging symbols of the toolchains.
+# Use 'install' only if you want to enable debug symbols for the toolchains.
+# This may be useful only if you plan to debug the toolchain itself.
+install_mode=install-strip
+
+# Make jobs (-jn|<empty>)
+# Set this value to -jn where n is the number of jobs you want to run with make.
+# If you only want one job, just set this to nothing (i.e, "makejobs=").
+# Tracking down problems with multiple make jobs is much more difficult than
+# with just one running at a time. So, if you run into trouble, then you should
+# clear this variable and try again with just one job running.
+# Please note, this value may be overriden in some cases; as issues were
+# detected on some OS.
+makejobs=-j2
+
+# Languages (c|c++|objc|obj-c++)
+# Set the languages to build for pass 2 of building gcc for sh-elf. The default
+# here is to build C, C++, Objective C, and Objective C++. You may want to take
+# out the latter two if you're not worried about them and/or you're short on
+# hard drive space.
+pass2_languages=c,c++,objc,obj-c++
+
+# GCC threading model (single|kos|posix*)
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
+# should use it. If you really don't want threading support for C++ (or 
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
+# is not anymore supported.
+thread_model=kos
+
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
+# Automatic fixup SH-4 Newlib (1|0)
+# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
+# KallistiOS. This will keep the generated toolchain completely raw. This will
+# also disable the 'kos' thread model. Don't mess with that flag unless you know
+# exactly what you are doing.
+#auto_fixup_sh4_newlib=0
+
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types.
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance.
+#newlib_opt_space=1
+
+# MinGW/MSYS
+# Standalone binaries (1|0)
+# Define this if you want a standalone, no dependency binaries (i.e. static)
+# When the binaries are standalone, it can be run outside MinGW/MSYS
+# environment. This is NOT recommended. Use it if you know what you are doing.
+#standalone_binary=1
+
+# Force installation of BFD for SH (1|0)
+# Uncomment this if you want to force the installation of 'libbfd' for the SH
+# toolchain. This is required for MinGW/MSYS and can't be disabled in this
+# scenario. This option is here mainly if you want to force the installation of
+# 'libbfd' under other environments; but this won't be necessary in most cases,
+# as 'libelf' is used almost everywhere. Please note, 'libbfd' couldn't be
+# portable if you built it on another environment. Don't mess with that flag
+# unless you know exactly what you are doing.
+#sh_force_libbfd_installation=1

--- a/utils/dc-chain/config/config.mk.stable.sample
+++ b/utils/dc-chain/config/config.mk.stable.sample
@@ -5,19 +5,8 @@
 # Initially adapted from Stalin's build script version 0.3.
 #
 
-# Interesting targets (you can 'make' any of these):
-# all: patch build
-# patch: patch-gcc patch-newlib patch-kos
-# build: build-sh4 build-arm
-# build-sh4: build-sh4-binutils build-sh4-gcc
-# build-arm: build-arm-binutils build-arm-gcc
-# build-sh4-gcc: build-sh4-gcc-pass1 build-sh4-newlib build-sh4-gcc-pass2
-# build-arm-gcc: build-arm-gcc-pass1
-# build-sh4-newlib: build-sh4-newlib-only fixup-sh4-newlib
-# gdb
-
 # Toolchain versions for SH
-sh_binutils_ver=2.40
+sh_binutils_ver=2.41
 sh_gcc_ver=13.2.0
 newlib_ver=4.3.0.20230120
 gdb_ver=13.2
@@ -29,9 +18,9 @@ newlib_download_type=gz
 gdb_download_type=xz
 
 # Toolchain for ARM
-# The ARM version of binutils/gcc is separated out as the particular CPU
-# versions we need may not be available in newer versions of GCC.
-arm_binutils_ver=2.40
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
+arm_binutils_ver=2.41
 arm_gcc_ver=8.5.0
 
 # Tarball extensions to download for ARM
@@ -39,17 +28,13 @@ arm_binutils_download_type=xz
 arm_gcc_download_type=xz
 
 # GCC custom dependencies
-# Specify here if you want to use custom GMP, MPFR and MPC libraries as they are
-# required when building GCC. If you leave this variable commented, all 
-# these dependencies will be automatically downloaded by using the provided 
-# '/contrib/download_prerequisites' shell script from the GCC packages, which is
-# recommended. The ISL dependency isn't mandatory; if you don't want it, you may 
-# just comment the version numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to
-# disable the ISL library.
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
 #use_custom_dependencies=1
-
-# Internal custom GCC libraries (i.e. GMP, MPFR, MPC and ISL) versions to use
-# only if the 'use_custom_dependencies' flag is set to '1'.
 
 # GCC dependencies for SH
 sh_gmp_ver=6.2.1
@@ -75,18 +60,40 @@ arm_mpfr_download_type=bz2
 arm_mpc_download_type=gz
 arm_isl_download_type=bz2
 
+# Download protocol (http|https|ftp)
+# Specify here the protocol you want to use for downloading the packages.
+download_protocol=https
+
+# Force downloader (curl|wget)
+# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
+# web downloader tool will be auto-detected in the following order: cURL, Wget.
+# You must have either Wget or cURL installed to use dc-chain.
+#force_downloader=wget
+
+# Specify GNU Mirror override
+# The default mirror for GNU sources is `ftpmirror.gnu.org`
+# Setting this will allow overriding the default mirror which
+# may be desirable if you have a prefered mirror.
+#gnu_mirror=mirrors.kernel.org
+
 # Toolchains base
 # Indicate the root directory where toolchains will be installed
 # This should match your 'environ.sh' configuration
 toolchains_base=/opt/toolchains/dc
 
+# Verbose (1|0)
+# Display output to screen as well as log files
+verbose=1
+
 # Erase (1|0)
 # Erase build directories on the fly to save space
 erase=1
 
-# Verbose (1|0)
-# Display output to screen as well as log files
-verbose=1
+# Install mode (install-strip|install)
+# Use 'install-strip' mode for removing debugging symbols of the toolchains.
+# Use 'install' only if you want to enable debug symbols for the toolchains.
+# This may be useful only if you plan to debug the toolchain itself.
+install_mode=install-strip
 
 # Make jobs (-jn|<empty>)
 # Set this value to -jn where n is the number of jobs you want to run with make.
@@ -105,16 +112,6 @@ makejobs=-j2
 # hard drive space.
 pass2_languages=c,c++,objc,obj-c++
 
-# Download protocol (http|https|ftp)
-# Specify here the protocol you want to use for downloading the packages.
-download_protocol=https
-
-# Force downloader (curl|wget)
-# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
-# web downloader tool will be auto-detected in the following order: cURL, Wget.
-# You must have either Wget or cURL installed to use dc-chain.
-#force_downloader=wget
-
 # GCC threading model (single|kos|posix*)
 # With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
 # should use it. If you really don't want threading support for C++ (or 
@@ -123,11 +120,17 @@ download_protocol=https
 # is not anymore supported.
 thread_model=kos
 
-# Install mode (install-strip|install)
-# Use 'install-strip' mode for removing debugging symbols of the toolchains.
-# Use 'install' only if you want to enable debug symbols for the toolchains.
-# This may be useful only if you plan to debug the toolchain itself.
-install_mode=install-strip
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
+# Automatic fixup SH-4 Newlib (1|0)
+# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
+# KallistiOS. This will keep the generated toolchain completely raw. This will
+# also disable the 'kos' thread model. Don't mess with that flag unless you know
+# exactly what you are doing.
+#auto_fixup_sh4_newlib=0
 
 # C99 Format Specifier Support (1|0)
 # Define this to build SH4 Newlib with additional support for the C99 format
@@ -148,18 +151,6 @@ install_mode=install-strip
 # environment. This is NOT recommended. Use it if you know what you are doing.
 #standalone_binary=1
 
-# Automatic fixup SH-4 Newlib (1|0)
-# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
-# KallistiOS. This will keep the generated toolchain completely raw. This will
-# also disable the 'kos' thread model. Don't mess with that flag unless you know
-# exactly what you are doing.
-#auto_fixup_sh4_newlib=0
-
-# Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
-#use_kos_patches=0
-
 # Force installation of BFD for SH (1|0)
 # Uncomment this if you want to force the installation of 'libbfd' for the SH
 # toolchain. This is required for MinGW/MSYS and can't be disabled in this
@@ -169,9 +160,3 @@ install_mode=install-strip
 # portable if you built it on another environment. Don't mess with that flag
 # unless you know exactly what you are doing.
 #sh_force_libbfd_installation=1
-
-# Specify GNU Mirror override
-# The default mirror for GNU sources is `ftpmirror.gnu.org`
-# Setting this will allow overriding the default mirror which
-# may be desirable if you have a prefered mirror.
-# gnu_mirror=mirrors.kernel.org

--- a/utils/dc-chain/doc/CONTRIBUTORS.md
+++ b/utils/dc-chain/doc/CONTRIBUTORS.md
@@ -18,3 +18,4 @@
 * 2020 [Ben Baron](https://github.com/einsteinx2)
 * 2020 [Jon Daniel](https://github.com/jopadan)
 * 2023 [Colton Pawielski](https://github.com/cepawiel)
+* 2023 [Eric Fradella](https://github.com/darcagn)

--- a/utils/dc-chain/doc/changelog.txt
+++ b/utils/dc-chain/doc/changelog.txt
@@ -1,0 +1,175 @@
+2023-07-31: Update Binutils to 2.41. Verified no regressions in KOS examples compared to
+            current stable GCC 9.3.0, so promoting GCC 13.2.0 configuration to stable.
+            New config directory created to store alternative configurations, currently
+            including 4.7.4, 9.3.0, 10.5.0, 11.4.0, 13.2.0, and the latest development
+            version from git. Large revision of documentation. Updated Alpine
+            Dockerimage. (Eric Fradella)
+2023-07-27: Update GCC to 13.2.0 and GDB to 13.2. (Eric Fradella)
+2023-06-26: Fix an issue where patch stamps weren't getting deleted, add option to
+            make clean-keep-archives. (Eric Fradella)
+2023-06-06: Move Newlib 4.1.0 patch to historical folder as no configuration uses it.
+            (Donald Haase)
+2023-06-06: Update older Newlib patches to copy lock.h instead of patching it in. Adjust
+            patches to patching out syscalls as older Newlib versions do not support
+            the disable syscalls flag. (Donald Haase)
+2023-06-05: Change lock.h to get copied directly into Newlib and move lock.h patching
+            into patch.mk. (Donald Haase)
+2023-06-05: Fix patch.mk to add fetch dependency to sh4-fixup, fixing parallel building.
+            (Eric Fradella, Colton Pawielski)
+2023-06-04: Remove fake-kos, gthr-kos, and crt1 from GCC patches and copy them over from
+            file tree instead, reducing labor to generate GCC patches.
+            (Eric Fradella, Colton Pawielski)
+2023-06-03: Remove download/unpack/cleanup bash scripts and implement functionality
+            within Makefiles. (Colton Pawielski)
+2023-05-26: Set Newlib flag to disable syscalls instead of patching them out. Copy lock.h
+            instead of patching it in. Stop copying the DC include folder as it is
+            unneeded. (Donald Haase)
+2023-05-22: Update patches to fix libobjc Makefile so that library and headers are
+            properly installed with GCC. (Falco Girgis, Andrew Apperley, Eric Fradella)
+2023-05-20: Update GDB to use download_type variable in configuration. (Colton Pawielski)
+2023-05-15: Fix libobjc building after regression. (Eric Fradella)
+2023-05-15: Use mirrors instead of main GNU server for download sources. (James Peach)
+2023-05-14: Remove option to build insight as it no longer works. (Colton Pawielski)
+2023-05-13: Adjust GCC patches to allow sourcing stack address from C for both 16MB and
+            32MB stacks. (Paul Cercueil)
+2023-05-07: Fixed critical 'Access Violation' bug in Binutils 2.34 with LTO under MinGW. 
+            (SiZiOUS)
+2023-04-29: Add exit code as argument to dcload exit syscall. (Colton Pawielski)
+2023-04-27: Add ability to specify git repositories as download sources.
+            (Colton Pawielski)
+2023-04-25: Add support for Newlib configuration options newlib_c99_formats to enable
+            support for extended C99 format specifiers for printf and friends and
+            newlib_opt_space to enable building Newlib with size optimization enabled.
+            (Falco Girgis)
+2023-04-24: Add GCC 13.1.0 patch for SH toolchain under testing configuration.
+            (Eric Fradella)
+2023-04-19: Add GCC 8.5.0 patch for ARM toolchain under testing configuration.
+            (Eric Fradella)
+2023-04-03: Fix compilation of GDB under macOS. (Colton Pawielski)
+2023-03-23: Add use_kos_patches option to configuration to allow the building of fully
+            raw toolchains. (Colton Pawielski)
+2023-03-12: Separate pass1 and pass2 GCC build folders as using the same build folder for
+            both was causing an issue in pass 2 where gthr-kos.h file was failing to
+            replace gthr-default.h, causing issues threading support in GCC 9 and 12.
+            (Colton Pawielski).
+2023-03-11: Change arm-Darwin patches to run in addition to standard patches instead of
+            exclusively, bringing behavior in line with SiZiOUS's MinGW-w64 patches and
+            eliminating duplication of labor. (Eric Fradella)
+2023-03-04: Add gmp-dev to Dockerfile to fix GDB compilation. (Tchan0)
+2023-03-03: Add sh_force_libbfd_installation flag and remove libdep.a BFD plugin for
+            MinGW-w64. (SiZiOUS)
+2023-03-02: Merge Dockerfiles into one and allow building any of the three configurations
+            with the one Dockerfile using an argument. (Tchan0)
+2023-02-28: Update GDB version to 13.1 for testing configuration. (Eric Fradella)
+2023-02-27: Fix Dockerfile due to lack of --check option in sha512sum. (Tchan0)
+2023-02-26: Fix GCC 8.4.0 building under MinGW-w64. (SiZiOUS)
+2023-02-26: Fix Dockerfiles to specify python3 version and add missing endline continues.
+            (Tchan0)
+2023-02-24: Fix GCC 12.2.0 building under MinGW-w64/MSYS2. Adjust script to allow applying
+            several patch files at once. (SiZiOUS)
+2023-02-21: Update GCC dependency versions for "testing" configuration. (Falco Girgis)
+2023-02-04: Adjust configurations: 4.7.4 changes from "stable" to "legacy", 9.3.0 changes
+            from "testing" to "stable", 12.2.0 changes from "latest" to "testing".
+            (Falco Girgis)
+2023-02-04: Add patch for building GCC 12.2.0 on macOS. (Eric Fradella)
+2023-02-03: Add new "latest" configuration with new GCC 12.2.0 and Newlib 4.3.0 patches
+            and latest 2.40 Binutils version.
+            (Falco Girgis, Eric Fradella, Colton Pawielski)
+2023-01-04: Move old irrelevant GCC patches to historical folder. (Lawrence Sebald)
+2023-01-02: Add built-in __KOS_GCC_PATCHED__, __KOS_GCC_PATCHLEVEL__, and
+            __KOS_GCC_32MB__ defines to GCC to help track which KOS patches are applied to
+            GCC and which features may be patched in. Add support for detecting the
+            additional memory available in NAOMI systems and 32MB-modded Dreamcast
+            consoles and adjusting the stack pointer as necessary.
+            (Eric Fradella, Falco Girgis)
+2022-09-03: Fix for building under macOS with Apple Silicon processor. (Bemo)
+2022-08-25: Update readme to document that bash is the recommended shell for the download
+            and unpack scripts. (Lawrence Sebald)
+2022-08-17: Remove -J flag from cURL command in dc-chain. Update readme to mention
+            pitfalls of using older versions of toolchain. (Lawrence Sebald)
+2021-05-03: Fix download script to properly download Binutils for ARM. (7dog123)
+2021-02-25: Add stack protector stuff to Newlib 3.3.0 patch. (Lawrence Sebald)
+2020-09-22: Create separate "stable" (4.7.4) and "testing" (9.3.0) configurations.
+            (SiZiOUS)
+2020-08-31: Update dc-chain utility to work out of the box under many different
+            environments, including MinGW/MSYS, MinGW-w64/MSYS2, Cygin, Windows Subsystem
+            for Linux, macOS, Linux, and BSD. (SiZiOUS)
+2020-07-23: Fix Newlib 3.3.0 patch to use a sensible type for ino_t. (Lawrence Sebald)
+2020-04-07: Update to prefer curl over wget in download script. (Ben Baron)
+2020-04-06: Change GCC to install-strip to save hundreds of megabytes in space.
+            (Ben Baron)
+2020-04-05: Fix building GCC 9.3.0 with dependencies, update GMP, MPFR, MPC, and GDB
+            versions, fixed GDB clean in main Makefile. (Ben Baron)
+2020-04-03: Update GCC to 9.3.0, Binutils to 2.34, and Newlib to 3.3.0. Add support for
+            using different versions of GCC and Binutils for ARM due to GCC dropping
+            support for the AICA's ARM7DI core after GCC 8.x. GCC for ARM version bumped
+            to version 8.4.0. (Lawrence Sebald)
+2020-03-26: Add 4.7.4 patch with concurrence error fix, remove broken 4.7.3 patch.
+            (Luke Benstead)
+2019-07-17: Update download scripts to prefer HTTPS over FTP (Ellen Marie Dash)
+2018-09-18: Update Binutils version to 2.31.1. (Lawrence Sebald)
+2017-01-17: Make dc-chain not fail if patches have already been applied. (Lawrence Sebald)
+2016-12-11: Update GCC patch to make it compatible with newer makeinfo versions.
+            (Lawrence Sebald)
+2016-10-01: Update Binutils to 2.27.
+2016-09-22: Add cleanup.sh script. (Lawrence Sebald)
+2016-07-01: Update GDB to 7.11.1 and insight to 6.8 due to previous versions being
+            removed. Add more files to be cleaned up related to GDB/insight in the make
+            clean target. (Corbin, Nia, Lawrence Sebald)
+2016-01-14: Fix compiling GCC 4.7.3 with a host GCC version of 5.x and above.
+            (Luke Benstead)
+2014-12-05: Fix for systems using "gmake" instead of "make". Add --disable-werror to GDB
+            and insight configure arguments. (Christian Groessler)
+2014-04-30: Use GMP, MPC, and MPFR versions hosted and recommended by GCC developers.
+            (Lawrence Sebald)
+2014-02-17: Roll back to GCC 4.7.3 due to performance regressions in 4.8.x. Add a flag
+            to download/unpack scripts to not download and set up GCC dependencies in case
+            they are installed separately. (Lawrence Sebald)
+2013-12-06: Bump GCC back to 4.8.2 as issue should be fixed in KOS commit c2bdfac.
+            (Lawrence Sebald)
+2013-12-06: Rolling back GCC to 4.7.3 due to issues reported with 4.8.2 at
+            http://dcemulation.org/phpBB/viewtopic.php?f=29&t=102800. (Lawrence Sebald)
+2013-11-17: Update GCC to 4.8.2, automatically build GCC dependencies with GCC, add fix
+            for Mac OS X Mavericks. (Lawrence Sebald)
+2013-11-10: Remove --disable-werror to allow successful building with Clang.
+            (Lawrence Sebald)
+2013-05-30: Minor adjustments to Makefile: Get rid of #!, remove cd and add -d, remove +x
+            bit on the file. (Lawrence Sebald)
+2013-05-18: Update Binutils to 2.23.2, GCC to 4.7.3, Newlib to 2.0.0. Add makejobs
+            variable to allow multiple jobs to build. Fix issue causing Makefile to not
+            fail when verbose set to 1 and one of the jobs failed. (Lawrence Sebald)
+2012-07-08: Modify Makefile to allow KallistiOS to be in root folder other than 'kos'.
+            (Donald Haase)
+2012-07-06: Fix a possible parallel build issue. (Harley Laue)
+2012-06-11: Update GCC 4.5.2 and 4.7.0 patches. Make GCC 4.7.0 default now due to working
+            patches. (Lawrence Sebald)
+2012-06-10: Fix the GCC 4.5.2 patch so that GCC will actually compile. Building a new
+            toolchain is not recommended at the moment, as the patch is still using
+            deprecated functions. (Lawrence Sebald)
+2012-06-09: Revert to GCC 4.5.2 due to bug with frame pointers in sh-elf on GCC 4.7.0.
+            (Lawrence Sebald)
+2012-06-05: Add patches for GCC 4.7.0 and Newlib 1.12.0 and make them default.
+            (Lawrence Sebald)
+2011-12-11: Update Binutils to 2.22 due to 2.21 disappearing from GNU FTP.
+            (Lawrence Sebald)
+2011-01-31: Update dc-chain version to 0.3, add note to note use multiple jobs with make.
+            (Lawrence Sebald)
+2011-01-09: Binutils updated to 2.21, GCC to 4.5.2, and Newlib to 1.19.0.
+            (Lawrence Sebald)
+2011-01-08: Add in patches for GCC 4.5.2 and Newlib 1.19.0. These are updated for all
+            the new stuff in the KOS thread code. (Lawrence Sebald)
+2010-08-21: Add init fini patch to Newlib. (Cyle Terry, Lawrence Sebald)
+2010-05-15: Adding patches to support GCC 4.4.0 and 4.4.4, add patch to support
+            Newlib 1.18.0. Add cond_wait_recursive and cond_wait_timed_recursive (for GCC
+            4.4.4's C++0x threading support). Add _isatty_r function, as needed by
+            Newlib 1.18.0. (Lawrence Sebald)
+2010-04-10: Make Newlib 1.15.0 default as it is now required by KOS (Harley Laue)
+2008-05-21: Adjust DESTDIR. (Cyle Terry)
+2008-05-02: Revert default Newlib to 1.12.0 due to instability with 1.15.0. (Cyle Terry)
+2008-04-14: Update Newlib patch for Newlib 1.15.0. (Atani)
+2008-03-09: Adjust Newlib 1.12.0 patch. (Lawrence Sebald)
+2008-02-16: Add support for building GDB and insight. (Sam Steele, Christian Henz)
+2007-07-18: Update Binutils to 2.17 to fix GCC 4.x compilation. (Atani)
+2007-07-18: Update default paths. (Atani)
+2006-11-24: Fix commented out paths in dc-chain. (Megan Potter, Christian Henz)
+2006-09-17: dc-chain 0.1 added to KOS utils tree with GCC 3.4.6. (Megan Potter)

--- a/utils/dc-chain/docker/Dockerfile
+++ b/utils/dc-chain/docker/Dockerfile
@@ -4,8 +4,7 @@
 # usage:
 #   - build one of the images:
 #       docker build -t dcchain:latest . 
-#       docker build -t dcchain:testing --build-arg dc_chain=testing . 
-#       docker build -t dcchain:bleeding --build-arg dc_chain=bleeding . 
+#       docker build -t dcchain:stable --build-arg dc_chain=stable .
 #       docker build -t dcchain:legacy --build-arg dc_chain=legacy . 
 #   - create and run a container, eg for latest:
 #       docker run -it --name containername dcchain:latest /bin/bash
@@ -15,7 +14,6 @@ FROM alpine:latest as build
 MAINTAINER KallistiOS <cadcdev-kallistios@lists.sourceforge.net>
 
 # Installing prerequisites
-# Note: libelf-dev is not available in main repository, so we use the v3.9 package
 RUN apk --update add --no-cache \
 	build-base \
 	patch \
@@ -29,7 +27,7 @@ RUN apk --update add --no-cache \
 	python3 \
 	subversion \
 	gmp-dev \
-	&& apk --update add --no-cache libelf-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.9/main \
+	elfutils-dev \
 	&& rm -rf /var/cache/apk/*
 
 # Making Sega Dreamcast toolchains
@@ -38,9 +36,9 @@ ARG dc_chain=stable
 RUN mkdir -p /opt/toolchains/dc \
 	&& git clone https://git.code.sf.net/p/cadcdev/kallistios /opt/toolchains/dc/kos \
 	&& cd /opt/toolchains/dc/kos/utils/dc-chain \
-	&& cp config.mk.$dc_chain.sample config.mk \
+	&& cp config/config.mk.$dc_chain.sample config.mk \
 	&& sed -i -e 's/#use_custom_dependencies=1/use_custom_dependencies=1/g' config.mk \
-	&& ./download.sh && ./unpack.sh && make && make gdb \
+	&& make && make gdb \
 	&& rm -rf /opt/toolchains/dc/kos
 
 # Stage 2

--- a/utils/dc-chain/patches/gcc-10.5.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-10.5.0-kos.diff
@@ -1,0 +1,184 @@
+diff --color -ruN gcc-10.5.0/gcc/config/sh/sh-c.c gcc-10.5.0-kos/gcc/config/sh/sh-c.c
+--- gcc-10.5.0/gcc/config/sh/sh-c.c	2023-06-05 16:32:30.829538181 -0500
++++ gcc-10.5.0-kos/gcc/config/sh/sh-c.c	2023-06-05 16:32:33.202546142 -0500
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff --color -ruN gcc-10.5.0/gcc/config/sh/sh_treg_combine.cc gcc-10.5.0-kos/gcc/config/sh/sh_treg_combine.cc
+--- gcc-10.5.0/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:32:30.830538184 -0500
++++ gcc-10.5.0-kos/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:32:33.202546142 -0500
+@@ -37,6 +37,7 @@
+ #include "cfgrtl.h"
+ #include "tree-pass.h"
+ #include "expr.h"
++#include "tm-preds.h"
+ 
+ /*
+ This pass tries to optimize for example this:
+@@ -426,10 +427,6 @@
+   return GET_CODE (p) == SET && GET_CODE (XEXP (p, 1)) == IF_THEN_ELSE;
+ }
+ 
+-// FIXME: Remove dependency on SH predicate function somehow.
+-extern int t_reg_operand (rtx, machine_mode);
+-extern int negt_reg_operand (rtx, machine_mode);
+-
+ // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ // RTL pass class
+ 
+diff --color -ruN gcc-10.5.0/gcc/configure gcc-10.5.0-kos/gcc/configure
+--- gcc-10.5.0/gcc/configure	2023-06-05 16:32:32.916545183 -0500
++++ gcc-10.5.0-kos/gcc/configure	2023-06-05 16:32:33.204546149 -0500
+@@ -12255,7 +12255,7 @@
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32)
++  single | tpf | vxworks | win32 | kos)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff --color -ruN gcc-10.5.0/libgcc/config/sh/t-sh gcc-10.5.0-kos/libgcc/config/sh/t-sh
+--- gcc-10.5.0/libgcc/config/sh/t-sh	2023-06-05 16:32:30.171535973 -0500
++++ gcc-10.5.0-kos/libgcc/config/sh/t-sh	2023-06-05 16:32:33.205546152 -0500
+@@ -23,6 +23,8 @@
+   $(LIB1ASMFUNCS_CACHE)
+ LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
+ 
++LIB2ADD = $(srcdir)/config/sh/fake-kos.S
++
+ crt1.o: $(srcdir)/config/sh/crt1.S
+ 	$(gcc_compile) -c $<
+ 
+diff --color -ruN gcc-10.5.0/libgcc/configure gcc-10.5.0-kos/libgcc/configure
+--- gcc-10.5.0/libgcc/configure	2023-06-05 16:32:30.202536077 -0500
++++ gcc-10.5.0-kos/libgcc/configure	2023-06-05 16:32:33.209546166 -0500
+@@ -5649,6 +5649,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)    thread_header=config/sh/gthr-kos.h ;;
+ esac
+ 
+ 
+diff --color -ruN gcc-10.5.0/libobjc/configure gcc-10.5.0-kos/libobjc/configure
+--- gcc-10.5.0/libobjc/configure	2023-06-05 16:32:30.204536084 -0500
++++ gcc-10.5.0-kos/libobjc/configure	2023-06-05 16:32:33.211546172 -0500
+@@ -2917,11 +2917,9 @@
+ 
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#include <stdio.h>
+ int
+ main ()
+ {
+-printf ("hello world\n");
+   ;
+   return 0;
+ }
+diff --color -ruN gcc-10.5.0/libobjc/Makefile.in gcc-10.5.0-kos/libobjc/Makefile.in
+--- gcc-10.5.0/libobjc/Makefile.in	2023-06-05 16:32:30.203536081 -0500
++++ gcc-10.5.0-kos/libobjc/Makefile.in	2023-06-05 16:32:33.211546172 -0500
+@@ -308,14 +308,16 @@
+ $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
+ 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+ 
+-install: install-libs install-headers
++install-strip: INSTALL_STRIP_FLAG = -s
++install install-strip: install-libs install-headers
+ 
+ install-libs: installdirs
+ 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
+-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
++	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+ 	if [ "$(OBJC_BOEHM_GC)" ]; then \
+-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
+-				$(DESTDIR)$(toolexeclibdir);\
++	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
+ 	fi
+ 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
+ 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
+@@ -328,7 +330,7 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
+diff --color -ruN gcc-10.5.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-10.5.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-10.5.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:32:30.398536735 -0500
++++ gcc-10.5.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:32:33.211546172 -0500
+@@ -22,14 +22,40 @@
+ // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ // <http://www.gnu.org/licenses/>.
+ 
+-// Use the default atomicity stuff, which will use __atomic* builtins
+-// if threads are available, or the *_single functions on single-thread
+-// configurations.
+-// Actually we wouldn't need this header at all, but because of PR 53579
+-// libstdc++'s configury will not pickup the -matomic-model= option when
+-// set in the environment.  This makes it impossible to enable the proper
+-// atomic model on SH without modifying GCC itself, because libstdc++ always
+-// thinks the target doesn't do any atomics and uses the default mutex based
+-// implementation from cpu/generic/atomicity_mutex.
++/* This is generic/atomicity.h */
+ 
+ #include <ext/atomicity.h>
++#include <ext/concurrence.h>
++
++namespace 
++{
++  __gnu_cxx::__mutex&
++  get_atomic_mutex()
++  {
++    static __gnu_cxx::__mutex atomic_mutex;
++    return atomic_mutex;
++  }
++} // anonymous namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val) throw ()
++  {
++    __gnu_cxx::__scoped_lock sentry(get_atomic_mutex());
++    _Atomic_word __result;
++    __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word* __mem, int __val) throw ()
++  { __exchange_and_add(__mem, __val); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --color -ruN gcc-10.5.0/libstdc++-v3/configure gcc-10.5.0-kos/libstdc++-v3/configure
+--- gcc-10.5.0/libstdc++-v3/configure	2023-06-05 16:32:30.729537845 -0500
++++ gcc-10.5.0-kos/libstdc++-v3/configure	2023-06-05 16:32:33.218546196 -0500
+@@ -15648,6 +15648,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)    thread_header=config/sh/gthr-kos.h ;;
+ esac
+ 
+ 

--- a/utils/dc-chain/patches/gcc-11.4.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-11.4.0-kos.diff
@@ -1,0 +1,184 @@
+diff --color -ruN gcc-11.4.0/gcc/config/sh/sh-c.c gcc-11.4.0-kos/gcc/config/sh/sh-c.c
+--- gcc-11.4.0/gcc/config/sh/sh-c.c	2023-06-05 16:36:14.199287582 -0500
++++ gcc-11.4.0-kos/gcc/config/sh/sh-c.c	2023-06-05 16:36:16.723296050 -0500
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff --color -ruN gcc-11.4.0/gcc/config/sh/sh_treg_combine.cc gcc-11.4.0-kos/gcc/config/sh/sh_treg_combine.cc
+--- gcc-11.4.0/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:36:14.199287582 -0500
++++ gcc-11.4.0-kos/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:36:16.724296054 -0500
+@@ -37,6 +37,7 @@
+ #include "cfgrtl.h"
+ #include "tree-pass.h"
+ #include "expr.h"
++#include "tm-preds.h"
+ 
+ /*
+ This pass tries to optimize for example this:
+@@ -426,10 +427,6 @@
+   return GET_CODE (p) == SET && GET_CODE (XEXP (p, 1)) == IF_THEN_ELSE;
+ }
+ 
+-// FIXME: Remove dependency on SH predicate function somehow.
+-extern int t_reg_operand (rtx, machine_mode);
+-extern int negt_reg_operand (rtx, machine_mode);
+-
+ // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ // RTL pass class
+ 
+diff --color -ruN gcc-11.4.0/gcc/configure gcc-11.4.0-kos/gcc/configure
+--- gcc-11.4.0/gcc/configure	2023-06-05 16:36:16.428295060 -0500
++++ gcc-11.4.0-kos/gcc/configure	2023-06-05 16:36:16.726296060 -0500
+@@ -12635,7 +12635,7 @@
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32)
++  single | tpf | vxworks | win32 | kos)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff --color -ruN gcc-11.4.0/libgcc/config/sh/t-sh gcc-11.4.0-kos/libgcc/config/sh/t-sh
+--- gcc-11.4.0/libgcc/config/sh/t-sh	2023-06-05 16:36:13.515285288 -0500
++++ gcc-11.4.0-kos/libgcc/config/sh/t-sh	2023-06-05 16:36:16.726296060 -0500
+@@ -23,6 +23,8 @@
+   $(LIB1ASMFUNCS_CACHE)
+ LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
+ 
++LIB2ADD = $(srcdir)/config/sh/fake-kos.S
++
+ crt1.o: $(srcdir)/config/sh/crt1.S
+ 	$(gcc_compile) -c $<
+ 
+diff --color -ruN gcc-11.4.0/libgcc/configure gcc-11.4.0-kos/libgcc/configure
+--- gcc-11.4.0/libgcc/configure	2023-06-05 16:36:13.547285395 -0500
++++ gcc-11.4.0-kos/libgcc/configure	2023-06-05 16:36:16.727296064 -0500
+@@ -5688,6 +5688,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)    thread_header=config/sh/gthr-kos.h ;;
+ esac
+ 
+ 
+diff --color -ruN gcc-11.4.0/libobjc/configure gcc-11.4.0-kos/libobjc/configure
+--- gcc-11.4.0/libobjc/configure	2023-06-05 16:36:13.230284332 -0500
++++ gcc-11.4.0-kos/libobjc/configure	2023-06-05 16:36:16.728296067 -0500
+@@ -2917,11 +2917,9 @@
+ 
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#include <stdio.h>
+ int
+ main ()
+ {
+-printf ("hello world\n");
+   ;
+   return 0;
+ }
+diff --color -ruN gcc-11.4.0/libobjc/Makefile.in gcc-11.4.0-kos/libobjc/Makefile.in
+--- gcc-11.4.0/libobjc/Makefile.in	2023-06-05 16:36:13.229284328 -0500
++++ gcc-11.4.0-kos/libobjc/Makefile.in	2023-06-05 16:36:16.728296067 -0500
+@@ -308,14 +308,16 @@
+ $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
+ 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+ 
+-install: install-libs install-headers
++install-strip: INSTALL_STRIP_FLAG = -s
++install install-strip: install-libs install-headers
+ 
+ install-libs: installdirs
+ 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
+-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
++	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+ 	if [ "$(OBJC_BOEHM_GC)" ]; then \
+-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
+-				$(DESTDIR)$(toolexeclibdir);\
++	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
+ 	fi
+ 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
+ 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
+@@ -328,7 +330,7 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
+diff --color -ruN gcc-11.4.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-11.4.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-11.4.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:36:13.754286089 -0500
++++ gcc-11.4.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:36:16.728296067 -0500
+@@ -22,14 +22,40 @@
+ // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ // <http://www.gnu.org/licenses/>.
+ 
+-// Use the default atomicity stuff, which will use __atomic* builtins
+-// if threads are available, or the *_single functions on single-thread
+-// configurations.
+-// Actually we wouldn't need this header at all, but because of PR 53579
+-// libstdc++'s configury will not pickup the -matomic-model= option when
+-// set in the environment.  This makes it impossible to enable the proper
+-// atomic model on SH without modifying GCC itself, because libstdc++ always
+-// thinks the target doesn't do any atomics and uses the default mutex based
+-// implementation from cpu/generic/atomicity_mutex.
++/* This is generic/atomicity.h */
+ 
+ #include <ext/atomicity.h>
++#include <ext/concurrence.h>
++
++namespace 
++{
++  __gnu_cxx::__mutex&
++  get_atomic_mutex()
++  {
++    static __gnu_cxx::__mutex atomic_mutex;
++    return atomic_mutex;
++  }
++} // anonymous namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val) throw ()
++  {
++    __gnu_cxx::__scoped_lock sentry(get_atomic_mutex());
++    _Atomic_word __result;
++    __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word* __mem, int __val) throw ()
++  { __exchange_and_add(__mem, __val); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --color -ruN gcc-11.4.0/libstdc++-v3/configure gcc-11.4.0-kos/libstdc++-v3/configure
+--- gcc-11.4.0/libstdc++-v3/configure	2023-06-05 16:36:14.088287210 -0500
++++ gcc-11.4.0-kos/libstdc++-v3/configure	2023-06-05 16:36:16.733296084 -0500
+@@ -15753,6 +15753,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)    thread_header=config/sh/gthr-kos.h ;;
+ esac
+ 
+ 

--- a/utils/dc-chain/patches/gcc-12.3.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-12.3.0-kos.diff
@@ -1,0 +1,184 @@
+diff --color -ruN gcc-12.3.0/gcc/config/sh/sh-c.cc gcc-12.3.0-kos/gcc/config/sh/sh-c.cc
+--- gcc-12.3.0/gcc/config/sh/sh-c.cc	2023-06-05 16:40:30.114092324 -0500
++++ gcc-12.3.0-kos/gcc/config/sh/sh-c.cc	2023-06-05 16:40:33.324101836 -0500
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff --color -ruN gcc-12.3.0/gcc/config/sh/sh_treg_combine.cc gcc-12.3.0-kos/gcc/config/sh/sh_treg_combine.cc
+--- gcc-12.3.0/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:40:30.113092321 -0500
++++ gcc-12.3.0-kos/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:40:33.325101839 -0500
+@@ -37,6 +37,7 @@
+ #include "cfgrtl.h"
+ #include "tree-pass.h"
+ #include "expr.h"
++#include "tm-preds.h"
+ 
+ /*
+ This pass tries to optimize for example this:
+@@ -426,10 +427,6 @@
+   return GET_CODE (p) == SET && GET_CODE (XEXP (p, 1)) == IF_THEN_ELSE;
+ }
+ 
+-// FIXME: Remove dependency on SH predicate function somehow.
+-extern int t_reg_operand (rtx, machine_mode);
+-extern int negt_reg_operand (rtx, machine_mode);
+-
+ // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ // RTL pass class
+ 
+diff --color -ruN gcc-12.3.0/gcc/configure gcc-12.3.0-kos/gcc/configure
+--- gcc-12.3.0/gcc/configure	2023-06-05 16:40:32.624099762 -0500
++++ gcc-12.3.0-kos/gcc/configure	2023-06-05 16:40:33.327101845 -0500
+@@ -12885,7 +12885,7 @@
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32)
++  single | tpf | vxworks | win32 | kos)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff --color -ruN gcc-12.3.0/libgcc/config/sh/t-sh gcc-12.3.0-kos/libgcc/config/sh/t-sh
+--- gcc-12.3.0/libgcc/config/sh/t-sh	2023-06-05 16:40:32.839100399 -0500
++++ gcc-12.3.0-kos/libgcc/config/sh/t-sh	2023-06-05 16:40:33.327101845 -0500
+@@ -23,6 +23,8 @@
+   $(LIB1ASMFUNCS_CACHE)
+ LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
+ 
++LIB2ADD = $(srcdir)/config/sh/fake-kos.S
++
+ crt1.o: $(srcdir)/config/sh/crt1.S
+ 	$(gcc_compile) -c $<
+ 
+diff --color -ruN gcc-12.3.0/libgcc/configure gcc-12.3.0-kos/libgcc/configure
+--- gcc-12.3.0/libgcc/configure	2023-06-05 16:40:32.844100414 -0500
++++ gcc-12.3.0-kos/libgcc/configure	2023-06-05 16:40:33.327101845 -0500
+@@ -5698,6 +5698,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)    thread_header=config/sh/gthr-kos.h ;;
+ esac
+ 
+ 
+diff --color -ruN gcc-12.3.0/libobjc/configure gcc-12.3.0-kos/libobjc/configure
+--- gcc-12.3.0/libobjc/configure	2023-06-05 16:40:29.860091572 -0500
++++ gcc-12.3.0-kos/libobjc/configure	2023-06-05 16:40:33.328101848 -0500
+@@ -2917,11 +2917,9 @@
+ 
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#include <stdio.h>
+ int
+ main ()
+ {
+-printf ("hello world\n");
+   ;
+   return 0;
+ }
+diff --color -ruN gcc-12.3.0/libobjc/Makefile.in gcc-12.3.0-kos/libobjc/Makefile.in
+--- gcc-12.3.0/libobjc/Makefile.in	2023-06-05 16:40:29.859091569 -0500
++++ gcc-12.3.0-kos/libobjc/Makefile.in	2023-06-05 16:40:33.328101848 -0500
+@@ -308,14 +308,16 @@
+ $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
+ 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+ 
+-install: install-libs install-headers
++install-strip: INSTALL_STRIP_FLAG = -s
++install install-strip: install-libs install-headers
+ 
+ install-libs: installdirs
+ 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
+-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
++	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+ 	if [ "$(OBJC_BOEHM_GC)" ]; then \
+-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
+-				$(DESTDIR)$(toolexeclibdir);\
++	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
+ 	fi
+ 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
+ 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
+@@ -328,7 +330,7 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
+diff --color -ruN gcc-12.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-12.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-12.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:40:33.196101457 -0500
++++ gcc-12.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:40:33.328101848 -0500
+@@ -22,14 +22,40 @@
+ // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ // <http://www.gnu.org/licenses/>.
+ 
+-// Use the default atomicity stuff, which will use __atomic* builtins
+-// if threads are available, or the *_single functions on single-thread
+-// configurations.
+-// Actually we wouldn't need this header at all, but because of PR 53579
+-// libstdc++'s configury will not pickup the -matomic-model= option when
+-// set in the environment.  This makes it impossible to enable the proper
+-// atomic model on SH without modifying GCC itself, because libstdc++ always
+-// thinks the target doesn't do any atomics and uses the default mutex based
+-// implementation from cpu/generic/atomicity_mutex.
++/* This is generic/atomicity.h */
+ 
+ #include <ext/atomicity.h>
++#include <ext/concurrence.h>
++
++namespace 
++{
++  __gnu_cxx::__mutex&
++  get_atomic_mutex()
++  {
++    static __gnu_cxx::__mutex atomic_mutex;
++    return atomic_mutex;
++  }
++} // anonymous namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val) throw ()
++  {
++    __gnu_cxx::__scoped_lock sentry(get_atomic_mutex());
++    _Atomic_word __result;
++    __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word* __mem, int __val) throw ()
++  { __exchange_and_add(__mem, __val); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --color -ruN gcc-12.3.0/libstdc++-v3/configure gcc-12.3.0-kos/libstdc++-v3/configure
+--- gcc-12.3.0/libstdc++-v3/configure	2023-06-05 16:40:33.205101484 -0500
++++ gcc-12.3.0-kos/libstdc++-v3/configure	2023-06-05 16:40:33.332101860 -0500
+@@ -15774,6 +15774,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)    thread_header=config/sh/gthr-kos.h ;;
+ esac
+ 
+ 

--- a/utils/dc-chain/patches/gcc-devel-kos.diff
+++ b/utils/dc-chain/patches/gcc-devel-kos.diff
@@ -1,0 +1,162 @@
+diff -ruN gcc-devel/gcc/config/sh/sh-c.cc gcc-devel-kos/gcc/config/sh/sh-c.cc
+--- gcc-devel/gcc/config/sh/sh-c.cc	2023-06-05 16:50:21.431844529 -0500
++++ gcc-devel-kos/gcc/config/sh/sh-c.cc	2023-06-05 16:50:25.324856064 -0500
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff -ruN gcc-devel/gcc/configure gcc-devel-kos/gcc/configure
+--- gcc-devel/gcc/configure	2023-06-05 16:50:21.441844558 -0500
++++ gcc-devel-kos/gcc/configure	2023-06-05 16:50:25.326856070 -0500
+@@ -13015,7 +13015,7 @@
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32 | mcf)
++  single | tpf | vxworks | win32 | kos | mcf)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff -ruN gcc-devel/libgcc/config/sh/t-sh gcc-devel-kos/libgcc/config/sh/t-sh
+--- gcc-devel/libgcc/config/sh/t-sh	2023-06-05 16:50:24.448853468 -0500
++++ gcc-devel-kos/libgcc/config/sh/t-sh	2023-06-05 16:50:25.327856073 -0500
+@@ -23,6 +23,8 @@
+   $(LIB1ASMFUNCS_CACHE)
+ LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
+ 
++LIB2ADD = $(srcdir)/config/sh/fake-kos.S
++
+ crt1.o: $(srcdir)/config/sh/crt1.S
+ 	$(gcc_compile) -c $<
+ 
+diff -ruN gcc-devel/libgcc/configure gcc-devel-kos/libgcc/configure
+--- gcc-devel/libgcc/configure	2023-06-05 16:50:24.452853480 -0500
++++ gcc-devel-kos/libgcc/configure	2023-06-05 16:50:25.327856073 -0500
+@@ -5699,6 +5699,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 
+diff -ruN gcc-devel/libobjc/configure gcc-devel-kos/libobjc/configure
+--- gcc-devel/libobjc/configure	2023-06-05 16:50:24.778854446 -0500
++++ gcc-devel-kos/libobjc/configure	2023-06-05 16:50:25.328856076 -0500
+@@ -2918,11 +2918,9 @@
+ 
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#include <stdio.h>
+ int
+ main ()
+ {
+-printf ("hello world\n");
+   ;
+   return 0;
+ }
+diff -ruN gcc-devel/libobjc/Makefile.in gcc-devel-kos/libobjc/Makefile.in
+--- gcc-devel/libobjc/Makefile.in	2023-06-05 16:50:24.778854446 -0500
++++ gcc-devel-kos/libobjc/Makefile.in	2023-06-05 16:50:25.328856076 -0500
+@@ -308,14 +308,16 @@
+ $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
+ 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+ 
+-install: install-libs install-headers
++install-strip: INSTALL_STRIP_FLAG = -s
++install install-strip: install-libs install-headers
+ 
+ install-libs: installdirs
+ 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
+-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
++	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+ 	if [ "$(OBJC_BOEHM_GC)" ]; then \
+-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
+-				$(DESTDIR)$(toolexeclibdir);\
++	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
+ 	fi
+ 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
+ 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
+@@ -328,7 +330,7 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
+diff -ruN gcc-devel/libstdc++-v3/config/cpu/sh/atomicity.h gcc-devel-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-devel/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:50:24.866854707 -0500
++++ gcc-devel-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:50:25.328856076 -0500
+@@ -22,14 +22,40 @@
+ // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ // <http://www.gnu.org/licenses/>.
+ 
+-// Use the default atomicity stuff, which will use __atomic* builtins
+-// if threads are available, or the *_single functions on single-thread
+-// configurations.
+-// Actually we wouldn't need this header at all, but because of PR 53579
+-// libstdc++'s configury will not pickup the -matomic-model= option when
+-// set in the environment.  This makes it impossible to enable the proper
+-// atomic model on SH without modifying GCC itself, because libstdc++ always
+-// thinks the target doesn't do any atomics and uses the default mutex based
+-// implementation from cpu/generic/atomicity_mutex.
++/* This is generic/atomicity.h */
+ 
+ #include <ext/atomicity.h>
++#include <ext/concurrence.h>
++
++namespace 
++{
++  __gnu_cxx::__mutex&
++  get_atomic_mutex()
++  {
++    static __gnu_cxx::__mutex atomic_mutex;
++    return atomic_mutex;
++  }
++} // anonymous namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val) throw ()
++  {
++    __gnu_cxx::__scoped_lock sentry(get_atomic_mutex());
++    _Atomic_word __result;
++    __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word* __mem, int __val) throw ()
++  { __exchange_and_add(__mem, __val); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff -ruN gcc-devel/libstdc++-v3/configure gcc-devel-kos/libstdc++-v3/configure
+--- gcc-devel/libstdc++-v3/configure	2023-06-05 16:50:24.872854725 -0500
++++ gcc-devel-kos/libstdc++-v3/configure	2023-06-05 16:50:25.332856088 -0500
+@@ -15809,6 +15809,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 


### PR DESCRIPTION
This PR is the first in my big update to dc-chain.

- Updated binutils to 2.41
- Compiled all examples with GCC 13.2/Binutils 2.41/Newlib 4.3.0 and verified no regressions since the previous stable GCC 9.3/Binutils 2.34/Newlib 3.3.0 configuration. A few bugs were discovered which will I will be opening reports for, but in these cases the behavior was the same in 9.3.0 anyway. 
- This therefore should be enough to mark 13.2 as the stable toolchain. 
- Created `config` directory which now includes the following configurations:
  - 4.7.4 (legacy)
  - 9.3.0 (previous stable)
  - 10.5.0 (new, released 2023-07-07)
  - 11.4.0 (new, released 2023-05-29)
  - 12.3.0 (new, released 2023-05-08)
  - 13.2.0 (new stable!)
  - 14.0.1 (devel, git development branch)
- Added `config/README.md` file to explain the different configuration templates available.
- Revised and reordered comments and options in the configuration templates.
- Added `diff` files in the `patch` directory for the new configs above.
- Added `doc/changelog.txt` which goes all the way back to 2006. 
- Overhauled `README.md` to reflect changes.
- Updated the Dockerfile to reflect these new changes and to fix some issues that popped up due to other recent changes in dc-chain.