### PR TITLE
Updating Dynamic ELF Library/Module Loading

### DIFF
--- a/include/kos/elf.h
+++ b/include/kos/elf.h
@@ -1,12 +1,14 @@
 /* KallistiOS ##version##
 
    kos/elf.h
-   Copyright (C)2000,2001,2003 Megan Potter
+   Copyright (C) 2000, 2001, 2003 Megan Potter
+   Copyright (C) 2023 Falco Girgis
 
 */
 
 /** \file   kos/elf.h
     \brief  ELF binary loading support.
+    \ingroup elf
 
     This file contains the support functionality for loading ELF binaries in
     KOS. This includes the various header structures and whatnot that are used
@@ -15,6 +17,7 @@
     within KOS.
 
     \author Megan Potter
+    \author Falco Girgis
 */
 
 #ifndef __KOS_ELF_H
@@ -26,31 +29,51 @@ __BEGIN_DECLS
 #include <arch/types.h>
 #include <sys/queue.h>
 
-/** \brief  ELF file header.
-
-    This header is at the beginning of any valid ELF binary and serves to
-    identify the architecture of the binary and various data about it.
-
-    \headerfile kos/elf.h
+/** \defgroup elf                       ELF Format
+    \brief Structures and API for working with the ELF format
 */
-struct elf_hdr_t {
-    uint8 ident[16];    /**< \brief ELF identifier */
-    uint16 type;        /**< \brief ELF file type */
-    uint16 machine;     /**< \brief ELF file architecture */
-    uint32 version;     /**< \brief Object file version */
-    uint32 entry;       /**< \brief Entry point */
-    uint32 phoff;       /**< \brief Program header offset */
-    uint32 shoff;       /**< \brief Section header offset */
-    uint32 flags;       /**< \brief Processor flags */
-    uint16 ehsize;      /**< \brief ELF header size in bytes */
-    uint16 phentsize;   /**< \brief Program header entry size */
-    uint16 phnum;       /**< \brief Program header entry count */
-    uint16 shentsize;   /**< \brief Section header entry size */
-    uint16 shnum;       /**< \brief Section header entry count */
-    uint16 shstrndx;    /**< \brief String table section index */
-};
+
+/** \defgroup elf_ident                 ELF Identification Bytes
+    \ingroup elf
+
+    Initial bytes of the ELF file, specifying how it should be
+    interpreted.
+
+    @{
+*/
+#define EI_MAG0         0   /**< \brief File identification: 0x7f */
+#define EI_MAG1         1   /**< \brief File identification: 'E' */
+#define EI_MAG2         2   /**< \brief File identification: 'L' */
+#define EI_MAG3         3   /**< \brief File identificaiton: 'F" */
+#define EI_CLASS        4   /**< \brief File class */
+#define EI_DATA         5   /**< \brief Data encoding */ 
+#define EI_VERSION      6   /**< \brief File version */
+#define EI_OSABI        7   /**< \brief Operating System/ABI identification */
+#define EI_ABIVERSION   8   /**< \brief ABI version */
+#define EI_PAD          9   /**< \brief Start of padding bytes */
+#define EI_NIDENT       16  /**< \brief Size of elf_hdr::ident */
+/** @} */
+
+/** \defgroup elf_types                 ELF object file types
+    \ingroup elf
+
+    Identifies the object file type.
+
+    @{
+*/
+#define ET_NONE     0       /**< \brief No file type */
+#define ET_REL      1       /**< \brief Relocatable file */
+#define ET_EXEC     2       /**< \brief Executable file */
+#define ET_DYN      3       /**< \brief Shared object file */
+#define ET_CORE     4       /**< \brief Core file */
+#define ET_LOOS     0xfe00  /**< \brief OS-specific */
+#define ET_HIOS     0xfeff  /**< \brief OS-specific */
+#define ET_LOPROC   0xff00  /**< \brief Processor-specific */
+#define ET_HIPROC   0xffff  /**< \brief Processor-specific */
+/** @} */
 
 /** \defgroup elf_archs                 ELF architecture types
+    \ingroup elf
 
     These are the various architectures that we might care about for ELF files.
 
@@ -61,7 +84,80 @@ struct elf_hdr_t {
 #define EM_SH   42  /**< \brief SuperH */
 /** @} */
 
+/** \brief ELF file header.
+    \ingroup elf
+
+    This header is at the beginning of any valid ELF binary and serves to
+    identify the architecture of the binary and various data about it.
+*/
+typedef struct elf_hdr {
+    uint8 ident[EI_NIDENT]; /**< \brief ELF identifier */
+    uint16 type;            /**< \brief ELF file type */
+    uint16 machine;         /**< \brief ELF file architecture */
+    uint32 version;         /**< \brief Object file version */
+    uint32 entry;           /**< \brief Entry point */
+    uint32 phoff;           /**< \brief Program header offset */
+    uint32 shoff;           /**< \brief Section header offset */
+    uint32 flags;           /**< \brief Processor flags */
+    uint16 ehsize;          /**< \brief ELF header size in bytes */
+    uint16 phentsize;       /**< \brief Program header entry size */
+    uint16 phnum;           /**< \brief Program header entry count */
+    uint16 shentsize;       /**< \brief Section header entry size */
+    uint16 shnum;           /**< \brief Section header entry count */
+    uint16 shstrndx;        /**< \brief String table section index */
+} elf_hdr_t;
+
+/** \defgroup elf_segments              Segment types
+    \ingroup elf
+
+    Identifies an ELF segment type.
+
+    @{
+*/
+#define PT_NULL     0           /**< \brief Unused */
+#define PT_LOAD     1           /**< \brief Loadable segment */
+#define PT_DYNAMIC  2           /**< \brief Dynamic linking information */
+#define PT_INTERP   3           /**< \brief Interpreter path */
+#define PT_NOTE     4           /**< \brief Auxiliary information */
+#define PT_SHLIB    5           /**< \brief Unspecified semantics */
+#define PT_PHDR     6           /**< \brief Program header */
+#define PT_LOPROC   0x70000000  /**< \brief Processor-specific start */
+#define PT_HIPROC   0x7fffffff  /**< \brief Processor-specific end */
+/** @} */
+
+/** \defgroup phdr_flags                Segment flags
+    \ingroup elf
+
+    Flags for permissions given to a particular segment.
+
+    @{
+*/
+#define PF_X        0x1         /**< \brief Execute */
+#define PF_W        0x2         /**< \brief Write */
+#define PF_R        0x4         /**< \brief Read */
+#define PF_MASKOS   0x0ff00000  /**< \brief Reserved for opperating system */
+#define PF_MASKPROC 0xf0000000  /**< \brief Reserved for processor */
+/** @} */
+
+/** \brief ELF program header.
+    \ingroup elf
+    
+    Describes a segment or other information the system needs to 
+    prepare a program for execution. 
+*/
+typedef struct elf_phdr {
+    uint32 type;    /**< \brief Type of segment */
+    uint32 offset;  /**< \brief File offset */
+    uint32 vaddr;   /**< \brief Virtual address for segment */
+    uint32 paddr;   /**< \brief Physical address for segment */
+    uint32 filesz;  /**< \brief Byte size of file image */
+    uint32 memsz;   /**< \brief Byte size of memory image */
+    uint32 flags;   /**< \brief Flags describing segment */
+    uint32 align;   /**< \brief Alignment in memory and file */
+} elf_phdr_t;
+
 /** \defgroup elf_sections              Section header types
+    \ingroup elf
 
     These are the various types of section headers that can exist in an ELF
     file.
@@ -76,8 +172,7 @@ struct elf_hdr_t {
 #define SHT_HASH        5       /**< \brief Symbol hash table */
 #define SHT_DYNAMIC     6       /**< \brief Dynamic linking info */
 #define SHT_NOTE        7       /**< \brief Notes section */
-#define SHT_NOBITS      8       /**< \brief A section that occupies no space in
-the file */
+#define SHT_NOBITS      8       /**< \brief Occupies no file space */
 #define SHT_REL         9       /**< \brief Relocation table, no addends */
 #define SHT_SHLIB       10      /**< \brief Reserved */
 #define SHT_DYNSYM      11      /**< \brief Dynamic-only sym tab */
@@ -88,6 +183,7 @@ the file */
 /** @} */
 
 /** \defgroup elf_hdrflags              Section header flags
+    \ingroup elf
 
     These are the flags that can be set on a section header. These are related
     to whether the section should reside in memory and permissions on it.
@@ -101,6 +197,7 @@ the file */
 /** @} */
 
 /** \defgroup elf_specsec               Special section indeces
+    \ingroup elf
 
     These are the indices to be used in special situations in the section array.
 
@@ -111,12 +208,31 @@ the file */
 /** @} */
 
 /** \brief  ELF Section header.
+    \ingroup elf
 
     This structure represents the header on each ELF section.
 
-    \headerfile kos/elf.h
+    \note
+    Link and info fields:
+    switch (sh_type) {
+        case SHT_DYNAMIC:
+            link = section header index of the string table used by
+                the entries in this section
+            info = 0
+        case SHT_HASH:
+            ilnk = section header index of the string table to which
+                this info applies
+            info = 0
+        case SHT_REL, SHT_RELA:
+            link = section header index of associated symbol table
+            info = section header index of section to which reloc applies
+        case SHT_SYMTAB, SHT_DYNSYM:
+            link = section header index of associated string table
+            info = one greater than the symbol table index of the last
+                local symbol (binding STB_LOCAL)
+    }
 */
-struct elf_shdr_t {
+typedef struct elf_shdr {
     uint32 name;        /**< \brief Index into string table */
     uint32 type;        /**< \brief Section type \see elf_sections */
     uint32 flags;       /**< \brief Section flags \see elf_hdrflags */
@@ -127,30 +243,10 @@ struct elf_shdr_t {
     uint32 info;        /**< \brief Section header extra info */
     uint32 addralign;   /**< \brief Alignment constraints */
     uint32 entsize;     /**< \brief Fixed-size table entry sizes */
-};
-/* Link and info fields:
-
-switch (sh_type) {
-    case SHT_DYNAMIC:
-        link = section header index of the string table used by
-            the entries in this section
-        info = 0
-    case SHT_HASH:
-        ilnk = section header index of the string table to which
-            this info applies
-        info = 0
-    case SHT_REL, SHT_RELA:
-        link = section header index of associated symbol table
-        info = section header index of section to which reloc applies
-    case SHT_SYMTAB, SHT_DYNSYM:
-        link = section header index of associated string table
-        info = one greater than the symbol table index of the last
-            local symbol (binding STB_LOCAL)
-}
-
-*/
+} elf_shdr_t;
 
 /** \defgroup elf_binding               Symbol binding types.
+    \ingroup elf
 
     These are the values that can be set to say how a symbol is bound in an ELF
     binary. This is stored in the upper 4 bits of the info field in elf_sym_t.
@@ -163,6 +259,7 @@ switch (sh_type) {
 /** @} */
 
 /** \defgroup elf_symtype               Symbol types.
+    \ingroup elf
 
     These are the values that can be set to say what kind of symbol a given
     symbol in an ELF file is. This is stored in the lower 4 bits of the info
@@ -178,62 +275,66 @@ switch (sh_type) {
 /** @} */
 
 /** \brief  Symbol table entry
+    \ingroup elf
 
     This structure represents a single entry in a symbol table in an ELF file.
-
-    \headerfile kos/elf.h
 */
-struct elf_sym_t {
+typedef struct elf_sym {
     uint32 name;        /**< \brief Index into file's string table */
     uint32 value;       /**< \brief Value of the symbol */
     uint32 size;        /**< \brief Size of the symbol */
     uint8 info;         /**< \brief Symbol type and binding */
     uint8 other;        /**< \brief 0. Holds no meaning. */
     uint16 shndx;       /**< \brief Section index */
-};
+} elf_sym_t;
 
 /** \brief  Retrieve the binding type for a symbol.
+    \ingroup elf
+
     \param  info            The info field of an elf_sym_t.
     \return                 The binding type of the symbol.
+    
     \see                    elf_binding
 */
 #define ELF32_ST_BIND(info) ((info) >> 4)
 
 /** \brief  Retrieve the symbol type for a symbol.
+    \ingroup elf 
+
     \param  info            The info field of an elf_sym_t.
     \return                 The symbol type of the symbol.
+    
     \see                    elf_symtype
 */
 #define ELF32_ST_TYPE(info) ((info) & 0xf)
 
 /** \brief  ELF Relocation entry (with explicit addend).
+    \ingroup elf
 
     This structure represents an ELF relocation entry with an explicit addend.
     This structure is used on some architectures, whereas others use the
     elf_rel_t structure instead.
-
-    \headerfile kos/elf.h
 */
-struct elf_rela_t {
+typedef struct elf_rela {
     uint32 offset;      /**< \brief Offset within section */
     uint32 info;        /**< \brief Symbol and type */
     int32 addend;       /**< \brief Constant addend for the symbol */
-};
+} elf_rela_t;
 
 /** \brief  ELF Relocation entry (without explicit addend).
+    \ingroup elf
 
     This structure represents an ELF relocation entry without an explicit
     addend. This structure is used on some architectures, whereas others use the
     elf_rela_t structure instead.
-
-    \headerfile kos/elf.h
 */
-struct elf_rel_t {
+typedef struct elf_rel {
     uint32      offset;     /**< \brief Offset within section */
     uint32      info;       /**< \brief Symbol and type */
-};
+} elf_rel_t;
 
 /** \defgroup elf_reltypes              ELF relocation types
+    \ingroup elf
 
     These define the types of operations that can be done to calculate
     relocations within ELF files.
@@ -246,41 +347,50 @@ struct elf_rel_t {
 /** @} */
 
 /** \brief  Retrieve the symbol index from a relocation entry.
+    \ingroup elf 
+
     \param  i               The info field of an elf_rel_t or elf_rela_t.
     \return                 The symbol table index from that relocation entry.
 */
 #define ELF32_R_SYM(i) ((i) >> 8)
 
 /** \brief  Retrieve the relocation type from a relocation entry.
+    \ingroup elf
+
     \param  i               The info field of an elf_rel_t or an elf_rela_t.
     \return                 The relocation type of that relocation.
     \see                    elf_reltypes
 */
 #define ELF32_R_TYPE(i) ((uint8)(i))
 
+/** \brief Maximum size for the name of an ELF program
+    \ingroup elf
+*/
+#define ELF_PROG_NAME_SIZE  256
+
 struct klibrary;
 
 /** \brief  Kernel-specific definition of a loaded ELF binary.
+    \ingroup elf
 
     This structure represents the internal representation of a loaded ELF binary
     in KallistiOS (specifically as a dynamically loaded library).
-
-    \headerfile kos/elf.h
 */
 typedef struct elf_prog {
-    void *data;             /**< \brief Pointer to program in memory */
-    uint32 size;            /**< \brief Memory image size (rounded up to page size) */
+    void *data;                  /**< \brief Pointer to program in memory */
+    uint32 size;                 /**< \brief Memory image size (rounded up to page size) */
 
     /* Library exports */
-    ptr_t lib_get_name;     /**< \brief Pointer to get_name() function */
-    ptr_t lib_get_version;  /**< \brief Pointer to get_version() function */
-    ptr_t lib_open;         /**< \brief Pointer to library's open function */
-    ptr_t lib_close;        /**< \brief Pointer to library's close function */
+    ptr_t lib_get_name;          /**< \brief Pointer to get_name() function */
+    ptr_t lib_get_version;       /**< \brief Pointer to get_version() function */
+    ptr_t lib_open;              /**< \brief Pointer to library's open function */
+    ptr_t lib_close;             /**< \brief Pointer to library's close function */
 
-    char fn[256];           /**< \brief Filename of library */
+    char fn[ELF_PROG_NAME_SIZE]; /**< \brief Filename of library */
 } elf_prog_t;
 
 /** \brief  Load an ELF binary.
+    \ingroup elf
 
     This function loads an ELF binary from the VFS and fills in an elf_prog_t
     for it.
@@ -290,9 +400,10 @@ typedef struct elf_prog {
     \param  out             Storage for the binary that will be loaded.
     \return                 0 on success, <0 on failure.
 */
-int elf_load(const char *fn, struct klibrary * shell, elf_prog_t * out);
+int elf_load(const char *fn, struct klibrary *shell, elf_prog_t *out);
 
 /** \brief  Free a loaded ELF program.
+    \inroup elf
 
     This function cleans up an ELF binary that was loaded with elf_load().
 


### PR DESCRIPTION
I'm taking a look at dynamic library and module loading for the first time after several of us have taken an interest in it. The D language apparently uses this kind of stuff widely, other console homebrew communities such as N64 and PSP are doing it, and we have no examples or validation tests for ensuring we don't break anything... which is bad, because we know @DC-SWAT and DreamShell depend on it. I was going to address a bunch of library-related things at once with this PR.

- Clean up Doxygen modules and documentation: We're polluting the global Doxygen module namespace with a billion ELF-related things that should all be in a single module, and it's making the Doxygen modules harder to navigate
- Add missing ELF data: The GDC maintainer mentioned that we're missing some structures (program header) for managing dynamic ELFs, which are going to be needed later
- Clean up code: I noticed many things, such as a debug macro which should use variadics, inconsistent struct naming (using the `_t` suffix without typedefs), and extra places where error checking/validation should be happening but isn't. There's also leftovers from when KOS supported GP32 and GBA in there.
- Additional API support for doing things such as iterating over all currently loaded libraries
- Stop requiring KOS's library entry points (lib_get_name(), lib_get_version(), lib_open(), lib_close()). They are a great idea, and the way libraries work is very nice; however, we cannot expect every single dynamic library to have all of these functions, especially if the user is building some multi-level project  in which one dependency which isn't even their code is a dynamic library. This requirement for these methods is intrusive and isn't necessary. We can gracefully ignore these methods, by checking if they're NULL and ignoring them if they aren't present. This will make the system more flexible and still keep compatibility with the KOS-style versioned/named libraries.
- Dynamic TLS: Our TLS model right now necessitates that everything be statically linked. This is also the first step for supporting the full dynamic model; however, more work must be done to support TLS within dynamically loaded libraries.
- Provide an example: I have a feeling nobody is using this fantastic feature of KOS simply because there are no examples. We need an example of dynamically discovering and loading a set of libraries as "plugins" which all implement some common interface
- Provide a standard POSIX API around libraries: It would be very trivial to implement `dl_open()`, `dl_sym()`, and friends as very minimal wrappers over the native API. Several developers such as myself and some of the PSP guys I've been talking to would use this cross-platform API at the application layer to target multiple devices, including the Dreamcast. We might as well for compatibility reasons. 
