### PR TITLE
Fixed broken KGL examples

### DIFF
--- a/examples/dreamcast/kgl/basic/elements/gl-elements.c
+++ b/examples/dreamcast/kgl/basic/elements/gl-elements.c
@@ -16,6 +16,7 @@
 #include <GL/glut.h>
 
 #include <kos/init.h>
+#include <dc/maple/controller.h>
 
 /* Load a PVR texture - located in pvr-texture.c */
 extern GLuint glTextureLoadPVR(char *fname, unsigned char isMipMapped, unsigned char glMipMap);

--- a/examples/dreamcast/kgl/basic/zclip_arrays/gl-arrays.c
+++ b/examples/dreamcast/kgl/basic/zclip_arrays/gl-arrays.c
@@ -16,6 +16,7 @@
 #include <GL/glut.h>
 
 #include <kos/init.h>
+#include <dc/maple/controller.h>
 
 /* Load a PVR texture - located in pvr-texture.c */
 extern GLuint glTextureLoadPVR(char *fname, unsigned char isMipMapped, unsigned char glMipMap);


### PR DESCRIPTION
- When we added "press start to exit," we forgot to include controller.h in a few places