### PR TITLE
Enforced matrix alignment, matrix ASM cleanup

### DIFF
--- a/kernel/arch/dreamcast/include/dc/matrix.h
+++ b/kernel/arch/dreamcast/include/dc/matrix.h
@@ -31,6 +31,12 @@ __BEGIN_DECLS
 
     This function stores the current internal matrix to one in memory.
 
+    \warning
+    \p out MUST be at least 8-byte aligned!
+
+    \note
+    For best performance, 32-byte alignment of \p out is recommended.
+
     \param  out             A pointer to where to store the matrix (must be at
                             least 8-byte aligned, should be 32-byte aligned).
 */
@@ -39,6 +45,12 @@ void mat_store(matrix_t *out);
 /** \brief  Copy a memory matrix into the internal one.
 
     This function loads the internal matrix with the values of one in memory.
+
+    \warning
+    \p out MUST be at least 8-byte aligned!
+
+    \note 
+    For best performance, 32-byte alignment of \p out is recommended.
 
     \param  out             A pointer to where to load the matrix from (must be
                             at least 8-byte aligned, should be 32-byte aligned).
@@ -54,6 +66,12 @@ void mat_identity(void);
 /** \brief  Apply a matrix.
 
     This function multiplies a matrix in memory onto the internal matrix.
+
+    \warning
+    \p src MUST be at least 8-byte aligned!
+
+    \note 
+    For best performance, 32-byte alignment of \p src is recommended.
 
     \param  src             A poitner to the matrix to multiply.
 */

--- a/kernel/arch/dreamcast/include/dc/vec3f.h
+++ b/kernel/arch/dreamcast/include/dc/vec3f.h
@@ -109,7 +109,7 @@ typedef struct vec3f {
         register float __z  __asm__("fr2") = (z2-z1); \
         register float __w  __asm__("fr3"); \
         __asm__ __volatile__( \
-                       "fldi0 fr3\n" \
+                              "fldi0 fr3\n" \
                               "fipr  fv0,fv0\n" \
                               "fsqrt fr3\n" \
                               : "+f" (__w) \

--- a/kernel/arch/dreamcast/include/dc/vector.h
+++ b/kernel/arch/dreamcast/include/dc/vector.h
@@ -22,8 +22,14 @@ __BEGIN_DECLS
 
 /** \brief  Basic 4x4 matrix type.
     \headerfile dc/vector.h
+
+    \warning
+    This type must always be allocated on 8-byte boundaries,
+    or else the API operating on it will crash on unaligned
+    accesses. Keep this in mind with heap allocation, where
+    you must ensure alignment manually.
 */
-typedef float matrix_t[4][4];
+typedef __attribute__ ((aligned (8))) float matrix_t[4][4];
 
 /** \brief  4-part vector type.
     \headerfile dc/vector.h

--- a/kernel/arch/dreamcast/math/matrix.s
+++ b/kernel/arch/dreamcast/math/matrix.s
@@ -1,4 +1,8 @@
-! Simple matrix math module
+! Simple Matrix Math Module
+!
+! NOTE: The majority of these routines are assuming that the FP mode is
+!       always set to single-precision upon entry. They were designed with
+!       the GCC flag `-m4-single-only` in mind.
 !
 ! This module consists of a number of matrix operations that operate on an
 ! "internal" matrix and potentially one "external" matrix. The internal
@@ -28,11 +32,11 @@
 
 
 ! -The lines:
-!	nop
+!   nop
 ! indicates a place where you can put a parallelizable instruction with an issue
 ! rate of 1.
 ! -The lines:
-!	nop nop
+!   nop nop
 ! indicates a place where you can put a non parallelizable instruction with
 ! an issue rate of 1, or 2 parallelizables instructions each with an issue
 ! rate of 1.
@@ -66,13 +70,13 @@
 ! same offset.
 ! Example:
 ! r0=x and r1=16384+x, with 0<=x<32 (cache line size).
-! 	mov		@r0,r2
-!	mov		@r1,r3 ! Cache trashing !!!!!
+!   mov     @r0,r2
+!   mov     @r1,r3 ! Cache trashing !!!!!
 ! Or:
-!	mov		#1,r3
-!	mov		@r0,r2 ! Read a memory word. The corresponding cache line is filled
-!	mov		r3,@r1 ! The same cache line is filled again for writeback.
-!	mov		@r0,r4 ! Cache trashing: the cache line need to be filled again.
+!   mov     #1,r3
+!   mov     @r0,r2 ! Read a memory word. The corresponding cache line is filled
+!   mov     r3,@r1 ! The same cache line is filled again for writeback.
+!   mov     @r0,r4 ! Cache trashing: the cache line need to be filled again.
 ! With this 3 lines, the same cache line is filled 3 times with
 ! the corresponding memory penalties (high with the SH4).
 
@@ -81,138 +85,138 @@
 .globl _mat_store
 ! Number of cycles: ~12 cycles.
 _mat_store:
-	fschg
-	add		#4*16,r4		! Start at the end
+    fschg
+    add         #4*16, r4       ! Start at the end
 
-	fmov		xd14,@-r4
-	fmov		xd12,@-r4
-	fmov		xd10,@-r4
-	fmov		xd8,@-r4
-	fmov		xd6,@-r4
-	fmov		xd4,@-r4
-	fmov		xd2,@-r4
-	fmov		xd0,@-r4
+    fmov        xd14, @-r4
+    fmov        xd12, @-r4
+    fmov        xd10, @-r4
+    fmov        xd8, @-r4
+    fmov        xd6, @-r4
+    fmov        xd4, @-r4
+    fmov        xd2, @-r4
+    fmov        xd0, @-r4
 
-	rts
-	fschg
+    rts
+    fschg
 
 ! Copy a memory matrix into the internal one
 .globl _mat_load
 ! Number of cycles: ~11 cycles.
 _mat_load:
-	fschg
-	fmov		@r4+,xd0
+    fschg
+    fmov        @r4+, xd0
 
-	fmov		@r4+,xd2
-	fmov		@r4+,xd4
-	fmov		@r4+,xd6
-	fmov		@r4+,xd8
-	fmov		@r4+,xd10
-	fmov		@r4+,xd12
-	fmov		@r4+,xd14
+    fmov        @r4+, xd2
+    fmov        @r4+, xd4
+    fmov        @r4+, xd6
+    fmov        @r4+, xd8
+    fmov        @r4+, xd10
+    fmov        @r4+, xd12
+    fmov        @r4+, xd14
 
-	rts
-	fschg
+    rts
+    fschg
 
 ! Clear internal to an identity matrix
 ! Number of cycles: ~17 cycles.
 .globl _mat_identity
 _mat_identity:
 ! Load up identity numbers as 'doubles'
-	fldi0		fr0 ! Entirely zero.
-	fldi0		fr1
-	fldi1		fr2 ! First float is one.
-	fldi0		fr3
-	fldi0		fr4
+    fldi0       fr0         ! Entirely zero.
+    fldi0       fr1
+    fldi1       fr2         ! First float is one.
+    fldi0       fr3
+    fldi0       fr4
 
-	fldi1		fr5 ! Second float is one.
-	fschg
+    fldi1       fr5         ! Second float is one.
+    fschg
 
-	fmov		dr2,xd0 ! Setup matrix.
-	fmov		dr0,xd2
-	fmov		dr4,xd4
-	fmov		dr0,xd6
-	fmov		dr0,xd8
-	fmov		dr2,xd10
-	fmov		dr0,xd12
-	fmov		dr4,xd14
+    fmov        dr2, xd0    ! Setup matrix.
+    fmov        dr0, xd2
+    fmov        dr4, xd4
+    fmov        dr0, xd6
+    fmov        dr0, xd8
+    fmov        dr2, xd10
+    fmov        dr0, xd12
+    fmov        dr4, xd14
 
-	rts
-	fschg
+    rts
+    fschg
 
 ! "Apply" a matrix: multiply a matrix onto the "internal" one.
 ! Number of cycles: ~32.
 .globl _mat_apply
 _mat_apply:
-        fmov.s          fr15,@-r15
-        fmov.s          fr14,@-r15
-        fmov.s          fr13,@-r15
-        fmov.s          fr12,@-r15
-	fschg
-!	nop
+        fmov.s          fr15, @-r15
+        fmov.s          fr14, @-r15
+        fmov.s          fr13, @-r15
+        fmov.s          fr12, @-r15
+    fschg
+!   nop
 
-	fmov		@r4+,dr0 ! Load up first row.
-!	nop
-	fmov		@r4+,dr2
-!	nop
-	fmov		@r4+,dr4 ! Load up second row.
-!	nop
-	fmov		@r4+,dr6
-!	nop
+    fmov        @r4+,dr0 ! Load up first row.
+!   nop
+    fmov        @r4+, dr2
+!   nop
+    fmov        @r4+, dr4 ! Load up second row.
+!   nop
+    fmov        @r4+, dr6
+!   nop
 
-	ftrv		xmtrx,fv0
-!	nop
+    ftrv        xmtrx, fv0
+!   nop
 
-	fmov		@r4+,dr8
-!	nop
-	fmov		@r4+,dr10
-!	nop
+    fmov        @r4+, dr8
+!   nop
+    fmov        @r4+, dr10
+!   nop
 
-!	nop nop
+!   nop nop
 
-	ftrv		xmtrx,fv4
-!	nop
+    ftrv        xmtrx, fv4
+!   nop
 
-	fmov		@r4+,dr12
-!	nop
-	fmov		@r4+,dr14
-!	nop
+    fmov        @r4+, dr12
+!   nop
+    fmov        @r4+, dr14
+!   nop
 
-!	nop nop
+!   nop nop
 
-	ftrv		xmtrx,fv8
-!	nop
+    ftrv        xmtrx, fv8
+!   nop
 
-!	nop nop
-!	nop nop
-!	nop nop
+!   nop nop
+!   nop nop
+!   nop nop
 
-	ftrv		xmtrx,fv12
-!	nop
+    ftrv        xmtrx, fv12
+!   nop
 
-	fmov		dr0,xd0 ! Copy the resulting matrix back to internal.
-!	nop
-	fmov		dr2,xd2
-!	nop
-	fmov		dr4,xd4
-!	nop
-	fmov		dr6,xd6
-!	nop
-	fmov		dr8,xd8
-!	nop
-	fmov		dr10,xd10
-!	nop
-	fmov		dr12,xd12
-!	nop
-	fmov		dr14,xd14
-!	nop
+    fmov        dr0, xd0    ! Copy the resulting matrix back to internal.
+!   nop
+    fmov        dr2, xd2
+!   nop
+    fmov        dr4, xd4
+!   nop
+    fmov        dr6, xd6
+!   nop
+    fmov        dr8, xd8
+!   nop
+    fmov        dr10, xd10
+!   nop
+    fmov        dr12, xd12
+!   nop
+    fmov        dr14, xd14
+!   nop
 
-	fschg
-        fmov.s          @r15+,fr12
-        fmov.s          @r15+,fr13
-        fmov.s          @r15+,fr14
+    fschg
+        fmov.s      @r15+, fr12
+        fmov.s      @r15+, fr13
+        fmov.s      @r15+, fr14
         rts
-        fmov.s          @r15+,fr15
+        fmov.s      @r15+, fr15
 
 
 ! Transform zero or more sets of vectors using the current internal
@@ -228,292 +232,292 @@ _mat_apply:
 !
 .globl _mat_transform
 _mat_transform:
-	! Save registers and setup pointers.
-	pref		@r4
-	mov		r7,r2 ! r2=Stride.
-	fmov		fr12,@-r15
-	add		#-8,r2 ! r2=Stride-12=read stride.
-	fmov		fr13,@-r15
-	mov		r7,r3 ! r3=Stride.
-	fmov		fr14,@-r15
-	add		#12,r3 ! r3=Stride+12=write stride.
+    ! Save registers and setup pointers.
+    pref        @r4
+    mov         r7, r2          ! r2=Stride.
+    fmov        fr12, @-r15
+    add         #-8, r2         ! r2=Stride-12=read stride.
+    fmov        fr13, @-r15
+    mov         r7, r3          ! r3=Stride.
+    fmov        fr14, @-r15
+    add         #12, r3         ! r3=Stride+12=write stride.
 
-	! Load the first vertex.
-	fmov		@r4+,fr0
-	add		#12,r5 ! End of the first destination vector.
-	fmov		@r4+,fr1
-!	nop
-	fmov		@r4,fr2
-	add		r2,r4
-	fldi1		fr3
-	dt			r6
+    ! Load the first vertex.
+    fmov        @r4+, fr0
+    add         #12, r5         ! End of the first destination vector.
+    fmov        @r4+, fr1
+!   nop
+    fmov        @r4, fr2
+    add         r2, r4
+    fldi1       fr3
+    dt          r6
 
-	pref		@r4
-	ftrv		xmtrx,fv0
-	bt			.only1Vertex
-	fldi1		fr12
+    pref        @r4
+    ftrv        xmtrx, fv0
+    bt          .only1Vertex
+    fldi1       fr12
 
-	! Load the second vertex.
-	fmov		@r4+,fr4
-!	nop
-	fmov		@r4+,fr5
-!	nop
-	fmov		@r4,fr6
-	add		r2,r4
-	fldi1		fr7
-!	nop
+    ! Load the second vertex.
+    fmov        @r4+, fr4
+!   nop
+    fmov        @r4+, fr5
+!   nop
+    fmov        @r4, fr6
+    add         r2, r4
+    fldi1       fr7
+!   nop
 
-	pref		@r4
-	fdiv		fr3,fr12
-	dt			r6
-	ftrv		xmtrx,fv4
-	bt			.loopEnd
+    pref        @r4
+    fdiv        fr3, fr12
+    dt          r6
+    ftrv        xmtrx, fv4
+    bt          .loopEnd
 
 .loop:
-	pref		@r5
-!	nop
+    pref        @r5
+!   nop
 
-	fldi1		fr13
-!	nop
+    fldi1       fr13
+!   nop
 
-	! Load a vector.
-	fmov		@r4+,fr8
-!	nop
-	fmov		@r4+,fr9
-!	nop
-	fmov		@r4,fr10
-	add		r2,r4
-	fldi1		fr11
-!	nop
+    ! Load a vector.
+    fmov        @r4+, fr8
+!   nop
+    fmov        @r4+, fr9
+!   nop
+    fmov        @r4, fr10
+    add         r2, r4
+    fldi1       fr11
+!   nop
 
-	pref		@r4
-	fdiv		fr7,fr13
-	dt			r6
-	fmul		fr12,fr1
-	fmul		fr12,fr0
-!	nop
+    pref        @r4
+    fdiv        fr7, fr13
+    dt          r6
+    fmul        fr12, fr1
+    fmul        fr12, fr0
+!   nop
 
-	! Store a vector.
-	ftrv		xmtrx,fv8
-	fmov		fr12,@-r5
-	fmov		fr1,@-r5
-!	nop
-	fmov		fr0,@-r5
-	bt/s		.firstInLoop
-	 add		r3,r5
-	pref		@r5
+    ! Store a vector.
+    ftrv        xmtrx, fv8
+    fmov        fr12, @-r5
+    fmov        fr1, @-r5
+!   nop
+    fmov        fr0, @-r5
+    bt/s        .firstInLoop
+    add         r3, r5
+    pref        @r5
 
-	fldi1		fr14
-!	nop
-	
-	! Load a vector.
-	fmov		@r4+,fr0
-!	nop
-	fmov		@r4+,fr1
-!	nop
-	fmov		@r4,fr2
-	add		r2,r4
-	fldi1		fr3
-!	nop
+    fldi1       fr14
+!   nop
 
-	pref		@r4
-	fdiv		fr11,fr14
-	dt			r6
-	fmul		fr13,fr5
-	fmul		fr13,fr4
-!	nop
+    ! Load a vector.
+    fmov        @r4+, fr0
+!   nop
+    fmov        @r4+, fr1
+!   nop
+    fmov        @r4, fr2
+    add         r2, r4
+    fldi1       fr3
+!   nop
 
-	! Store a vector.
-	ftrv		xmtrx,fv0
-	fmov		fr13,@-r5
-	fmov		fr5,@-r5
-!	nop
-	fmov		fr4,@-r5
-	bt/s		.secondInLoop
-	 add		r3,r5
-	pref		@r5
+    pref        @r4
+    fdiv        fr11, fr14
+    dt          r6
+    fmul        fr13, fr5
+    fmul        fr13, fr4
+!   nop
 
-	fldi1		fr12
-!	nop
+    ! Store a vector.
+    ftrv        xmtrx, fv0
+    fmov        fr13, @-r5
+    fmov        fr5, @-r5
+!   nop
+    fmov        fr4, @-r5
+    bt/s        .secondInLoop
+     add        r3, r5
+    pref        @r5
 
-	! Load a vector.
-	fmov		@r4+,fr4
-!	nop
-	fmov		@r4+,fr5
-!	nop
-	fmov		@r4,fr6
-	add		r2,r4
-	fldi1		fr7
-!	nop
+    fldi1       fr12
+!   nop
 
-	pref		@r4
-	fdiv		fr3,fr12
-	dt			r6
-	fmul		fr14,fr9
-	fmul		fr14,fr8
-!	nop
+    ! Load a vector.
+    fmov        @r4+, fr4
+!   nop
+    fmov        @r4+, fr5
+!   nop
+    fmov        @r4, fr6
+    add         r2, r4
+    fldi1       fr7
+!   nop
 
-	! Store a vector.
-	ftrv		xmtrx,fv4
-	fmov		fr14,@-r5
-	fmov		fr9,@-r5
-!	nop
-	fmov		fr8,@-r5
-	bf/s		.loop
-	 add		r3,r5
+    pref        @r4
+    fdiv        fr3, fr12
+    dt          r6
+    fmul        fr14, fr9
+    fmul        fr14, fr8
+!   nop
+
+    ! Store a vector.
+    ftrv        xmtrx, fv4
+    fmov        fr14, @-r5
+    fmov        fr9, @-r5
+!   nop
+    fmov        fr8, @-r5
+    bf/s        .loop
+    add         r3, r5
 
 .loopEnd:
-	pref		@r5
+    pref        @r5
 
-	fldi1		fr13
-	fdiv		fr7,fr13
+    fldi1       fr13
+    fdiv        fr7, fr13
 
-	fmul		fr12,fr1
-!	nop
-	fmul		fr12,fr0
-	fmov		fr12,@-r5
-!	nop nop
-!	nop nop
-	fmov		fr1,@-r5
-!	nop
-	fmov		fr0,@-r5
-!	nop
+    fmul        fr12, fr1
+!   nop
+    fmul        fr12, fr0
+    fmov        fr12, @-r5
+!   nop nop
+!   nop nop
+    fmov        fr1, @-r5
+!   nop
+    fmov        fr0, @-r5
+!   nop
 
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
 
-	fmov		@r15+,fr14
-	fmul		fr13,fr5
-	add		r3,r5
-	fmul		fr13,fr4
-	fmov		fr13,@-r5
-!	nop
-	fmov		@r15+,fr13
-!	nop
-	fmov		@r15+,fr12
-!	nop
-	fmov		fr5,@-r5
-	rts
- 	 fmov		fr4,@-r5
+    fmov        @r15+, fr14
+    fmul        fr13, fr5
+    add         r3, r5
+    fmul        fr13, fr4
+    fmov        fr13, @-r5
+!   nop
+    fmov        @r15+, fr13
+!   nop
+    fmov        @r15+, fr12
+!   nop
+    fmov        fr5, @-r5
+    rts
+     fmov       fr4, @-r5
 
 
 .only1Vertex:
-	fldi1		fr12
-	fdiv		fr3,fr12
-	fmov		@r15+,fr14
-!	nop
-	fmov		@r15+,fr13
-!	nop
+    fldi1       fr12
+    fdiv        fr3, fr12
+    fmov        @r15+, fr14
+!   nop
+    fmov        @r15+, fr13
+!   nop
 
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
 
-	fmul		fr12,fr1
-!	nop
-	fmul		fr12,fr0
-	fmov		fr12,@-r5
-	fmov		@r15+,fr12
-!	nop
+    fmul        fr12, fr1
+!   nop
+    fmul        fr12, fr0
+    fmov        fr12, @-r5
+    fmov        @r15+, fr12
+!   nop
 
-!	nop nop
+!   nop nop
 
-	fmov		fr1,@-r5
-	rts
-	fmov		fr0,@-r5
+    fmov        fr1, @-r5
+    rts
+    fmov        fr0, @-r5
 
 
 .firstInLoop:
-	pref		@r5
+    pref        @r5
 
-	fldi1		fr14
-	fdiv		fr11,fr14
+    fldi1       fr14
+    fdiv        fr11, fr14
 
-	fmul		fr13,fr5
-!	nop
-	fmul		fr13,fr4
-	fmov		fr13,@-r5
-	fmov		fr5,@-r5
-!	nop
+    fmul        fr13, fr5
+!   nop
+    fmul        fr13, fr4
+    fmov        fr13, @-r5
+    fmov        fr5, @-r5
+!   nop
 
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
 
-	fmov		fr4,@-r5
-	fmul		fr14,fr9
-	add		r3,r5
-	fmul		fr14,fr8
-	fmov		fr14,@-r5
-!	nop
-	fmov		fr9,@-r5
-!	nop
-	fmov		fr8,@-r5
-!	nop
-	fmov		@r15+,fr14
-!	nop
-	fmov		@r15+,fr13
-	rts
-	fmov		@r15+,fr12
+    fmov        fr4, @-r5
+    fmul        fr14, fr9
+    add         r3, r5
+    fmul        fr14, fr8
+    fmov        fr14, @-r5
+!   nop
+    fmov        fr9, @-r5
+!   nop
+    fmov        fr8, @-r5
+!   nop
+    fmov        @r15+, fr14
+!   nop
+    fmov        @r15+, fr13
+    rts
+    fmov        @r15+, fr12
 
 
 .secondInLoop:
-	pref		@r5
+    pref        @r5
 
-	fldi1		fr12
-	fdiv		fr3,fr12
+    fldi1       fr12
+    fdiv        fr3, fr12
 
-	fmul		fr14,fr9
-!	nop
-	fmul		fr14,fr8
-	fmov		fr14,@-r5
+    fmul        fr14, fr9
+!   nop
+    fmul        fr14, fr8
+    fmov        fr14, @-r5
 
-!	nop nop
-!	nop nop
+!   nop nop
+!   nop nop
 
-	fmov		fr9,@-r5
-!	nop
-	fmov		fr8,@-r5
-!	nop
-	fmov		@r15+,fr14
-!	nop
+    fmov        fr9, @-r5
+!   nop
+    fmov        fr8, @-r5
+!   nop
+    fmov        @r15+, fr14
+!   nop
 
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
-!	nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
+!   nop nop
 
-	fmov		@r15+,fr13
-	fmul		fr12,fr1
-	add		r3,r5
-	fmul		fr12,fr0
-	fmov		fr12,@-r5
-!	nop
-	fmov		@r15+,fr12
-!	nop
-	fmov		fr1,@-r5
-	rts
-	fmov		fr0,@-r5
+    fmov        @r15+, fr13
+    fmul        fr12, fr1
+    add         r3, r5
+    fmul        fr12, fr0
+    fmov        fr12, @-r5
+!   nop
+    fmov        @r15+, fr12
+!   nop
+    fmov        fr1, @-r5
+    rts
+    fmov        fr0, @-r5
 
-	
+
 ! Transform zero or more sets of vertices using the current internal
 ! matrix, directly to the store queues. Each vertex is 32 bytes long.
 ! All non-xyz data will be copied over along with the transformed
@@ -530,68 +534,68 @@ _mat_transform:
 .globl _mat_transform_sq
 _mat_transform_sq:
 
-	pref @r4
+    pref @r4
 !   nop
 
-	fldi1		fr9
-	add         #4,r4     ! skip over flags
+    fldi1       fr9
+    add         #4, r4      ! skip over flags
 
 .loop1:
-	! Load a vector.
+    ! Load a vector.
 
-	fmov		@r4+,fr0  ! x
-	add			#32, r5   ! end of destination sq
-	fmov		@r4+,fr1  ! y
-!	nop
-	fmov		@r4+,fr2  ! z
-	! nop
-	fldi1		fr3       ! w (1)
-	! nop                   
-	! nop nop
-	! nop nop   ! 2 cycle stall: fldi1->ftrv dependency
+    fmov        @r4+, fr0   ! x
+    add         #32, r5     ! end of destination sq
+    fmov        @r4+, fr1   ! y
+!   nop
+    fmov        @r4+, fr2   ! z
+    ! nop
+    fldi1       fr3         ! w (1)
+    ! nop
+    ! nop nop
+    ! nop nop               ! 2 cycle stall: fldi1->ftrv dependency
 
-	ftrv		xmtrx,fv0
-	fmov		@r4+,fr4  ! u
-	fmov		@r4+,fr5  ! v
-!	nop
-	fmov		@r4+,fr6  ! argb
-!	nop
-	fmov		@r4+,fr7  ! oargb
-!	nop
+    ftrv        xmtrx, fv0
+    fmov        @r4+, fr4   ! u
+    fmov        @r4+, fr5   ! v
+!   nop
+    fmov        @r4+, fr6   ! argb
+!   nop
+    fmov        @r4+, fr7   ! oargb
+!   nop
 !   nop nop
 
-	fdiv		fr3,fr9
-	add         #-32,r4
+    fdiv        fr3, fr9
+    add         #-32, r4
 
-	! store a vector
-	
-	fmov		@r4,fr8   ! flags
-	add         #32,r4
-	fmov		fr7, @-r5 ! oargb
-	fmov		fr6, @-r5 ! argb
-	fmov		fr5, @-r5 ! v
-	fmov		fr4, @-r5 ! u
+    ! store a vector
 
-	pref        @r4
-	add         #4,r4
-	dt			r6
-	! nop
-	! 5x nop nop
+    fmov        @r4,fr8     ! flags
+    add         #32,r4
+    fmov        fr7, @-r5   ! oargb
+    fmov        fr6, @-r5   ! argb
+    fmov        fr5, @-r5   ! v
+    fmov        fr4, @-r5   ! u
 
-	fmul		fr9,fr1
-	fmul		fr9,fr0
-!	nop
+    pref        @r4
+    add         #4, r4
+    dt          r6
+    ! nop
+    ! 5x nop nop
 
-	fmov		fr9,@-r5   ! z (1/w)
-	fmov		fr1,@-r5   ! y
-	fmov		fr0,@-r5   ! x
-	fmov		fr8,@-r5   ! flags
-	pref		@r5
-	add			#32,r5
+    fmul        fr9, fr1
+    fmul        fr9, fr0
+!   nop
 
-	bf/s		.loop1
-	fldi1		fr9
+    fmov        fr9, @-r5   ! z (1/w)
+    fmov        fr1, @-r5   ! y
+    fmov        fr0, @-r5   ! x
+    fmov        fr8, @-r5   ! flags
+    pref        @r5
+    add         #32, r5
 
-	rts
-	nop
+    bf/s        .loop1
+    fldi1       fr9
+
+    rts
+    nop
 

--- a/kernel/arch/dreamcast/math/matrix3d.c
+++ b/kernel/arch/dreamcast/math/matrix3d.c
@@ -126,7 +126,7 @@ void mat_perspective(float xcenter, float ycenter, float cot_fovy_2,
 
 /* The following lookat code is based heavily on KGL's gluLookAt */
 
-static void cross(const vec3f_t *v1, const vec3f_t *v2, vec3f_t *r) {
+static inline void cross(const vec3f_t *v1, const vec3f_t *v2, vec3f_t *r) {
     r->x = v1->y * v2->z - v1->z * v2->y;
     r->y = v1->z * v2->x - v1->x * v2->z;
     r->z = v1->x * v2->y - v1->y * v2->x;


### PR DESCRIPTION
I got kinda sick of seeing `mat_load()` and `mat_store()` crash on people for the 9999th time on real hardware but work on emulators due to unaligned memory accesses and decided to look into seeing if we could do something about it at the API level... and looks like we can. Oh, and I also made these requirements more clear in the Doxygen. 

While I was mucking around in the 'semblies and matrix/vector routines, I just did some code prettification/formatting.

1) Enforcing alignment for matrix_t types, so we stop getting unaligned
   access crashes (at least for things not on the heap)
2) Minor formatting and stylistic changes to vector and matrix
   assembly routines
    - consistent spacing between operands
    - normalized spaces vs tabs 
3) Added doxygen warnings and notes for required and optimal alignments