### PR TITLE
Add missing includes to a few more more files

### DIFF
--- a/kernel/arch/dreamcast/hardware/modem/mdata.c
+++ b/kernel/arch/dreamcast/hardware/modem/mdata.c
@@ -1,7 +1,7 @@
 /* KallistiOS ##version##
 
    mdata.c
-   Copyright (C)2002, 2004 Nick Kochakian
+   Copyright (C) 2002, 2004 Nick Kochakian
 
    Distributed under the terms of the KOS license.
 */
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <kos/dbglog.h>
+#include <kos/thread.h>
 #include <assert.h>
 #include <dc/modem/modem.h>
 #include "mintern.h"

--- a/kernel/arch/dreamcast/hardware/network/lan_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/lan_adapter.c
@@ -16,6 +16,7 @@
 #include <dc/net/lan_adapter.h>
 #include <arch/irq.h>
 #include <kos/net.h>
+#include <kos/thread.h>
 
 /*
 
@@ -780,4 +781,3 @@ int la_shutdown(void) {
     la_if_shutdown(&la_if);
     return 0;
 }
-

--- a/kernel/arch/dreamcast/hardware/spudma.c
+++ b/kernel/arch/dreamcast/hardware/spudma.c
@@ -1,7 +1,7 @@
 /* KallistiOS ##version##
 
    spudma.c
-   Copyright (C)2001,2002,2004 Megan Potter
+   Copyright (C) 2001, 2002, 2004 Megan Potter
  */
 
 #include <assert.h>
@@ -10,6 +10,7 @@
 #include <dc/spu.h>
 #include <dc/asic.h>
 #include <kos/sem.h>
+#include <kos/thread.h>
 
 /* testing */
 #define ASIC_IRQ ASIC_IRQB
@@ -283,4 +284,3 @@ void spu_dma_shutdown(void) {
         dma_disable(i);
     }
 }
-


### PR DESCRIPTION
Add missing includes to the following files:
- kernel/arch/dreamcast/hardware/spudma.c
- kernel/arch/dreamcast/hardware/modem/mdata.c
- kernel/arch/dreamcast/hardware/network/lan_adapter.c