### PR TITLE
Vmu extra blocks

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -190,6 +190,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
       Added yuv examples [AB]
 - *** Added GCC builtin functions for supporting all of C11 atomics [FG]
 - *** Added toolchain and KOS support for C/C++ compiler-level TLS [CP && FG]
+- DC  Added vmu functions to check/enable/disable the extra 41 blocks [AB]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -182,7 +182,7 @@ int vmu_has_extra_blocks(maple_device_t *dev) {
     return 0;
 }
 
-int vmu_use_extra_blocks(maple_device_t *dev, int enable) {
+int vmu_toggle_241_blocks(maple_device_t *dev, int enable) {
     vmu_root_t root;
 
     if(vmufs_root_read(dev, &root) < 0)

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -179,9 +179,6 @@ int vmu_has_extra_blocks(maple_device_t *dev) {
     if(root.blk_cnt == 241)
         return 1;
 
-    if(vmufs_root_write(dev, &root) < 0)
-        return -1;
-
     return 0;
 }
 

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -170,6 +170,35 @@ int vmu_get_buttons_enabled(void) {
     return !!vmu_drv.periodic;
 }
 
+int vmu_has_extra_blocks(maple_device_t *dev) {
+    vmu_root_t root;
+
+    if(vmufs_root_read(dev, &root) < 0)
+        return -1;
+
+    if(root.blk_cnt == 241)
+        return 1;
+
+    if(vmufs_root_write(dev, &root) < 0)
+        return -1;
+
+    return 0;
+}
+
+int vmu_use_extra_blocks(maple_device_t *dev, int enable) {
+    vmu_root_t root;
+
+    if(vmufs_root_read(dev, &root) < 0)
+        return -1;
+
+    root.blk_cnt = (enable != 0) ? 241 : 200;
+
+    if(vmufs_root_write(dev, &root) < 0)
+        return -1;
+
+    return 0;
+}
+
 int vmu_use_custom_color(maple_device_t *dev, int enable) {
     vmu_root_t root;
 

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -170,7 +170,7 @@ int vmu_get_buttons_enabled(void) {
     return !!vmu_drv.periodic;
 }
 
-int vmu_has_extra_blocks(maple_device_t *dev) {
+int vmu_has_241_blocks(maple_device_t *dev) {
     vmu_root_t root;
 
     if(vmufs_root_read(dev, &root) < 0)

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -108,6 +108,9 @@ int vmu_has_extra_blocks(maple_device_t *dev);
 
     This function enables/disables the extra 41 blocks of a specific VMU.
 
+    \warning    Enabling the extra blocks of a VMU may render it unusable
+                for a very few commercial games.
+
     \param  dev             The device to enable/disable 41 blocks.
     \param  enable          Values other than 0 enables. Equal to 0 disables.
 

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -98,10 +98,8 @@ __BEGIN_DECLS
     \retval 1               On success: extra blocks are enabled
     \retval 0               On success: extra blocks are disabled
     \retval -1              On failure
-
-    \sa vmu_has_extra_blocks
 */
-int vmu_has_extra_blocks(maple_device_t *dev);
+int vmu_has_241_blocks(maple_device_t *dev);
 
 /** \brief   Enable the extra 41 blocks of a VMU
     \ingroup vmu_settings

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -3,7 +3,7 @@
    dc/maple/vmu.h
    Copyright (C) 2000-2002 Jordan DeLong, Megan Potter
    Copyright (C) 2008 Donald Haase
-   Copyright (C) 2023 Falco Girgis
+   Copyright (C) 2023 Falco Girgis, Andy Barajas
 
 */
 
@@ -87,13 +87,44 @@ __BEGIN_DECLS
     a VMU has been formatted.
 */
 
+/** \brief   Get the status of a VMUs extra 41 blocks
+    \ingroup vmu_settings
+
+    This function checks if the extra 41 blocks of a VMU have been
+    enabled.
+
+    \param  dev             The device to check the status of.
+
+    \retval 1               On success: extra blocks are enabled
+    \retval 0               On success: extra blocks are disabled
+    \retval -1              On failure
+
+    \sa vmu_has_extra_blocks
+*/
+int vmu_has_extra_blocks(maple_device_t *dev);
+
+/** \brief   Enable the extra 41 blocks of a VMU
+    \ingroup vmu_settings
+
+    This function enables/disables the extra 41 blocks of a specific VMU.
+
+    \param  dev             The device to enable/disable 41 blocks.
+    \param  enable          Values other than 0 enables. Equal to 0 disables.
+
+    \retval 0               On success
+    \retval -1              On failure
+
+    \sa vmu_use_extra_blocks
+*/
+int vmu_use_extra_blocks(maple_device_t *dev, int enable);
+
 /** \brief   Enable custom color of a VMU
     \ingroup vmu_settings
 
     This function enables/disables the custom color of a specific VMU. 
     This color is only displayed in the Dreamcast's file manager.
 
-    \param  dev             The device to enable custom color.
+    \param  dev             The device to enable/disable custom color.
     \param  enable          Values other than 0 enables. Equal to 0 disables.
 
     \retval 0               On success

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -116,10 +116,8 @@ int vmu_has_extra_blocks(maple_device_t *dev);
 
     \retval 0               On success
     \retval -1              On failure
-
-    \sa vmu_use_extra_blocks
 */
-int vmu_use_extra_blocks(maple_device_t *dev, int enable);
+int vmu_toggle_241_blocks(maple_device_t *dev, int enable);
 
 /** \brief   Enable custom color of a VMU
     \ingroup vmu_settings


### PR DESCRIPTION
Add two functions to VMU API:

1. Check the enabled status of a VMUs extra blocks.
2. Enable/Disable the status of the VMUs extra blocks.