### PR TITLE
Implemented posix_memalign() addition to stdlib.h

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -178,6 +178,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Add example for VMU speaker use [DH && FG]
 - DC  Add example for rumble accessory use [DH]
 - *** Split init flags from <arch/arch.h> into <kos/init.h> [LS]
+- *** Added posix_memalign() implementation [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/stdlib.h
+++ b/include/kos/stdlib.h
@@ -1,0 +1,23 @@
+/* KallistiOS ##version##
+
+   kos/stdlib.h
+   Copyright (C) 2023 Falco Girgis
+*/
+
+#ifndef _STDLIB_H_
+#error "Do not include this file directly. Use <stdlib.h> instead."
+#endif /* !_STDLIB_H_ */
+
+#ifndef __KOS_STDLIB_H
+#define __KOS_STDLIB_H
+
+#if !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L)
+
+#include <kos/cdefs.h>
+
+__BEGIN_DECLS
+
+extern int posix_memalign(void **memptr, size_t alignment, size_t size);
+
+#endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L) */
+#endif /* !__KOS_STDLIB_H */

--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -27,6 +27,27 @@ struct timespec;
 
 extern int timespec_get(struct timespec *ts, int base);
 
+#ifndef _POSIX_TIMERS
+#define _POSIX_TIMERS 1
+#endif 
+#ifdef _POSIX_MONOTONIC_CLOCK
+#define _POSIX_MONOTONIC_CLOCK 1
+#endif
+#ifdef _POSIX_CPUTIME
+#define _POSIX_CPUTIME 1
+#endif
+#ifdef _POSIX_THREAD_CPU_TIME
+#define _POSIX_THREAD_CPUTIME 1
+#endif
+
+#define CLOCK_MONOTONIC          (CLOCK_REALTIME + 1)
+#define CLOCK_PROCESS_CPUTIME_ID (CLOCK_REALTIME + 2)
+#define CLOCK_THREAD_CPUTIME_ID  (CLOCK_REALTIME + 3)
+
+extern int clock_getres(__clockid_t clk_id, struct timespec *res);
+extern int clock_gettime(__clockid_t clk_id, struct timespec *tp);
+extern int clock_settime(__clockid_t clk_id, const struct timespec *tp);
+
 __END_DECLS
 
 #endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L) */

--- a/include/sys/_types.h
+++ b/include/sys/_types.h
@@ -227,3 +227,8 @@ __END_DECLS
 #ifdef _TIME_H_
 #include <kos/time.h>
 #endif
+
+#ifdef _STDLIB_H_
+#include <kos/stdlib.h>
+#endif
+

--- a/kernel/libc/Makefile
+++ b/kernel/libc/Makefile
@@ -4,7 +4,7 @@
 # Copyright (C)2004 Megan Potter
 #
 
-SUBDIRS = koslib newlib pthreads c11
+SUBDIRS = koslib newlib pthreads c11 posix
 
 all: subdirs
 clean: clean_subdirs

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -1,0 +1,11 @@
+# KallistiOS ##version##
+#
+# kernel/libc/c11/Makefile
+# Copyright (C) 2023 Falco Girgis
+#
+
+KOS_CFLAGS += -std=c11
+
+OBJS = clock_gettime.o
+
+include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -1,6 +1,6 @@
 # KallistiOS ##version##
 #
-# kernel/libc/c11/Makefile
+# kernel/libc/posix/Makefile
 # Copyright (C) 2023 Falco Girgis
 #
 

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -6,6 +6,6 @@
 
 KOS_CFLAGS += -std=c11
 
-OBJS = clock_gettime.o
+OBJS = posix_memalign.o
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/posix/clock_gettime.c
+++ b/kernel/libc/posix/clock_gettime.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   timespec_get.c
+   clock_gettime.c
    Copyright (C) 2023 Falco Girgis
 */
 

--- a/kernel/libc/posix/clock_gettime.c
+++ b/kernel/libc/posix/clock_gettime.c
@@ -1,0 +1,67 @@
+/* KallistiOS ##version##
+
+   timespec_get.c
+   Copyright (C) 2023 Falco Girgis
+*/
+
+#include <time.h>
+#include <arch/timer.h>
+#include <arch/rtc.h>
+#include <errno.h>
+
+int clock_getres(clockid_t clk_id, struct timespec *res) {
+    switch(clk_id) {
+    case CLOCK_REALTIME:
+    case CLOCK_MONOTONIC:
+    case CLOCK_PROCESS_CPUTIME_ID:
+    case CLOCK_THREAD_CPUTIME_ID:
+        if(!res) {
+            errno = EFAULT;
+            return -1;
+        }
+        res->tv_sec = 0;
+        res->tv_nsec = 1000 * 1000;
+        return 0;
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+}
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp) {
+    if(!tp) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    switch(clk_id) {
+    case CLOCK_REALTIME:
+        return timespec_get(tp, TIME_UTC) == TIME_UTC? 0 : -1;
+    case CLOCK_MONOTONIC:
+    case CLOCK_PROCESS_CPUTIME_ID:
+    case CLOCK_THREAD_CPUTIME_ID: {
+        uint32_t secs, msecs;
+        timer_ms_gettime(&secs, &msecs);
+        tp->tv_sec = secs;
+        tp->tv_nsec = msecs * 1000 * 1000;
+        return 0;
+    }
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+}
+
+int clock_settime(clockid_t clk_id, const struct timespec *tp) {
+    switch(clk_id) {
+    case CLOCK_REALTIME:
+        if(!tp) {
+            errno = EFAULT;
+            return -1;
+        }
+        return rtc_set_unix_secs(tp->tv_sec); 
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+}

--- a/kernel/libc/posix/posix_memalign.c
+++ b/kernel/libc/posix/posix_memalign.c
@@ -1,0 +1,44 @@
+/* KallistiOS ##version##
+
+   posix_memalign.c
+   Copyright (C) 2023 Falco Girgis
+*/
+
+#include <stdlib.h>
+#include <errno.h>
+
+static inline int is_power_of_two(size_t x) {
+   return (x & (x - 1)) == 0;
+}
+
+static inline size_t aligned_size(size_t size, size_t alignment) {
+   const size_t align_rem = size % alignment;
+   size_t new_size = size;
+
+   if(align_rem)
+      new_size += (alignment - align_rem);
+
+   return new_size;
+}
+
+int posix_memalign(void **memptr, size_t alignment, size_t size) {
+   if(alignment == 0 || !is_power_of_two(alignment) || alignment % sizeof(void*)) {
+      *memptr = NULL;
+      return EINVAL; 
+   }
+
+   if(!size) {
+      *memptr = NULL;
+      return 0;
+   }
+
+   size = aligned_size(size, alignment);
+
+   printf("ALIGN = %zu, SIZE = %zu\n", alignment, size);
+
+   *memptr = aligned_alloc(alignment, size);
+
+   printf("MEMPTR = %p\n", *memptr);
+
+   return *memptr? 0 : ENOMEM;
+}


### PR DESCRIPTION
This was another popular request for the sake of porting other codebases and compatibility with KOS. I modeled the way it's handled after how BlueCrab added the <kos/time.h> private header, only with <kos/stdlib.h>, which is where the function is declared on POSIX platforms.

In terms of implementation, it's a little bit of validation logic that then gets (size adjusted and) forwarded to C11's `aligned_alloc()`. Ran a bunch of tests locally on my Dreamcast, allocating weird sizes, 0 sizes, non-pow2 sizes, etc and everything looks good. Masked off respective low bits and ensured they were 0 for proper alignment. 