### PR TITLE
Fixing missing vmu_beep_waveform() symbol

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -287,8 +287,10 @@ int vmu_beep_raw(maple_device_t *dev, uint32_t beep) {
     return MAPLE_EOK;
 }
 
-int vmu_beep(maple_device_t *dev, uint8_t period, uint8_t duty) {
-    const uint32_t raw_beep = ((period << 24) | ((period - duty)) << 16);
+int vmu_beep_waveform(maple_device_t *dev, uint8_t period1, uint8_t duty_cycle1, uint8_t period2, uint8_t duty_cycle2) {
+    const uint32_t raw_beep = (((period2 - duty_cycle2) << 24) | (period2 << 16) |
+                               ((period1 - duty_cycle1) <<  8) | (period1));
+
     return vmu_beep_raw(dev, raw_beep);
 }
 


### PR DESCRIPTION
- Big VMU driver update accidentally had a name mismatch between the header and source file
- vmu_beep_waveform() would've been an unresolved symbol if used
- changed vmu_beep() in vmu.c to vmu_beep_waveform(), as advertised in the header

Sorry about this one, guys, I'm normally super rigorous about testing everything, but this one slipped, because we already had Quzar's VMU beep tests which were testing the `vmu_beep_raw()` symbol. 