### PR TITLE
Implemented posix_memalign() addition to stdlib.h

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -178,6 +178,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Add example for VMU speaker use [DH && FG]
 - DC  Add example for rumble accessory use [DH]
 - *** Split init flags from <arch/arch.h> into <kos/init.h> [LS]
+- *** Implemented posix_memalign() from stdlib.h [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/stdlib.h
+++ b/include/kos/stdlib.h
@@ -15,7 +15,8 @@
 #ifndef __KOS_STDLIB_H
 #define __KOS_STDLIB_H
 
-#if !defined(__STRICT_ANSI__)
+#if !defined(__STRICT_ANSI__) || (_POSIX_C_SOURCE >= 200112L) || \
+    (_XOPEN_SOURCE >= 600)
 
 #include <kos/cdefs.h>
 
@@ -25,5 +26,6 @@ extern int posix_memalign(void **memptr, size_t alignment, size_t size);
 
 __END_DECLS
 
-#endif /* !defined(__STRICT_ANSI__) */
+#endif /* !defined(__STRICT_ANSI__) || (_POSIX_C_SOURCE >= 200112L) ||
+          (_XOPEN_SOURCE >= 600) */
 #endif /* !__KOS_STDLIB_H */

--- a/include/kos/stdlib.h
+++ b/include/kos/stdlib.h
@@ -1,0 +1,30 @@
+/* KallistiOS ##version##
+
+   kos/time.h
+   Copyright (C) 2023 Falco Girgis
+*/
+
+/* 
+   Add select POSIX extensions to stdlib.h which are not present within Newlib.
+*/ 
+
+#ifndef _STDLIB_H_
+#error "Do not include this file directly. Use <stdlib.h> instead."
+#endif /* !_STDLIB_H_ */
+
+#ifndef __KOS_STDLIB_H
+#define __KOS_STDLIB_H
+
+#if !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L)
+
+#include <kos/cdefs.h>
+
+__BEGIN_DECLS
+
+
+extern int posix_memalign(void **memptr, size_t alignment, size_t size);
+
+__END_DECLS
+
+#endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L) */
+#endif /* !__KOS_STDLIB_H */

--- a/include/kos/stdlib.h
+++ b/include/kos/stdlib.h
@@ -15,16 +15,15 @@
 #ifndef __KOS_STDLIB_H
 #define __KOS_STDLIB_H
 
-#if !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L)
+#if !defined(__STRICT_ANSI__)
 
 #include <kos/cdefs.h>
 
 __BEGIN_DECLS
 
-
 extern int posix_memalign(void **memptr, size_t alignment, size_t size);
 
 __END_DECLS
 
-#endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L) */
+#endif /* !defined(__STRICT_ANSI__) */
 #endif /* !__KOS_STDLIB_H */

--- a/include/kos/stdlib.h
+++ b/include/kos/stdlib.h
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   kos/time.h
+   kos/stdlib.h
    Copyright (C) 2023 Falco Girgis
 */
 

--- a/include/sys/_types.h
+++ b/include/sys/_types.h
@@ -227,3 +227,8 @@ __END_DECLS
 #ifdef _TIME_H_
 #include <kos/time.h>
 #endif
+
+#ifdef _STDLIB_H_
+#include <kos/stdlib.h>
+#endif
+

--- a/kernel/libc/Makefile
+++ b/kernel/libc/Makefile
@@ -4,7 +4,7 @@
 # Copyright (C)2004 Megan Potter
 #
 
-SUBDIRS = koslib newlib pthreads c11
+SUBDIRS = koslib newlib pthreads c11 posix
 
 all: subdirs
 clean: clean_subdirs

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -10,6 +10,7 @@
 # are not provided as part of Newlib.
 #
 
+CFLAGS += -std=c11
 OBJS = posix_memalign.o
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -1,0 +1,15 @@
+# KallistiOS ##version##
+#
+# kernel/libc/posix/Makefile
+# Copyright (C) 2023 Falco Girgis
+#
+
+#
+# This dir contains the implementation of POSIX-specific 
+# C and C++ extensions which are implemented by KOS and 
+# are not provided as part of Newlib.
+#
+
+OBJS = posix_memalign.o
+
+include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/posix/posix_memalign.c
+++ b/kernel/libc/posix/posix_memalign.c
@@ -24,7 +24,9 @@ static inline size_t aligned_size(size_t size, size_t alignment) {
 }
 
 int posix_memalign(void **memptr, size_t alignment, size_t size) {
-    assert(memptr);
+    if(!memptr) {
+        return EFAULT;
+    }
 
     if(!alignment || !is_power_of_two(alignment) || alignment % sizeof(void*)) {
         *memptr = NULL;

--- a/kernel/libc/posix/posix_memalign.c
+++ b/kernel/libc/posix/posix_memalign.c
@@ -1,0 +1,40 @@
+/* KallistiOS ##version##
+
+   posix_memalign.c
+   Copyright (C) 2023 Falco Girgis
+*/
+
+#include <stdlib.h>
+#include <errno.h>
+
+static inline int is_power_of_two(size_t x) {
+   return (x & (x - 1)) == 0;
+}
+
+static inline size_t aligned_size(size_t size, size_t alignment) {
+   const size_t align_rem = size % alignment;
+   size_t new_size = size;
+
+   if(align_rem)
+      new_size += (alignment - align_rem);
+
+   return new_size;
+}
+
+int posix_memalign(void **memptr, size_t alignment, size_t size) {
+   if(alignment == 0 || !is_power_of_two(alignment) || alignment % sizeof(void*)) {
+      *memptr = NULL;
+      return EINVAL; 
+   }
+
+   if(!size) {
+      *memptr = NULL;
+      return 0;
+   }
+
+   size = aligned_size(size, alignment);
+
+   *memptr = aligned_alloc(alignment, size);
+
+   return *memptr? 0 : ENOMEM;
+}

--- a/kernel/libc/posix/posix_memalign.c
+++ b/kernel/libc/posix/posix_memalign.c
@@ -39,5 +39,5 @@ int posix_memalign(void **memptr, size_t alignment, size_t size) {
     size = aligned_size(size, alignment);
     *memptr = aligned_alloc(alignment, size);
 
-    return *memptr? 0 : ENOMEM;
+    return *memptr ? 0 : ENOMEM;
 }

--- a/kernel/libc/posix/posix_memalign.c
+++ b/kernel/libc/posix/posix_memalign.c
@@ -6,35 +6,38 @@
 
 #include <stdlib.h>
 #include <errno.h>
+#include <stdlib.h>
+#include <assert.h>
 
 static inline int is_power_of_two(size_t x) {
-   return (x & (x - 1)) == 0;
+    return (x & (x - 1)) == 0;
 }
 
 static inline size_t aligned_size(size_t size, size_t alignment) {
-   const size_t align_rem = size % alignment;
-   size_t new_size = size;
+    const size_t align_rem = size % alignment;
+    size_t new_size = size;
 
-   if(align_rem)
-      new_size += (alignment - align_rem);
+    if(align_rem)
+        new_size += (alignment - align_rem);
 
-   return new_size;
+    return new_size;
 }
 
 int posix_memalign(void **memptr, size_t alignment, size_t size) {
-   if(alignment == 0 || !is_power_of_two(alignment) || alignment % sizeof(void*)) {
-      *memptr = NULL;
-      return EINVAL; 
-   }
+    assert(memptr);
 
-   if(!size) {
-      *memptr = NULL;
-      return 0;
-   }
+    if(!alignment || !is_power_of_two(alignment) || alignment % sizeof(void*)) {
+        *memptr = NULL;
+        return EINVAL;
+    }
 
-   size = aligned_size(size, alignment);
+    if(!size) {
+        *memptr = NULL;
+        return 0;
+    }
 
-   *memptr = aligned_alloc(alignment, size);
+    size = aligned_size(size, alignment);
+    *memptr = aligned_alloc(alignment, size);
 
-   return *memptr? 0 : ENOMEM;
+    return *memptr? 0 : ENOMEM;
 }


### PR DESCRIPTION
This was another popular request for the sake of porting other codebases and compatibility with KOS. I modeled the way it's handled after how BlueCrab added the <kos/time.h> private header, only with <kos/stdlib.h>, which is where the function is declared on POSIX platforms.

In terms of implementation, it's a little bit of validation logic that then gets (size adjusted and) forwarded to C11's aligned_alloc(). Ran a bunch of tests locally on my Dreamcast, allocating weird sizes, 0 sizes, non-pow2 sizes, etc and everything looks good. Masked off respective low bits and ensured they were 0 for proper alignment.