### PR TITLE
Rework romdisks

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -67,5 +67,7 @@ romdisk.img:
 	$(KOS_GENROMFS) -f romdisk.img -d $(KOS_ROMDISK_DIR) -v -x .svn -x .keepme
 
 romdisk.o: romdisk.img
-	$(KOS_BASE)/utils/bin2o/bin2o romdisk.img romdisk romdisk.o
+	$(KOS_BASE)/utils/bin2o/bin2o romdisk.img romdisk romdisk_tmp.o
+	$(KOS_CC) -o romdisk.o -r romdisk_tmp.o $(KOS_LIB_PATHS) -Wl,--whole-archive -lromdiskbase
+	rm romdisk_tmp.o
 endif

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -193,6 +193,8 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Added vmu functions to check/enable/disable the extra 41 blocks [AB]
 - *** Added driver for the SH4's Watchdog Timer peripheral [FG]
 - DC  Added Moop powered fast path to sq_cpy, added TapamN pvr related sq functions [AB]
+- DC  Garbage-collect network stack [PC]
+- DC  Rework romdisks [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -48,16 +48,19 @@ __BEGIN_DECLS
     void (*bba_la_init_weak)(void) = ((flags) & INIT_NET) ? bba_la_init : NULL; \
     extern void bba_la_shutdown(void); \
     void (*bba_la_shutdown_weak)(void) = ((flags) & INIT_NET) ? bba_la_shutdown : NULL; \
+    extern int fs_romdisk_init(void); \
+    int (*fs_romdisk_init_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_init : NULL; \
+    extern int fs_romdisk_shutdown(void); \
+    int (*fs_romdisk_shutdown_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_shutdown : NULL; \
     extern int export_init(void); \
     int (*export_init_weak)(void) = ((flags) & INIT_EXPORT) ? export_init : NULL
 
 /** \brief  The init flags. Do not modify this directly! */
 extern uint32 __kos_init_flags;
 
-/** \brief  Define a romdisk for your program, if you'd like one.
-    \param  rd                  Pointer to the romdisk image in your code.
-*/
-#define KOS_INIT_ROMDISK(rd)    void * __kos_romdisk = (rd)
+/** \brief  Deprecated and not useful anymore. */
+#define KOS_INIT_ROMDISK(rd) \
+    static void *__old_romdisk __attribute__((unused)) = (rd)
 
 /** \brief  Built-in romdisk. Do not modify this directly! */
 extern void * __kos_romdisk;
@@ -81,9 +84,9 @@ extern void * __kos_romdisk;
     \see    dreamcast_initflags
     @{
 */
-/** \brief  Default init flags (IRQs on, preemption enabled). */
+/** \brief  Default init flags (IRQs on, preemption enabled, romdisks). */
 #define INIT_DEFAULT \
-    (INIT_IRQ | INIT_THD_PREEMPT)
+    (INIT_IRQ | INIT_THD_PREEMPT | INIT_FS_ROMDISK)
 
 #define INIT_NONE           0x0000  /**< \brief Don't init optional things */
 #define INIT_IRQ            0x0001  /**< \brief Enable IRQs at startup */
@@ -93,6 +96,7 @@ extern void * __kos_romdisk;
 #define INIT_MALLOCSTATS    0x0008  /**< \brief Enable malloc statistics */
 #define INIT_QUIET          0x0010  /**< \brief Disable dbgio */
 #define INIT_EXPORT         0x0020  /**< \brief Export kernel symbols */
+#define INIT_FS_ROMDISK     0x0040  /**< \brief Enable support for romdisks */
 /** @} */
 
 __END_DECLS

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -5,7 +5,7 @@
 #
 
 OBJS =
-SUBDIRS = arch debug fs thread net libc exports
+SUBDIRS = arch debug fs thread net libc exports romdisk
 STUBS = stubs/kernel_export_stubs.o stubs/arch_export_stubs.o
 
 # Everything from here up should be plain old C.
@@ -13,6 +13,7 @@ KOS_CFLAGS += $(KOS_CSTD)
 
 all: subdirs $(STUBS)
 	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a
+	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libromdiskbase.a romdisk/*.o
 	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a build/*.o
 	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti_exports.a stubs/*.o
 
@@ -27,6 +28,7 @@ include $(KOS_BASE)/Makefile.prefab
 clean: clean_subdirs
 	rm -f build/*.o
 	rm -f build/libc/*.o
+	rm -f romdisk/*.o
 	rm -f stubs/*.o stubs/kernel_export_stubs.c stubs/arch_export_stubs.c
 
 run:

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -89,6 +89,10 @@ void arch_init_net(void) {
 void (*init_net_weak)(void) __attribute__((weak));
 void (*net_shutdown_weak)(void) __attribute__((weak));
 
+int (*fs_romdisk_init_weak)(void) __attribute__((weak));
+int (*fs_romdisk_shutdown_weak)(void) __attribute__((weak));
+int (*fs_romdisk_mount_weak)(void) __attribute__((weak));
+
 /* Auto-init stuff: override with a non-weak symbol if you don't want all of
    this to be linked into your code (and do the same with the
    arch_auto_shutdown function too). */
@@ -141,7 +145,10 @@ int  __attribute__((weak)) arch_auto_init(void) {
     fs_init();          /* VFS */
     fs_pty_init();          /* Pty */
     fs_ramdisk_init();      /* Ramdisk */
-    fs_romdisk_init();      /* Romdisk */
+
+    if(fs_romdisk_init_weak) {
+        fs_romdisk_init_weak(); /* Romdisk */
+    }
 
 /* The arc4random_buf() function used for random & urandom is only
    available in newlib starting with version 2.4.0 */
@@ -153,8 +160,8 @@ int  __attribute__((weak)) arch_auto_init(void) {
 
     hardware_periph_init();     /* DC peripheral init */
 
-    if(__kos_romdisk != NULL) {
-        fs_romdisk_mount("/rd", __kos_romdisk, 0);
+    if(fs_romdisk_mount_weak) {
+        fs_romdisk_mount_weak();
     }
 
 #ifndef _arch_sub_naomi
@@ -210,7 +217,9 @@ void  __attribute__((weak)) arch_auto_shutdown(void) {
     fs_dev_shutdown();
 #endif
     fs_ramdisk_shutdown();
-    fs_romdisk_shutdown();
+    if(fs_romdisk_shutdown_weak) {
+        fs_romdisk_shutdown_weak();
+    }
     fs_pty_shutdown();
     fs_shutdown();
     thd_shutdown();

--- a/kernel/romdisk/Makefile
+++ b/kernel/romdisk/Makefile
@@ -1,0 +1,9 @@
+# KallistiOS ##version##
+#
+# romdisk/Makefile
+# (c)2023 Paul Cercueil
+#
+
+OBJS = romdiskbase.o
+
+include $(KOS_BASE)/Makefile.prefab

--- a/kernel/romdisk/romdiskbase.c
+++ b/kernel/romdisk/romdiskbase.c
@@ -1,0 +1,16 @@
+/* KallistiOS ##version##
+
+   kernel/romdisk/romdiskbase.c
+   Copyright (C) 2023 Paul Cercueil
+*/
+
+#include <kos/fs_romdisk.h>
+
+extern unsigned char romdisk[];
+
+void *__kos_romdisk = romdisk;
+
+int fs_romdisk_mount_weak(void)
+{
+    return fs_romdisk_mount("/rd", __kos_romdisk, 0);
+}


### PR DESCRIPTION
- KOS_INIT_ROMDISK() is now useless; it is automatically added to the romdisk.o object file. The macro remains just for compatibility with older source code.
- If a generated romdisk.o file is linked, romdisk support will be initialized when KallistiOS starts. Otherwise, the romdisk init/shutdown code (as well as any unused dependency) will be garbage-collected automatically.
- Loading external romdisks should still be supported, but unless a romdisk was built-in, you'll need to manually call fs_romdisk_init().