### PR TITLE
SH4 cache improvements

### DIFF
--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -87,32 +87,34 @@ void dcache_purge_range(uint32 start, uint32 count);
 */
 void dcache_purge_all(uint32 start, uint32 count);
 
-/** \brief  Prefetch memory to the data/operand cache.
-
-    This function prefetch a range of the data/operand cache.
-
-    \param  start           The physical address to begin prefetching at.
-    \param  count           The number of bytes to prefetch.
-    \return                 The physical address aligned to cache block size.
-*/
-void *dcache_pref_range(uint32 start, uint32 count);
-
 /** \brief  Prefetch one block to the data/operand cache.
 
-    This function prefetch a range of the data/operand cache.
+    This function prefetch a block of the data/operand cache.
 
-    \param  src             The buffer to prefetch.
-    \return                 The buffer aligned to cache block size.
+    \param  src             The physical address to prefetch.
 */
-static __always_inline void *dcache_pref_block(const void *src) {
-    uint32 __cache_aligned = ((uint32)src) & ~(CPU_CACHE_BLOCK_SIZE - 1);
-    __asm__ __volatile__("pref @%[ptr]\n"
+static __always_inline void dcache_pref_block(const void *src) {
+    __asm__ __volatile__("pref @%0\n"
                          :
-                         : [ptr] "r" (__cache_aligned)
-                         :
+                         : "r" (src)
+                         : "memory"
     );
+}
 
-    return (void *)__cache_aligned;
+/** \brief  Allocate one block of the data/operand cache.
+
+    This function allocate a block of the data/operand cache.
+
+    \param  src             The physical address to allocate.
+    \param  value           The value written to first 4-byte.
+*/
+static __always_inline void dcache_alloc_block(const void *src, uint32 value) {
+    register int __value __asm__("r0") = value;
+    __asm__ __volatile__ ("movca.l r0,@%0\n\t"
+                         :
+                         : "r" (src), "r" (__value)
+                         : "memory"
+    );
 }
 
 __END_DECLS

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -76,6 +76,17 @@ void dcache_flush_range(uint32 start, uint32 count);
 */
 void dcache_purge_range(uint32 start, uint32 count);
 
+/** \brief  Purge all the data/operand cache.
+
+    This function flushes all the data/operand cache, forcing a write-
+    back and invalidate on all of the cache blocks.
+
+    \param  start           The physical address for temporary buffer (32-byte aligned)
+    \param  count           The number of bytes of temporary buffer (8 KB or 16 KB)
+
+*/
+void dcache_purge_all(uint32 start, uint32 count);
+
 /** \brief  Prefetch memory to the data/operand cache.
 
     This function prefetch a range of the data/operand cache.

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -11,7 +11,6 @@
 	.globl _dcache_flush_range
 	.globl _dcache_purge_range
 	.globl _dcache_purge_all
-	.globl _dcache_pref_range
 
 ! r4 is starting address
 ! r5 is count
@@ -166,27 +165,6 @@ dpurge_all_loop:
 	add #32, r4		! += CPU_CACHE_BLOCK_SIZE
 	rts
 	nop
-
-
-! This routine prefetch to operand cache the specified data range.
-! r4 is starting address
-! r5 is count
-_dcache_pref_range:
-	! Get ending address from count and align start address
-	add	r4,r5
-	mov.l	l1align,r0
-	and	r0,r4
-	mov	r4,r6
-
-dpref_loop:
-	! Prefetch to the O cache
-	pref	@r4
-	cmp/hs	r4,r5
-	bt/s	dpref_loop
-	add	#32,r4		! += CPU_CACHE_BLOCK_SIZE
-
-	rts
-	mov	r6,r0
 
 
 	.align	2

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -10,6 +10,7 @@
 	.globl _dcache_inval_range
 	.globl _dcache_flush_range
 	.globl _dcache_purge_range
+	.globl _dcache_purge_all
 	.globl _dcache_pref_range
 
 ! r4 is starting address
@@ -148,6 +149,24 @@ dpurge_loop:
 
 	rts
 	nop
+
+
+! This routine just forces a write-back and invalidate all O cache.
+! r4 is address for temporary buffer 32-byte aligned
+! r5 is size of temporary buffer (8 KB or 16 KB)
+_dcache_purge_all:
+	mov #0, r0
+	add r4, r5
+dpurge_all_loop:
+	! Allocate and then invalidate the O cache block
+	movca.l r0, @r4
+	ocbi @r4
+	cmp/hs r4, r5
+	bt/s dpurge_all_loop
+	add #32, r4		! += CPU_CACHE_BLOCK_SIZE
+	rts
+	nop
+
 
 ! This routine prefetch to operand cache the specified data range.
 ! r4 is starting address

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -175,7 +175,6 @@ dcache_inval_range
 dcache_flush_range
 dcache_purge_range
 dcache_purge_all
-dcache_pref_range
 
 # Low-level debug I/O
 dbgio_set_irq_usage

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -174,6 +174,7 @@ icache_flush_range
 dcache_inval_range
 dcache_flush_range
 dcache_purge_range
+dcache_purge_all
 dcache_pref_range
 
 # Low-level debug I/O


### PR DESCRIPTION
Added purge the entire data/operand cache based on TapamN's idea.
Instead of processing a large amount of data, we can re-allocate the entire cache (max 16KB), which will lead to a purge of what was in it. The only requirements is that we need a buffer for 16 KB.
Also I removed prefetch a range (is not an efficient), update block prefetch and add block allocation.