### PR TITLE
bba: don't shut it down if it hasnt been initialized

### DIFF
--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -1310,8 +1310,10 @@ int bba_init(void) {
 /* Shutdown */
 int bba_shutdown(void) {
     /* Shutdown hardware */
-    bba_if.if_stop(&bba_if);
-    bba_if.if_shutdown(&bba_if);
+    if(bba_if.flags & NETIF_RUNNING)
+        bba_if.if_stop(&bba_if);
+    if(bba_if.flags & NETIF_INITIALIZED)
+        bba_if.if_shutdown(&bba_if);
 
 #ifdef TX_SEMA
     sem_destroy(&tx_sema);


### PR DESCRIPTION
KOS crashes during shutdown if there isn't a BBA plugged in because bba_if.if_stop and bba_if.if_shutdown will both be NULL.

This is a problem if you don't have one plugged in and you're trying to debug using dcload-serial because it will reboot the dreamcast instead of returning to the bootloader.