### PR TITLE
Fix Addons Makefile Deps

### DIFF
--- a/addons/Makefile.prefab
+++ b/addons/Makefile.prefab
@@ -18,7 +18,7 @@
 
 defaultall: $(OBJS) subdirs linklib
 
-linklib:
+linklib: $(OBJS) $(LIB_OBJS)
 	rm -f $(KOS_BASE)/addons/lib/$(KOS_ARCH)/$(TARGET)
 	$(KOS_AR) rcs $(KOS_BASE)/addons/lib/$(KOS_ARCH)/$(TARGET) $(OBJS) $(LIB_OBJS)
 


### PR DESCRIPTION
Prior to this change, attempting to build the KOS kernel with more than one job (i.e. `-j32`) would cause an error when attempting to build `libkosext2fs`:
```
/opt/toolchains/dc/sh-elf/lib/gcc/sh-elf/13.0.1/../../../../sh-elf/bin/ar: ext2fs.o: No such file or directory
```
The fix was adding `$(OBJS)` as a dependency to the `linklib` target. 

I believe `$(LIB_OBJS)` should also be a dependency based on the comment that describes its usage, however its not used anywhere at the moment so not 100% sure I'm correct with that change.
