### PR TITLE
environ.sh.sample cleanup + KOS debugging + optimizations

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -1,69 +1,71 @@
-# KallistiOS environment variable settings
+# KallistiOS Environment Variable Settings
 #
-# This is a sample script. Configure to suit your setup. Some possible
-# alternatives for the values below are included as an example.
+# This is a sample script for configuring and customizing your
+# KOS buid environment. Modify it to suit your setup. Several 
+# settings are provided with alternative values or may be enabled
+# optionally. 
 #
-# This script should be sourced in your current shell environment (probably
-# by bashrc or something similar).
+# This script is typically sourced in your current shell environment 
+# (probably by .bashrc, .bash_profile, or something similar), so that
+# the KOS environment is set up automatically for each shell session.
 #
 
-# Build architecture. Set the major architecture you'll be building for.
+# Build Architecture 
+# Set the major architecture you'll be building for.
 # The only option here is "dreamcast" as of KOS 2.0.0.
 export KOS_ARCH="dreamcast"
 
-# Build sub-architecture. If you need a particular sub-architecture, then set
-# that here; otherwise use "pristine".
+# Build Sub-Architecture 
+# Defines the sub architecture your configuration
+# is targetting or uses an existing value that
+# can be set externally via your IDE.
+#
 # Possible subarch options include:
-#  "pristine" - a normal Dreamcast console or HKT-0120 devkit
-#  "naomi" - a NAOMI or NAOMI 2 arcade board
-# You can also pre-define it in eg the build config of your IDE
+#  "pristine" - Dreamcast console or HKT-0120 devkit (default)
+#  "naomi"    - NAOMI or NAOMI 2 arcade board
+# 
 if [ -z "${KOS_SUBARCH}" ] ; then
     export KOS_SUBARCH="pristine"
 else
     export KOS_SUBARCH
 fi
 
-# KOS main base path
+# KOS root path
 export KOS_BASE="/opt/toolchains/dc/kos"
+
+# KOS-ports path
 export KOS_PORTS="${KOS_BASE}/../kos-ports"
 
 # Make utility
 export KOS_MAKE="make"
-#export KOS_MAKE="gmake"
 
 # CMake toolchain
 export KOS_CMAKE_TOOLCHAIN="${KOS_BASE}/utils/cmake/dreamcast.toolchain.cmake"
 
-# Load utility
-export KOS_LOADER="dc-tool -x"				# dcload, preconfigured
-# export KOS_LOADER="dc-tool-ser -t /dev/ttyS0 -x"	# dcload-serial
-
 # Genromfs utility
 export KOS_GENROMFS="${KOS_BASE}/utils/genromfs/genromfs"
-#export KOS_GENROMFS="genromfs"
 
-# Compiler prefixes
-#export KOS_CC_BASE="/usr/local/dc/dc-elf"
-#export KOS_CC_PREFIX="dc"
-export KOS_CC_BASE="/opt/toolchains/dc/sh-elf"		# DC
+# SH compiler prefixes
+export KOS_CC_BASE="/opt/toolchains/dc/sh-elf"  
 export KOS_CC_PREFIX="sh-elf"
 
-# If you are compiling for DC and have an ARM compiler, use these too.
-# If you're using a newer compiler (GCC 4.7.0 and newer), you should probably be
-# using arm-eabi as the target, rather than arm-elf. dc-chain now defaults to
-# arm-eabi, so that's the default here.
-#export DC_ARM_BASE="/usr/local/dc/arm-elf"
-#export DC_ARM_PREFIX="arm-elf"
+# ARM compiler prefixes
 export DC_ARM_BASE="/opt/toolchains/dc/arm-eabi"
 export DC_ARM_PREFIX="arm-eabi"
 
-# Expand PATH if not already set (comment out if you don't want this done here)
-if [[ ":$PATH:" != *":${KOS_CC_BASE}/bin:/opt/toolchains/dc/bin"* ]]; then
-  export PATH="${PATH}:${KOS_CC_BASE}/bin:/opt/toolchains/dc/bin"
-fi
+# Loader Utility
+# Specifies the loader to be used with the "make run" targets
+# in the KOS examples. Defaults to using a preconfigured version
+# of dc-tool. Use one of the other options for a manual dc-tool-ip
+# or dc-tool-serial configuration, remembering to change the values
+# for the Dreamcast's IP address or the serial port interface.
+export KOS_LOADER="dc-tool -x"				       
+#export KOS_LOADER="dc-tool-ip -t 192.168.1.100 -x"
+#export KOS_LOADER="dc-tool-ser -t /dev/ttyS0 -x" 
 
-# reset some options because there's no reason for them to persist across
-# multiple sourcing of this
+# Default Flags
+# Resets build flags. You can also initialize them to some preset
+# default values here if you wish.
 export KOS_INC_PATHS=""
 export KOS_CFLAGS=""
 export KOS_CPPFLAGS=""
@@ -71,18 +73,26 @@ export KOS_LDFLAGS=""
 export KOS_AFLAGS=""
 export DC_ARM_LDFLAGS=""
 
-# Setup some default CFLAGS for compilation. The things that will go here
-# are user specifyable, like optimization level and whether you want stack
-# traces enabled. Some platforms may have optimization restrictions,
-# please check README.
-# GCC seems to have made -fomit-frame-pointer the default on many targets, so
-# hence you may need -fno-omit-frame-pointer to actually have GCC spit out frame
-# pointers. It won't hurt to have it in there either way.
-# Link-time optimizations can be enabled by adding -flto. It however requires a
-# recent toolchain (GCC 10+), and has not been thoroughly tested.
-export KOS_CFLAGS="-O2 -fomit-frame-pointer"
-# export KOS_CFLAGS="-O2 -DFRAME_POINTERS -fno-omit-frame-pointer"
+# Optimization Level 
+# Controls the baseline optimization level to use when building. 
+# Typically this is -Og (debugging), -O0, -01, -02, or -03.
+# NOTE: For our target, -O4 is a valid optimization level that has 
+# been seen to have some performance impact as well.
+export KOS_CFLAGS="${KOS_CFLAGS} -O2"
 
+# Additional Optimizations
+# Uncomment this to enable what has been found imperically to be 
+# the optimal set of additional flags for release build performance 
+# on the current stable toolchain.
+#export KOS_CFLAGS="${KOS_CFLAGS} -freorder-blocks-algorithm=simple -flto=auto"
+
+# Frame Pointers
+# Controls whether frame pointers are emitted or not. Disabled by
+# default. Enable them if you plan to use GDB for debugging. 
+export KOS_CFLAGS="${KOS_CFLAGS} -fomit-frame-pointer"
+#export KOS_CFLAGS="${KOS_CFLAGS} -fno-omit-frame-pointer -DFRAME_POINTERS"
+
+# GCC Builtin Functions
 # Comment out this line to enable GCC to use its own builtin implementations of 
 # certain standard library functions. Under certain conditions, this can allow
 # compiler-optimized implementations to replace standard function invocations.
@@ -90,12 +100,37 @@ export KOS_CFLAGS="-O2 -fomit-frame-pointer"
 # of these functions, and it has not been tested thoroughly to ensure compatibility. 
 export KOS_CFLAGS="${KOS_CFLAGS} -fno-builtin"
 
+# Fast Math Instructions
 # Uncomment this line to enable the optimized fast-math instructions (FSSRA,
 # FSCA, and FSQRT) for calculating sin/cos, inverse square root, and square roots.
 # These can result in substantial performance gains for these kinds of operations;
 # however, they do so at the price of accuracy and are not IEEE compliant.
 # NOTE: This also requires -fno-builtin be removed from KOS_CFLAGS to take effect!
 # export KOS_CFLAGS="${KOS_CFLAGS} -ffast-math -ffp-contract=fast -mfsrra -mfsca"
+
+# KOS Debug Level
+# Sets the debug level to configure KOS with. Values range from 0 to 3, with 0
+# disabling all debugging and each subsequent value enabling the options from
+# the previous level plus additional options.
+# 
+# Level 0: Disabled
+# Level 1: Heap allocation debugging + validation
+# Level 2: Verbose heap allocation debugging + PVR VRAM allocation debugging
+# Level 3: Verbose PVR VRAM allocation debugging + VMU filesystem debugging
+export KOS_CFLAGS="${KOS_CFLAGS} -DKOS_DEBUG=0"
+
+# Filesystem Limits
+# The following settings control the limits on how many files of each
+# type can be open simultaneously within the filesystem, with a larger
+# number requiring more runtime memory resources. 
+export KOS_CFLAGS="${KOS_CFLAGS} -DFS_CD_MAX_FILES=8"
+export KOS_CFLAGS="${KOS_CFLAGS} -DFS_ROMDISK_MAX_FILES=16"
+export KOS_CFLAGS="${KOS_CFLAGS} -DFS_RAMDISK_MAX_FILES=8"
+
+# Expand PATH if not already set (comment out if you don't want this done here)
+if [[ ":$PATH:" != *":${KOS_CC_BASE}/bin:/opt/toolchains/dc/bin"* ]]; then
+  export PATH="${PATH}:${KOS_CC_BASE}/bin:/opt/toolchains/dc/bin"
+fi
 
 # Everything else is pretty much shared. If you want to configure compiler
 # options or other such things, look at this file.

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -83,6 +83,9 @@ __BEGIN_DECLS
    malloc, as well as everything in level 2. */
 /* #define KOS_DEBUG 3 */
 
+#ifndef KOS_DEBUG 
+#define KOS_DEBUG 0
+#endif
 
 #if KOS_DEBUG >= 1
 #define MALLOC_DEBUG 1
@@ -101,13 +104,19 @@ __BEGIN_DECLS
 #endif
 
 /** \brief  The maximum number of cd files that can be open at a time. */
+#ifndef FS_CD_MAX_FILES
 #define FS_CD_MAX_FILES 8
+#endif
 
 /** \brief  The maximum number of romdisk files that can be open at a time. */
+#ifndef FS_ROMDISK_MAX_FILES
 #define FS_ROMDISK_MAX_FILES 16
+#endif
 
 /** \brief  The maximum number of ramdisk files that can be open at a time. */
+#ifndef FS_RAMDISK_MAX_FILES
 #define FS_RAMDISK_MAX_FILES 8
+#endif
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -106,7 +106,7 @@ pvr_ptr_t pvr_mem_malloc(size_t size) {
 #endif  /* PVR_KM_DBG */
 
 #ifdef PVR_KM_DBG_VERBOSE
-    printf("Thread %d/%08lx allocated %d bytes at %08lx\n",
+    printf("Thread %d/%08lx allocated %lu bytes at %08lx\n",
            ctl->thread, ctl->addr, ctl->size, rv32);
 #endif
 
@@ -157,8 +157,8 @@ void pvr_mem_print_list(void) {
 
     printf("pvr_mem_print_list block list:\n");
     LIST_FOREACH(ctl, &block_list, list) {
-        printf("  unfreed block at %08lx size %d, allocated by thread %d/%08lx\n",
-               ctl->block, ctl->size, ctl->thread, ctl->addr);
+        printf("  unfreed block at %08lx size %lu, allocated by thread %d/%08lx\n",
+               (unsigned long)ctl->block, ctl->size, ctl->thread, (unsigned long)ctl->addr);
     }
     printf("pvr_mem_print_list end block list\n");
 #endif  /* PVR_KM_DBG */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
@@ -1333,7 +1333,7 @@ static void do_check_malloc_state(void) {
 
     max_fast_bin = fastbin_index(av->max_fast);
 
-    for(i = 0; i < NFASTBINS; ++i) {
+    for(i = 0; i < (int)NFASTBINS; ++i) {
         p = av->fastbins[i];
 
         /* all bins past max_fast are empty */
@@ -1345,7 +1345,7 @@ static void do_check_malloc_state(void) {
             do_check_inuse_chunk(p);
             total += chunksize(p);
             /* chunk belongs in this bin */
-            assert(fastbin_index(chunksize(p)) == i);
+            assert(fastbin_index(chunksize(p)) == (unsigned)i);
             p = p->fd;
         }
     }
@@ -1379,7 +1379,7 @@ static void do_check_malloc_state(void) {
             if(i >= 2) {
                 /* chunk belongs in bin */
                 idx = bin_index(size);
-                assert(idx == i);
+                assert(idx == (unsigned)i);
                 /* lists are sorted */
                 assert(p->bk == b ||
                        (unsigned long)chunksize(p->bk) >= (unsigned long)chunksize(p));

--- a/kernel/libc/koslib/malloc.c
+++ b/kernel/libc/koslib/malloc.c
@@ -1719,7 +1719,7 @@ Void_t* public_mALLOc(size_t bytes) {
     m = (void *)(nt1 + BUFFER_SIZE / 4);
 
 #ifdef KM_DBG_VERBOSE
-    printf("Thread %d/%08lx allocated %d bytes at %08lx\n",
+    printf("Thread %d/%08lx allocated %lu bytes at %08lx\n",
            ctl->thread, ctl->addr, ctl->size, (uint32)m);
 #endif
 
@@ -2070,7 +2070,7 @@ Void_t* public_mEMALIGn(size_t alignment, size_t bytes) {
     assert(!((uint32)m % alignment));
 
 #ifdef KM_DBG_VERBOSE
-    printf("Thread %d/%08lx memalign allocated %d bytes at %08lx\n",
+    printf("Thread %d/%08lx memalign allocated %lu bytes at %08lx\n",
            ctl->thread, ctl->addr, ctl->size, (uint32)m);
 #endif
 
@@ -2145,7 +2145,7 @@ Void_t* public_cALLOc(size_t n, size_t elem_size) {
     memset(m, 0, bytes);
 
 #ifdef KM_DBG_VERBOSE
-    printf("Thread %d/%08lx calloc allocated %d bytes at %08lx\n",
+    printf("Thread %d/%08lx calloc allocated %lu bytes at %08lx\n",
            ctl->thread, ctl->addr, ctl->size, (uint32)m);
 #endif
 


### PR DESCRIPTION
I'm ashamed to say that I've only just stumbled upon @ljsebald's beautiful `kos/include/kos/opts.h` header file, containing `#defines` for various compile-time configurable values in KOS. I realized that if I didn't know they existed, probably most people don't know either... So I thought it would be a good idea to expose this stuff as the `KOS_DEBUG` level within the environ.sample.sh which the user can easily configure.

While I was going about adding that, I realized we're probably overdue for a cleanup of the file in general. I got rid of a bunch of old comments that applied to ancient toolchains (pre GCC 4.7) that KOS doesn't support anymore. I added a few more configuration options and tried to mirror the way we handle dc-chain's config.mk. 

- Cleaned up environ.sh.sample to more closely reflect the model we're using for the dc-chain config files. 
     * more optimization flags added 
     * more detailed descriptions added 
     * legacy comments removed 
     * KOS debug levels exposed * KOS filesystem limits exposed
- Actually enabling KOS debug levels has exposed a bunch of warnings which I had to take care of in pvr_mem.c, pvr_mem_core.c, malloc.c
- opts.h was modified to only define default values if none were specified already

! - Everything tested and works great EXCEPT enabling KOS's malloc() verbose debugging hangs. The root cause still needs to be determined.