### PR TITLE
Updated CHANGELOG to reflect VMU driver update

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -181,6 +181,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Implemented posix_memalign() from stdlib.h [FG]
 - *** Added clock_gettime(), clock_settime(), clock_getres() [FG]
 - DC  Refactored controller API, added capability groups and types [FG]
+- DC  VMU driver update for date/time, buttons, buzzer, and docs [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]


### PR DESCRIPTION
...because I totally forgot to do it with my PR, and it was a pretty big update that should probably be captured in the CHANGELOG. :)