### PR TITLE
Rework once controls, once again.

### DIFF
--- a/kernel/thread/once.c
+++ b/kernel/thread/once.c
@@ -4,39 +4,66 @@
    Copyright (C) 2009, 2023 Lawrence Sebald
 */
 
-#include <malloc.h>
-#include <stdio.h>
-#include <assert.h>
 #include <errno.h>
 
 #include <kos/once.h>
 #include <kos/mutex.h>
-#include <arch/irq.h>
+#include <kos/cond.h>
 
 /* The lock used to make sure multiple threads don't try to run the same routine
    at the same time. */
-static mutex_t lock = RECURSIVE_MUTEX_INITIALIZER;
+static mutex_t lock = MUTEX_INITIALIZER;
+static condvar_t cond = COND_INITIALIZER;
+
+#define ONCE_COMPLETE   1
+#define ONCE_INPROGRESS -1
 
 int kthread_once(kthread_once_t *once_control, void (*init_routine)(void)) {
-    if(!once_control || *once_control < 0 || *once_control > 1) {
+    if(!once_control) {
         errno = EINVAL;
         return -1;
     }
 
     /* Lock the lock. */
-    if(mutex_lock(&lock) == -1) {
+    if(mutex_lock(&lock)) {
         return -1;
     }
 
     /* If the function has already been run, unlock the lock and return. */
-    if(*once_control) {
+    if(*once_control == ONCE_COMPLETE) {
         mutex_unlock(&lock);
         return 0;
     }
 
-    /* Run the function, set the control, and unlock the lock. */
-    *once_control = 1;
+    /* If the function is in progress in another thread, wait for it to finish.
+       We share one mutex/condvar across all once controls, so we have to do
+       this in a loop to prevent spurious wakeups. */
+    if(*once_control == ONCE_INPROGRESS) {
+        while(*once_control == ONCE_INPROGRESS) {
+            if(cond_wait(&cond, &lock)) {
+                mutex_unlock(&lock);
+                return -1;
+            }
+        }
+
+        /* We'll only get here once the once control has been set to 1, so
+           return success. */
+        mutex_unlock(&lock);
+        return 0;
+    }
+
+    /* Set that we're in progress and unlock the lock (so other once controls
+       can be used). Once that's done, run the function, re-obtain the lock,
+       set that the function has been run and wake all threads waiting on this
+       particular once control. */
+    *once_control = ONCE_INPROGRESS;
+    mutex_unlock(&lock);
+
     init_routine();
+
+    mutex_lock(&lock);
+    *once_control = ONCE_COMPLETE;
+    cond_broadcast(&cond);
     mutex_unlock(&lock);
 
     return 0;


### PR DESCRIPTION
1. Make them into a tristate value: not done, in progress, and done.
2. Use a condvar to wake up any threads that try to use the same once control before the first caller's function finishes.
3. Make sure another once control can be used while one's init routine is being run. Even if that is done in another thread that the init routine from the first is waiting on somehow (looking at you libstdc++).