### PR TITLE
Simplify the structures of some sync primitives.

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -184,7 +184,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  VMU driver update for date/time, buttons, buzzer, and docs [FG]
 - DC  Add spinlock_trylock macro [LS]
 - *** Simplify kthread_once_t into a simple variable rather than a struct [LS]
-- *** Simplify sync primivitve structures to remove initialized member [LS]
+- *** Simplify sync primitive structures to remove initialized member [LS]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -184,6 +184,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  VMU driver update for date/time, buttons, buzzer, and docs [FG]
 - DC  Add spinlock_trylock macro [LS]
 - *** Simplify kthread_once_t into a simple variable rather than a struct [LS]
+- *** Simplify sync primivitve structures to remove initialized member [LS]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/cond.h
+++ b/include/kos/cond.h
@@ -59,12 +59,12 @@ __BEGIN_DECLS
     \headerfile kos/cond.h
 */
 typedef struct condvar {
-    int initialized;
+    int dummy;
     int dynamic;
 } condvar_t;
 
 /** \brief  Initializer for a transient condvar. */
-#define COND_INITIALIZER    { 1, 0 }
+#define COND_INITIALIZER    { 0, 0 }
 
 /** \brief  Allocate a new condition variable.
 

--- a/include/kos/mutex.h
+++ b/include/kos/mutex.h
@@ -78,7 +78,8 @@ typedef struct kos_mutex {
 
     @{
 */
-#define MUTEX_TYPE_NORMAL       1   /**< \brief Normal mutex type */
+#define MUTEX_TYPE_NORMAL       0   /**< \brief Normal mutex type */
+#define MUTEX_TYPE_OLDNORMAL    1   /**< \brief Alias for MUTEX_TYPE_NORMAL */
 #define MUTEX_TYPE_ERRORCHECK   2   /**< \brief Error-checking mutex type */
 #define MUTEX_TYPE_RECURSIVE    3   /**< \brief Recursive mutex type */
 

--- a/include/kos/rwsem.h
+++ b/include/kos/rwsem.h
@@ -40,8 +40,8 @@ __BEGIN_DECLS
     \headerfile kos/rwsem.h
 */
 typedef struct rw_semaphore {
-    /** \brief  Are we initialized? */
-    int initialized;
+    /** \brief  Was this structure created with rwsem_create()? */
+    int dynamic;
 
     /** \brief  The number of readers that are currently holding the lock. */
     int read_count;
@@ -54,7 +54,7 @@ typedef struct rw_semaphore {
 } rw_semaphore_t;
 
 /** \brief  Initializer for a transient reader/writer semaphore */
-#define RWSEM_INITIALIZER   { 1, 0, NULL, NULL }
+#define RWSEM_INITIALIZER   { 0, 0, NULL, NULL }
 
 /** \brief  Allocate a reader/writer semaphore.
 

--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -86,8 +86,10 @@ int mutex_lock_timed(mutex_t *m, int timeout) {
     int old, rv = 0;
 
     if((rv = irq_inside_int())) {
-        dbglog(DBG_WARNING, "%s: called inside an interrupt with code: %x evt: %.4x\n",
-               timeout ? "mutex_lock_timed" : "mutex_lock", ((rv>>16) & 0xf), (rv & 0xffff));
+        dbglog(DBG_WARNING, "%s: called inside an interrupt with code: "
+               "%x evt: %.4x\n",
+               timeout ? "mutex_lock_timed" : "mutex_lock",
+               ((rv >> 16) & 0xf), (rv & 0xffff));
         errno = EPERM;
         return -1;
     }
@@ -165,6 +167,7 @@ int mutex_trylock(mutex_t *m) {
 
         switch(m->type) {
             case MUTEX_TYPE_NORMAL:
+            case MUTEX_TYPE_OLDNORMAL:
             case MUTEX_TYPE_ERRORCHECK:
                 if(m->count) {
                     errno = EDEADLK;
@@ -198,6 +201,7 @@ static int mutex_unlock_common(mutex_t *m, kthread_t *thd) {
 
     switch(m->type) {
         case MUTEX_TYPE_NORMAL:
+        case MUTEX_TYPE_OLDNORMAL:
             m->count = 0;
             m->holder = NULL;
             wakeup = 1;


### PR DESCRIPTION
- Remove useless `initialized` members
- Renumber `MUTEX_TYPE_NORMAL` to 0, providing `MUTEX_TYPE_OLDNORMAL` as an alias with a value of 1 (the old value for it)
- Clean up some formatting issues