### PR TITLE
PVR: Add option to specify additional OPBs for TA overflow

### DIFF
--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -59,6 +59,9 @@ __BEGIN_DECLS
 /* #define PVR_KM_DBG 1 */
 /* #define PVR_KM_DBG_VERBOSE 1 */
 
+/* Enable this define to enable PVR error interrupts and to have the interrupt
+   handler print them when they occur.  */
+/* #define PVR_RENDER_DBG */
 
 /* Aggregate debugging levels. It's probably best to enable these with your
    KOS_CFLAGS when compiling KOS itself, but they're all documented here and

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
@@ -191,7 +191,16 @@ void pvr_allocate_buffers(pvr_init_params_t *params) {
     /* Look at active lists and figure out how much to allocate
        for each poly type */
     opb_total_size = 0;
+
+    /**
+     * Previously, we specified 1 << 20 to say that the OPB grows "down" when the TA needs more than one.
+     * To make it grow "up" instead (increasing addresses), we set 0 as the default value.
+    */
+#if 0
     pvr_state.list_reg_mask = 1 << 20;
+#else
+    pvr_state.list_reg_mask = 0;
+#endif
 
     for(i = 0; i < PVR_OPB_COUNT; i++) {
         pvr_state.opb_size[i] = WORDS_TO_BYTES(params->opb_sizes[i]);   /* in bytes */
@@ -245,10 +254,13 @@ void pvr_allocate_buffers(pvr_init_params_t *params) {
         /* N-byte align */
         outaddr = APPLY_ALIGNMENT(outaddr);
 
-        /* Object Pointer Buffers */
+        /* Object Pointer Blocks */
         buf->opb = outaddr;
         buf->opb_size = opb_total_size;
-        outaddr += opb_total_size;
+
+        /* Allocate extra space for overflow (when one OPB isn't big enough) */
+        buf->opb_overflow_count = params->opb_overflow_count;
+        outaddr += opb_total_size * buf->opb_overflow_count;
 
         /* Set up the opb pointers to each section */
         opb_size_accum = 0;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
@@ -260,7 +260,7 @@ void pvr_allocate_buffers(pvr_init_params_t *params) {
 
         /* Allocate extra space for overflow (when one OPB isn't big enough) */
         buf->opb_overflow_count = params->opb_overflow_count;
-        outaddr += opb_total_size * buf->opb_overflow_count;
+        outaddr += opb_total_size * (1 + buf->opb_overflow_count);
 
         /* Set up the opb pointers to each section */
         opb_size_accum = 0;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
@@ -192,10 +192,10 @@ void pvr_allocate_buffers(pvr_init_params_t *params) {
        for each poly type */
     opb_total_size = 0;
 
-    /**
-     * Previously, we specified 1 << 20 to say that the OPB grows "down" when the TA needs more than one.
-     * To make it grow "up" instead (increasing addresses), we set 0 as the default value.
-    */
+    /* Previously, we specified 1 << 20 to say that the OPB grows "down" when
+       the TA needs more than one. To make it grow "up" instead (increasing addresses),
+       we set 0 as the default value.
+     */
 #if 0
     pvr_state.list_reg_mask = 1 << 20;
 #else

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -154,7 +154,7 @@ int pvr_init(pvr_init_params_t *params) {
     asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE_TSP, pvr_int_handler);
     asic_evt_enable(ASIC_EVT_PVR_RENDERDONE_TSP, ASIC_IRQ_DEFAULT);
 
-#ifdef DBG_PVR_ERRORS
+#ifdef PVR_RENDER_DBG
     /* Hook up interrupt handlers for error events */
     asic_evt_set_handler(ASIC_EVT_PVR_ISP_OUTOFMEM, pvr_int_handler);
     asic_evt_enable(ASIC_EVT_PVR_ISP_OUTOFMEM, ASIC_IRQ_DEFAULT);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -39,7 +39,10 @@ int pvr_init_defaults(void) {
         0,
 
         /* Translucent Autosort enabled. */
-        0
+        0,
+
+        /* Extra OPBs */
+        3
     };
 
     return pvr_init(&params);
@@ -137,6 +140,7 @@ int pvr_init(pvr_init_params_t *params) {
 
     /* Hook the PVR interrupt events on G2 */
     pvr_state.vbl_handle = vblank_handler_add(pvr_int_handler);
+    
     asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEDONE, pvr_int_handler);
     asic_evt_enable(ASIC_EVT_PVR_OPAQUEDONE, ASIC_IRQ_DEFAULT);
     asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEMODDONE, pvr_int_handler);
@@ -147,8 +151,22 @@ int pvr_init(pvr_init_params_t *params) {
     asic_evt_enable(ASIC_EVT_PVR_TRANSMODDONE, ASIC_IRQ_DEFAULT);
     asic_evt_set_handler(ASIC_EVT_PVR_PTDONE, pvr_int_handler);
     asic_evt_enable(ASIC_EVT_PVR_PTDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE, pvr_int_handler);
-    asic_evt_enable(ASIC_EVT_PVR_RENDERDONE, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE_TSP, pvr_int_handler);
+    asic_evt_enable(ASIC_EVT_PVR_RENDERDONE_TSP, ASIC_IRQ_DEFAULT);
+
+#ifdef DBG_PVR_ERRORS
+    /* Hook up interrupt handlers for error events */
+    asic_evt_set_handler(ASIC_EVT_PVR_ISP_OUTOFMEM, pvr_int_handler);
+    asic_evt_enable(ASIC_EVT_PVR_ISP_OUTOFMEM, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_STRIP_HALT, pvr_int_handler);
+    asic_evt_enable(ASIC_EVT_PVR_STRIP_HALT, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_OPB_OUTOFMEM, pvr_int_handler);
+    asic_evt_enable(ASIC_EVT_PVR_OPB_OUTOFMEM, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_ERR, pvr_int_handler);
+    asic_evt_enable(ASIC_EVT_PVR_TA_INPUT_ERR, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_OVERFLOW, pvr_int_handler);
+    asic_evt_enable(ASIC_EVT_PVR_TA_INPUT_OVERFLOW, ASIC_IRQ_DEFAULT);
+#endif
 
     /* 3d-specific parameters; these are all about rendering and
        nothing to do with setting up the video; some stuff in here
@@ -169,7 +187,8 @@ int pvr_init(pvr_init_params_t *params) {
     PVR_SET(PVR_UNK_007C, 0x0027df77);      /* M */
     PVR_SET(PVR_TEXTURE_MODULO, 0x00000000);    /* stride width */
     PVR_SET(PVR_FOG_DENSITY, 0x0000ff07);       /* fog density */
-    PVR_SET(PVR_UNK_00C8, PVR_GET(0x00d4) << 16);   /* M */
+    PVR_SET(PVR_HPOS_IRQ, PVR_GET(PVR_BORDER_X) << 16);   /* HBLANK settings (fire on line 0 at the start of the line) */
+    PVR_SET(PVR_VPOS_IRQ, PVR_GET(PVR_BORDER_Y));   /* VBLANK settings (VBLANK begin at start, VBLANK end at end) */
     PVR_SET(PVR_UNK_0118, 0x00008040);      /* M */
 
     /* Initialize PVR DMA */
@@ -218,8 +237,8 @@ int pvr_shutdown(void) {
     asic_evt_disable(ASIC_EVT_PVR_TRANSMODDONE, ASIC_IRQ_DEFAULT);
     asic_evt_set_handler(ASIC_EVT_PVR_PTDONE, NULL);
     asic_evt_disable(ASIC_EVT_PVR_PTDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE, NULL);
-    asic_evt_disable(ASIC_EVT_PVR_RENDERDONE, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE_TSP, NULL);
+    asic_evt_disable(ASIC_EVT_PVR_RENDERDONE_TSP, ASIC_IRQ_DEFAULT);
 
     /* Shut down PVR DMA */
     pvr_dma_shutdown();

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -126,6 +126,7 @@ typedef struct {
     uint32  opb, opb_size;                  /* Object pointer buffers, size */
     uint32  opb_addresses[PVR_OPB_COUNT];        /* Object pointer buffers (of each type) */
     uint32  tile_matrix, tile_matrix_size;  /* Tile matrix, size */
+    uint32  opb_overflow_count;             /* Extra OPB space after opb_size for TA overflow */
 } pvr_ta_buffers_t;
 
 // DMA buffers structure: we have two sets of these
@@ -221,6 +222,9 @@ typedef struct {
 
     // Output address for to-texture mode
     uint32  to_txr_addr[2];
+
+    // Number of additional OPBs to allocate, allowing more geometry per tile.
+    uint32 opb_overflow_count;
 } pvr_state_t;
 
 /* There will be exactly one of these in KOS (in pvr_globals.c) */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -12,6 +12,10 @@
 #include <arch/cache.h>
 #include "pvr_internal.h"
 
+#ifdef DBG_PVR_ERRORS
+#include <stdio.h>
+#endif
+
 /*
    PVR interrupt handler; the way things are setup, we're gonna get
    one of these for each full vertical refresh and at the completion
@@ -96,16 +100,45 @@ void pvr_int_handler(uint32 code) {
         case ASIC_EVT_PVR_PTDONE:
             pvr_state.lists_transferred |= 1 << PVR_OPB_PT;
             break;
-        case ASIC_EVT_PVR_RENDERDONE:
+        case ASIC_EVT_PVR_RENDERDONE_TSP:
             //DBG(("irq_renderdone\n"));
             pvr_state.render_busy = 0;
             pvr_state.render_completed = 1;
             pvr_sync_stats(PVR_SYNC_RNDDONE);
             break;
-        case ASIC_EVT_PVR_VBLINT:
+        case ASIC_EVT_PVR_VBLANK_BEG:
             pvr_sync_stats(PVR_SYNC_VBLANK);
             break;
     }
+
+#ifdef DBG_PVR_ERRORS
+    /* Show register values on each interrupt */
+    switch (code) {
+        case ASIC_EVT_PVR_ISP_OUTOFMEM:
+            DBG(("[ERROR]: ASIC_EVT_PVR_ISP_OUTOFMEM\n"));
+            break;
+
+        case ASIC_EVT_PVR_STRIP_HALT:
+            DBG(("[ERROR]: ASIC_EVT_PVR_STRIP_HALT\n"));
+            break;
+
+        case ASIC_EVT_PVR_OPB_OUTOFMEM:
+            DBG(("[ERROR]: ASIC_EVT_PVR_OPB_OUTOFMEM\n"));
+            DBG(("PVR_TA_OPB_START: %08lx\nPVR_TA_OPB_END: %08lx\nPVR_TA_OPB_POS: %08lx\n",
+                PVR_GET(PVR_TA_OPB_START),
+                PVR_GET(PVR_TA_OPB_END),
+                PVR_GET(PVR_TA_OPB_POS) << 2));
+            break;
+
+        case ASIC_EVT_PVR_TA_INPUT_ERR:
+            DBG(("[ERROR]: ASIC_EVT_PVR_TA_INPUT_ERR\n"));
+            break;
+
+        case ASIC_EVT_PVR_TA_INPUT_OVERFLOW:
+            DBG(("[ERROR]: ASIC_EVT_PVR_TA_INPUT_OVERFLOW\n"));
+            break;
+    }
+#endif
 
     /* Update our stats if we finished all registration */
     switch(code) {
@@ -124,7 +157,7 @@ void pvr_int_handler(uint32 code) {
 
     if(!pvr_state.to_texture[bufn]) {
         // If it's not a vblank, ignore the rest of this for now.
-        if(code != ASIC_EVT_PVR_VBLINT)
+        if(code != ASIC_EVT_PVR_VBLANK_BEG)
             return;
     }
     else {

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -12,7 +12,7 @@
 #include <arch/cache.h>
 #include "pvr_internal.h"
 
-#ifdef DBG_PVR_ERRORS
+#ifdef PVR_RENDER_DBG
 #include <stdio.h>
 #endif
 
@@ -106,12 +106,12 @@ void pvr_int_handler(uint32 code) {
             pvr_state.render_completed = 1;
             pvr_sync_stats(PVR_SYNC_RNDDONE);
             break;
-        case ASIC_EVT_PVR_VBLANK_BEG:
+        case ASIC_EVT_PVR_VBLANK_BEGIN:
             pvr_sync_stats(PVR_SYNC_VBLANK);
             break;
     }
 
-#ifdef DBG_PVR_ERRORS
+#ifdef PVR_RENDER_DBG
     /* Show register values on each interrupt */
     switch (code) {
         case ASIC_EVT_PVR_ISP_OUTOFMEM:
@@ -157,7 +157,7 @@ void pvr_int_handler(uint32 code) {
 
     if(!pvr_state.to_texture[bufn]) {
         // If it's not a vblank, ignore the rest of this for now.
-        if(code != ASIC_EVT_PVR_VBLANK_BEG)
+        if(code != ASIC_EVT_PVR_VBLANK_BEGIN)
             return;
     }
     else {

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -150,17 +150,23 @@ void pvr_sync_reg_buffer(void) {
     //PVR_SET(PVR_RESET, PVR_RESET_NONE);
 
     /* Set buffer pointers */
-    PVR_SET(PVR_TA_OPB_START,   buf->opb);
-    PVR_SET(PVR_TA_OPB_END,     buf->opb - buf->opb_size);
+    PVR_SET(PVR_TA_OPB_START,       buf->opb);
+    PVR_SET(PVR_TA_OPB_INIT,        buf->opb + buf->opb_size);
+    PVR_SET(PVR_TA_OPB_END,         buf->opb + buf->opb_size * (1 + buf->opb_overflow_count));
     PVR_SET(PVR_TA_VERTBUF_START,   buf->vertex);
-    PVR_SET(PVR_TA_VERTBUF_END, buf->vertex + buf->vertex_size);
-    PVR_SET(PVR_TA_OPB_INIT,    buf->opb);
+    PVR_SET(PVR_TA_VERTBUF_END,     buf->vertex + buf->vertex_size);
 
     /* Misc config parameters */
-    PVR_SET(PVR_TILEMAT_CFG,    pvr_state.tsize_const);     /* Tile count: (H/32-1) << 16 | (W/32-1) */
-    PVR_SET(PVR_OPB_CFG,        pvr_state.list_reg_mask);   /* List enables */
-    PVR_SET(PVR_TA_INIT,        PVR_TA_INIT_GO);        /* Confirm settings */
+    PVR_SET(PVR_TILEMAT_CFG,        pvr_state.tsize_const);     /* Tile count: (H/32-1) << 16 | (W/32-1) */
+    PVR_SET(PVR_OPB_CFG,            pvr_state.list_reg_mask);   /* List enables */
+    PVR_SET(PVR_TA_INIT,            PVR_TA_INIT_GO);            /* Confirm settings */
     (void)PVR_GET(PVR_TA_INIT);
+
+#if 0
+    printf("== SYNC REG BUFFER:\n");
+    printf("TA_OL_BASE: %08lx\nTA_OL_LIMIT: %08lx\nTA_NEXT_OPB: %08lx\n",
+           PVR_GET(TA_OL_BASE), PVR_GET(TA_OL_LIMIT), PVR_GET(TA_NEXT_OPB) << 2);
+#endif
 }
 
 /* Begin a render operation that has been queued completely (i.e., the

--- a/kernel/arch/dreamcast/hardware/vblank.c
+++ b/kernel/arch/dreamcast/hardware/vblank.c
@@ -95,8 +95,8 @@ int vblank_init(void) {
     vblid_high = 1;
 
     /* Hook and enable the interrupt */
-    asic_evt_set_handler(ASIC_EVT_PVR_VBLINT, vblank_handler);
-    asic_evt_enable(ASIC_EVT_PVR_VBLINT, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEG, vblank_handler);
+    asic_evt_enable(ASIC_EVT_PVR_VBLANK_BEG, ASIC_IRQ_DEFAULT);
 
     return 0;
 }
@@ -105,8 +105,8 @@ int vblank_shutdown(void) {
     struct vblhnd * c, * n;
 
     /* Disable and unhook the interrupt */
-    asic_evt_disable(ASIC_EVT_PVR_VBLINT, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_VBLINT, NULL);
+    asic_evt_disable(ASIC_EVT_PVR_VBLANK_BEG, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEG, NULL);
 
     /* Free any allocated handlers */
     c = TAILQ_FIRST(&vblhnds);

--- a/kernel/arch/dreamcast/hardware/vblank.c
+++ b/kernel/arch/dreamcast/hardware/vblank.c
@@ -95,8 +95,8 @@ int vblank_init(void) {
     vblid_high = 1;
 
     /* Hook and enable the interrupt */
-    asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEG, vblank_handler);
-    asic_evt_enable(ASIC_EVT_PVR_VBLANK_BEG, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEGIN, vblank_handler);
+    asic_evt_enable(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);
 
     return 0;
 }
@@ -105,8 +105,8 @@ int vblank_shutdown(void) {
     struct vblhnd * c, * n;
 
     /* Disable and unhook the interrupt */
-    asic_evt_disable(ASIC_EVT_PVR_VBLANK_BEG, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEG, NULL);
+    asic_evt_disable(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);
+    asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEGIN, NULL);
 
     /* Free any allocated handlers */
     c = TAILQ_FIRST(&vblhnds);

--- a/kernel/arch/dreamcast/include/dc/asic.h
+++ b/kernel/arch/dreamcast/include/dc/asic.h
@@ -44,9 +44,9 @@ __BEGIN_DECLS
 #define ASIC_EVT_PVR_RENDERDONE_VIDEO     0x0000  /**< \brief Video render stage completed */
 #define ASIC_EVT_PVR_RENDERDONE_ISP       0x0001  /**< \brief ISP render stage completed */
 #define ASIC_EVT_PVR_RENDERDONE_TSP       0x0002  /**< \brief TSP render stage completed */
-#define ASIC_EVT_PVR_VBLANK_BEG           0x0003  /**< \brief VBLANK begin interrupt */
+#define ASIC_EVT_PVR_VBLANK_BEGIN         0x0003  /**< \brief VBLANK begin interrupt */
 #define ASIC_EVT_PVR_VBLANK_END           0x0004  /**< \brief VBLANK end interrupt */
-#define ASIC_EVT_PVR_HBLANK_BEG           0x0005  /**< \brief HBLANK begin interrupt */
+#define ASIC_EVT_PVR_HBLANK_BEGIN         0x0005  /**< \brief HBLANK begin interrupt */
 
 #define ASIC_EVT_PVR_YUV_DONE             0x0007  /**< \brief YUV completed */
 #define ASIC_EVT_PVR_OPAQUEDONE           0x0007  /**< \brief Opaque list completed */
@@ -56,9 +56,6 @@ __BEGIN_DECLS
 
 #define ASIC_EVT_PVR_DMA                  0x0013  /**< \brief PVR DMA complete */
 #define ASIC_EVT_PVR_PTDONE               0x0015  /**< \brief Punch-thrus completed */
-
-/* Uncomment to print a message if an error is received in the PVR interrupt handler */
-/* #define DBG_PVR_ERRORS */
 
 #define ASIC_EVT_PVR_ISP_OUTOFMEM         0x0200  /**< \brief ISP out of memory */
 #define ASIC_EVT_PVR_STRIP_HALT           0x0201  /**< \brief Halt due to strip buffer error */

--- a/kernel/arch/dreamcast/include/dc/asic.h
+++ b/kernel/arch/dreamcast/include/dc/asic.h
@@ -40,18 +40,33 @@ __BEGIN_DECLS
     These are events that the PVR itself generates that can be hooked.
     @{
 */
-#define ASIC_EVT_PVR_RENDERDONE     0x0002  /**< \brief Render completed */
-#define ASIC_EVT_PVR_SCANINT1       0x0003  /**< \brief Scanline interrupt 1 */
-#define ASIC_EVT_PVR_SCANINT2       0x0004  /**< \brief Scanline interrupt 2 */
-#define ASIC_EVT_PVR_VBLINT         0x0005  /**< \brief VBL interrupt */
-#define ASIC_EVT_PVR_OPAQUEDONE     0x0007  /**< \brief Opaque list completed */
-#define ASIC_EVT_PVR_OPAQUEMODDONE  0x0008  /**< \brief Opaque modifiers completed */
-#define ASIC_EVT_PVR_TRANSDONE      0x0009  /**< \brief Transparent list completed */
-#define ASIC_EVT_PVR_TRANSMODDONE   0x000a  /**< \brief Transparent modifiers completed */
-#define ASIC_EVT_PVR_DMA            0x0013  /**< \brief PVR DMA complete */
-#define ASIC_EVT_PVR_PTDONE         0x0015  /**< \brief Punch-thrus completed */
-#define ASIC_EVT_PVR_PRIMOUTOFMEM   0x0202  /**< \brief Out of primitive memory */
-#define ASIC_EVT_PVR_MATOUTOFMEM    0x0203  /**< \brief Out of matrix memory */
+
+#define ASIC_EVT_PVR_RENDERDONE_VIDEO     0x0000  /**< \brief Video render stage completed */
+#define ASIC_EVT_PVR_RENDERDONE_ISP       0x0001  /**< \brief ISP render stage completed */
+#define ASIC_EVT_PVR_RENDERDONE_TSP       0x0002  /**< \brief TSP render stage completed */
+#define ASIC_EVT_PVR_VBLANK_BEG           0x0003  /**< \brief VBLANK begin interrupt */
+#define ASIC_EVT_PVR_VBLANK_END           0x0004  /**< \brief VBLANK end interrupt */
+#define ASIC_EVT_PVR_HBLANK_BEG           0x0005  /**< \brief HBLANK begin interrupt */
+
+#define ASIC_EVT_PVR_YUV_DONE             0x0007  /**< \brief YUV completed */
+#define ASIC_EVT_PVR_OPAQUEDONE           0x0007  /**< \brief Opaque list completed */
+#define ASIC_EVT_PVR_OPAQUEMODDONE        0x0008  /**< \brief Opaque modifiers completed */
+#define ASIC_EVT_PVR_TRANSDONE            0x0009  /**< \brief Transparent list completed */
+#define ASIC_EVT_PVR_TRANSMODDONE         0x000a  /**< \brief Transparent modifiers completed */
+
+#define ASIC_EVT_PVR_DMA                  0x0013  /**< \brief PVR DMA complete */
+#define ASIC_EVT_PVR_PTDONE               0x0015  /**< \brief Punch-thrus completed */
+
+/* Uncomment to print a message if an error is received in the PVR interrupt handler */
+/* #define DBG_PVR_ERRORS */
+
+#define ASIC_EVT_PVR_ISP_OUTOFMEM         0x0200  /**< \brief ISP out of memory */
+#define ASIC_EVT_PVR_STRIP_HALT           0x0201  /**< \brief Halt due to strip buffer error */
+#define ASIC_EVT_PVR_PARAM_OUTOFMEM       0x0202  /**< \brief Param out of memory */
+#define ASIC_EVT_PVR_OPB_OUTOFMEM         0x0203  /**< \brief OPB went past PVR_TA_OPB_END */
+#define ASIC_EVT_PVR_TA_INPUT_ERR         0x0204  /**< \brief Vertex input error */
+#define ASIC_EVT_PVR_TA_INPUT_OVERFLOW    0x0205  /**< \brief Vertex input overflowed queue */
+
 /** @} */
 
 /** \defgroup asic_gd_evts          Event codes for the GD controller

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1030,7 +1030,7 @@ Striplength set to 2 */
 #define PVR_COLOR_CLAMP_MAX     0x00bc  /**< \brief RGB Color clamp max */
 #define PVR_COLOR_CLAMP_MIN     0x00c0  /**< \brief RGB Color clamp min */
 #define PVR_GUN_POS             0x00c4  /**< \brief Light gun position */
-#define PVR_UNK_00C8            0x00c8  /**< \brief ?? -- write same as border H in 00d4 << 16 */
+#define PVR_HPOS_IRQ            0x00c8  /**< \brief Horizontal position IRQ */
 #define PVR_VPOS_IRQ            0x00cc  /**< \brief Vertical position IRQ */
 #define PVR_IL_CFG              0x00d0  /**< \brief Interlacing config */
 #define PVR_BORDER_X            0x00d4  /**< \brief Window border X position */
@@ -1160,6 +1160,17 @@ typedef struct {
         when rendering translucent polygons, meaning you must pre-sort them
         yourself if you want them to appear in the right order. */
     int     autosort_disabled;
+
+
+    /** \brief  OPB Overflow Count.
+
+        Preallocates this many extra OPBs (sets of tile bins), allowing the PVR
+        to use the extra space when there's too much geometry in the first OPB.
+    
+        Increasing this value can eliminate artifacts where pieces of geometry
+        flicker in and out of existence along the tile boundaries. */
+
+    int     opb_overflow_count;
 
 } pvr_init_params_t;
 


### PR DESCRIPTION
# OPB Overflow Support

Adds a new parameter to `pvr_init_params_t` that allows the user to specify a number of "overflow OPBs". These are additional OPBs preallocated so that the TA can use them if too much geometry is sent to fit in one OPB. This is a fix for the situation where rendered output has some geometry missing or flickering in certain tiles.

The direction new OPBs are added by the TA has been modified. Previously it used descending addresses (growing down) and now it uses ascending addresses (growing up). This is for consistency with the vertex buffer allocation and to prevent confusion for future maintainers.

_Note_: I added a new parameter to the end of `pvr_init_params_t` so that existing code using aggregate initialization wouldn't break (it would become 0). Unfortunately if existing code were to initialize each member separately, it could still break if they don't first memset to 0 as it would leave the new member uninitialized.

## VBlank Interrupt Swapped

The wrong interrupt was being used to signal VBlank. The HBlank interrupt was used, but it had been configured to only fire on line zero making it work effectively like VBlank. This has been swapped for the actual VBlank interrupt.

## PVR Error Codes Added

The PVR generates error interrupts that can signal buffer overflows and similar. These have been added along with an `#ifdef` guard allowing  the user to define `DBG_PVR_ERRORS` if they want to print errors from the PVR interrupt handler routine.

## Sources for Register and Interrupt Definitions

HBlank interrupt control register behaviour:
https://github.com/flyinghead/flycast/blob/c1f0a5a15f07ba82ccb974e5c7dc82206324b0a3/core/hw/pvr/pvr_regs.cpp#L208

Interrupt definitions:
https://github.com/flyinghead/flycast/blob/c1f0a5a15f07ba82ccb974e5c7dc82206324b0a3/core/types.h#L46

