### PR TITLE
Watchdog Timer Driver

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -191,6 +191,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added GCC builtin functions for supporting all of C11 atomics [FG]
 - *** Added toolchain and KOS support for C/C++ compiler-level TLS [CP && FG]
 - DC  Added vmu functions to check/enable/disable the extra 41 blocks [AB]
+- *** Added driver for the SH4's Watchdog Timer peripheral [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/examples/dreamcast/basic/Makefile
+++ b/examples/dreamcast/basic/Makefile
@@ -13,6 +13,7 @@ all:
 	$(KOS_MAKE) -C mmu
 	$(KOS_MAKE) -C stackprotector
 	$(KOS_MAKE) -C memtest32
+	$(KOS_MAKE) -C watchdog
 
 clean:
 	$(KOS_MAKE) -C exec clean
@@ -23,6 +24,7 @@ clean:
 	$(KOS_MAKE) -C mmu clean
 	$(KOS_MAKE) -C stackprotector clean
 	$(KOS_MAKE) -C memtest32 clean
+	$(KOS_MAKE) -C watchdog clean
 
 dist:
 	$(KOS_MAKE) -C exec dist
@@ -33,3 +35,4 @@ dist:
 	$(KOS_MAKE) -C mmu dist
 	$(KOS_MAKE) -C stackprotector dist
 	$(KOS_MAKE) -C memtest32 dist
+	$(KOS_MAKE) -C watchdog dist

--- a/examples/dreamcast/basic/watchdog/Makefile
+++ b/examples/dreamcast/basic/watchdog/Makefile
@@ -1,0 +1,28 @@
+# KallistiOS ##version##
+#
+# examples/dreamcast/basic/watchdog/Makefile
+# Copyright (c) 2023 Falco Girgis
+#
+
+TARGET = watchdog.elf
+OBJS = watchdog.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist: $(TARGET)
+	-rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/basic/watchdog/watchdog.c
+++ b/examples/dreamcast/basic/watchdog/watchdog.c
@@ -104,17 +104,17 @@ int main(int argc, char *argv[]) {
 
     /* Enable the WDT in interval counter mode, with a period of 500ms,
        an interrupt priority level of 15 (highest), and give it our 
-       timeout callback plus pass it out counter as its userdata pointer. */
+       timeout callback plus pass it our counter as its userdata pointer. */
     atomic_uint counter = 0;
     wdt_enable_timer(0, WDT_INTERVAL, 15, wdt_timeout, &counter);
 
     /* Begin spinning in a loop until either condition is met:
        1) The counter becomes greater than or equal to the expected value
-          (meaning our timeout has been called the expected number of times
-          from the Watchdog timer driver).
+          (meaning our callback has been called the expected number of times
+          from the Watchdog timer's interval interrupt).
        2) The elapsed time becomes greater than twice the expected number of
           seconds, meaning the watchdog interval timer is not behaving as we
-          expected it to behave.
+          expected it to behave (probably running on emulator).
      */ 
     const time_t start_time = time(NULL);
     time_t current_time = start_time;

--- a/examples/dreamcast/basic/watchdog/watchdog.c
+++ b/examples/dreamcast/basic/watchdog/watchdog.c
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
 
     /* Enable watchdog mode with a period of 5.25ms, causing a manual 
        reset interrupt signal to be raised upon timeout. This will 
-       case your Dreamcast to reboot immediately. */
+       cause your Dreamcast to reboot immediately. */
     wdt_enable_watchdog(0, WDT_CLK_DIV_4096, WDT_RST_MANUAL);
 
     /* Continually "pet" the watchdog timer in a loop, resetting its
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
     /* Immediately disable the WDT once we're done with it. */
     wdt_disable();
 
-    /* Ensure that the WDT's counter wasn't stack at zero the whole
+    /* Ensure that the WDT's counter wasn't stuck at zero the whole
        time and that it was actually updating as expected. */
     if(!max_count) {
         fprintf(stderr, "The WDT counter never even incremented!\n\n");

--- a/examples/dreamcast/basic/watchdog/watchdog.c
+++ b/examples/dreamcast/basic/watchdog/watchdog.c
@@ -7,7 +7,6 @@
 
 static void quit(void) {
      printf("DISABLING WATCHDOG!\n");
-     fflush(stdout); 
      wdt_disable();
      exit(EXIT_SUCCESS);
 }
@@ -26,7 +25,7 @@ int main(int argc, char* argv[]) {
     cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
                       (cont_btn_callback_t)quit);
 
-    wdt_enable_timer(0, 100, timer_callback, NULL);
+    wdt_enable_timer(0, 100, 5, timer_callback, NULL);
 
     while(1) {
         if(triggered) {

--- a/examples/dreamcast/basic/watchdog/watchdog.c
+++ b/examples/dreamcast/basic/watchdog/watchdog.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdatomic.h>
 #include <kos.h>
+#include <time.h>
 
 static void quit(void) {
      printf("DISABLING WATCHDOG!\n");
@@ -12,23 +13,28 @@ static void quit(void) {
 }
 
 static atomic_bool triggered = false;
+static atomic_int counter = 0;
 
 static void timer_callback(void* user_data) {
+    (void)user_data;
+    
+    ++counter;
     triggered = true;
 }
 
 int main(int argc, char* argv[]) { 
-    /* If the face buttons are all pressed, exit the app */
     cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
                       (cont_btn_callback_t)quit);
 
-    wdt_enable_timer(WDT_CLK_DIV_4096,
-                     0,
-                     timer_callback,
-                     "trololo random userdata");
+    wdt_enable_timer(0, 100, timer_callback, NULL);
+
     while(1) {
         if(triggered) {
-            printf("WDT event fired!\n");
+            struct timespec spec;    
+            timespec_get(&spec, TIME_UTC);
+            printf("WDT event fired at [%llu]: %d\n", 
+                    spec.tv_sec, counter);
+            
             triggered = false;
         }
     }

--- a/examples/dreamcast/basic/watchdog/watchdog.c
+++ b/examples/dreamcast/basic/watchdog/watchdog.c
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
+#include <stdatomic.h>
 #include <kos.h>
 
 static void quit(void) {
@@ -9,11 +11,10 @@ static void quit(void) {
      exit(EXIT_SUCCESS);
 }
 
-int callbackFired = 0;
+static atomic_bool triggered = false;
 
-void timer_callback(void* user_data) {
-     printf("USER TIMER CALLBACK!!!\n");
-     callbackFired = !callbackFired;
+static void timer_callback(void* user_data) {
+    triggered = true;
 }
 
 int main(int argc, char* argv[]) { 
@@ -21,26 +22,16 @@ int main(int argc, char* argv[]) {
     cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
                       (cont_btn_callback_t)quit);
 
-#if 0
-     wdt_enable_watchdog(WDT_CLK_DIV_2048,
-                         12, 
-                         WDT_RST_POWER_ON);
-#else 
-     wdt_enable_timer(WDT_CLK_DIV_64,
-                      0,
-                      timer_callback,
-                      NULL);
-     #endif
+    wdt_enable_timer(WDT_CLK_DIV_4096,
+                     0,
+                     timer_callback,
+                     "trololo random userdata");
+    while(1) {
+        if(triggered) {
+            printf("WDT event fired!\n");
+            triggered = false;
+        }
+    }
 
-     while(1) {
-          if(!callbackFired)
-               printf("WDT counter: %u\n", wdt_get_counter());
-          else 
-               printf("FIIIRE!\n");
-                         wdt_pet();
-          fflush(stdout);
-     }
-
-
-     return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/examples/dreamcast/basic/watchdog/watchdog.c
+++ b/examples/dreamcast/basic/watchdog/watchdog.c
@@ -1,42 +1,161 @@
+/* KallistiOS ##version##
+
+   watchdog.c
+   Copyright (C) 2023 Falco Girgis
+
+*/
+
+/* This program serves as both an example of using the Watchdog Timer
+   peripheral on the Dreamcast's SH4 CPU as well as a test to validate
+   the behavior of its driver in KOS.
+
+   NOTE:
+   At the time this is being written, there are no Dreamcast emulators
+   out there which are bothering to emulate the SH4 WDT, since apparently
+   no commercial games actually used it. Special care has been taken to
+   fail the tests gracefully when there is no functioning WDT.
+*/ 
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdatomic.h>
-#include <kos.h>
 #include <time.h>
 
-static void quit(void) {
-     printf("DISABLING WATCHDOG!\n");
-     wdt_disable();
-     exit(EXIT_SUCCESS);
+#include <arch/wdt.h>
+#include <dc/maple/controller.h>
+
+/* Microsecond-based units */
+#define MSEC            1000
+#define SEC             (1000 * MSEC)
+
+/* Test configuration constants */
+#define WDT_PET_COUNT   2000
+#define WDT_INTERVAL    (500 * MSEC)
+#define WDT_SECONDS     10 
+#define WDT_COUNT_MAX   ((WDT_SECONDS * SEC) / WDT_INTERVAL)
+
+/* User callback to be invoked from the WDT's interval timer 
+   interrupt when the requested microsecond period has elapsed. 
+   Our generic userdata pointer is passed back to us as void*. 
+   We use it to store our atomic counter to count the number 
+   of times this callback has been invoked. 
+
+   NOTE: Since we're accessing both from within and outside
+   of the interrupt, we make it atomic to ensure that it 
+   doesn't get updated while it's being read or vice-versa. */
+static void wdt_timeout(void *user_data) {
+    ++(*(atomic_uint *)user_data);
 }
 
-static atomic_bool triggered = false;
-static atomic_int counter = 0;
+/* Main entry point */
+int main(int argc, char *argv[]) { 
+    bool success = true;
 
-static void timer_callback(void* user_data) {
-    (void)user_data;
-    
-    ++counter;
-    triggered = true;
-}
-
-int main(int argc, char* argv[]) { 
+    /* Press all buttons simultaneously to exit early. */
     cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
-                      (cont_btn_callback_t)quit);
+                      (cont_btn_callback_t)exit);
 
-    wdt_enable_timer(0, 100, 5, timer_callback, NULL);
+    /* Note that is EXTREMELY important that the WDT gets disabled 
+       when it is done being used, otherwise it can continue running
+       after the application exits and can interfere with DC-Load 
+       operation. Since we have multiple exit points (one from returning
+       from main and one from the button callback), the safest thing to do
+       is to register wdt_disable() to be called automatically upon exit. */
+    atexit(wdt_disable);
 
+    printf("\nEnabling WDT in watchdog mode!\n");
+
+    /* Enable watchdog mode with a period of 5.25ms, causing a manual 
+       reset interrupt signal to be raised upon timeout. This will 
+       case your Dreamcast to reboot immediately. */
+    wdt_enable_watchdog(0, WDT_CLK_DIV_4096, WDT_RST_MANUAL);
+
+    /* Continually "pet" the watchdog timer in a loop, resetting its
+       counter value and preventing a timeout (and reboot). We also
+       store its max value as we're iterating. */
+    uint8_t max_count = 0;
+    for(int p = 0; p < WDT_PET_COUNT; ++p) {
+        const uint8_t current_count = wdt_get_counter();
+        
+        if(current_count > max_count)  
+            max_count = current_count;
+
+        wdt_pet();
+    }
+
+    /* Immediately disable the WDT once we're done with it. */
+    wdt_disable();
+
+    /* Ensure that the WDT's counter wasn't stack at zero the whole
+       time and that it was actually updating as expected. */
+    if(!max_count) {
+        fprintf(stderr, "The WDT counter never even incremented!\n\n");
+        success = false;
+    }
+    else {
+        printf("Pet it %d times! Maximum counter value was %u.\n\n", 
+               WDT_PET_COUNT, max_count);
+    }
+
+    printf("Enabling WDT timer with interval: %uus.\n", WDT_INTERVAL);
+    printf("Expecting %u callbacks over %u seconds.\n",
+           WDT_COUNT_MAX, WDT_SECONDS);
+
+    /* Enable the WDT in interval counter mode, with a period of 500ms,
+       an interrupt priority level of 15 (highest), and give it our 
+       timeout callback plus pass it out counter as its userdata pointer. */
+    atomic_uint counter = 0;
+    wdt_enable_timer(0, WDT_INTERVAL, 15, wdt_timeout, &counter);
+
+    /* Begin spinning in a loop until either condition is met:
+       1) The counter becomes greater than or equal to the expected value
+          (meaning our timeout has been called the expected number of times
+          from the Watchdog timer driver).
+       2) The elapsed time becomes greater than twice the expected number of
+          seconds, meaning the watchdog interval timer is not behaving as we
+          expected it to behave.
+     */ 
+    const time_t start_time = time(NULL);
+    time_t current_time = start_time;
+    time_t elapsed_time = 0;
     while(1) {
-        if(triggered) {
-            struct timespec spec;    
-            timespec_get(&spec, TIME_UTC);
-            printf("WDT event fired at [%llu]: %d\n", 
-                    spec.tv_sec, counter);
-            
-            triggered = false;
+        /* Measure our current time (using the C standard library, 
+           which internally uses the TMU2 peripheral). */
+        current_time = time(NULL);
+        elapsed_time = current_time - start_time;
+
+        /* Check whether the WDT timer has incremented our counter the 
+           expected number of times and exit if so. */
+        if(counter >= WDT_COUNT_MAX) {
+            break;
+        }
+        /* Check whether we should just give up on the WDT. */
+        else if(elapsed_time > WDT_SECONDS * 2) {
+            fprintf(stderr, "Test is taking too long... timing out!\n");
+            success = false;
+            break;
         }
     }
 
-    return EXIT_SUCCESS;
+    printf("%u callbacks in %llu seconds!\n", counter, elapsed_time);
+
+    /* Ensure that the amount of time elapsed based on WDT callbacks agrees
+       with the amount of time elapsed as reported by TMU2. */
+    const unsigned diff_seconds = abs((int)elapsed_time - (int)WDT_SECONDS);
+    if(diff_seconds > 1) {
+        printf("Watchdog timing did not match system timing!\n"
+               "\t[%u sec delta]\n", diff_seconds);
+        success = false;
+    }
+
+    /* Report results and return status code. */
+    if(success) {
+        printf("\n\n***** WATCHDOG TIMER TEST SUCCEEDED! *****\n\n");
+        return EXIT_SUCCESS;
+    }
+    else {
+        fprintf(stderr, "\n\nXXXXX WATCHDOG TIMER TEST FAILED! XXXXX\n\n");
+        return EXIT_FAILURE;
+    }
 }

--- a/examples/dreamcast/basic/watchdog/watchdog.c
+++ b/examples/dreamcast/basic/watchdog/watchdog.c
@@ -1,0 +1,46 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <kos.h>
+
+static void quit(void) {
+     printf("DISABLING WATCHDOG!\n");
+     fflush(stdout); 
+     wdt_disable();
+     exit(EXIT_SUCCESS);
+}
+
+int callbackFired = 0;
+
+void timer_callback(void* user_data) {
+     printf("USER TIMER CALLBACK!!!\n");
+     callbackFired = !callbackFired;
+}
+
+int main(int argc, char* argv[]) { 
+    /* If the face buttons are all pressed, exit the app */
+    cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
+                      (cont_btn_callback_t)quit);
+
+#if 0
+     wdt_enable_watchdog(WDT_CLK_DIV_2048,
+                         12, 
+                         WDT_RST_POWER_ON);
+#else 
+     wdt_enable_timer(WDT_CLK_DIV_64,
+                      0,
+                      timer_callback,
+                      NULL);
+     #endif
+
+     while(1) {
+          if(!callbackFired)
+               printf("WDT counter: %u\n", wdt_get_counter());
+          else 
+               printf("FIIIRE!\n");
+                         wdt_pet();
+          fflush(stdout);
+     }
+
+
+     return EXIT_SUCCESS;
+}

--- a/include/kos.h
+++ b/include/kos.h
@@ -63,6 +63,7 @@ __BEGIN_DECLS
 #include <arch/irq.h>
 #include <arch/spinlock.h>
 #include <arch/timer.h>
+#include <arch/wdt.h>
 #include <arch/types.h>
 #include <arch/exec.h>
 #include <arch/stack.h>

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -47,12 +47,6 @@ __BEGIN_DECLS
 */
 #define TMU2    2
 
-/** \brief  SH4 Watchdog Timer.
-
-    KallistiOS does not currently support using this timer.
-*/
-#define WDT     3
-
 /** \brief  Which timer does the thread system use? */
 #define TIMER_ID TMU0
 

--- a/kernel/arch/dreamcast/include/arch/wdt.h
+++ b/kernel/arch/dreamcast/include/arch/wdt.h
@@ -6,12 +6,19 @@
 */
 
 /** \file   arch/wdt.h
-    \brief  Watchdog timer API
+    \brief  Watchdog Timer API
 
     This file provides an API built around utilizing the SH4's watchdog timer.
-    There are two different modes which are supported:
+    There are two different modes of operation which are supported:
         - watchdog mode: counter overflow causes a reset interrupt
         - interval timer mode: counter overflow causes a timer interrupt
+
+    To start the WDT in watchdog mode, use wdt_enable_watchdog(). To use the 
+    WDT as a general-purpose interval timer, use wdt_enable_timer().
+
+    The timer can be stopped in either mode by calling wdt_disable_timer().
+
+    \sa timer.h, wdt.h
 
     \author Falco Girgis
 */
@@ -24,32 +31,67 @@ __BEGIN_DECLS
 
 #include <stdint.h>
 
+/** \brief Clock divider settings 
+ 
+    Denominators used to set the frequency divider
+    for the input clock to the WDT.
+ */
 typedef enum WDT_CLK_DIV {
-    WDT_CLK_DIV_32,
-    WDT_CLK_DIV_64,
-    WDT_CLK_DIV_128,
-    WDT_CLK_DIV_256,
-    WDT_CLK_DIV_512,
-    WDT_CLK_DIV_1024,
-    WDT_CLK_DIV_2048,
-    WDT_CLK_DIV_4096
+    WDT_CLK_DIV_32,     /** \brief Period: 41us */
+    WDT_CLK_DIV_64,     /** \brief Period: 82us */
+    WDT_CLK_DIV_128,    /** \brief Period: 164us */
+    WDT_CLK_DIV_256,    /** \brief Period: 328us */
+    WDT_CLK_DIV_512,    /** \brief Period: 656us */
+    WDT_CLK_DIV_1024,   /** \brief Period: 1.31ms */
+    WDT_CLK_DIV_2048,   /** \brief Period: 2.62ms */
+    WDT_CLK_DIV_4096    /** \brief Period: 5.25ms */
 } WDT_CLK_DIV;
 
+/** \brief Reset signal type
+ 
+    Specifies the kind of reset to be performed when the WDT
+    overflows in watchdog mode.
+*/
 typedef enum WDT_RST {
-    WDT_RST_POWER_ON,
-    WDT_RST_MANUAL
+    WDT_RST_POWER_ON,   /** \brief Power-On Resest */
+    WDT_RST_MANUAL      /** \brief Manual Reset */
 } WDT_RST;
 
+/* \brief WDT interval timer callback function type */
 typedef void (*wdt_callback)(void *user_data);
 
-void wdt_enable_timer(WDT_CLK_DIV clk_config,
-                      uint8_t initial_count,
+/** \brief  Enables the WDT as an interval timer
+
+    Stops the WDT if it was previously running and reconfigures it 
+    to be used as a generic interval timer, calling the given callback
+    periodically at the requested interval (or as close to it as possible
+    without calling it prematurely).
+
+    \note 
+    The internal resolution for each tick of the WDT in this mode is 
+    41us, meaning a requested \p microsec_period of 100us will result
+    in an actual callback interval of 123us.
+
+    \warning
+    \p callback is invoked within an interrupt context, meaning that 
+    special care should be taken to not perform any logic requiring 
+    additional interrupts. Data that is accessed from both within
+    and outside of the callback should be atomic or protected by a 
+    lock.
+
+    \param  initial_count   Initial value of the WDT counter (Normally 0).
+    \param  microsec_period Timer callback interval in microseconds
+    \param  callback        User function to invoke periodically
+    \param  user_data       Arbitrary user-provided data for the callback
+*/
+void wdt_enable_timer(uint8_t initial_count,
+                      uint32_t microsec_period,
                       wdt_callback callback,
                       void *user_data);
 
 
-void wdt_enable_watchdog(WDT_CLK_DIV clk_config,
-                         uint8_t initial_count,
+void wdt_enable_watchdog(uint8_t initial_count,
+                         WDT_CLK_DIV clk_config,
                          WDT_RST reset_select);
 
 uint8_t wdt_get_counter(void);

--- a/kernel/arch/dreamcast/include/arch/wdt.h
+++ b/kernel/arch/dreamcast/include/arch/wdt.h
@@ -1,3 +1,27 @@
+/* KallistiOS ##version##
+
+   arch/dreamcast/include/wdt.h
+   Copyright (c) 2023 Falco Girgis
+
+*/
+
+/** \file   arch/wdt.h
+    \brief  Watchdog timer API
+
+    This file provides an API built around utilizing the SH4's watchdog timer.
+    There are two different modes which are supported:
+        - watchdog mode: counter overflow causes a reset interrupt
+        - interval timer mode: counter overflow causes a timer interrupt
+
+    \author Falco Girgis
+*/
+
+#ifndef __ARCH_WDT_H
+#define __ARCH_WDT_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
 #include <stdint.h>
 
 typedef enum WDT_CLK_DIV {
@@ -34,4 +58,8 @@ void wdt_pet(void);
 
 void wdt_disable(void);
 int wdt_is_enabled(void);
+
+__END_DECLS
+
+#endif  /* __ARCH_WDT_H */
 

--- a/kernel/arch/dreamcast/include/arch/wdt.h
+++ b/kernel/arch/dreamcast/include/arch/wdt.h
@@ -11,14 +11,21 @@
     This file provides an API built around utilizing the SH4's watchdog timer.
     There are two different modes of operation which are supported:
         - watchdog mode: counter overflow causes a reset interrupt
-        - interval timer mode: counter overflow causes a timer interrupt
+        - interval timer mode: counter overflow invokes a callback function
 
     To start the WDT in watchdog mode, use wdt_enable_watchdog(). To use the 
     WDT as a general-purpose interval timer, use wdt_enable_timer().
 
     The timer can be stopped in either mode by calling wdt_disable_timer().
 
-    \sa timer.h, wdt.h
+    \warning
+    Once the WDT has been enabled, special care must be taken to disable it
+    when exiting from the application. If left enabled, the WDT will continue
+    running beyond the lifetime of the application, causing either a reset or
+    an unhandled exception (depending on which mode was used), preventing you
+    from gracefully returning to a DC-Load session when testing.
+
+    \sa timer.h, rtc.h
 
     \author Falco Girgis
 */
@@ -53,7 +60,7 @@ typedef enum WDT_CLK_DIV {
     overflows in watchdog mode.
 */
 typedef enum WDT_RST {
-    WDT_RST_POWER_ON,   /** \brief Power-On Resest */
+    WDT_RST_POWER_ON,   /** \brief Power-On Reset */
     WDT_RST_MANUAL      /** \brief Manual Reset */
 } WDT_RST;
 
@@ -81,27 +88,85 @@ typedef void (*wdt_callback)(void *user_data);
 
     \param  initial_count   Initial value of the WDT counter (Normally 0).
     \param  microsec_period Timer callback interval in microseconds
+    \param  irq_prio        Priority for the interval timer IRQ (1-7)
     \param  callback        User function to invoke periodically
     \param  user_data       Arbitrary user-provided data for the callback
+
+    \sa wdt_disable()
 */
 void wdt_enable_timer(uint8_t initial_count,
                       uint32_t microsec_period,
+                      uint8_t irq_prio,
                       wdt_callback callback,
                       void *user_data);
 
+/** \brief  Enables the WDT in watchdog mode
 
+    Stops the WDT if it was previously running and reconfigures it 
+    to be used as a typical watchdog timer, generating a resest 
+    interupt upon counter overflow. To prevent this from happening,
+    the user should be periodically resetting the counter.
+
+    \note
+    Keep in mind the speed of the WDT. With a range of 41us to 5.2ms,
+    the WDT will overflow before a single frame in a typical game. 
+
+    \param  initial_count   Initial value of the WDT counter (Normally 0)
+    \param  clk_config      Clock divider to set watchdog period
+    \param  reset_select    The type of reset generated upon overflow
+
+    \sa wdt_disable()
+*/
 void wdt_enable_watchdog(uint8_t initial_count,
                          WDT_CLK_DIV clk_config,
                          WDT_RST reset_select);
 
+/** \brief  Fetches the counter value
+ 
+    Returns the current 8-bit value of the WDT counter. 
+
+    \return     Current counter value
+
+    \sa wdt_set_counter()
+*/
 uint8_t wdt_get_counter(void);
+
+/** \brief  Sets the counter value
+ 
+    Sets the current 8-bit value of the WDT counter.
+
+    \param  value       New value for the counter 
+
+    \sa wdt_get_counter(), wdt_pet()
+*/
 void wdt_set_counter(uint8_t value);
+
+/** \brief  Resets the counter value 
+ 
+    "Petting" or "kicking" the WDT is the same thing as
+    resetting its counter value to 0.
+
+    \sa wdt_set_counter()
+*/
 void wdt_pet(void);
 
+/** \brief Disables the WDT
+    
+    Disables the WDT if it was previously enabled, 
+    otherwise does nothing. 
+
+    \sa wdt_enable_timer(), wdt_enable_watchdog()
+*/
 void wdt_disable(void);
+
+/** \brief  Returns whether the WDT is enabled
+
+    Checks to see whether the WDT has been enabled.
+
+    \return     1 if enabled, 0 if disabled
+*/
 int wdt_is_enabled(void);
 
 __END_DECLS
 
 #endif  /* __ARCH_WDT_H */
-

--- a/kernel/arch/dreamcast/include/arch/wdt.h
+++ b/kernel/arch/dreamcast/include/arch/wdt.h
@@ -104,7 +104,7 @@ void wdt_enable_timer(uint8_t initial_count,
 
     Stops the WDT if it was previously running and reconfigures it 
     to be used as a typical watchdog timer, generating a resest 
-    interupt upon counter overflow. To prevent this from happening,
+    interrupt upon counter overflow. To prevent this from happening,
     the user should be periodically resetting the counter.
 
     \note

--- a/kernel/arch/dreamcast/include/arch/wdt.h
+++ b/kernel/arch/dreamcast/include/arch/wdt.h
@@ -88,7 +88,7 @@ typedef void (*wdt_callback)(void *user_data);
 
     \param  initial_count   Initial value of the WDT counter (Normally 0).
     \param  microsec_period Timer callback interval in microseconds
-    \param  irq_prio        Priority for the interval timer IRQ (1-7)
+    \param  irq_prio        Priority for the interval timer IRQ (1-15)
     \param  callback        User function to invoke periodically
     \param  user_data       Arbitrary user-provided data for the callback
 

--- a/kernel/arch/dreamcast/include/arch/wdt.h
+++ b/kernel/arch/dreamcast/include/arch/wdt.h
@@ -1,0 +1,37 @@
+#include <stdint.h>
+
+typedef enum WDT_CLK_DIV {
+    WDT_CLK_DIV_32,
+    WDT_CLK_DIV_64,
+    WDT_CLK_DIV_128,
+    WDT_CLK_DIV_256,
+    WDT_CLK_DIV_512,
+    WDT_CLK_DIV_1024,
+    WDT_CLK_DIV_2048,
+    WDT_CLK_DIV_4096
+} WDT_CLK_DIV;
+
+typedef enum WDT_RST {
+    WDT_RST_POWER_ON,
+    WDT_RST_MANUAL
+} WDT_RST;
+
+typedef void (*wdt_callback)(void *user_data);
+
+void wdt_enable_timer(WDT_CLK_DIV clk_config,
+                      uint8_t initial_count,
+                      wdt_callback callback,
+                      void *user_data);
+
+
+void wdt_enable_watchdog(WDT_CLK_DIV clk_config,
+                         uint8_t initial_count,
+                         WDT_RST reset_select);
+
+uint8_t wdt_get_counter(void);
+void wdt_set_counter(uint8_t value);
+void wdt_pet(void);
+
+void wdt_disable(void);
+int wdt_is_enabled(void);
+

--- a/kernel/arch/dreamcast/kernel/Makefile
+++ b/kernel/arch/dreamcast/kernel/Makefile
@@ -10,7 +10,7 @@
 # that minimum set must be present.
 
 COPYOBJS = banner.o cache.o entry.o irq.o init.o mm.o panic.o
-COPYOBJS += rtc.o timer.o
+COPYOBJS += rtc.o timer.o wdt.o
 COPYOBJS += init_flags_default.o init_romdisk_default.o
 COPYOBJS += mmu.o itlb.o
 COPYOBJS += exec.o execasm.o stack.o gdb_stub.o thdswitch.o arch_exports.o

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -339,4 +339,6 @@ void irq_shutdown(void) {
             "ldc    r0,sr" : : "m"(pre_sr));
     __asm__("mov.l  %0,r0\n"
             "ldc    r0,vbr" : : "m"(pre_vbr));
+
+    initted = 0;
 }

--- a/kernel/arch/dreamcast/kernel/wdt.c
+++ b/kernel/arch/dreamcast/kernel/wdt.c
@@ -1,67 +1,84 @@
-#include <stdint.h>
+/* KallistiOS ##version##
+
+   arch/dreamcast/kernel/wdt.c
+   Copyright (C) 2023 Falco Girgis
+*/
+
+/* This file contains the implementation of the SH4 watchdog timer driver. */
+
 #include <arch/wdt.h>
 #include <arch/irq.h>
-#include <stdio.h>
 
-#define WDT_BASE        0xffc00008
-#define WTCNT_HIGH      0x5a
-#define WTCSR_HIGH      0xa5
-
+/* Macros for accessing WDT registers */
 #define WDT(o, t)       (*((volatile t *)(WDT_BASE + o)))
 #define WDT_READ(o)     (WDT(o, uint8_t))
 #define WDT_WRITE(o, v) (WDT(o, uint16_t) = ((o##_HIGH << 8) | ((v) & 0xff)))
 
-#define WTCNT           0x0
-#define WTCSR           0x4
+/* Constants for WDT register access */
+#define WDT_BASE        0xffc00008  /* Base address for WDT registers */
+#define WTCNT_HIGH      0x5a        /* High byte value when writing to WTCNT */
+#define WTCSR_HIGH      0xa5        /* Low byte value when writing to WTCSR */
 
-#define WTCSR_TME       7
-#define WTCSR_WTIT      6
-#define WTCSR_RSTS      5
-#define WTCSR_WOVF      4
-#define WTCSR_IOVF      3
-#define WTCSR_CKS2      2   
+/* Offsets of WDT registers */
+#define WTCNT           0x0 /* Watchdog Timer Counter */ 
+#define WTCSR           0x4 /* Watchdog Timer Control/Status */
+
+/* WDT Control/Status Register flags */
+#define WTCSR_TME       7   /* Timer Enable */
+#define WTCSR_WTIT      6   /* Timer Mode Select */
+#define WTCSR_RSTS      5   /* Reset Select */
+#define WTCSR_WOVF      4   /* Watchdog Timer Overflow Flag */
+#define WTCSR_IOVF      3   /* Interval Timer Overflow Flag */
+#define WTCSR_CKS2      2   /* Clock Select (3 bits) */
 #define WTCSR_CKS1      1
 #define WTCSR_CKS0      0
 
-#define IPR_BASE        0xffd00004
+/* Default values for interval timer mode */
+#define WDT_CLK_DEFAULT WDT_CLK_DIV_32  /* Interval timer mode clock divider */
+#define WDT_INT_DEFAULT 41              /* Interval timer mode period (us) */
+
+/* Interrupt Priority Register access */
 #define IPR(o)          (*((volatile uint16_t *)(IPR_BASE + o)))
-#define IPRA            0x0
-#define IPRB            0x4
-#define IPRC            0x8
-#define IPRD            0xc
+#define IPR_BASE        0xffd00004  /* Base Address */
+#define IPRB            0x4         /* Interrupt Priority Register B offset */
+#define IPRB_WDT        12          /* IRB WDT IRQ priority field (3 bits) */
+#define IPRB_WDT_MASK   0x7         /* Mask for IRB WDT IRQ priority field */
 
-#define IPRB_WDT        12
-
-#define WDT_CLK_DEFAULT WDT_CLK_DIV_32
-#define WDT_INT_DEFAULT 41
-
+/* Interval timer state data */
 static void *user_data = NULL;
 static wdt_callback callback = NULL;
 static uint32_t us_interval = 0;
 static uint32_t us_elapsed = 0;
 
+/* Interval timer mode interrupt handler */
 static void wdt_isr(irq_t src, irq_context_t *cxt) {
     (void)src;
     (void)cxt;
 
+    /* Update elapsed time */
     us_elapsed += WDT_INT_DEFAULT;
     
+    /* Invoke user callback when enough time has elapsed */
     if(us_elapsed >= us_interval) { 
         callback(user_data);
         us_elapsed = 0;
     }
 
-    WDT_WRITE(WTCSR, WDT_READ(WTCSR) & (~(1 << WTCSR_IOVF)));
+    /* Reset interval timer overflow flag */
+    WDT_WRITE(WTCSR, WDT_READ(WTCSR) & ~(1 << WTCSR_IOVF));
 }
 
+/* Enables the WDT in interval timer mode */
 void wdt_enable_timer(uint8_t initial_count,
                       uint32_t micro_seconds,
+                      uint8_t irq_prio,
                       wdt_callback callback_,
                       void *user_data_) {
-    
+    /* Initial WTCSR register configuration */
+    const uint8_t wtcsr = WDT_CLK_DEFAULT;
 
-    /* Stop WDT, Enable Interval Timer, Set Clock Divisor */
-    WDT_WRITE(WTCSR, WDT_CLK_DEFAULT);
+    /* Stop WDT, enable interval timer mode, set clock divider */
+    WDT_WRITE(WTCSR, wtcsr);
 
     /* Store user callback data for later */
     callback = callback_;
@@ -72,47 +89,66 @@ void wdt_enable_timer(uint8_t initial_count,
     /* Register our interrupt handler */
     irq_set_handler(EXC_WDT_ITI, wdt_isr);
 
-    /* Unmask the WDTIT interrupt */
-    IPR(IPRB) = IPR(IPRB) | (5 << IPRB_WDT);
+    /* Unmask the WDTIT interrupt, giving it a new priority */
+    IPR(IPRB) = IPR(IPRB) | ((irq_prio & IPRB_WDT_MASK) << IPRB_WDT);
 
-    /* Reset the WDT counter */
+    /* Initialize WDT counter to starting value */
     WDT_WRITE(WTCNT, initial_count);
 
-    /* Write same configuration plus the enable bit set to start the WDT */
-    WDT_WRITE(WTCSR, (1 << WTCSR_TME) | WDT_CLK_DEFAULT);
+    /* Write same configuration plus the enable bit to start the WDT */
+    WDT_WRITE(WTCSR, wtcsr | (1 << WTCSR_TME));
 }
 
-
+/* Enables the WDT in watchdog mode */
 void wdt_enable_watchdog(uint8_t initial_count,
                          WDT_CLK_DIV clk_config,
                          WDT_RST reset_select) {
-    WDT_WRITE(WTCSR, (1 << WTCSR_WTIT));
+    /* Initial WTCSR register configuration */
+    const uint8_t wtcsr = (1 << WTCSR_WTIT) | 
+                          (reset_select << WTCSR_RSTS) | 
+                          clk_config;
+
+    /* Stop WDT, enable watchdog mode, set reset type, set clock divider */
+    WDT_WRITE(WTCSR, wtcsr);
+    
+    /* Initialize WDT counter to starting value */
     WDT_WRITE(WTCNT, initial_count);
-    WDT_WRITE(WTCSR, (1 << WTCSR_TME) | (1 << WTCSR_WTIT) | 
-                     (reset_select << WTCSR_RSTS) | clk_config);
+    
+    /* Write same configuration plus the enable bit to start the WDT */
+    WDT_WRITE(WTCSR, wtcsr | (1 << WTCSR_TME));
 }
 
+/* Set the value of the WTCNT register */
 void wdt_set_counter(uint8_t count) {
     WDT_WRITE(WTCNT, count);
 }
 
+/* Returns the value of the WTCNT register */
 uint8_t wdt_get_counter(void) {
     return WDT_READ(WTCNT);
 }
 
+/* Resets the WTCNT register to 0 */
 void wdt_pet(void) {
     wdt_set_counter(0);
 }
 
+/* Disables the WDT */
 void wdt_disable(void) {
-    /* Mask the WDTIT interrupt */
-    IPR(IPRB) = IPR(IPRB) & ~(7 << IPRB_WDT);
-
+    /* Stop the WDT */
     WDT_WRITE(WTCSR, WDT_READ(WTCSR) & ~(1 << WTCSR_TME));
 
+    /* Mask the WDTIT interrupt */
+    IPR(IPRB) = IPR(IPRB) & ~(IPRB_WDT_MASK << IPRB_WDT);
+
+    /* Unregister our interrupt handler */
+    irq_set_handler(EXC_WDT_ITI, NULL);
+
+    /* Reset the WDT counter */
     wdt_pet();
 }
 
+/* Returns whether the WDT is enabled */
 int wdt_is_enabled(void) {
     return WDT_READ(WTCSR) & (1 << WTCSR_TME);
 }

--- a/kernel/arch/dreamcast/kernel/wdt.c
+++ b/kernel/arch/dreamcast/kernel/wdt.c
@@ -1,0 +1,78 @@
+#include <stdint.h>
+#include <arch/wdt.h>
+#include <arch/irq.h>
+#include <stdio.h>
+
+#define WDT_BASE        0xffc00008
+#define WTCNT_HIGH      0x5a
+#define WTCSR_HIGH      0xa5
+
+#define WDT(o, t)       (*((volatile t *)(WDT_BASE + o)))
+#define WDT_READ(o)     (WDT(o, uint8_t))
+#define WDT_WRITE(o, v) (WDT(o, uint16_t) = ((o##_HIGH << 8) | ((v) & 0xff)))
+
+#define WTCNT           0x0
+#define WTCSR           0x4
+
+#define WTCSR_TME       7
+#define WTCSR_WTIT      6
+#define WTCSR_RSTS      5
+#define WTCSR_WOVF      4
+#define WTCSR_IOVF      3
+#define WTCSR_CKS2      2   
+#define WTCSR_CKS1      1
+#define WTCSR_CKS0      0
+
+static void *user_data = NULL;
+static wdt_callback callback = NULL;
+
+static void wdt_isr(irq_t src, irq_context_t *cxt) {
+    printf("WDT IRQ!!!!!!!");
+    //fflush(stdout);
+    callback(user_data);
+}
+
+void wdt_enable_timer(WDT_CLK_DIV clk_config,
+                      uint8_t initial_count,
+                      wdt_callback callback_,
+                      void *user_data_) {
+    WDT_WRITE(WTCSR, 0);
+
+    callback = callback_;
+    user_data = user_data_;
+    irq_set_handler(EXC_WDT_ITI, wdt_isr);
+
+    WDT_WRITE(WTCNT, initial_count);
+    WDT_WRITE(WTCSR, (1 << WTCSR_TME) | clk_config);
+}
+
+
+void wdt_enable_watchdog(WDT_CLK_DIV clk_config,
+                         uint8_t initial_count,
+                         WDT_RST reset_select) {
+    WDT_WRITE(WTCSR, (1 << WTCSR_WTIT));
+    WDT_WRITE(WTCNT, initial_count);
+    WDT_WRITE(WTCSR, (1 << WTCSR_TME) | (1 << WTCSR_WTIT) | 
+                     (reset_select << WTCSR_RSTS) | clk_config);
+}
+
+void wdt_set_counter(uint8_t count) {
+    WDT_WRITE(WTCNT, count);
+}
+
+uint8_t wdt_get_counter(void) {
+    return WDT_READ(WTCNT);
+}
+
+void wdt_pet(void) {
+    wdt_set_counter(0);
+}
+
+void wdt_disable(void) {
+    WDT_WRITE(WTCSR, ~(1 << WTCSR_TME));
+}
+
+int wdt_is_enabled(void) {
+    return WDT_READ(WTCSR) & (1 << WTCSR_TME);
+}
+

--- a/kernel/arch/dreamcast/kernel/wdt.c
+++ b/kernel/arch/dreamcast/kernel/wdt.c
@@ -61,7 +61,7 @@ static void wdt_isr(irq_t src, irq_context_t *cxt) {
     /* Invoke user callback when enough time has elapsed */
     if(us_elapsed >= us_interval) { 
         callback(user_data);
-        us_elapsed = 0;
+        us_elapsed -= us_interval;
     }
 
     /* Reset interval timer overflow flag */


### PR DESCRIPTION
The other day I noticed a comment in the timer code about us not supporting the SH4's WDT... over my dead body! 

But seriously, it turns out the WDT can also be used as an additional general interval timer with a max resolution of 41us, which is pretty nice. I figure that would probably be the main use-case for it. 

- [x] Added new API and driver for WDT to kernel/arch
- [x] Added Doxygen documentation
- [x] Added example/test program to show how it's used and verify correctness