### PR TITLE
Kazade's Authorship Update (2022 + 2023 Edition)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,7 +41,7 @@ Brian Paul: 1999, 2000, 2001
 Josh Pearson: 2013, 2014, 2015, 2016
 Joe Fenton: 2016
 Stefan Galowicz: 2016, 2017
-Luke Benstead: 2020, 2021
+Luke Benstead: 2020, 2021, 2022, 2023
 Eric Fradella: 2023
 Falco Girgis: 2023
 Ruslan Rostovtsev: 2014, 2016, 2023


### PR DESCRIPTION
- Just realized we hadn't updated AUTHORS in awhile. Checked and noticed we're missing some dates for @Kazade's contributions. Also checked to see that he most definitely does have KOS repo commits for 2022 and 2023.