### PR TITLE
Fix: MEM_AREA_P4_MASK should be MEM_AREA_P4_BASE

### DIFF
--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1663,7 +1663,7 @@ typedef uint32 pvr_dr_state_t;
 */
 #define pvr_dr_target(vtx_buf_ptr) \
     ({ (vtx_buf_ptr) ^= 32; \
-        (pvr_vertex_t *)(MEM_AREA_P4_MASK | (vtx_buf_ptr)); \
+        (pvr_vertex_t *)(MEM_AREA_P4_BASE | (vtx_buf_ptr)); \
     })
 
 /** \brief  Commit a primitive written into the Direct Rendering target address.


### PR DESCRIPTION
Looks like there was a mixup in Quzar's memory map PR and one MEM_AREA_P4_MASK was left behind after BlueCrab suggested renaming MEM_AREA_P4_MASK to MEM_AREA_P4_BASE. libparallax from kos-ports therefore fails to build.