### PR TITLE
Cplusplus apparently hates optimizations based on pointers

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -184,7 +184,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  VMU driver update for date/time, buttons, buzzer, and docs [FG]
 - DC  Add spinlock_trylock macro [LS]
 - *** Simplify kthread_once_t into a simple variable rather than a struct [LS]
-- *** Add definition of restrict to <kos/cdefs.h> for C++ [LS]
+- *** Move definition of __RESTRICT from <sys/_types.h> to <kos/cdefs.h> [LS]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -184,6 +184,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  VMU driver update for date/time, buttons, buzzer, and docs [FG]
 - DC  Add spinlock_trylock macro [LS]
 - *** Simplify kthread_once_t into a simple variable rather than a struct [LS]
+- *** Add definition of restrict to <kos/cdefs.h> for C++ [LS]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -115,4 +115,17 @@
 /* GCC macros for special cases */
 /* #if __GNUC__ ==  */
 
+/* C++ doesn't support the restrict keyword from C99. As long as we're using
+   GCC (or something like it), we can use __restrict__ instead in C++. */
+#ifndef restrict
+#ifdef __cplusplus
+#ifdef __GNUC__
+/** \brief  Identify a C99-style restricted pointer. */
+#define restrict __restrict__
+#else /* __GNUC__ */
+#define restrict
+#endif /* __GNUC__ */
+#endif /* __cplusplus */
+#endif /* !restrict */
+
 #endif  /* __KOS_CDEFS_H */

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -117,15 +117,9 @@
 
 /* C++ doesn't support the restrict keyword from C99. As long as we're using
    GCC (or something like it), we can use __restrict__ instead in C++. */
-#ifndef restrict
-#ifdef __cplusplus
-#ifdef __GNUC__
+#if !defined(restrict) && (defined(__cplusplus) || __STDC_VERSION__ < 199901L)
 /** \brief  Identify a C99-style restricted pointer. */
 #define restrict __restrict__
-#else /* __GNUC__ */
-#define restrict
-#endif /* __GNUC__ */
-#endif /* __cplusplus */
-#endif /* !restrict */
+#endif /* !restrict && (__cplusplus || __STDC_VERSION__ < 199901L) */
 
 #endif  /* __KOS_CDEFS_H */

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -115,11 +115,18 @@
 /* GCC macros for special cases */
 /* #if __GNUC__ ==  */
 
-/* C++ doesn't support the restrict keyword from C99. As long as we're using
-   GCC (or something like it), we can use __restrict__ instead in C++. */
-#if !defined(restrict) && (defined(__cplusplus) || __STDC_VERSION__ < 199901L)
-/** \brief  Identify a C99-style restricted pointer. */
-#define restrict __restrict__
-#endif /* !restrict && (__cplusplus || __STDC_VERSION__ < 199901L) */
+#ifndef __RESTRICT
+#if (__STDC_VERSION__ >= 199901L)
+#define __RESTRICT restrict
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define __RESTRICT __restrict__
+#else /* < C99 and not GCC */
+#define __RESTRICT
+#endif
+#endif /* !__RESTRICT */
+
+#ifndef __GNUC__
+#define __extension__
+#endif
 
 #endif  /* __KOS_CDEFS_H */

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -386,7 +386,7 @@ kthread_t *thd_create(int detach, void *(*routine)(void *param), void *param);
 
     \sa thd_create, thd_destroy
 */
-kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
+kthread_t *thd_create_ex(const kthread_attr_t *__RESTRICT attr,
                          void *(*routine)(void *param), void *param);
 
 /** \brief       Brutally kill the given thread.
@@ -520,7 +520,7 @@ const char *thd_get_label(kthread_t *thd);
 
     \sa thd_get_label
 */
-void thd_set_label(kthread_t *thd, const char *restrict label);
+void thd_set_label(kthread_t *thd, const char *__RESTRICT label);
 
 /** \brief       Retrieve the thread's current working directory.
     \ingroup     threads
@@ -553,7 +553,7 @@ const char *thd_get_pwd(kthread_t *thd);
 
     \sa thd_get_pwd
 */
-void thd_set_pwd(kthread_t *thd, const char *restrict pwd);
+void thd_set_pwd(kthread_t *thd, const char *__RESTRICT pwd);
 
 /** \brief       Retrieve a pointer to the thread errno.
     \ingroup     threads

--- a/include/sys/_types.h
+++ b/include/sys/_types.h
@@ -203,16 +203,6 @@ typedef _CLOCK_T_   __clock_t;
 /* Include stuff to make pthreads work as well. */
 #include <sys/_pthread.h>
 
-#ifndef __RESTRICT
-#if (__STDC_VERSION__ >= 199901L)
-#define __RESTRICT restrict
-#elif defined(__GNUC__) || defined(__GNUG__)
-#define __RESTRICT __restrict
-#else /* < C99 and not GCC */
-#define __RESTRICT
-#endif
-#endif /* !__RESTRICT */
-
 #if __GNUC_MINOR__ > 95 || __GNUC__ >= 3
 typedef __builtin_va_list   __va_list;
 #else
@@ -231,4 +221,3 @@ __END_DECLS
 #ifdef _STDLIB_H_
 #include <kos/stdlib.h>
 #endif
-


### PR DESCRIPTION
- Add a definition for `restrict` to `<kos/cdefs.h>` for C++ code, because the C++ language apparently hates aliasing-related, pointer-based optimizations... Even though the `restrict` keyword has been in C since C99.