### PR TITLE
Implement POSIX clock_gettime() and friends

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -178,6 +178,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Add example for VMU speaker use [DH && FG]
 - DC  Add example for rumble accessory use [DH]
 - *** Split init flags from <arch/arch.h> into <kos/init.h> [LS]
+- *** Added clock_gettime(), clock_settime(), clock_getres() [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -27,6 +27,8 @@ struct timespec;
 
 extern int timespec_get(struct timespec *ts, int base);
 
+#ifndef __STRICT_ANSI__
+
 #ifndef _POSIX_TIMERS
 #define _POSIX_TIMERS 1
 #endif 
@@ -47,6 +49,8 @@ extern int timespec_get(struct timespec *ts, int base);
 extern int clock_getres(__clockid_t clk_id, struct timespec *res);
 extern int clock_gettime(__clockid_t clk_id, struct timespec *tp);
 extern int clock_settime(__clockid_t clk_id, const struct timespec *tp);
+
+#endif /* !defined(__STRICT_ANSI__) */
 
 __END_DECLS
 

--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -27,6 +27,27 @@ struct timespec;
 
 extern int timespec_get(struct timespec *ts, int base);
 
+#ifndef _POSIX_TIMERS
+#define _POSIX_TIMERS 1
+#endif 
+#ifdef _POSIX_MONOTONIC_CLOCK
+#define _POSIX_MONOTONIC_CLOCK 1
+#endif
+#ifdef _POSIX_CPUTIME
+#define _POSIX_CPUTIME 1
+#endif
+#ifdef _POSIX_THREAD_CPU_TIME
+#define _POSIX_THREAD_CPUTIME 1
+#endif
+
+#define CLOCK_MONOTONIC          (CLOCK_REALTIME + 1)
+#define CLOCK_PROCESS_CPUTIME_ID (CLOCK_REALTIME + 2)
+#define CLOCK_THREAD_CPUTIME_ID  (CLOCK_REALTIME + 3)
+
+extern int clock_getres(__clockid_t clk_id, struct timespec *res);
+extern int clock_gettime(__clockid_t clk_id, struct timespec *tp);
+extern int clock_settime(__clockid_t clk_id, const struct timespec *tp);
+
 __END_DECLS
 
 #endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L) */

--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -27,7 +27,7 @@ struct timespec;
 
 extern int timespec_get(struct timespec *ts, int base);
 
-#ifndef __STRICT_ANSI__
+#if !defined(__STRICT_ANSI__) || (_POSIX_C_SOURCE >= 199309L)
 
 #ifndef _POSIX_TIMERS
 #define _POSIX_TIMERS 1

--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -50,7 +50,7 @@ extern int clock_getres(__clockid_t clk_id, struct timespec *res);
 extern int clock_gettime(__clockid_t clk_id, struct timespec *tp);
 extern int clock_settime(__clockid_t clk_id, const struct timespec *tp);
 
-#endif /* !defined(__STRICT_ANSI__) */
+#endif /* !defined(__STRICT_ANSI__) || (_POSIX_C_SOURCE >= 199309L) */
 
 __END_DECLS
 

--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -14,11 +14,11 @@
 #ifndef __KOS_TIME_H
 #define __KOS_TIME_H
 
-#if !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L)
-
 #include <kos/cdefs.h>
 
 __BEGIN_DECLS
+
+#if !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L)
 
 /* Forward declaration. */
 struct timespec;
@@ -26,6 +26,8 @@ struct timespec;
 #define TIME_UTC 1
 
 extern int timespec_get(struct timespec *ts, int base);
+
+#endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L) */
 
 #if !defined(__STRICT_ANSI__) || (_POSIX_C_SOURCE >= 199309L)
 
@@ -54,5 +56,4 @@ extern int clock_settime(__clockid_t clk_id, const struct timespec *tp);
 
 __END_DECLS
 
-#endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L) */
 #endif /* !__KOS_TIME_H */

--- a/kernel/libc/Makefile
+++ b/kernel/libc/Makefile
@@ -4,7 +4,7 @@
 # Copyright (C)2004 Megan Potter
 #
 
-SUBDIRS = koslib newlib pthreads c11
+SUBDIRS = koslib newlib pthreads c11 posix
 
 all: subdirs
 clean: clean_subdirs

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -1,0 +1,11 @@
+# KallistiOS ##version##
+#
+# kernel/libc/c11/Makefile
+# Copyright (C) 2023 Falco Girgis
+#
+
+KOS_CFLAGS += -std=c11
+
+OBJS = clock_gettime.o
+
+include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -1,6 +1,6 @@
 # KallistiOS ##version##
 #
-# kernel/libc/c11/Makefile
+# kernel/libc/posix/Makefile
 # Copyright (C) 2023 Falco Girgis
 #
 

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -4,7 +4,7 @@
 # Copyright (C) 2023 Falco Girgis
 #
 
-KOS_CFLAGS += -std=c11
+KOS_CFLAGS += -std=gnu11
 
 OBJS = clock_gettime.o
 

--- a/kernel/libc/posix/clock_gettime.c
+++ b/kernel/libc/posix/clock_gettime.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   timespec_get.c
+   clock_gettime.c
    Copyright (C) 2023 Falco Girgis
 */
 

--- a/kernel/libc/posix/clock_gettime.c
+++ b/kernel/libc/posix/clock_gettime.c
@@ -36,7 +36,7 @@ int clock_gettime(clockid_t clk_id, struct timespec *ts) {
 
     switch(clk_id) {
     case CLOCK_REALTIME:
-        return timespec_get(ts, TIME_UTC) == TIME_UTC? 0 : -1;
+        return timespec_get(ts, TIME_UTC) == TIME_UTC ? 0 : -1;
     case CLOCK_MONOTONIC:
     case CLOCK_PROCESS_CPUTIME_ID:
     case CLOCK_THREAD_CPUTIME_ID: {

--- a/kernel/libc/posix/clock_gettime.c
+++ b/kernel/libc/posix/clock_gettime.c
@@ -11,57 +11,61 @@
 
 int clock_getres(clockid_t clk_id, struct timespec *ts) {
     switch(clk_id) {
-    case CLOCK_REALTIME:
-    case CLOCK_MONOTONIC:
-    case CLOCK_PROCESS_CPUTIME_ID:
-    case CLOCK_THREAD_CPUTIME_ID:
-        if(!ts) {
-            errno = EFAULT;
+        case CLOCK_REALTIME:
+        case CLOCK_MONOTONIC:
+        case CLOCK_PROCESS_CPUTIME_ID:
+        case CLOCK_THREAD_CPUTIME_ID:
+            if(!ts) {
+                errno = EFAULT;
+                return -1;
+            }
+            ts->tv_sec = 0;
+            ts->tv_nsec = 1000 * 1000;
+            return 0;
+            
+        default:
+            errno = EINVAL;
             return -1;
-        }
-        ts->tv_sec = 0;
-        ts->tv_nsec = 1000 * 1000;
-        return 0;
-    default:
-        errno = EINVAL;
-        return -1;
     }
 }
 
 int clock_gettime(clockid_t clk_id, struct timespec *ts) {
+    uint32_t secs, msecs; 
+
     if(!ts) {
         errno = EFAULT;
         return -1;
     }
 
     switch(clk_id) {
-    case CLOCK_REALTIME:
-        return timespec_get(ts, TIME_UTC) == TIME_UTC ? 0 : -1;
-    case CLOCK_MONOTONIC:
-    case CLOCK_PROCESS_CPUTIME_ID:
-    case CLOCK_THREAD_CPUTIME_ID: {
-        uint32_t secs, msecs;
-        timer_ms_gettime(&secs, &msecs);
-        ts->tv_sec = secs;
-        ts->tv_nsec = msecs * 1000 * 1000;
-        return 0;
-    }
-    default:
-        errno = EINVAL;
-        return -1;
+        case CLOCK_REALTIME:
+            return timespec_get(ts, TIME_UTC) == TIME_UTC ? 0 : -1;
+
+        case CLOCK_MONOTONIC:
+        case CLOCK_PROCESS_CPUTIME_ID:
+        case CLOCK_THREAD_CPUTIME_ID:
+            timer_ms_gettime(&secs, &msecs);
+            ts->tv_sec = secs;
+            ts->tv_nsec = msecs * 1000 * 1000;
+            return 0;
+
+        default:
+            errno = EINVAL;
+            return -1;
     }
 }
 
 int clock_settime(clockid_t clk_id, const struct timespec *ts) {
     switch(clk_id) {
-    case CLOCK_REALTIME:
-        if(!ts) {
-            errno = EFAULT;
+        case CLOCK_REALTIME:
+            if(!ts) {
+                errno = EFAULT;
+                return -1;
+            }
+            return rtc_set_unix_secs(ts->tv_sec);
+
+        default:
+            errno = EINVAL;
             return -1;
-        }
-        return rtc_set_unix_secs(ts->tv_sec);
-    default:
-        errno = EINVAL;
-        return -1;
     }
 }

--- a/kernel/libc/posix/clock_gettime.c
+++ b/kernel/libc/posix/clock_gettime.c
@@ -9,18 +9,18 @@
 #include <arch/rtc.h>
 #include <errno.h>
 
-int clock_getres(clockid_t clk_id, struct timespec *res) {
+int clock_getres(clockid_t clk_id, struct timespec *ts) {
     switch(clk_id) {
     case CLOCK_REALTIME:
     case CLOCK_MONOTONIC:
     case CLOCK_PROCESS_CPUTIME_ID:
     case CLOCK_THREAD_CPUTIME_ID:
-        if(!res) {
+        if(!ts) {
             errno = EFAULT;
             return -1;
         }
-        res->tv_sec = 0;
-        res->tv_nsec = 1000 * 1000;
+        ts->tv_sec = 0;
+        ts->tv_nsec = 1000 * 1000;
         return 0;
     default:
         errno = EINVAL;
@@ -28,22 +28,22 @@ int clock_getres(clockid_t clk_id, struct timespec *res) {
     }
 }
 
-int clock_gettime(clockid_t clk_id, struct timespec *tp) {
-    if(!tp) {
+int clock_gettime(clockid_t clk_id, struct timespec *ts) {
+    if(!ts) {
         errno = EFAULT;
         return -1;
     }
 
     switch(clk_id) {
     case CLOCK_REALTIME:
-        return timespec_get(tp, TIME_UTC) == TIME_UTC? 0 : -1;
+        return timespec_get(ts, TIME_UTC) == TIME_UTC? 0 : -1;
     case CLOCK_MONOTONIC:
     case CLOCK_PROCESS_CPUTIME_ID:
     case CLOCK_THREAD_CPUTIME_ID: {
         uint32_t secs, msecs;
         timer_ms_gettime(&secs, &msecs);
-        tp->tv_sec = secs;
-        tp->tv_nsec = msecs * 1000 * 1000;
+        ts->tv_sec = secs;
+        ts->tv_nsec = msecs * 1000 * 1000;
         return 0;
     }
     default:
@@ -52,14 +52,14 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp) {
     }
 }
 
-int clock_settime(clockid_t clk_id, const struct timespec *tp) {
+int clock_settime(clockid_t clk_id, const struct timespec *ts) {
     switch(clk_id) {
     case CLOCK_REALTIME:
-        if(!tp) {
+        if(!ts) {
             errno = EFAULT;
             return -1;
         }
-        return rtc_set_unix_secs(tp->tv_sec); 
+        return rtc_set_unix_secs(ts->tv_sec);
     default:
         errno = EINVAL;
         return -1;

--- a/kernel/libc/posix/clock_gettime.c
+++ b/kernel/libc/posix/clock_gettime.c
@@ -1,0 +1,67 @@
+/* KallistiOS ##version##
+
+   timespec_get.c
+   Copyright (C) 2023 Falco Girgis
+*/
+
+#include <time.h>
+#include <arch/timer.h>
+#include <arch/rtc.h>
+#include <errno.h>
+
+int clock_getres(clockid_t clk_id, struct timespec *res) {
+    switch(clk_id) {
+    case CLOCK_REALTIME:
+    case CLOCK_MONOTONIC:
+    case CLOCK_PROCESS_CPUTIME_ID:
+    case CLOCK_THREAD_CPUTIME_ID:
+        if(!res) {
+            errno = EFAULT;
+            return -1;
+        }
+        res->tv_sec = 0;
+        res->tv_nsec = 1000 * 1000;
+        return 0;
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+}
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp) {
+    if(!tp) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    switch(clk_id) {
+    case CLOCK_REALTIME:
+        return timespec_get(tp, TIME_UTC) == TIME_UTC? 0 : -1;
+    case CLOCK_MONOTONIC:
+    case CLOCK_PROCESS_CPUTIME_ID:
+    case CLOCK_THREAD_CPUTIME_ID: {
+        uint32_t secs, msecs;
+        timer_ms_gettime(&secs, &msecs);
+        tp->tv_sec = secs;
+        tp->tv_nsec = msecs * 1000 * 1000;
+        return 0;
+    }
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+}
+
+int clock_settime(clockid_t clk_id, const struct timespec *tp) {
+    switch(clk_id) {
+    case CLOCK_REALTIME:
+        if(!tp) {
+            errno = EFAULT;
+            return -1;
+        }
+        return rtc_set_unix_secs(tp->tv_sec); 
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+}


### PR DESCRIPTION
So several people have been asking about `clock_gettime()` as the POSIX successor to `gettimeofday()` (which we support). I looked at the docs and didn't see any reason we couldn't support most of it, including even setting the clock... and we already support all of C, C++, and some of POSIX time()... I figured this might be useful for people porting and also this really does seem like the most accurate/desirable of all of the low-level time calls...

Anyway, double check what I've done here:

- CLOCK_REALTIME: getting the standard date/time as we do for `time()` and `timespec_get()` using the initial RTC time + our time-since-boot timer offset
- CLOCK_MONOTONIC: considering this the amount of time that has elapsed since KOS has been running, which means it returns the current time-since-boot 
- CLOCK_PROCESS_CPUTIME_ID: Since we only have one process in KOS, and that process started when KOS started, I'm making this return the same thing as CLOCK_MONOTONIC?
- CLOCK_THREAD_CPUTIME_ID: Okay, maybe we should do something different here... I was going to attempt to follow up this PR with implementing per-thread CPU timing, but in the meantime should we support this? I'm returning the same thing as CLOCK_THREAD_CPUTIME_ID, which... I guess isn't really true. 


References: https://linux.die.net/man/3/clock_gettime