### PR TITLE
maple_dev_status: check for nullptr input

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_enum.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_enum.c
@@ -103,7 +103,7 @@ maple_device_t * maple_enum_type_ex(int n, uint32 func, uint32 cap) {
    valid before returning. Cast to the appropriate type you're expecting. */
 void * maple_dev_status(maple_device_t *dev) {
     /* Is the device valid? */
-    if(!dev->valid)
+    if(!dev || !dev->valid)
         return NULL;
 
     /* Waits until the first DMA happens: crude but effective (replace me later) */


### PR DESCRIPTION
maple_dev_status() does not check for NULL passed as input parameter, crashing eg nehe06 when no controller was detected

Some examples might need a better error-handling, but that can be improved in another Merge Request.
