### PR TITLE
Enabled atomics support in environ_dreamcast.h

### DIFF
--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -1,7 +1,7 @@
 # KallistiOS environment variable settings. These are the shared pieces
 # for the Dreamcast(tm) platform.
 
-export KOS_CFLAGS="${KOS_CFLAGS} -ml -m4-single-only -ffunction-sections -fdata-sections"
+export KOS_CFLAGS="${KOS_CFLAGS} -ml -m4-single-only -ffunction-sections -fdata-sections -matomic-model=soft-imask"
 export KOS_AFLAGS="${KOS_AFLAGS} -little"
 
 if [ x${KOS_SUBARCH} = xnaomi ]; then


### PR DESCRIPTION
- Using the soft-imask model for SH, which essentially does "atomic" operations between disabling and reenabling interrupts
- This gives us basic C99 atomic support and C++11 atomics support for types of size byte, short, or word, but additional libatomics back-end implementation is required for generic types and for dwords.