### PR TITLE
Garbage-collect network stack

### DIFF
--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -40,6 +40,14 @@ __BEGIN_DECLS
 */
 #define KOS_INIT_FLAGS(flags) \
     uint32 __kos_init_flags = (flags); \
+    extern void arch_init_net(void); \
+    void (*init_net_weak)(void) = ((flags) & INIT_NET) ? arch_init_net : NULL; \
+    extern void net_shutdown(void); \
+    void (*net_shutdown_weak)(void) = ((flags) & INIT_NET) ? net_shutdown : NULL; \
+    extern void bba_la_init(void); \
+    void (*bba_la_init_weak)(void) = ((flags) & INIT_NET) ? bba_la_init : NULL; \
+    extern void bba_la_shutdown(void); \
+    void (*bba_la_shutdown_weak)(void) = ((flags) & INIT_NET) ? bba_la_shutdown : NULL; \
     extern int export_init(void); \
     int (*export_init_weak)(void) = ((flags) & INIT_EXPORT) ? export_init : NULL
 

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -38,7 +38,10 @@ __BEGIN_DECLS
     \see    kos_initflags
     \see    dreamcast_initflags
 */
-#define KOS_INIT_FLAGS(flags)   uint32 __kos_init_flags = (flags)
+#define KOS_INIT_FLAGS(flags) \
+    uint32 __kos_init_flags = (flags); \
+    extern int export_init(void); \
+    int (*export_init_weak)(void) = ((flags) & INIT_EXPORT) ? export_init : NULL
 
 /** \brief  The init flags. Do not modify this directly! */
 extern uint32 __kos_init_flags;
@@ -81,6 +84,7 @@ extern void * __kos_romdisk;
 #define INIT_NET            0x0004  /**< \brief Enable built-in networking */
 #define INIT_MALLOCSTATS    0x0008  /**< \brief Enable malloc statistics */
 #define INIT_QUIET          0x0010  /**< \brief Disable dbgio */
+#define INIT_EXPORT         0x0020  /**< \brief Export kernel symbols */
 /** @} */
 
 __END_DECLS

--- a/kernel/arch/dreamcast/hardware/hardware.c
+++ b/kernel/arch/dreamcast/hardware/hardware.c
@@ -40,6 +40,20 @@ int hardware_sys_init(void) {
     return 0;
 }
 
+void (*bba_la_init_weak)(void) __attribute__((weak));
+void (*bba_la_shutdown_weak)(void) __attribute__((weak));
+
+void bba_la_init(void) {
+    /* Setup network (this won't do anything unless we enable netcore) */
+    bba_init();
+    la_init();
+}
+
+void bba_la_shutdown(void) {
+    la_shutdown();
+    bba_shutdown();
+}
+
 int hardware_periph_init(void) {
     /* Init sound */
     spu_init();
@@ -57,9 +71,8 @@ int hardware_periph_init(void) {
     vid_init(DEFAULT_VID_MODE, DEFAULT_PIXEL_MODE);
 
 #ifndef _arch_sub_naomi
-    /* Setup network (this won't do anything unless we enable netcore) */
-    bba_init();
-    la_init();
+    if(bba_la_init_weak)
+        (*bba_la_init_weak)();
 #endif
 
     initted = 2;
@@ -71,8 +84,8 @@ void hardware_shutdown(void) {
     switch(initted) {
         case 2:
 #ifndef _arch_sub_naomi
-            la_shutdown();
-            bba_shutdown();
+            if(bba_la_shutdown_weak)
+                (*bba_la_shutdown_weak)();
 #endif
             maple_shutdown();
 #if 0

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -59,17 +59,40 @@ dbgio_handler_t * dbgio_handlers[] = {
 };
 int dbgio_handler_cnt = sizeof(dbgio_handlers) / sizeof(dbgio_handler_t *);
 
+void arch_init_net(void) {
+    union {
+        uint32 ipl;
+        uint8 ipb[4];
+    } ip = { 0 };
+
+    if(!(__kos_init_flags & INIT_NO_DCLOAD) && dcload_type == DCLOAD_TYPE_IP) {
+        /* Grab the IP address from dcload before we disable dbgio... */
+        ip.ipl = _fs_dclsocket_get_ip();
+        dbglog(DBG_INFO, "dc-load says our IP is %d.%d.%d.%d\n", ip.ipb[3],
+               ip.ipb[2], ip.ipb[1], ip.ipb[0]);
+        dbgio_disable();
+    }
+
+    net_init(ip.ipl);     /* Enable networking (and drivers) */
+
+    if(!(__kos_init_flags & INIT_NO_DCLOAD) && dcload_type == DCLOAD_TYPE_IP) {
+        fs_dclsocket_init_console();
+
+        if(!fs_dclsocket_init()) {
+            dbgio_dev_select("fs_dclsocket");
+            dbgio_enable();
+            dbglog(DBG_INFO, "fs_dclsocket console support enabled\n");
+        }
+    }
+}
+
+void (*init_net_weak)(void) __attribute__((weak));
+void (*net_shutdown_weak)(void) __attribute__((weak));
+
 /* Auto-init stuff: override with a non-weak symbol if you don't want all of
    this to be linked into your code (and do the same with the
    arch_auto_shutdown function too). */
 int  __attribute__((weak)) arch_auto_init(void) {
-#ifndef _arch_sub_naomi
-    union {
-        uint32 ipl;
-        uint8 ipb[4];
-    } ip;
-#endif
-
     /* Initialize memory management */
     mm_init();
 
@@ -155,31 +178,8 @@ int  __attribute__((weak)) arch_auto_init(void) {
     }
 
 #ifndef _arch_sub_naomi
-    if(__kos_init_flags & INIT_NET) {
-        ip.ipl = 0;
-
-        /* Check if the dcload-ip console is up, and if so, disable it,
-           otherwise we'll crash when we attempt to bring up the BBA */
-        if(!(__kos_init_flags & INIT_NO_DCLOAD) && dcload_type == DCLOAD_TYPE_IP) {
-            /* Grab the IP address from dcload before we disable dbgio... */
-            ip.ipl = _fs_dclsocket_get_ip();
-            dbglog(DBG_INFO, "dc-load says our IP is %d.%d.%d.%d\n", ip.ipb[3],
-                   ip.ipb[2], ip.ipb[1], ip.ipb[0]);
-            dbgio_disable();
-        }
-
-        net_init(ip.ipl);     /* Enable networking (and drivers) */
-
-        if(!(__kos_init_flags & INIT_NO_DCLOAD) && dcload_type == DCLOAD_TYPE_IP) {
-            fs_dclsocket_init_console();
-
-            if(!fs_dclsocket_init()) {
-                dbgio_dev_select("fs_dclsocket");
-                dbgio_enable();
-                dbglog(DBG_INFO, "fs_dclsocket console support enabled\n");
-            }
-        }
-    }
+    if(init_net_weak)
+        (*init_net_weak)();
 #endif
 
     return 0;
@@ -188,7 +188,8 @@ int  __attribute__((weak)) arch_auto_init(void) {
 void  __attribute__((weak)) arch_auto_shutdown(void) {
 #ifndef _arch_sub_naomi
     fs_dclsocket_shutdown();
-    net_shutdown();
+    if(net_shutdown_weak)
+        (*net_shutdown_weak)();
 #endif
 
     irq_disable();

--- a/kernel/exports/nmmgr.c
+++ b/kernel/exports/nmmgr.c
@@ -88,6 +88,8 @@ int nmmgr_handler_remove(nmmgr_handler_t *hnd) {
     return rv;
 }
 
+int (*export_init_weak)(void) __attribute__((weak));
+
 /* Initialize structures */
 int nmmgr_init(void) {
     int rv = 0;
@@ -96,7 +98,8 @@ int nmmgr_init(void) {
     LIST_INIT(&nmmgr_handlers);
 
     /* Initialize our internal exports */
-    export_init();
+    if (export_init_weak)
+        (*export_init_weak)();
 
     return rv;
 }

--- a/kernel/exports/nmmgr.c
+++ b/kernel/exports/nmmgr.c
@@ -98,7 +98,7 @@ int nmmgr_init(void) {
     LIST_INIT(&nmmgr_handlers);
 
     /* Initialize our internal exports */
-    if (export_init_weak)
+    if(export_init_weak)
         (*export_init_weak)();
 
     return rv;


### PR DESCRIPTION
Tweak the code so that the network stack (and BBA and LAN adapter code) will be garbage-collected when a KOS program has been compiled without the INIT_NET flag.

This really drops the size of the compiled binaries. For instance, the dreamcast "hello" example dropped from 284 KiB to 156 KiB (both stripped).

Note that this breaks the ABI a bit, as KOS' symbols are not exported anymore by default, and will be exported only if the `INIT_EXPORT` flag has been passed to `KOS_INIT_FLAGS`. This should be fine for the vast majority of programs out there though.