### PR TITLE
Add new "WinXP-Latest" toolchain configuration

### DIFF
--- a/utils/dc-chain/config/README.md
+++ b/utils/dc-chain/config/README.md
@@ -4,6 +4,7 @@ The available templates include the following configurations:
 |---------:|:-------:|:----------:|:------------:|:-------:|:----------------:|:------|
 | config.mk.legacy.sample | 4.7.4 | 2.0.0 | 2.34 | 4.7.4 | 2.34 | older toolchain based on GCC 4<br />former "stable" / "legacy" configuration<br /> [some issues may happen in C++](https://dcemulation.org/phpBB/viewtopic.php?f=29&t=104724) |
 | config.mk.9.3.0.sample | 9.3.0 | 3.3.0 | 2.34 | 8.4.0 | 2.34 | older toolchain based on GCC 9<br />former "stable" configuration |
+| config.mk.winxp-latest.sample | 9.5.0 | 4.3.0 | 2.34 | 8.5.0 | 2.34 | latest WinXP-compatible toolchain with GCC 9 |
 | config.mk.10.5.0.sample | 10.5.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 10 |
 | config.mk.11.4.0.sample | 11.4.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 11 |
 | config.mk.12.3.0.sample | 12.3.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 12 |

--- a/utils/dc-chain/config/config.mk.9.5.0.sample
+++ b/utils/dc-chain/config/config.mk.9.5.0.sample
@@ -1,0 +1,162 @@
+# Sega Dreamcast Toolchains Maker (dc-chain)
+# This file is part of KallistiOS.
+#
+# Created by Jim Ursetto (2004)
+# Initially adapted from Stalin's build script version 0.3.
+#
+
+# Toolchain versions for SH
+sh_binutils_ver=2.41
+sh_gcc_ver=9.5.0
+newlib_ver=4.3.0.20230120
+gdb_ver=13.2
+
+# Tarball extensions to download for SH
+sh_binutils_download_type=xz
+sh_gcc_download_type=xz
+newlib_download_type=gz
+gdb_download_type=xz
+
+# Toolchain for ARM
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
+arm_binutils_ver=2.41
+arm_gcc_ver=8.5.0
+
+# Tarball extensions to download for ARM
+arm_binutils_download_type=xz
+arm_gcc_download_type=xz
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies for SH
+sh_gmp_ver=6.2.1
+sh_mpfr_ver=4.1.0
+sh_mpc_ver=1.2.1
+sh_isl_ver=0.24
+
+# Tarball extensions to download for GCC dependencies for SH
+sh_gmp_download_type=bz2
+sh_mpfr_download_type=bz2
+sh_mpc_download_type=gz
+sh_isl_download_type=bz2
+
+# GCC dependencies for ARM
+arm_gmp_ver=6.1.0
+arm_mpfr_ver=3.1.4
+arm_mpc_ver=1.0.3
+arm_isl_ver=0.18
+
+# Tarball extensions to download for GCC dependencies for ARM
+arm_gmp_download_type=bz2
+arm_mpfr_download_type=bz2
+arm_mpc_download_type=gz
+arm_isl_download_type=bz2
+
+# Download protocol (http|https|ftp)
+# Specify here the protocol you want to use for downloading the packages.
+download_protocol=https
+
+# Force downloader (curl|wget)
+# You may specify here 'wget' or 'curl'. If this variable is empty or commented,
+# web downloader tool will be auto-detected in the following order: cURL, Wget.
+# You must have either Wget or cURL installed to use dc-chain.
+#force_downloader=wget
+
+# Specify GNU Mirror override
+# The default mirror for GNU sources is `ftpmirror.gnu.org`
+# Setting this will allow overriding the default mirror which
+# may be desirable if you have a prefered mirror.
+#gnu_mirror=mirrors.kernel.org
+
+# Toolchains base
+# Indicate the root directory where toolchains will be installed
+# This should match your 'environ.sh' configuration
+toolchains_base=/opt/toolchains/dc
+
+# Verbose (1|0)
+# Display output to screen as well as log files
+verbose=1
+
+# Erase (1|0)
+# Erase build directories on the fly to save space
+erase=1
+
+# Install mode (install-strip|install)
+# Use 'install-strip' mode for removing debugging symbols of the toolchains.
+# Use 'install' only if you want to enable debug symbols for the toolchains.
+# This may be useful only if you plan to debug the toolchain itself.
+install_mode=install-strip
+
+# Make jobs (-jn|<empty>)
+# Set this value to -jn where n is the number of jobs you want to run with make.
+# If you only want one job, just set this to nothing (i.e, "makejobs=").
+# Tracking down problems with multiple make jobs is much more difficult than
+# with just one running at a time. So, if you run into trouble, then you should
+# clear this variable and try again with just one job running.
+# Please note, this value may be overriden in some cases; as issues were
+# detected on some OS.
+makejobs=-j2
+
+# Languages (c|c++|objc|obj-c++)
+# Set the languages to build for pass 2 of building gcc for sh-elf. The default
+# here is to build C, C++, Objective C, and Objective C++. You may want to take
+# out the latter two if you're not worried about them and/or you're short on
+# hard drive space.
+pass2_languages=c,c++,objc,obj-c++
+
+# GCC threading model (single|kos|posix*)
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
+# should use it. If you really don't want threading support for C++ (or 
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
+# is not anymore supported.
+thread_model=kos
+
+# Automatic patching for KOS (1|0)
+# Uncomment this if you want to disable applying KOS patches to the toolchain 
+# source files before building. This will disable usage of the 'kos' thread model. 
+#use_kos_patches=0
+
+# Automatic fixup SH-4 Newlib (1|0)
+# Uncomment this if you want to disable the automatic fixup sh4 newlib needed by
+# KallistiOS. This will keep the generated toolchain completely raw. This will
+# also disable the 'kos' thread model. Don't mess with that flag unless you know
+# exactly what you are doing.
+#auto_fixup_sh4_newlib=0
+
+# C99 Format Specifier Support (1|0)
+# Define this to build SH4 Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types.
+#newlib_c99_formats=1
+
+# Optimize Newlib for Space (1|0)
+# Define this to enable optimizing for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance.
+#newlib_opt_space=1
+
+# MinGW/MSYS
+# Standalone binaries (1|0)
+# Define this if you want a standalone, no dependency binaries (i.e. static)
+# When the binaries are standalone, it can be run outside MinGW/MSYS
+# environment. This is NOT recommended. Use it if you know what you are doing.
+#standalone_binary=1
+
+# Force installation of BFD for SH (1|0)
+# Uncomment this if you want to force the installation of 'libbfd' for the SH
+# toolchain. This is required for MinGW/MSYS and can't be disabled in this
+# scenario. This option is here mainly if you want to force the installation of
+# 'libbfd' under other environments; but this won't be necessary in most cases,
+# as 'libelf' is used almost everywhere. Please note, 'libbfd' couldn't be
+# portable if you built it on another environment. Don't mess with that flag
+# unless you know exactly what you are doing.
+#sh_force_libbfd_installation=1

--- a/utils/dc-chain/config/config.mk.9.5.0.sample
+++ b/utils/dc-chain/config/config.mk.9.5.0.sample
@@ -37,10 +37,10 @@ arm_gcc_download_type=xz
 #use_custom_dependencies=1
 
 # GCC dependencies for SH
-sh_gmp_ver=6.2.1
-sh_mpfr_ver=4.1.0
-sh_mpc_ver=1.2.1
-sh_isl_ver=0.24
+sh_gmp_ver=6.1.0
+sh_mpfr_ver=3.1.4
+sh_mpc_ver=1.0.3
+sh_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for SH
 sh_gmp_download_type=bz2

--- a/utils/dc-chain/config/config.mk.winxp-latest.sample
+++ b/utils/dc-chain/config/config.mk.winxp-latest.sample
@@ -6,7 +6,7 @@
 #
 
 # Toolchain versions for SH
-sh_binutils_ver=2.41
+sh_binutils_ver=2.34
 sh_gcc_ver=9.5.0
 newlib_ver=4.3.0.20230120
 gdb_ver=13.2
@@ -20,7 +20,7 @@ gdb_download_type=xz
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.41
+arm_binutils_ver=2.34
 arm_gcc_ver=8.5.0
 
 # Tarball extensions to download for ARM

--- a/utils/dc-chain/patches/arm-Darwin/gcc-9.5.0-kos.diff
+++ b/utils/dc-chain/patches/arm-Darwin/gcc-9.5.0-kos.diff
@@ -1,0 +1,28 @@
+diff --color -ruN gcc-9.5.0/gcc/config/host-darwin.c gcc-9.5.0-kos/gcc/config/host-darwin.c
+--- gcc-9.5.0/gcc/config/host-darwin.c	2023-03-11 14:28:07
++++ gcc-9.5.0-kos/gcc/config/host-darwin.c	2023-03-11 14:28:57
+@@ -22,6 +22,10 @@
+ #include "coretypes.h"
+ #include "diagnostic-core.h"
+ #include "config/host-darwin.h"
++#include "hosthooks.h"
++#include "hosthooks-def.h"
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
+ 
+ /* Yes, this is really supposed to work.  */
+ static char pch_address_space[1024*1024*1024] __attribute__((aligned (4096)));
+diff --color -ruN gcc-9.5.0/gcc/config.host gcc-9.5.0-kos/gcc/config.host
+--- gcc-9.5.0/gcc/config.host	2023-03-11 14:28:19
++++ gcc-9.5.0-kos/gcc/config.host	2023-03-11 14:29:14
+@@ -93,8 +93,8 @@
+ case ${host} in
+   *-darwin*)
+     # Generic darwin host support.
+-    out_host_hook_obj=host-darwin.o
+-    host_xmake_file="${host_xmake_file} x-darwin"
++    # out_host_hook_obj=host-darwin.o
++    # host_xmake_file="${host_xmake_file} x-darwin"
+     ;;
+ esac
+ 

--- a/utils/dc-chain/patches/gcc-9.5.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-9.5.0-kos.diff
@@ -1,0 +1,147 @@
+diff --color -ruN gcc-9.5.0/gcc/config/sh/sh-c.c gcc-9.5.0-kos/gcc/config/sh/sh-c.c
+--- gcc-9.5.0/gcc/config/sh/sh-c.c	2023-06-05 16:31:29.396332076 -0500
++++ gcc-9.5.0-kos/gcc/config/sh/sh-c.c	2023-06-05 16:31:31.707339829 -0500
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff --color -ruN gcc-9.5.0/gcc/configure gcc-9.5.0-kos/gcc/configure
+--- gcc-9.5.0/gcc/configure	2023-06-05 16:31:31.219338192 -0500
++++ gcc-9.5.0-kos/gcc/configure	2023-06-05 16:31:31.712339846 -0500
+@@ -11862,7 +11862,7 @@
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32)
++  single | tpf | vxworks | win32 | kos)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff --color -ruN gcc-9.5.0/libgcc/config/sh/t-sh gcc-9.5.0-kos/libgcc/config/sh/t-sh
+--- gcc-9.5.0/libgcc/config/sh/t-sh	2023-06-05 16:31:31.318338524 -0500
++++ gcc-9.5.0-kos/libgcc/config/sh/t-sh	2023-06-05 16:31:31.712339846 -0500
+@@ -23,6 +23,8 @@
+   $(LIB1ASMFUNCS_CACHE)
+ LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
+ 
++LIB2ADD = $(srcdir)/config/sh/fake-kos.S
++
+ crt1.o: $(srcdir)/config/sh/crt1.S
+ 	$(gcc_compile) -c $<
+ 
+diff --color -ruN gcc-9.5.0/libgcc/configure gcc-9.5.0-kos/libgcc/configure
+--- gcc-9.5.0/libgcc/configure	2023-06-05 16:31:31.323338541 -0500
++++ gcc-9.5.0-kos/libgcc/configure	2023-06-05 16:31:31.713339849 -0500
+@@ -5602,6 +5602,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)    thread_header=config/sh/gthr-kos.h ;;
+ esac
+ 
+ 
+diff --color -ruN gcc-9.5.0/libobjc/Makefile.in gcc-9.5.0-kos/libobjc/Makefile.in
+--- gcc-9.5.0/libobjc/Makefile.in	2023-06-05 16:31:29.138331210 -0500
++++ gcc-9.5.0-kos/libobjc/Makefile.in	2023-06-05 16:31:31.713339849 -0500
+@@ -307,14 +307,16 @@
+ $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
+ 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+ 
+-install: install-libs install-headers
++install-strip: INSTALL_STRIP_FLAG = -s
++install install-strip: install-libs install-headers
+ 
+ install-libs: installdirs
+ 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
+-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
++	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+ 	if [ "$(OBJC_BOEHM_GC)" ]; then \
+-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
+-				$(DESTDIR)$(toolexeclibdir);\
++	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
+ 	fi
+ 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
+ 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
+@@ -327,7 +329,7 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
+diff --color -ruN gcc-9.5.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-9.5.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-9.5.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:31:31.373338708 -0500
++++ gcc-9.5.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:31:31.714339853 -0500
+@@ -22,14 +22,40 @@
+ // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ // <http://www.gnu.org/licenses/>.
+ 
+-// Use the default atomicity stuff, which will use __atomic* builtins
+-// if threads are available, or the *_single functions on single-thread
+-// configurations.
+-// Actually we wouldn't need this header at all, but because of PR 53579
+-// libstdc++'s configury will not pickup the -matomic-model= option when
+-// set in the environment.  This makes it impossible to enable the proper
+-// atomic model on SH without modifying GCC itself, because libstdc++ always
+-// thinks the target doesn't do any atomics and uses the default mutex based
+-// implementation from cpu/generic/atomicity_mutex.
++/* This is generic/atomicity.h */
+ 
+ #include <ext/atomicity.h>
++#include <ext/concurrence.h>
++
++namespace 
++{
++  __gnu_cxx::__mutex&
++  get_atomic_mutex()
++  {
++    static __gnu_cxx::__mutex atomic_mutex;
++    return atomic_mutex;
++  }
++} // anonymous namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val) throw ()
++  {
++    __gnu_cxx::__scoped_lock sentry(get_atomic_mutex());
++    _Atomic_word __result;
++    __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word* __mem, int __val) throw ()
++  { __exchange_and_add(__mem, __val); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --color -ruN gcc-9.5.0/libstdc++-v3/configure gcc-9.5.0-kos/libstdc++-v3/configure
+--- gcc-9.5.0/libstdc++-v3/configure	2023-06-05 16:31:31.657339661 -0500
++++ gcc-9.5.0-kos/libstdc++-v3/configure	2023-06-05 16:31:31.720339873 -0500
+@@ -15631,6 +15631,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)    thread_header=config/sh/gthr-kos.h ;;
+ esac
+ 
+ 


### PR DESCRIPTION
This PR adds a new GCC 9.5.0 + Newlib 4.3.0 + Binutils 2.34 configuration. This consists of the latest versions of these components to work on Windows XP, and is currently in use as an option in the latest beta of DreamSDK. 