### PR TITLE
Modified thd_each() to support early exit + retval

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -650,10 +650,12 @@ int thd_detach(kthread_t *thd);
     \ingroup     threads
     \relatesalso kthread_t
 
-    \param cb               The callback to call for each thread
+    \param cb               The callback to call for each thread. 
+                            If a nonzero value is returned, iteration
+                            ceases immediately.
     \param data             User data to be passed to the callback
 
-    \retval 0               On success.
+    \retval                 0 or the first nonzero value returned by \p cb.
 
     \sa thd_pslist
 */

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -92,9 +92,11 @@ static const char *thd_state_to_str(kthread_t *thd) {
 
 int thd_each(int (*cb)(kthread_t *thd, void *user_data), void *data) {
     kthread_t *cur;
+    int retval;
 
     LIST_FOREACH(cur, &thd_list, t_list) {
-        cb(cur, data);
+        if((retval = cb(cur, data)))
+            return retval;
     }
 
     return 0;


### PR DESCRIPTION
It is often the case that iteration over a thread is doing a search for a particular thread or group of threads, allowing iteration to halt early if the thread or thread group is found. It is also the case that frequently the user may wish to return different values from their callback depending on the result of said iteration.

If it's cool with everyone else, I'd like to establish this practice as how we handle iteration with a user-function in general from an API-perspective:
- Take a user callback function
- Take a userdata void* to pass back to the callback
- Allow for ceasing iteration early upon non-zero return from the callback
- Return the callback's value from the API

I've been using this pattern all around my codebase, and it seems like the most versatile/robust way to handle iteration in C. 



Presently we take a user callback whose return value is simply ignored and we return a "result code" that is hardcoded to always be zero.

- Modified thd_each() to cease iteration early upon encountering a non-zero return value from the user's callback
- Modified thd_each() to return the callback's return value