### PR TITLE
Add missing #include <kos/thread.h> to libppp/ppp_modem.c

### DIFF
--- a/addons/libppp/ppp_modem.c
+++ b/addons/libppp/ppp_modem.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <kos/dbglog.h>
+#include <kos/thread.h>
 
 #include <arch/timer.h>
 


### PR DESCRIPTION
See title.

Note that this doesn't currently cause any problems, but probably will soon if it isn't fixed, so, it pays to fix it now.