### PR TITLE
Add __attribute__((used)) to abort to fix linking issues when using LTO

### DIFF
--- a/kernel/libc/koslib/abort.c
+++ b/kernel/libc/koslib/abort.c
@@ -9,7 +9,7 @@
 #include <arch/arch.h>
 
 /* This is probably the closest mapping we've got for abort() */
-void abort(void) {
+__attribute__((used)) void abort(void) {
     arch_exit();
 }
 


### PR DESCRIPTION
Fixes #336 