### PR TITLE
Alter 10.5.0 and 11.4.0 configs so custom dependencies match GCC's download_prerequisites

### DIFF
--- a/utils/dc-chain/config/config.mk.10.5.0.sample
+++ b/utils/dc-chain/config/config.mk.10.5.0.sample
@@ -37,10 +37,10 @@ arm_gcc_download_type=xz
 #use_custom_dependencies=1
 
 # GCC dependencies for SH
-sh_gmp_ver=6.2.1
-sh_mpfr_ver=4.1.0
-sh_mpc_ver=1.2.1
-sh_isl_ver=0.24
+sh_gmp_ver=6.1.0
+sh_mpfr_ver=3.1.6
+sh_mpc_ver=1.0.3
+sh_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for SH
 sh_gmp_download_type=bz2

--- a/utils/dc-chain/config/config.mk.11.4.0.sample
+++ b/utils/dc-chain/config/config.mk.11.4.0.sample
@@ -37,10 +37,10 @@ arm_gcc_download_type=xz
 #use_custom_dependencies=1
 
 # GCC dependencies for SH
-sh_gmp_ver=6.2.1
-sh_mpfr_ver=4.1.0
-sh_mpc_ver=1.2.1
-sh_isl_ver=0.24
+sh_gmp_ver=6.1.0
+sh_mpfr_ver=3.1.6
+sh_mpc_ver=1.0.3
+sh_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for SH
 sh_gmp_download_type=bz2


### PR DESCRIPTION
The custom dependencies option listed in the 10.5.0 and 11.4.0 config sample files aren't consistent with what GCC uses in its download_prerequisites script. This PR changes them so they match. 

The Alpine dockerfile uses the custom dependencies option so we want to be consistent here and have that build the exact same toolchain as a native build that would not use this option.