### PR TITLE
Initial C11 libatomic GCC builtin implementation

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -188,7 +188,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Move definition of __RESTRICT from <sys/_types.h> to <kos/cdefs.h> [LS]
 - DC  Added DMA YUV converter path. Adjust some name of related #defines. 
       Added yuv examples [AB]
-- *** Added GCC builtin functions for supporting all of C99 atomics [FG]
+- *** Added GCC builtin functions for supporting all of C11 atomics [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -188,6 +188,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Move definition of __RESTRICT from <sys/_types.h> to <kos/cdefs.h> [LS]
 - DC  Added DMA YUV converter path. Adjust some name of related #defines. 
       Added yuv examples [AB]
+- *** Added GCC builtin functions for supporting all of C99 atomics [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -1,7 +1,7 @@
 # KallistiOS environment variable settings. These are the shared pieces
 # for the Dreamcast(tm) platform.
 
-export KOS_CFLAGS="${KOS_CFLAGS} -ml -m4-single-only -ffunction-sections -fdata-sections"
+export KOS_CFLAGS="${KOS_CFLAGS} -ml -m4-single-only -ffunction-sections -fdata-sections -matomic-model=soft-imask"
 export KOS_AFLAGS="${KOS_AFLAGS} -little"
 
 if [ x${KOS_SUBARCH} = xnaomi ]; then

--- a/examples/dreamcast/basic/threading/Makefile
+++ b/examples/dreamcast/basic/threading/Makefile
@@ -1,7 +1,7 @@
 # KallistiOS ##version##
 #
 # examples/dreamcast/basic/threading/Makefile
-# (c)2002 Megan Potter
+# (c) 2002 Megan Potter
 #
 
 all:
@@ -11,6 +11,7 @@ all:
 	$(KOS_MAKE) -C once
 	$(KOS_MAKE) -C tls
 	$(KOS_MAKE) -C spinlock_test
+	$(KOS_MAKE) -C atomics
 
 clean:
 	$(KOS_MAKE) -C general clean
@@ -19,6 +20,7 @@ clean:
 	$(KOS_MAKE) -C once clean
 	$(KOS_MAKE) -C tls clean
 	$(KOS_MAKE) -C spinlock_test clean
+	$(KOS_MAKE) -C atomics clean
 
 dist:
 	$(KOS_MAKE) -C general dist
@@ -27,4 +29,4 @@ dist:
 	$(KOS_MAKE) -C once dist
 	$(KOS_MAKE) -C tls dist
 	$(KOS_MAKE) -C spinlock_test dist
-
+	$(KOS_MAKE) -C atomics dist

--- a/examples/dreamcast/basic/threading/Makefile
+++ b/examples/dreamcast/basic/threading/Makefile
@@ -1,7 +1,7 @@
 # KallistiOS ##version##
 #
 # examples/dreamcast/basic/threading/Makefile
-# (c) 2002 Megan Potter
+# Copyright (C) 2002 Megan Potter
 #
 
 all:

--- a/examples/dreamcast/basic/threading/atomics/Makefile
+++ b/examples/dreamcast/basic/threading/atomics/Makefile
@@ -1,0 +1,30 @@
+# KallistiOS ##version##
+#
+# basic/threading/atomics/Makefile
+# Copyright (C) 2023 Falco Girgis
+#
+
+TARGET = atomics.elf
+OBJS = atomics.o
+KOS_CFLAGS += -std=c11
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist: $(TARGET)
+	-rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)
+

--- a/examples/dreamcast/basic/threading/atomics/atomics.c
+++ b/examples/dreamcast/basic/threading/atomics/atomics.c
@@ -115,7 +115,6 @@ int thread(void *arg) {
 
    /* Do several iterations worth of atomic operations for each thread. */
    for(unsigned i = 0; i < ITERATION_COUNT; ++i) {
-
       /* Create a spin-lock out of "flag_atomic" by repeatedly testing
          and setting its value, while its previous value was not false
          (our initial "unlocked" state). */
@@ -151,13 +150,13 @@ int thread(void *arg) {
       bool expected = false;
       while(!atomic_compare_exchange_weak(&bool_atomic,
                                           &expected,
-                                          true))
-      { 
+                                          true)) { 
          printf("Thread[%2u]: Waiting to acquire atomic bool lock.\n", tid);
          /* This time we won't hog all of the CPU time waiting. */
          thrd_yield();
          expected = false;     
       }
+
       printf("Thread[%2u]: Acquired atomic bool lock.\n", tid);
 
       /* This time lets give other threads a chance to mess
@@ -176,8 +175,7 @@ int thread(void *arg) {
       expected = true;
       if(!atomic_compare_exchange_strong(&bool_atomic,
                                          &expected,
-                                         false))
-      {
+                                         false)) {
          fprintf(stderr, 
                  "Thread[%2u]: Unexpected value for atomic bool lock!\n",
                  tid);
@@ -246,9 +244,8 @@ int main(int arg, char* argv[]) {
    /* Create N-1 threads running the "thread()" function to
       manipulate and fight over various atomic data. */ 
    for(unsigned t = 0; t < THREAD_COUNT - 1; ++t) {
-      if(thrd_create(&threads[t], thread, (void *)t + 1)
-            != thrd_success) 
-      {
+      if(thrd_create(&threads[t], thread,
+                     (void *)t + 1) != thrd_success) {
          fprintf(stderr, "Failed to create thread: [%u]\n", t + 1);
          retval = -1;
       }
@@ -281,68 +278,81 @@ int main(int arg, char* argv[]) {
    if(atomic_flag_test_and_set(&flag_atomic)) {
       fprintf(stderr, "flag_atomic left in unexpected state: [true]\n");
       retval = -1;
-   } else printf("\tFlag atomics work.\n");
+   }
+   else {
+       printf("\tFlag atomics work.\n");
+   }
 
    /* Verify atomic bool state. */
    bool expected = false;
    if(!atomic_compare_exchange_weak(&bool_atomic,
                                     &expected,
-                                    true))
-   {
+                                    true)) {
       fprintf(stderr, "bool_atomic left in unexpected state: [true]\n");
       retval = -1;
-   } else printf("\tBool atomics work.\n");
+   }
+   else {
+       printf("\tBool atomics work.\n");
+   }
 
    /* Verify atomic byte state. */
    uint8_t byte_value, byte_expected_value = 0;
-   for(unsigned i = 0; i < THREAD_COUNT; ++i)
-      byte_expected_value |= i;
+   for(unsigned i = 0; i < THREAD_COUNT; ++i) {
+       byte_expected_value |= i;
+   }
 
-   if((byte_value = atomic_load(&byte_atomic))
-         != byte_expected_value)
-   {
+   if((byte_value = atomic_load(&byte_atomic)) != byte_expected_value) {
       fprintf(stderr, 
               "byte_atomic left in unexpected state: [%u]\n", 
               byte_value);
       retval = -1;
-   } else printf("\t8-bit atomics work.\n");
+   }
+   else {
+       printf("\t8-bit atomics work.\n");
+   }
 
    /* Verify atomic short state. */
    short short_value;
    /* Note that memory order shouldn't do anything for our platform, just testing. */
-   if((short_value = atomic_load(&short_atomic))
-         != -(THREAD_COUNT * ITERATION_COUNT))
-   {
+   if((short_value = atomic_load(&short_atomic)) !=
+           -(THREAD_COUNT * ITERATION_COUNT)) {
       fprintf(stderr, 
               "short_atomic left in unexpected state: [%i]\n", 
               short_value);
       retval = -1;
-   } else printf("\t16-bit atomics work.\n");
+   }
+   else {
+       printf("\t16-bit atomics work.\n");
+   }
 
    /* Verify atomic int state. */
    int int_value, int_expected_value = INT_MAX;
-   for(int i = 0; i < THREAD_COUNT; ++i)
-      int_expected_value &= i;
+   for(int i = 0; i < THREAD_COUNT; ++i) {
+       int_expected_value &= i;
+   }
    
-   if((int_value = atomic_load(&int_atomic)) 
-         != int_expected_value)
-   {
+   if((int_value = atomic_load(&int_atomic)) != int_expected_value) {
       fprintf(stderr, 
               "int_atomic left in unexpected state: [%d]\n", 
               int_value);
       retval = -1;
-   } else printf("\t32-bit atomics work.\n");
+   }
+   else {
+       printf("\t32-bit atomics work.\n");
+   }
 
    /* Verify atomic long long state. */
    uint64_t longlong_value;
-   if((longlong_value = atomic_load(&longlong_atomic)) 
-         != THREAD_COUNT * ITERATION_COUNT) 
-   {
+   if((longlong_value = atomic_load(&longlong_atomic)) !=
+           THREAD_COUNT * ITERATION_COUNT) {
       fprintf(stderr, 
               "longlong_atomic left in unexpected state: [%llu]\n", 
               longlong_value);
       retval = -1;
-   } printf("\t64-bit atomics work.\n");
+   }
+   else {
+       printf("\t64-bit atomics work.\n");
+   }
 
    /* Verify atomic ptrdiff_t state. */
    ptrdiff_t ptrdiff_value, ptrdiff_expected_value = 0;
@@ -356,7 +366,10 @@ int main(int arg, char* argv[]) {
               "ptrdiff_atomic left in unexpected state: [%d]\n", 
               ptrdiff_value);
       retval = -1;
-   } else printf("\tptrdiff_t atomics work.\n");
+   }
+   else {
+       printf("\tptrdiff_t atomics work.\n");
+   }
 
    /* Verify atomic buffer state. */
    Buffer buff_value = atomic_load(&buffer_atomic);

--- a/examples/dreamcast/basic/threading/atomics/atomics.c
+++ b/examples/dreamcast/basic/threading/atomics/atomics.c
@@ -170,7 +170,7 @@ int thread(void *arg) {
 
       printf("Thread[%2u]: Releasing atomic bool lock.\n", tid);
       
-      /* Do the reverse compare + exhange operation to release the lock, this
+      /* Do the reverse compare + exchange operation to release the lock, this
          time expecting it to be previously owned (true) and setting it to 
          false to release. */
       expected = true;
@@ -298,7 +298,6 @@ int main(int arg, char* argv[]) {
    for(unsigned i = 0; i < THREAD_COUNT; ++i)
       byte_expected_value |= i;
 
-   /* Note that memory order shouldn't do anything for our platform, just testing. */
    if((byte_value = atomic_load(&byte_atomic))
          != byte_expected_value)
    {

--- a/examples/dreamcast/basic/threading/atomics/atomics.c
+++ b/examples/dreamcast/basic/threading/atomics/atomics.c
@@ -1,0 +1,164 @@
+/* KallistiOS ##version##
+
+   atomics.c
+
+   Copyright (C) 2023 Falco Girgis
+
+   This file serves as both an example of and and a validation test for
+   C11 atomics support with the SH4 DC toolchain and KOS.
+
+   C11 atomics are an extremely convenient, easy-to-use concurrency 
+   primitive supported at the language-level. They allow for thread-safe
+   access to and manipulation of variables without requiring an external
+   mutex or synchronization primitive to prevent multiple threads from
+   trying to modify the data simultaneously.
+
+   Atomics are also more efficient spatially, because there is no extra memory used 
+   for such additional mutexes to confer thread-safety around such variables. In 
+   terms of runtime, they are implemented similarly to mutexes, where interrupts are
+   disabled around load/store/fetch operations.
+
+   Most of the back-end for atomics is provided by the compiler when using the 
+   "-matomic-model=soft-imask" flag; however, KOS has to implement some of the 
+   back-end for primitive types (64-bit types in particular) and generic structs.
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <threads.h>
+#include <stdatomic.h>
+
+/* Test that the standard library advertises that we even have atomics. */
+#ifdef __STDC_NO_ATOMICS__
+#  error "The standard lib claims we don't support atomics!"
+#endif
+
+/* Test our compile-time macros for sanity. These can be used to detect
+   atomic locking characteristics at compile-time for your platform. 
+      0: The atomic type is never lock-free
+      1: the atomic type is sometimes lock-free
+      2: The atomic type is always lock-free
+*/
+_Static_assert(ATOMIC_BOOL_LOCK_FREE == 1,
+               "Our booleans are expected to sometimes be lock free!");
+_Static_assert(ATOMIC_CHAR_LOCK_FREE == 1,
+               "Our chars are expected to be lock free!");
+_Static_assert(ATOMIC_SHORT_LOCK_FREE == 1,
+               "Our shorts are expected to be lock free!");
+_Static_assert(ATOMIC_INT_LOCK_FREE == 1,
+               "Our ints are expected to be lock free!");
+_Static_assert(ATOMIC_LONG_LOCK_FREE == 1,
+               "Our longs are expected to be lock free!");
+_Static_assert(ATOMIC_LLONG_LOCK_FREE == 1,
+               "Our long longs are expected to be lock free!");
+_Static_assert(ATOMIC_POINTER_LOCK_FREE == 1,
+               "Our pointers are expected to be lock free!");
+
+#define THREAD_COUNT    20 /* # of threads to spawn */
+#define ITERATION_COUNT 30 /* # of times to iterate over each atomic */
+
+typedef struct {
+   char values[100];
+} Buffer;
+
+/* Atomic data our threads will be competing to access. */
+static atomic_flag      flag_atomic     = ATOMIC_FLAG_INIT;
+static atomic_bool      bool_atomic     = false;
+static atomic_int       int_atomic      = 0;
+static _Atomic uint64_t longlong_atomic = 0;
+static _Atomic(uint8_t) byte_atomic     = 0;
+static atomic_short     short_atomic    = 0;
+static atomic_ptrdiff_t ptrdiff_atomic  = 0;
+static _Atomic(Buffer)  buffer_atomic   = { {0} };
+
+//atomic_is_lock_free()
+
+/* Per-thread logic */
+int thread(void *arg) { 
+
+   return 0;
+
+}
+
+int main(int arg, char* argv[]) { 
+   int retval = 0;
+   thrd_t threads[THREAD_COUNT - 1];
+
+   printf("Checking locking characteristics.\n");
+
+   if(atomic_is_lock_free(&bool_atomic)) {
+      fprintf(stderr, "Bool atomics are lock free!\n");
+      retval = -1;
+   }
+
+   if(atomic_is_lock_free(&byte_atomic)) {
+      fprintf(stderr, "Byte atomics are lock free!\n");
+      retval = -1;
+   }
+
+   if(atomic_is_lock_free(&short_atomic)) {
+      fprintf(stderr, "Short atomics are lock free!\n");
+      retval = -1;
+   }
+
+   if(atomic_is_lock_free(&int_atomic)) {
+      fprintf(stderr, "Int atomics are lock free!\n");
+      retval = -1;
+   }
+
+   if(atomic_is_lock_free(&longlong_atomic)) {
+      fprintf(stderr, "Long long atomics are lock free!\n");
+      retval = -1;
+   }
+
+   if(atomic_is_lock_free(&ptrdiff_atomic)) {
+      fprintf(stderr, "Ptrdiff atomics are lock free!\n");
+      retval = -1;
+   }
+
+   if(atomic_is_lock_free(&buffer_atomic)) {
+      fprintf(stderr, "Struct atomics are lock free!\n");
+      retval = -1;
+   }
+
+   printf("Running threads: [%u]\n", THREAD_COUNT);
+
+   for(unsigned t = 0; t < THREAD_COUNT - 1; ++t) {
+      if(thrd_create(&threads[t], thread, (void *)t + 1)
+            != thrd_success) 
+      {
+         fprintf(stderr, "Failed to create thread: [%u]\n", t + 1);
+         retval = -1;
+      }
+   }
+
+   /* Run the same logic for the main thread. */
+   if(thread((void *)0) == -1) 
+      retval = -1;
+
+   printf("Joining threads: [%u]\n", THREAD_COUNT);
+   
+   for(unsigned t = 0; t < THREAD_COUNT - 1; ++t) {
+      int res;
+      if(thrd_join(threads[t], &res) == thrd_error) {
+         fprintf(stderr, "Failed to join thread: [%u]\n", t + 1);
+         retval = -1;
+         continue;
+      }
+
+      if(res == -1) 
+         retval = -1;
+   }   
+
+   if(retval == -1) {
+      fprintf(stderr, "\n\nATOMICS TEST FAILED!!!\n\n");
+      return EXIT_FAILURE;
+   }
+   else {
+      printf("\n\nATOMICS TEST PASSED!!!\n\n");
+      return EXIT_SUCCESS;
+   }
+}

--- a/examples/dreamcast/basic/threading/atomics/atomics.c
+++ b/examples/dreamcast/basic/threading/atomics/atomics.c
@@ -1,10 +1,10 @@
 /* KallistiOS ##version##
 
-   atomics.c
+   examples/dreamcast/basic/threading/atomics.c
 
    Copyright (C) 2023 Falco Girgis
 
-   This file serves as both an example of and and a validation test for
+   This file serves as both an example of and a validation test for
    C11 atomics support with the SH4 DC toolchain and KOS.
 
    C11 atomics are an extremely convenient, easy-to-use concurrency 
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <limits.h>
 #include <threads.h>
 #include <stdatomic.h>
 
@@ -42,23 +43,23 @@
       1: the atomic type is sometimes lock-free
       2: The atomic type is always lock-free
 */
-_Static_assert(ATOMIC_BOOL_LOCK_FREE == 1,
-               "Our booleans are expected to sometimes be lock free!");
-_Static_assert(ATOMIC_CHAR_LOCK_FREE == 1,
+_Static_assert(ATOMIC_BOOL_LOCK_FREE == 2,
+               "Our booleans are expected to be lock free!");
+_Static_assert(ATOMIC_CHAR_LOCK_FREE == 2,
                "Our chars are expected to be lock free!");
-_Static_assert(ATOMIC_SHORT_LOCK_FREE == 1,
+_Static_assert(ATOMIC_SHORT_LOCK_FREE == 2,
                "Our shorts are expected to be lock free!");
-_Static_assert(ATOMIC_INT_LOCK_FREE == 1,
+_Static_assert(ATOMIC_INT_LOCK_FREE == 2,
                "Our ints are expected to be lock free!");
-_Static_assert(ATOMIC_LONG_LOCK_FREE == 1,
+_Static_assert(ATOMIC_LONG_LOCK_FREE == 2,
                "Our longs are expected to be lock free!");
-_Static_assert(ATOMIC_LLONG_LOCK_FREE == 1,
-               "Our long longs are expected to be lock free!");
-_Static_assert(ATOMIC_POINTER_LOCK_FREE == 1,
+_Static_assert(ATOMIC_POINTER_LOCK_FREE == 2,
                "Our pointers are expected to be lock free!");
+_Static_assert(ATOMIC_LLONG_LOCK_FREE == 1,
+               "Our long longs are expected to sometimes be lock free!");
 
 #define THREAD_COUNT    20 /* # of threads to spawn */
-#define ITERATION_COUNT 30 /* # of times to iterate over each atomic */
+#define ITERATION_COUNT 5 /* # of times to iterate over each atomic */
 
 typedef struct {
    char values[100];
@@ -67,20 +68,78 @@ typedef struct {
 /* Atomic data our threads will be competing to access. */
 static atomic_flag      flag_atomic     = ATOMIC_FLAG_INIT;
 static atomic_bool      bool_atomic     = false;
-static atomic_int       int_atomic      = 0;
+static atomic_int       int_atomic      = INT_MAX;
 static _Atomic uint64_t longlong_atomic = 0;
 static _Atomic(uint8_t) byte_atomic     = 0;
 static atomic_short     short_atomic    = 0;
 static atomic_ptrdiff_t ptrdiff_atomic  = 0;
 static _Atomic(Buffer)  buffer_atomic   = { {0} };
 
-//atomic_is_lock_free()
+static void atomic_increment_buffer(void) {
+   Buffer buff = atomic_load(&buffer_atomic);
+
+   for(unsigned v = 0; v < sizeof(buff.values); ++v)
+      buff.values[v]++;
+
+   atomic_store(&buffer_atomic, buff);
+}
 
 /* Per-thread logic */
 int thread(void *arg) { 
+   unsigned tid = (unsigned)arg;
+   int retval = 0;
 
-   return 0;
+   for(unsigned i = 0; i < ITERATION_COUNT; ++i) {
 
+      while(atomic_flag_test_and_set(&flag_atomic))
+         printf("[Thread: %u]: Waiting to acquire flag_atomic.\n", tid);
+
+      printf("[Thread: %u]: Acquired flag_atomic.\n", tid);
+
+      thrd_yield();
+      atomic_fetch_add(&longlong_atomic, 1);
+
+      atomic_flag_clear(&flag_atomic);
+      printf("[Thread: %u]: Released flag_atomic.\n", tid);
+
+      bool expected = false;
+      while(!atomic_compare_exchange_weak(&bool_atomic,
+                                          &expected,
+                                          true))
+      { 
+         expected = false;     
+      }
+      printf("[Thread: %u]: Acquired bool_atomic.\n", tid);
+
+      static const struct timespec time = { .tv_nsec = 100000000 };
+      thrd_sleep(&time, NULL);
+
+      atomic_fetch_sub_explicit(&short_atomic,
+                                1, 
+                                memory_order_relaxed);
+
+      expected = true;
+      if(!atomic_compare_exchange_strong(&bool_atomic,
+                                         &expected,
+                                         false))
+      {
+         fprintf(stderr, 
+                 "[Thread: %u]: Unexpected value for bool atomic!\n",
+                 tid);
+         retval = -1;
+      }
+      printf("[Thread: %u]: Released bool_atomic.\n", tid);
+
+      atomic_fetch_or(&byte_atomic, tid);
+
+      atomic_fetch_xor(&ptrdiff_atomic, tid);
+
+      atomic_fetch_and(&int_atomic, tid);
+
+      atomic_increment_buffer();
+   }
+
+   return retval;
 }
 
 int main(int arg, char* argv[]) { 
@@ -89,38 +148,38 @@ int main(int arg, char* argv[]) {
 
    printf("Checking locking characteristics.\n");
 
-   if(atomic_is_lock_free(&bool_atomic)) {
-      fprintf(stderr, "Bool atomics are lock free!\n");
+   if(!atomic_is_lock_free(&bool_atomic)) {
+      fprintf(stderr, "Bool atomics are not lock free!\n");
       retval = -1;
    }
 
-   if(atomic_is_lock_free(&byte_atomic)) {
-      fprintf(stderr, "Byte atomics are lock free!\n");
+   if(!atomic_is_lock_free(&byte_atomic)) {
+      fprintf(stderr, "Byte atomics are not lock free!\n");
       retval = -1;
    }
 
-   if(atomic_is_lock_free(&short_atomic)) {
-      fprintf(stderr, "Short atomics are lock free!\n");
+   if(!atomic_is_lock_free(&short_atomic)) {
+      fprintf(stderr, "Short atomics are not lock free!\n");
       retval = -1;
    }
 
-   if(atomic_is_lock_free(&int_atomic)) {
-      fprintf(stderr, "Int atomics are lock free!\n");
+   if(!atomic_is_lock_free(&int_atomic)) {
+      fprintf(stderr, "Int atomics are not lock free!\n");
       retval = -1;
    }
 
-   if(atomic_is_lock_free(&longlong_atomic)) {
-      fprintf(stderr, "Long long atomics are lock free!\n");
+   if(!atomic_is_lock_free(&longlong_atomic)) {
+      fprintf(stderr, "Long long atomics are not lock free!\n");
       retval = -1;
    }
 
-   if(atomic_is_lock_free(&ptrdiff_atomic)) {
-      fprintf(stderr, "Ptrdiff atomics are lock free!\n");
+   if(!atomic_is_lock_free(&ptrdiff_atomic)) {
+      fprintf(stderr, "Ptrdiff atomics are not lock free!\n");
       retval = -1;
    }
 
-   if(atomic_is_lock_free(&buffer_atomic)) {
-      fprintf(stderr, "Struct atomics are lock free!\n");
+   if(!atomic_is_lock_free(&buffer_atomic)) {
+      fprintf(stderr, "Struct atomics are not lock free!\n");
       retval = -1;
    }
 
@@ -153,6 +212,97 @@ int main(int arg, char* argv[]) {
          retval = -1;
    }   
 
+   printf("Validating results.\n");
+
+   /* Verify atomic_flag state. */
+   if(atomic_flag_test_and_set(&flag_atomic)) {
+      fprintf(stderr, "flat_atomic left in unexpected state: [true]\n");
+      retval = -1;
+   }
+
+   /* Verify atomic bool state. */
+   bool expected = false;
+   if(!atomic_compare_exchange_weak(&bool_atomic,
+                                    &expected,
+                                    true))
+   {
+      fprintf(stderr, "bool_atomic left in unexpected state: [true]\n");
+      retval = -1;
+   }
+
+   /* Verify atomic byte state. */
+   uint8_t byte_value, byte_expected_value = 0;
+   for(unsigned i = 0; i < THREAD_COUNT; ++i)
+      byte_expected_value |= i;
+   if((byte_value = atomic_load_explicit(&byte_atomic, memory_order_acquire))
+         != byte_expected_value)
+   {
+      fprintf(stderr, 
+              "byte_atomic left in unexpected state: [%u]\n", 
+              byte_value);
+      retval = -1;
+   }
+
+   /* Verify atomic long long state. */
+   uint64_t longlong_value;
+   if((longlong_value = atomic_load(&longlong_atomic)) 
+         != THREAD_COUNT * ITERATION_COUNT) 
+   {
+      fprintf(stderr, 
+              "longlong_atomic left in unexpected state: [%llu]\n", 
+              longlong_value);
+      retval = -1;
+   }
+
+   /* Verify atomic short state. */
+   short short_value;
+   if((short_value = atomic_load_explicit(&short_atomic, memory_order_consume))
+         != -(THREAD_COUNT * ITERATION_COUNT))
+   {
+      fprintf(stderr, 
+              "short_atomic left in unexpected state: [%i]\n", 
+              short_value);
+      retval = -1;
+   }
+
+   /* Verify atomic int state. */
+   int int_value, int_expected_value = INT_MAX;
+   for(int i = 0; i < THREAD_COUNT; ++i)
+      int_expected_value &= i;
+   if((int_value = atomic_load(&int_atomic)) 
+         != int_expected_value)
+   {
+      fprintf(stderr, 
+              "int_atomic left in unexpected state: [%d]\n", 
+              int_value);
+      retval = -1;
+   }
+
+   /* Verify atomic ptrdiff_t state. */
+   ptrdiff_t ptrdiff_value, ptrdiff_expected_value = 0;
+   for(unsigned i = 0; i < THREAD_COUNT; ++i)
+      ptrdiff_expected_value ^= i;
+   if((ptrdiff_value = atomic_load(&ptrdiff_atomic)) 
+         != ptrdiff_expected_value)
+   {
+      fprintf(stderr, 
+              "ptrdiff_atomic left in unexpected state: [%d]\n", 
+              ptrdiff_value);
+      retval = -1;
+   }
+
+   /* Verify atomic buffer state. */
+   Buffer buff_value = atomic_load(&buffer_atomic);
+   for(unsigned v = 0; v < sizeof(buff_value.values); ++v) {
+      if(buff_value.values[v] != THREAD_COUNT * ITERATION_COUNT) {
+         fprintf(stderr, 
+                 "buffer_atomic[%u] left in unexpected state: [%d]",
+                 v, 
+                 buff_value.values[v]);
+         retval = -1;
+      }
+   }
+
    if(retval == -1) {
       fprintf(stderr, "\n\nATOMICS TEST FAILED!!!\n\n");
       return EXIT_FAILURE;
@@ -162,3 +312,4 @@ int main(int arg, char* argv[]) {
       return EXIT_SUCCESS;
    }
 }
+

--- a/examples/dreamcast/basic/threading/atomics/atomics.c
+++ b/examples/dreamcast/basic/threading/atomics/atomics.c
@@ -236,8 +236,8 @@ int main(int arg, char* argv[]) {
       retval = -1;
    }
 
-   if(!atomic_is_lock_free(&buffer_atomic)) {
-      fprintf(stderr, "Struct atomics are not lock free!\n");
+   if(atomic_is_lock_free(&buffer_atomic)) {
+      fprintf(stderr, "Struct atomics are lock free!\n");
       retval = -1;
    }
 

--- a/examples/dreamcast/basic/threading/atomics/atomics.c
+++ b/examples/dreamcast/basic/threading/atomics/atomics.c
@@ -109,7 +109,7 @@ static void atomic_add_buffer(unsigned tid, int delta) {
 }
 
 /* Per-thread entry point. */
-int thread(void *arg) { 
+static int thread(void *arg) { 
    unsigned tid = (unsigned)arg;
    int retval = 0;
 

--- a/kernel/libc/c11/Makefile
+++ b/kernel/libc/c11/Makefile
@@ -11,6 +11,6 @@ OBJS = call_once.o cnd_broadcast.o cnd_destroy.o cnd_init.o cnd_signal.o \
     mtx_timedlock.o mtx_trylock.o mtx_unlock.o thrd_create.o thrd_current.o \
     thrd_detach.o thrd_equal.o thrd_exit.o thrd_join.o thrd_sleep.o \
     thrd_yield.o tss_create.o tss_delete.o tss_get.o tss_set.o \
-    aligned_alloc.o timespec_get.o
+    aligned_alloc.o timespec_get.o atomics.o
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -171,7 +171,7 @@ bool __atomic_compare_exchange(size_t size,
 bool __atomic_is_lock_free(size_t size, void *ptr) {
     (void)ptr;
     (void) size;
-    return false;
+    return true;
 }
 
 

--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -34,8 +34,8 @@
 #define ATOMIC_STORE_N_(type, n) \
     void \
     __atomic_store_##n(volatile void *ptr, type val, int model) { \
-        (void)model; \
         const int irq = irq_disable(); \
+        (void)model; \
         *(type *)ptr = val; \
         irq_restore(irq); \
     }

--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -1,0 +1,177 @@
+/* KallistiOS ##version##
+
+   atomics.c
+   Copyright (C) 2023 Falco Girgis
+*/
+
+#include <arch/irq.h>
+#include <stdbool.h>
+
+#define ATOMIC_LOAD_N_(type, n) \
+    type \
+    __atomic_load_##n(const volatile void *ptr, int model) { \
+        (void)model; \
+        const int irq = irq_disable(); \
+        const type ret = *(type *)ptr; \
+        irq_restore(irq); \
+        return ret; \
+    }
+
+#define ATOMIC_STORE_N_(type, n) \
+    void \
+    __atomic_store_##n(volatile void *ptr, type val, int model) { \
+        (void)model; \
+        const int irq = irq_disable(); \
+        *(type *)ptr = val; \
+        irq_restore(irq); \
+    }
+    
+#define ATOMIC_EXCHANGE_N_(type, n) \
+    type \
+    __atomic_exchange_##n(volatile void* ptr, type val, int model) { \
+        (void)model; \
+        const int irq = irq_disable(); \
+        const type ret = *(type *)ptr; \
+        *(type*)ptr = val; \
+        irq_restore(irq); \
+        return ret; \
+    }
+
+#define ATOMIC_COMPARE_EXCHANGE_N_(type, n) \
+    bool \
+    __atomic_compare_exchange_##n(volatile void *ptr, \
+                                  void *expected, \
+                                  type desired, \
+                                  bool weak, \
+                                  int success_memorder, \
+                                  int failure_memorder) \
+    { \
+        (void)weak; \
+        (void)success_memorder; \
+        (void)failure_memorder; \
+        const int irq = irq_disable(); \
+        bool retval; \
+        if(*(type *)ptr == *(type *)expected) { \
+            *(type *)ptr = desired; \
+            retval = true; \
+        } else { \
+            *(type *)expected = *(type *)ptr; \
+            retval = false; \
+        } \
+        irq_restore(irq); \
+        return retval; \
+    }
+
+#define ATOMIC_FETCH_N_(type, n, opname, op) \
+    type \
+    __atomic_fetch_##opname##_##n(volatile void* ptr, \
+                                  type val, \
+                                  int memorder) { \
+        (void)memorder; \
+        const int irq = irq_disable(); \
+        type ret = *(type *)ptr; \
+        *(type *)ptr op val; \
+        irq_restore(irq); \
+        return ret;  \
+    }
+
+#define ATOMIC_FETCH_NAND_N_(type, n) \
+    type \
+    __atomic_fetch_nand_##n(volatile void* ptr, \
+                            type val, \
+                            int memorder) { \
+        (void)memorder; \
+        const int irq = irq_disable(); \
+        type ret = *(type *)ptr; \
+        *(type *)ptr = ~(*(type *)ptr & val); \
+        irq_restore(irq); \
+        return ret;  \
+    }
+
+ATOMIC_LOAD_N_(unsigned long long, 8)
+ATOMIC_STORE_N_(unsigned long long, 8)
+ATOMIC_EXCHANGE_N_(unsigned long long, 8)
+ATOMIC_COMPARE_EXCHANGE_N_(unsigned long long, 8)
+ATOMIC_FETCH_N_(unsigned long long, 8, add, +=)
+ATOMIC_FETCH_N_(unsigned long long, 8, sub, -=)
+ATOMIC_FETCH_N_(unsigned long long, 8, and, &=)
+ATOMIC_FETCH_N_(unsigned long long, 8, or, |=)
+ATOMIC_FETCH_N_(unsigned long long, 8, xor, ^=)
+ATOMIC_FETCH_NAND_N_(unsigned long long, 8)
+
+void __atomic_load(size_t size, 
+                   void *ptr, 
+                   void *ret, 
+                   int memorder)
+{
+    (void)memorder;
+
+    const int irq = irq_disable();
+    
+    memcpy(ret, ptr, size);
+    
+    irq_restore(irq);
+}
+
+void __atomic_store(size_t size, 
+                    void *ptr, 
+                    void *val, 
+                    int memorder) 
+{
+    (void)memorder;
+    
+    const int irq = irq_disable();
+    
+    memcpy(ptr, val, size);
+    
+    irq_restore(irq);
+}
+
+void __atomic_exchange(size_t size,
+                       void *ptr,
+                       void *val,
+                       void *ret,
+                       int memorder)
+{
+    (void)memorder;
+
+    const int irq = irq_disable();
+    
+    memcpy(ret, ptr, size);
+    memcpy(ptr, val, size);
+    
+    irq_restore(irq);                        
+}
+
+bool __atomic_compare_exchange(size_t size,
+                               void* ptr,
+                               void* expected,
+                               void* desired,
+                               int success_memorder,
+                               int fail_memorder)
+{
+    (void)success_memorder;
+    (void)fail_memorder;
+
+    bool retval;
+    const int irq = irq_disable();
+    
+    if(memcmp(ptr, expected, size) == 0) {
+        memcpy(ptr, desired, size);
+        retval = true;
+    } else {
+        memcpy(expected, ptr, size);
+        retval = false;
+    }
+    
+    irq_restore(irq);  
+    return retval;
+}
+
+bool __atomic_is_lock_free(size_t size, void *ptr) {
+    (void)ptr;
+    (void) size;
+    return false;
+}
+
+

--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -212,8 +212,10 @@ bool __atomic_compare_exchange(size_t size,
     return retval;
 }
 
-bool __atomic_is_lock_free(size_t size, void *ptr) {
+/* All atomics for builtin types are lock-free, while our
+   generic atomics back-end utilizes spinlocks. */
+bool __atomic_is_lock_free(size_t size, const volatile void *ptr) {
     (void)ptr;
     (void)size;
-    return true;
+    return (size <= sizeof(long long)) ? true : false;
 }


### PR DESCRIPTION
This PR is to add the remaining GCC builtins required to enable all of C11's atomics, located in `<stdatomic.h>`. The majority of the builtins for primitive types are given to us by the compiler with `-matomic-model=soft-imask`; however, this evidently does not cover 64-bit (long long) primitive types nor does it cover the generic cases for atomic structures and buffers.

I've implemented these missing builtins, and I've implemented the 64-bit primitive back-ends using generic macros to generate the function calls, just in case we find anything else missing or wind up wanting to handle all primitive atomics by ourselves. 

- Initial implementation should cover everything C11 atomics entail, located at kernel/libc/c11/atomics.c

All of my preliminary tests are passing; however, I'm keeping this as a draft until I've created a KOS example/test scenario fully exercising all of C11 atomics. 