### PR TITLE
Fix all warnings generating documentation with Doxygen 1.9.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # KallistiOS
 
-KOS is an unofficial development environment for the SEGA Dreamcast game console with some support for the NAOMI and NAOMI 2 arcade boards.  
+KOS is an unofficial development environment for the SEGA Dreamcast game console with some support for the NAOMI and NAOMI 2 arcade boards.
 
 KOS was developed from scratch over the internet by a group of free software developers and has no relation to the official Sega Katana or Microsoft Windows CE Dreamcast development kits. This has allowed it to fuel a thriving Dreamcast homebrew scene, powering many commercial releases for the platform over the years. It supports a signficiant portion of the Dreamcast's hardware capabilities and a wide variety of peripherals, accessories, and add-ons for the console, including custom hardware modifications that have been created by the scene. 
 
 Despite the console's age, KOS offers an extremely modern, programmer-friendly development environment, supporting portions of C23 and C++23, with the majority of their standard libraries fully supported and additional support for many POSIX APIs. Additionally, KOS-ports offers a rich set of add-on libraries such as SDL, OpenGL, and Lua for the platform.
 
 ## Features
-##### Core Functionality
+### Core Functionality
 * Concurrency with Kernel Threads, C11 Threads, C++11 `std::thread`, Pthreads
 * Virtual filesystem abstraction 
 * IPv4/IPv6 Network stack
 * Dynamically loading libraries/modules
 * GDB Debug stubs
 
-##### Dreamcast Hardware Support
+### Dreamcast Hardware Support
 * GD-Rom driver
 * Low-level 3D PowerVR Graphics 
 * SH4 ASM-Optimized Math Routines
@@ -27,7 +27,7 @@ Despite the console's age, KOS offers an extremely modern, programmer-friendly d
 * MMU Management API 
 * BIOS Font Rendering
 
-##### Peripherals and Accessory Support
+### Peripherals and Accessory Support
 * Visual Memory Unit
 * Puru Puru Vibration Pack
 * Seaman Microphone
@@ -41,7 +41,7 @@ Despite the console's age, KOS offers an extremely modern, programmer-friendly d
 * VGA Adapter
 * SD Card Reader
 
-##### Hardware Modification Support
+### Hardware Modification Support
 * IDE Hard Drive
 * 32MB RAM Upgrade
 * Custom BIOS Flashroms

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1333,15 +1333,6 @@ HTML_COLORSTYLE_SAT    = 100
 
 HTML_COLORSTYLE_GAMMA  = 80
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to YES can help to show when doxygen was last run and thus if the
-# documentation is up to date.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = NO
-
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
 # are dynamically created via JavaScript. If disabled, the navigation index will
@@ -2001,14 +1992,6 @@ LATEX_HIDE_INDICES     = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
-
-# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_TIMESTAMP        = NO
 
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,

--- a/kernel/arch/dreamcast/include/arch/memory.h
+++ b/kernel/arch/dreamcast/include/arch/memory.h
@@ -8,7 +8,7 @@
 /** \file   arch/memory.h
     \brief  Constants for areas of the system memory map.
 
-    Various addresses and masks that are set by the SH7750. None of the values 
+    Various addresses and masks that are set by the SH7750. None of the values
     here are Dreamcast-specific.
 
     These values are drawn from the Hitatchi SH7750 Series Hardware Manual rev 6.0.
@@ -25,9 +25,9 @@ __BEGIN_DECLS
 /** \defgroup memory Memory
     \brief    Basics of the SH4 Memory Map
 
-    The SH7750 Series physical address space is mapped onto a 29-bit external 
-    memory space, with the upper 3 bits of the address indicating which memory 
-    region will be used. The P0/U0 memory region spans a 2GB space with the 
+    The SH7750 Series physical address space is mapped onto a 29-bit external
+    memory space, with the upper 3 bits of the address indicating which memory
+    region will be used. The P0/U0 memory region spans a 2GB space with the
     bottom 512MB mirrored to the P1, P2, and P3 regions.
 
 */
@@ -35,8 +35,8 @@ __BEGIN_DECLS
 /** \brief Mask a cache-agnostic address.
     \ingroup memory
 
-    This masks out the upper 3 bits of an address. This is used when it is 
-    necssary to access memory with a specified caching mode. This is needed for 
+    This masks out the upper 3 bits of an address. This is used when it is
+    necssary to access memory with a specified caching mode. This is needed for
     DMA and SQ usage as well as various MMU functions.
 
 */
@@ -45,8 +45,8 @@ __BEGIN_DECLS
 /** \brief U0 memory region (cachable).
     \ingroup memory
 
-    This is the base user mode memory address. It is cacheable as determined 
-    by the WT bit of the cache control register. By default KOS sets this to 
+    This is the base user mode memory address. It is cacheable as determined
+    by the WT bit of the cache control register. By default KOS sets this to
     copy-back mode.
 
     KOS runs in privileged mode, so this is here merely for completeness.
@@ -57,8 +57,8 @@ __BEGIN_DECLS
 /** \brief P0 memory region (cachable).
     \ingroup memory
 
-    This is the base privileged mode memory address. It is cacheable as determined 
-    by the WT bit of the cache control register. By default KOS sets this to 
+    This is the base privileged mode memory address. It is cacheable as determined
+    by the WT bit of the cache control register. By default KOS sets this to
     copy-back mode.
 
 */
@@ -67,10 +67,10 @@ __BEGIN_DECLS
 /** \brief P1 memory region (cachable).
     \ingroup memory
 
-    This is a modularly cachable memory region. It is cacheable as determined by 
-    the CB bit of the cache control register. That allows it to function in a 
-    different caching mode (copy-back v write-through) than the U0, P0, and P3 
-    regions, whose cache mode are governed by the WT bit. By default KOS sets this 
+    This is a modularly cachable memory region. It is cacheable as determined by
+    the CB bit of the cache control register. That allows it to function in a
+    different caching mode (copy-back v write-through) than the U0, P0, and P3
+    regions, whose cache mode are governed by the WT bit. By default KOS sets this
     to the same	copy-back mode as the other cachable regions.
 
 */
@@ -79,7 +79,7 @@ __BEGIN_DECLS
 /** \brief P2 memory region (non-cachable).
     \ingroup memory
 
-    This is the non-cachable memory region. It is most frequently for DMA 
+    This is the non-cachable memory region. It is most frequently for DMA
     transactions to ensure reads are not cached.
 
 */
@@ -94,7 +94,7 @@ __BEGIN_DECLS
 #define MEM_AREA_P3_BASE    0xc0000000
 
 /** \brief P4 SH-internal memory region (non-cachable).
-    \defgroup p4mem
+    \defgroup p4mem P4 memory region
     \ingroup memory
 
     This offset maps to on-chip I/O channels.
@@ -105,7 +105,7 @@ __BEGIN_DECLS
 /** \brief Store Queue (SQ) memory base.
     \ingroup p4mem
 
-    This offset maps to the SQ memory region. RW to addresses from 
+    This offset maps to the SQ memory region. RW to addresses from
     0xe0000000-0xe3ffffff follow SQ rules.
 
     \see dc\sq.h

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1060,7 +1060,7 @@ Striplength set to 2 */
 #define PVR_TA_INIT             0x0144  /**< \brief Initialize vertex reg. params */
 #define PVR_YUV_ADDR            0x0148  /**< \brief YUV conversion destination */
 #define PVR_YUV_CFG             0x014c  /**< \brief YUV configuration */
-#define PVR_YUV_STAT            0x0150  /**< \bried The number of YUV macroblocks converted */
+#define PVR_YUV_STAT            0x0150  /**< \brief The number of YUV macroblocks converted */
 
 #define PVR_UNK_0160            0x0160  /**< \brief ?? */
 #define PVR_TA_OPB_INIT         0x0164  /**< \brief Object pointer buffer position init */


### PR DESCRIPTION
Fixes the following warnings in Doxygen generation:

```
warning: Tag 'HTML_TIMESTAMP' at line 1343 of file '-' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'LATEX_TIMESTAMP' at line 2011 of file '-' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
```

```
kos/kernel/arch/dreamcast/include/arch/memory.h:97: warning: missing title after \defgroup p4mem
```

```
kos/kernel/arch/dreamcast/include/dc/pvr.h:1063: warning: Found unknown command '\bried'
```

```
kos/README.md:10: warning: Unexpected paragraph command found inside section!
```