### PR TITLE
Simplify kthread_once_t into a simple variable rather than a struct

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -183,6 +183,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Refactored controller API, added capability groups and types [FG]
 - DC  VMU driver update for date/time, buttons, buzzer, and docs [FG]
 - DC  Add spinlock_trylock macro [LS]
+- *** Simplify kthread_once_t into a simple variable rather than a struct [LS]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/examples/dreamcast/basic/threading/once/once_test.c
+++ b/examples/dreamcast/basic/threading/once/once_test.c
@@ -1,11 +1,11 @@
 /* KallistiOS ##version##
 
    once_test.c
-   Copyright (C) 2009 Lawrence Sebald
+   Copyright (C) 2009, 2023 Lawrence Sebald
 
 */
 
-/* This program is a test for the kthread_once_t type added in KOS 1.3.0. A once
+/* This program is a test for the kthread_once_t type added in KOS 2.0.0. A once
    object is used with the kthread_once function to ensure that an initializer
    function is only run once in a program (meaning multiple threads will not run
    the function. */
@@ -15,6 +15,7 @@
 #include <kos/once.h>
 
 #include <arch/arch.h>
+#include <arch/spinlock.h>
 #include <dc/maple.h>
 #include <dc/maple/controller.h>
 
@@ -22,10 +23,13 @@
 #define THD_COUNT 600
 
 kthread_once_t once = KTHREAD_ONCE_INIT;
+spinlock_t lock = SPINLOCK_INITIALIZER;
 int counter = 0;
 
 void once_func(void) {
+    spinlock_lock(&lock);
     ++counter;
+    spinlock_unlock(&lock);
 }
 
 void *thd_func(void *param UNUSED) {

--- a/include/kos/once.h
+++ b/include/kos/once.h
@@ -1,7 +1,7 @@
 /* KallistiOS ##version##
 
    include/kos/once.h
-   Copyright (C) 2009, 2010 Lawrence Sebald
+   Copyright (C) 2009, 2010, 2023 Lawrence Sebald
 
 */
 
@@ -31,13 +31,10 @@ __BEGIN_DECLS
 
     \headerfile kos/once.h
 */
-typedef struct {
-    int initialized;
-    int run;
-} kthread_once_t;
+typedef volatile int kthread_once_t;
 
 /** \brief  Initializer for a kthread_once_t object. */
-#define KTHREAD_ONCE_INIT { 1, 0 }
+#define KTHREAD_ONCE_INIT   0
 
 /** \brief  Run a function once.
 
@@ -48,9 +45,9 @@ typedef struct {
 
     \param  once_control    The kthread_once_t object to run against.
     \param  init_routine    The function to call.
-    \retval -1      On failure, and sets errno to one of the following: ENOMEM
-                    if out of memory, EPERM if called inside an interrupt, or
-                    EINTR if interrupted.
+    \retval -1      On failure, and sets errno to one of the following: EPERM if
+                    called inside an interrupt or EINVAL if *once_control is not
+                    valid or was not initialized with KTHREAD_ONCE_INIT.
     \retval 0       On success. */
 int kthread_once(kthread_once_t *once_control, void (*init_routine)(void));
 


### PR DESCRIPTION
Change the `kthread_once_t` type from a two element struct to a `volatile int`. There really isn't a good reason for keeping it as a two-element struct, as we don't actually gain anything useful from having two elements that we can't get from a single simple variable. Plus, this is more in-line with how this is handled on Linux, so it can't be all that wrong...

Also, this has a tiny update to the once_test example to ensure that we don't just happen to get the right answer by chance.