### PR TITLE
Add spinlock_trylock macro

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -182,6 +182,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added clock_gettime(), clock_settime(), clock_getres() [FG]
 - DC  Refactored controller API, added capability groups and types [FG]
 - DC  VMU driver update for date/time, buttons, buzzer, and docs [FG]
+- DC  Add spinlock_trylock macro [LS]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/kernel/arch/dreamcast/include/arch/spinlock.h
+++ b/kernel/arch/dreamcast/include/arch/spinlock.h
@@ -76,6 +76,28 @@ typedef volatile int spinlock_t;
         } \
     } while(0)
 
+/** \brief  Try to lock, without spinning.
+
+    This macro will attempt to lock the lock, but will not spin. Instead, it
+    will return whether the lock was obtained or not.
+
+    \param  A               A pointer to the spinlock to be locked.
+    \return                 0 if the lock is held by another thread. Non-zero if
+                            the lock was successfully obtained.
+*/
+#define spinlock_trylock(A) ({ \
+        int __gotlock = 0; \
+        do { \
+            spinlock_t *__lock = A; \
+            __asm__ __volatile__("tas.b @%1\n\t" \
+                                 "movt %0\n\t" \
+                                 : "=r" (__gotlock) \
+                                 : "r" (__lock) \
+                                 : "t", "memory"); \
+        } while(0); \
+        __gotlock; \
+    })
+
 /** \brief  Free a lock.
 
     This macro will unlock the lock that is currently held by the calling
@@ -100,4 +122,3 @@ typedef volatile int spinlock_t;
 __END_DECLS
 
 #endif  /* __ARCH_SPINLOCK_H */
-


### PR DESCRIPTION
Add a `spinlock_trylock` macro to `<arch/spinlock.h>` that attempts to lock the lock, but doesn't spin if it cannot.

Note that this uses a GCC extension for implementing the macro. At some point I might reconsider and make it an inline function, but for now since everything else in that file is macros, I figured it should be kept that way.