### PR TITLE
Cache Refresh

### DIFF
--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -89,7 +89,7 @@ void dcache_flush_range(uintptr_t start, size_t count);
     This function flushes all the data/operand cache, forcing a write-
     back on all of the cache blocks that are marked as dirty.
 
-    \warning
+    \note
     dcache_flush_range() is faster than dcache_flush_all() if the count
     param is 107520 or less.
 */
@@ -107,11 +107,12 @@ void dcache_purge_range(uintptr_t start, size_t count);
 
 /** \brief  Purge all the data/operand cache.
 
-    This function flushes all the data/operand cache, forcing a write-
-    back on all cache blocks that are marked as dirty and invalidates 
-    all of the cache blocks.
+    This function flushes the entire data/operand cache, ensuring that all 
+    cache blocks marked as dirty are written back to memory and all cache 
+    entries are invalidated. It does not require an additional buffer and is 
+    preferred when memory resources are constrained.
 
-    \warning
+    \note
     dcache_purge_range() is faster than dcache_purge_all() if the count
     param is 39936 or less.
 */
@@ -119,11 +120,22 @@ void dcache_purge_all(void);
 
 /** \brief  Purge all the data/operand cache with buffer.
 
-    This function flushes all the data/operand cache, forcing a write-
-    back and invalidate on all of the cache blocks using a buffer.
+    This function performs a purge of all data/operand cache blocks by 
+    utilizing an external buffer to speed up the write-back and invalidation 
+    process. It is always faster than dcache_purge_all() and is recommended 
+    where maximum speed is required.
 
-    \param  start           The physical address for temporary buffer (32-byte aligned)
-    \param  count           The number of bytes of temporary buffer (8 KB or 16 KB)
+    \note While this function offers a superior purge rate, it does require
+    the use of a temporary buffer. So use this function if you have an extra 
+    8/16 kb of memory laying around that you can utilize for no other purpose 
+    than for this function.
+
+    \param  start           The physical address for temporary buffer (32-byte 
+                            aligned)
+    \param  count           The size of the temporary buffer, which can be 
+                            either 8 KB or 16 KB, depending on cache 
+                            configuration - 8 KB buffer with OCRAM enabled, 
+                            otherwise 16 KB.
 
 */
 void dcache_purge_all_with_buffer(uintptr_t start, size_t count);

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -27,23 +27,6 @@ __BEGIN_DECLS
 #include <stdint.h>
 #include <arch/types.h>
 
-/** \brief  Obtain a non-cached pointer.
-
-    Modifies an address to enable non-cached access. Uncached RAM is very 
-    slow, and bypassing the cache only helps in very specific circumstances.
-
-    \author TapamN
- */
-#define NONCACHED(addr) (typeof (&(addr)[0]))(((uintptr_t)(addr)) | 0x20000000)
-
-/** \brief  Obtain a cached pointer.
-
-    Modifies an address to enable cached access.
-
-    \author TapamN
- */
-#define CACHED(addr)    (typeof (&(addr)[0]))(((uintptr_t)(addr)) & ~(0x20000000))
-
 /** \brief  SH4 cache block size.
 
     The size of a cache block.

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -91,7 +91,7 @@ void dcache_flush_range(uintptr_t start, size_t count);
 
     \note
     dcache_flush_range() is faster than dcache_flush_all() if the count
-    param is 107520 or less.
+    param is 66560 or less.
 */
 void dcache_flush_all(void);
 

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -88,6 +88,10 @@ void dcache_flush_range(uintptr_t start, size_t count);
 
     This function flushes all the data/operand cache, forcing a write-
     back on all of the cache blocks that are marked as dirty.
+
+    \warning
+    dcache_flush_range() is faster than dcache_flush_all() if the count
+    param is 107520 or less.
 */
 void dcache_flush_all(void);
 
@@ -99,13 +103,17 @@ void dcache_flush_all(void);
     \param  start           The physical address to begin purging at.
     \param  count           The number of bytes to purge.
 */
-void dcache_purge_range(uintptr_t start, size_t count);
+void dcache_purge_range(uintptr_t start, uint32_t count);
 
 /** \brief  Purge all the data/operand cache.
 
     This function flushes all the data/operand cache, forcing a write-
     back on all cache blocks that are marked as dirty and invalidates 
     all of the cache blocks.
+
+    \warning
+    dcache_purge_range() is faster than dcache_purge_all() if the count
+    param is 39936 or less.
 */
 void dcache_purge_all(void);
 

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -103,7 +103,7 @@ void dcache_flush_all(void);
     \param  start           The physical address to begin purging at.
     \param  count           The number of bytes to purge.
 */
-void dcache_purge_range(uintptr_t start, uint32_t count);
+void dcache_purge_range(uintptr_t start, size_t count);
 
 /** \brief  Purge all the data/operand cache.
 

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -108,7 +108,7 @@ _dcache_flush_range:
     mov      #-5, r1
     shad     r1, r5           
 
-    ! Compare with 512
+    ! Compare with flush_check
     mov.w    flush_check, r2
     cmp/hi   r2, r5
     bt       _dcache_flush_all  ! If lines > flush_check, jump to _dcache_flush_all
@@ -146,7 +146,7 @@ _dcache_flush_all:
 
     bf/s     .dflush_all_loop
     add      #32, r1     ! Move on to next entry
-    
+
     rts
     nop
 
@@ -163,7 +163,7 @@ _dcache_purge_range:
     mov      #-5, r1
     shad     r1, r5           
 
-    ! Compare with 512
+    ! Compare with purge_check
     mov.w    purge_check, r2
     cmp/hi   r2, r5
     bt       _dcache_purge_all  ! If lines > purge_check, jump to _dcache_purge_all

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -1,67 +1,62 @@
-! This routine was such a PIA to get working in inside the C program
-! that I finally gave up and moved it out to an assembler file.
+
+.text
+	.globl _icache_flush_range
+	.globl _dcache_inval_range
+	.globl _dcache_flush_range
+	.globl _dcache_flush_all
+	.globl _dcache_purge_range
+	.globl _dcache_purge_all
+	.globl _dcache_purge_all_with_buffer
 
 ! Routine to flush parts of cache.. thanks to the Linux-SH guys
 ! for the algorithm. The original version of this routine was
 ! taken from sh-stub.c.
-
-	.text
-	.globl _icache_flush_range
-	.globl _dcache_inval_range
-	.globl _dcache_flush_range
-	.globl _dcache_purge_range
-	.globl _dcache_purge_all
-
+!
 ! r4 is starting address
 ! r5 is count
 _icache_flush_range:
-	mov.l	fraddr,r0
-	mov.l	p2mask,r1
-	or	r1,r0
-	jmp	@r0
+	mov.l	ifr_addr, r0
+	mov.l	p2_mask, r1
+	or	    r1, r0
+	jmp	    @r0
 	nop
 
-	.align	2
-fraddr:	.long	flush_real
-p2mask:	.long	0x20000000
-	
-
-flush_real:
+.iflush_real:
 	! Save old SR and disable interrupts
-	stc	sr,r0
-	mov.l	r0,@-r15
-	mov.l	ormask,r1
-	or	r1,r0
-	ldc	r0,sr
+	stc	    sr, r0
+	mov.l	r0, @-r15
+	mov.l	ormask, r1
+	or	    r1, r0
+	ldc	    r0, sr
 
 	! Get ending address from count and align start address
-	add	r4,r5
-	mov.l	l1align,r0
-	and	r0,r4
-	mov.l	addrarray,r1
-	mov.l	entrymask,r2
-	mov.l	validmask,r3
+	add	    r4, r5
+	mov.l	align_mask, r0
+	and	    r0, r4
+	mov.l	ica_addr, r1
+	mov.l	ic_entry_mask, r2
+	mov.l	ic_valid_mask, r3
 
-flush_loop:
-	! Write back O cache
+.flush_loop:
+	! Write back D cache
 	ocbwb	@r4
 
 	! Invalidate I cache
-	mov	r4,r6		! v & CACHE_IC_ENTRY_MASK
-	and	r2,r6
-	or	r1,r6		! CACHE_IC_ADDRESS_ARRAY | ^
+	mov	    r4, r6		! v & CACHE_IC_ENTRY_MASK
+	and	    r2, r6
+	or	    r1, r6		! CACHE_IC_ADDRESS_ARRAY | ^
 
-	mov	r4,r7		! v & 0xfffffc00
-	and	r3,r7
+	mov	    r4, r7		! v & 0xfffffc00
+	and	    r3, r7
 
-	add	#32,r4		! += CPU_CACHE_BLOCK_SIZE
-	cmp/hs	r4,r5
-	bt/s	flush_loop
-	mov.l	r7,@r6		! *addr = data	
+	add	    #32, r4		! Move on to next cache block
+	cmp/hs	r4, r5
+	bt/s	.flush_loop
+	mov.l	r7, @r6		! *addr = data	
 
 	! Restore old SR
-	mov.l	@r15+,r0
-	ldc	r0,sr
+	mov.l	@r15+, r0
+	ldc	    r0, sr
 
 	! make sure we have enough instrs before returning to P1
 	nop
@@ -74,99 +69,178 @@ flush_loop:
 	rts
 	nop
 
-	.align	2
-ormask:
-	.long	0x100000f0
-addrarray:
-	.long	0xf0000000	! CACHE_IC_ADDRESS_ARRAY
-entrymask:
-	.long	0x1fe0		! CACHE_IC_ENTRY_MASK
-validmask:
-	.long	0xfffffc00
-	
 
-! Goes through and invalidates the O-cache for a given block of
-! RAM. Make sure that you've called dcache_flush_range first if
-! you care about the contents.
+! This routine goes through and invalidates the dcache for a given 
+! range of RAM. Make sure that you've called dcache_flush_range first
+! if you care about the contents.
+!
 ! r4 is starting address
 ! r5 is count
 _dcache_inval_range:
 	! Get ending address from count and align start address
-	add	r4,r5
-	mov.l	l1align,r0
-	and	r0,r4
+	add	    r4, r5
+	mov.l	align_mask, r0
+	and	    r0, r4
 
-dinval_loop:
-	! Invalidate the O cache
+.dinval_loop:
+	! Invalidate the dcache
 	ocbi	@r4
-	cmp/hs	r4,r5
-	bt/s	dinval_loop
-	add	#32,r4		! += CPU_CACHE_BLOCK_SIZE
+	cmp/hs	r4, r5
+	bt/s	.dinval_loop
+	add	    #32, r4		! Move on to next cache block
 
 	rts
 	nop
 
 
-! This routine just goes through and forces a write-back on the
+! This routine goes through and forces a write-back on the
 ! specified data range. Use prior to dcache_inval_range if you
-! care about the contents.
+! care about the contents. If the range is bigger than the dcache,
+! we flush the whole cache instead.
+!
 ! r4 is starting address
 ! r5 is count
 _dcache_flush_range:
-	! Get ending address from count and align start address
-	add	r4,r5
-	mov.l	l1align,r0
-	and	r0,r4
+	! Divide byte count by 32 
+	mov     #-5, r1
+	shad    r1, r5           
 
-dflush_loop:
-	! Write back the O cache
+	! Compare with 512
+	mov.w   cache_lines, r2
+	cmp/hi  r2, r5
+	bt      _dcache_flush_all  ! If lines > 512, jump to _dcache_flush_all
+
+	! Align start address
+	mov.l	align_mask, r0
+	and	    r0, r4
+
+.dflush_loop:
+	! Write back the dcache
 	ocbwb	@r4
-	cmp/hs	r4,r5
-	bt/s	dflush_loop
-	add	#32,r4		! += CPU_CACHE_BLOCK_SIZE
+	dt	    r5
+	bf/s	.dflush_loop
+	add	    #32, r4		! Move on to next cache block
 
 	rts
 	nop
 
 
-! This routine just goes through and forces a write-back and invalidate
-! on the specified data range.
+! This routine uses the OC address array to have direct access to the
+! dcache entries.  It forces a write-back on all dcache entries where
+! the U bit and V bit are set to 1.  Then updates the entry with
+! U bit cleared.
+_dcache_flush_all:
+	mov.l   dca_addr, r1
+	mov.w	cache_lines, r2
+	mov.l   dc_ubit_mask, r3
+
+.dflush_all_loop:
+	mov.l   @r1, r0     ! Get dcache array entry value
+	and     r3, r0	    ! Zero out U bit
+	dt      r2
+	mov.l   r0, @r1     ! Update dcache entry
+
+	bf/s    .dflush_all_loop
+	add     #32, r1		! Move on to next entry
+	rts
+	nop
+
+
+! This routine goes through and forces a write-back and invalidate
+! on the specified data range. If the range is bigger than the dcache,
+! we purge the whole cache instead.
+!
 ! r4 is starting address
 ! r5 is count
 _dcache_purge_range:
-	! Get ending address from count and align start address
-	add	r4,r5
-	mov.l	l1align,r0
-	and	r0,r4
+	! Divide byte count by 32 
+	mov     #-5, r1
+	shad    r1, r5           
 
-dpurge_loop:
-	! Write back and invalidate the O cache
+	! Compare with 512
+	mov.w   cache_lines, r2
+	cmp/hi  r2, r5
+	bt      _dcache_purge_all  ! If lines > 512, jump to _dcache_purge_all
+
+	! Align start address
+	mov.l	align_mask, r0
+	and	    r0, r4
+
+.dpurge_loop:
+	! Write back and invalidate the D cache
 	ocbp	@r4
-	cmp/hs	r4,r5
-	bt/s	dpurge_loop
-	add	#32,r4		! += CPU_CACHE_BLOCK_SIZE
+	dt	    r5
+	bf/s	.dpurge_loop
+	add	    #32, r4		! Move on to next cache block
 
 	rts
 	nop
 
 
-! This routine just forces a write-back and invalidate all O cache.
+! This routine uses the OC address array to have direct access to the
+! dcache entries.  It goes through and forces a write-back and invalidate
+! on all of the dcache.
+_dcache_purge_all:
+    mov.l   dca_addr, r1
+    mov.w   cache_lines, r2
+    mov     #0, r3
+    
+.dpurge_all_loop:
+    mov.l   r3, @r1     ! Update dcache entry
+    dt      r2
+    bf/s    .dpurge_all_loop
+    add     #32, r1     ! Move on to next entry
+
+    rts
+    nop
+
+
+! This routine forces a write-back and invalidate all dcache
+! using a 8kb or 16kb 32-byte aligned buffer.
+!
 ! r4 is address for temporary buffer 32-byte aligned
 ! r5 is size of temporary buffer (8 KB or 16 KB)
-_dcache_purge_all:
-	mov #0, r0
-	add r4, r5
-dpurge_all_loop:
-	! Allocate and then invalidate the O cache block
+_dcache_purge_all_with_buffer:
+	mov     #0, r0
+	add     r4, r5
+
+.dpurge_all_buffer_loop:
+	! Allocate and then invalidate the dcache line
 	movca.l r0, @r4
-	ocbi @r4
-	cmp/hs r4, r5
-	bt/s dpurge_all_loop
-	add #32, r4		! += CPU_CACHE_BLOCK_SIZE
+	ocbi    @r4
+	cmp/hs  r4, r5
+	bt/s    .dpurge_all_buffer_loop
+	add     #32, r4		! Move on to next cache block
 	rts
 	nop
 
 
+! Variables
 	.align	2
-l1align:
-	.long	~31		! ~(CPU_CACHE_BLOCK_SIZE-1)
+
+! I-cache (Instruction cache)
+ica_addr:
+	.long	0xf0000000	! icache array address
+ic_entry_mask:
+	.long	0x1fe0		! CACHE_IC_ENTRY_MASK
+ic_valid_mask:
+	.long	0xfffffc00
+ifr_addr:	
+	.long	.iflush_real
+
+! D-cache (Data cache)
+dca_addr:
+	.long	0xf4000000	! dcache array address
+dc_ubit_mask:
+	.long   0xfffffffd  ! Mask to zero out U bit
+
+! Shared	
+p2_mask:	
+	.long	0xa0000000
+ormask:
+	.long	0x100000f0
+align_mask:
+	.long	~31		    ! Align address to 32-byte boundary
+cache_lines:
+	.word   512         ! Total number of cache lines in dcache
+

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -15,6 +15,7 @@
 ! r4 is starting address
 ! r5 is count
 _icache_flush_range:
+.align 2
 	mov.l	ifr_addr, r0
 	mov.l	p2_mask, r1
 	or	    r1, r0
@@ -77,6 +78,7 @@ _icache_flush_range:
 ! r4 is starting address
 ! r5 is count
 _dcache_inval_range:
+.align 2
 	! Get ending address from count and align start address
 	add	    r4, r5
 	mov.l	align_mask, r0
@@ -101,6 +103,7 @@ _dcache_inval_range:
 ! r4 is starting address
 ! r5 is count
 _dcache_flush_range:
+.align 2
 	! Divide byte count by 32 
 	mov     #-5, r1
 	shad    r1, r5           
@@ -130,6 +133,7 @@ _dcache_flush_range:
 ! the U bit and V bit are set to 1.  Then updates the entry with
 ! U bit cleared.
 _dcache_flush_all:
+.align 2
 	mov.l   dca_addr, r1
 	mov.w	cache_lines, r2
 	mov.l   dc_ubit_mask, r3
@@ -153,6 +157,7 @@ _dcache_flush_all:
 ! r4 is starting address
 ! r5 is count
 _dcache_purge_range:
+.align 2
 	! Divide byte count by 32 
 	mov     #-5, r1
 	shad    r1, r5           
@@ -181,6 +186,7 @@ _dcache_purge_range:
 ! dcache entries.  It goes through and forces a write-back and invalidate
 ! on all of the dcache.
 _dcache_purge_all:
+.align 2
     mov.l   dca_addr, r1
     mov.w   cache_lines, r2
     mov     #0, r3
@@ -201,6 +207,7 @@ _dcache_purge_all:
 ! r4 is address for temporary buffer 32-byte aligned
 ! r5 is size of temporary buffer (8 KB or 16 KB)
 _dcache_purge_all_with_buffer:
+.align 2
 	mov     #0, r0
 	add     r4, r5
 
@@ -216,7 +223,7 @@ _dcache_purge_all_with_buffer:
 
 
 ! Variables
-	.align	2
+.align	2
 
 ! I-cache (Instruction cache)
 ica_addr:
@@ -246,10 +253,10 @@ cache_lines:
 
 ! _dcache_flush_range can execute up to this amount of loops and 
 ! beat execution time of _dcache_flush_all.  This means that 
-! dcache_flush_range can have count param set up to 107520 bytes 
+! dcache_flush_range can have count param set up to 66560 bytes 
 ! and still be faster than dcache_flush_all.
 flush_check:
-	.word   3360
+	.word   2080
 	
 ! _dcache_purge_range can execute up to this amount of loops and 
 ! beat execution time of _dcache_purge_all.  This means that 

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -1,74 +1,74 @@
 
 .text
-	.globl _icache_flush_range
-	.globl _dcache_inval_range
-	.globl _dcache_flush_range
-	.globl _dcache_flush_all
-	.globl _dcache_purge_range
-	.globl _dcache_purge_all
-	.globl _dcache_purge_all_with_buffer
+    .globl _icache_flush_range
+    .globl _dcache_inval_range
+    .globl _dcache_flush_range
+    .globl _dcache_flush_all
+    .globl _dcache_purge_range
+    .globl _dcache_purge_all
+    .globl _dcache_purge_all_with_buffer
 
-! Routine to flush parts of cache.. thanks to the Linux-SH guys
+! Routine to flush parts of cache.. Thanks to the Linux-SH guys
 ! for the algorithm. The original version of this routine was
 ! taken from sh-stub.c.
 !
 ! r4 is starting address
 ! r5 is count
-_icache_flush_range:
 .align 2
-	mov.l	ifr_addr, r0
-	mov.l	p2_mask, r1
-	or	    r1, r0
-	jmp	    @r0
-	nop
+_icache_flush_range:
+    mov.l    ifr_addr, r0
+    mov.l    p2_mask, r1
+    or       r1, r0
+    jmp      @r0
+    nop
 
 .iflush_real:
-	! Save old SR and disable interrupts
-	stc	    sr, r0
-	mov.l	r0, @-r15
-	mov.l	ormask, r1
-	or	    r1, r0
-	ldc	    r0, sr
+    ! Save old SR and disable interrupts
+    stc      sr, r0
+    mov.l    r0, @-r15
+    mov.l    ormask, r1
+    or       r1, r0
+    ldc      r0, sr
 
-	! Get ending address from count and align start address
-	add	    r4, r5
-	mov.l	align_mask, r0
-	and	    r0, r4
-	mov.l	ica_addr, r1
-	mov.l	ic_entry_mask, r2
-	mov.l	ic_valid_mask, r3
+    ! Get ending address from count and align start address
+    add      r4, r5
+    mov.l    align_mask, r0
+    and      r0, r4
+    mov.l    ica_addr, r1
+    mov.l    ic_entry_mask, r2
+    mov.l    ic_valid_mask, r3
 
 .flush_loop:
-	! Write back D cache
-	ocbwb	@r4
+    ! Write back D cache
+    ocbwb    @r4
 
-	! Invalidate I cache
-	mov	    r4, r6		! v & CACHE_IC_ENTRY_MASK
-	and	    r2, r6
-	or	    r1, r6		! CACHE_IC_ADDRESS_ARRAY | ^
+    ! Invalidate I cache
+    mov      r4, r6        ! v & CACHE_IC_ENTRY_MASK
+    and      r2, r6
+    or       r1, r6        ! CACHE_IC_ADDRESS_ARRAY | ^
 
-	mov	    r4, r7		! v & 0xfffffc00
-	and	    r3, r7
+    mov      r4, r7        ! v & 0xfffffc00
+    and      r3, r7
 
-	add	    #32, r4		! Move on to next cache block
-	cmp/hs	r4, r5
-	bt/s	.flush_loop
-	mov.l	r7, @r6		! *addr = data	
+    add      #32, r4       ! Move on to next cache block
+    cmp/hs   r4, r5
+    bt/s     .flush_loop
+    mov.l    r7, @r6       ! *addr = data    
 
-	! Restore old SR
-	mov.l	@r15+, r0
-	ldc	    r0, sr
+    ! Restore old SR
+    mov.l    @r15+, r0
+    ldc      r0, sr
 
-	! make sure we have enough instrs before returning to P1
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	rts
-	nop
+    ! make sure we have enough instrs before returning to P1
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    rts
+    nop
 
 
 ! This routine goes through and invalidates the dcache for a given 
@@ -77,22 +77,22 @@ _icache_flush_range:
 !
 ! r4 is starting address
 ! r5 is count
-_dcache_inval_range:
 .align 2
-	! Get ending address from count and align start address
-	add	    r4, r5
-	mov.l	align_mask, r0
-	and	    r0, r4
+_dcache_inval_range:
+    ! Get ending address from count and align start address
+    add      r4, r5
+    mov.l    align_mask, r0
+    and      r0, r4
 
 .dinval_loop:
-	! Invalidate the dcache
-	ocbi	@r4
-	cmp/hs	r4, r5
-	bt/s	.dinval_loop
-	add	    #32, r4		! Move on to next cache block
+    ! Invalidate the dcache
+    ocbi     @r4
+    cmp/hs   r4, r5
+    bt/s     .dinval_loop
+    add      #32, r4        ! Move on to next cache block
 
-	rts
-	nop
+    rts
+    nop
 
 
 ! This routine goes through and forces a write-back on the
@@ -102,52 +102,53 @@ _dcache_inval_range:
 !
 ! r4 is starting address
 ! r5 is count
-_dcache_flush_range:
 .align 2
-	! Divide byte count by 32 
-	mov     #-5, r1
-	shad    r1, r5           
+_dcache_flush_range:
+    ! Divide byte count by 32 
+    mov      #-5, r1
+    shad     r1, r5           
 
-	! Compare with 512
-	mov.w   flush_check, r2
-	cmp/hi  r2, r5
-	bt      _dcache_flush_all  ! If lines > flush_check, jump to _dcache_flush_all
+    ! Compare with 512
+    mov.w    flush_check, r2
+    cmp/hi   r2, r5
+    bt       _dcache_flush_all  ! If lines > flush_check, jump to _dcache_flush_all
 
-	! Align start address
-	mov.l	align_mask, r0
-	and	    r0, r4
+    ! Align start address
+    mov.l    align_mask, r0
+    and      r0, r4
 
 .dflush_loop:
-	! Write back the dcache
-	ocbwb	@r4
-	dt	    r5
-	bf/s	.dflush_loop
-	add	    #32, r4		! Move on to next cache block
+    ! Write back the dcache
+    ocbwb    @r4
+    dt       r5
+    bf/s     .dflush_loop
+    add      #32, r4        ! Move on to next cache block
 
-	rts
-	nop
+    rts
+    nop
 
 
 ! This routine uses the OC address array to have direct access to the
 ! dcache entries.  It forces a write-back on all dcache entries where
 ! the U bit and V bit are set to 1.  Then updates the entry with
 ! U bit cleared.
-_dcache_flush_all:
 .align 2
-	mov.l   dca_addr, r1
-	mov.w	cache_lines, r2
-	mov.l   dc_ubit_mask, r3
+_dcache_flush_all:
+    mov.l    dca_addr, r1
+    mov.w    cache_lines, r2
+    mov.l    dc_ubit_mask, r3
 
 .dflush_all_loop:
-	mov.l   @r1, r0     ! Get dcache array entry value
-	and     r3, r0	    ! Zero out U bit
-	dt      r2
-	mov.l   r0, @r1     ! Update dcache entry
+    mov.l    @r1, r0     ! Get dcache array entry value
+    and      r3, r0      ! Zero out U bit
+    dt       r2
+    mov.l    r0, @r1     ! Update dcache entry
 
-	bf/s    .dflush_all_loop
-	add     #32, r1		! Move on to next entry
-	rts
-	nop
+    bf/s     .dflush_all_loop
+    add      #32, r1     ! Move on to next entry
+    
+    rts
+    nop
 
 
 ! This routine goes through and forces a write-back and invalidate
@@ -156,46 +157,46 @@ _dcache_flush_all:
 !
 ! r4 is starting address
 ! r5 is count
-_dcache_purge_range:
 .align 2
-	! Divide byte count by 32 
-	mov     #-5, r1
-	shad    r1, r5           
+_dcache_purge_range:
+    ! Divide byte count by 32 
+    mov      #-5, r1
+    shad     r1, r5           
 
-	! Compare with 512
-	mov.w   purge_check, r2
-	cmp/hi  r2, r5
-	bt      _dcache_purge_all  ! If lines > purge_check, jump to _dcache_purge_all
+    ! Compare with 512
+    mov.w    purge_check, r2
+    cmp/hi   r2, r5
+    bt       _dcache_purge_all  ! If lines > purge_check, jump to _dcache_purge_all
 
-	! Align start address
-	mov.l	align_mask, r0
-	and	    r0, r4
+    ! Align start address
+    mov.l    align_mask, r0
+    and      r0, r4
 
 .dpurge_loop:
-	! Write back and invalidate the D cache
-	ocbp	@r4
-	dt	    r5
-	bf/s	.dpurge_loop
-	add	    #32, r4		! Move on to next cache block
+    ! Write back and invalidate the D cache
+    ocbp     @r4
+    dt       r5
+    bf/s     .dpurge_loop
+    add      #32, r4     ! Move on to next cache block
 
-	rts
-	nop
+    rts
+    nop
 
 
 ! This routine uses the OC address array to have direct access to the
 ! dcache entries.  It goes through and forces a write-back and invalidate
 ! on all of the dcache.
-_dcache_purge_all:
 .align 2
-    mov.l   dca_addr, r1
-    mov.w   cache_lines, r2
-    mov     #0, r3
+_dcache_purge_all:
+    mov.l    dca_addr, r1
+    mov.w    cache_lines, r2
+    mov      #0, r3
     
 .dpurge_all_loop:
-    mov.l   r3, @r1     ! Update dcache entry
-    dt      r2
-    bf/s    .dpurge_all_loop
-    add     #32, r1     ! Move on to next entry
+    mov.l    r3, @r1     ! Update dcache entry
+    dt       r2
+    bf/s     .dpurge_all_loop
+    add      #32, r1     ! Move on to next entry
 
     rts
     nop
@@ -206,62 +207,63 @@ _dcache_purge_all:
 !
 ! r4 is address for temporary buffer 32-byte aligned
 ! r5 is size of temporary buffer (8 KB or 16 KB)
-_dcache_purge_all_with_buffer:
 .align 2
-	mov     #0, r0
-	add     r4, r5
+_dcache_purge_all_with_buffer:
+    mov      #0, r0
+    add      r4, r5
 
 .dpurge_all_buffer_loop:
-	! Allocate and then invalidate the dcache line
-	movca.l r0, @r4
-	ocbi    @r4
-	cmp/hs  r4, r5
-	bt/s    .dpurge_all_buffer_loop
-	add     #32, r4		! Move on to next cache block
-	rts
-	nop
+    ! Allocate and then invalidate the dcache line
+    movca.l  r0, @r4
+    ocbi     @r4
+    cmp/hs   r4, r5
+    bt/s     .dpurge_all_buffer_loop
+    add      #32, r4        ! Move on to next cache block
+
+    rts
+    nop
 
 
 ! Variables
-.align	2
+.align    2
 
 ! I-cache (Instruction cache)
 ica_addr:
-	.long	0xf0000000	! icache array address
+    .long    0xf0000000    ! icache array address
 ic_entry_mask:
-	.long	0x1fe0		! CACHE_IC_ENTRY_MASK
+    .long    0x1fe0        ! CACHE_IC_ENTRY_MASK
 ic_valid_mask:
-	.long	0xfffffc00
-ifr_addr:	
-	.long	.iflush_real
+    .long    0xfffffc00
+ifr_addr:    
+    .long    .iflush_real
 
 ! D-cache (Data cache)
 dca_addr:
-	.long	0xf4000000	! dcache array address
+    .long    0xf4000000    ! dcache array address
 dc_ubit_mask:
-	.long   0xfffffffd  ! Mask to zero out U bit
+    .long    0xfffffffd    ! Mask to zero out U bit
 
-! Shared	
-p2_mask:	
-	.long	0xa0000000
+! Shared    
+p2_mask:    
+    .long    0xa0000000
 ormask:
-	.long	0x100000f0
+    .long    0x100000f0
 align_mask:
-	.long	~31		    ! Align address to 32-byte boundary
+    .long    ~31           ! Align address to 32-byte boundary
 cache_lines:
-	.word   512         ! Total number of cache lines in dcache
+    .word    512           ! Total number of cache lines in dcache
 
 ! _dcache_flush_range can execute up to this amount of loops and 
 ! beat execution time of _dcache_flush_all.  This means that 
 ! dcache_flush_range can have count param set up to 66560 bytes 
 ! and still be faster than dcache_flush_all.
 flush_check:
-	.word   2080
-	
+    .word    2080
+    
 ! _dcache_purge_range can execute up to this amount of loops and 
 ! beat execution time of _dcache_purge_all.  This means that 
 ! dcache_purge_range can have count param set up to 39936 bytes 
 ! and still be faster than dcache_purge_all.
 purge_check:
-	.word   1248        
+    .word    1248        
 

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -3,8 +3,8 @@
 !
 ! arch/dreamcast/kernel/cache.s
 !
-! Copyright (C) 2003 Megan Potter
-! Copyright (C) 2023 Ruslan Rostovtsev
+! Copyright (C) 2001 Megan Potter
+! Copyright (C) 2014, 2016, 2023 Ruslan Rostovtsev
 ! Copyright (C) 2023 Andy Barajas
 !
 ! Optimized assembler code for managing the cache.

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -106,9 +106,9 @@ _dcache_flush_range:
 	shad    r1, r5           
 
 	! Compare with 512
-	mov.w   cache_lines, r2
+	mov.w   flush_check, r2
 	cmp/hi  r2, r5
-	bt      _dcache_flush_all  ! If lines > 512, jump to _dcache_flush_all
+	bt      _dcache_flush_all  ! If lines > flush_check, jump to _dcache_flush_all
 
 	! Align start address
 	mov.l	align_mask, r0
@@ -158,9 +158,9 @@ _dcache_purge_range:
 	shad    r1, r5           
 
 	! Compare with 512
-	mov.w   cache_lines, r2
+	mov.w   purge_check, r2
 	cmp/hi  r2, r5
-	bt      _dcache_purge_all  ! If lines > 512, jump to _dcache_purge_all
+	bt      _dcache_purge_all  ! If lines > purge_check, jump to _dcache_purge_all
 
 	! Align start address
 	mov.l	align_mask, r0
@@ -243,4 +243,18 @@ align_mask:
 	.long	~31		    ! Align address to 32-byte boundary
 cache_lines:
 	.word   512         ! Total number of cache lines in dcache
+
+! _dcache_flush_range can execute up to this amount of loops and 
+! beat execution time of _dcache_flush_all.  This means that 
+! dcache_flush_range can have count param set up to 107520 bytes 
+! and still be faster than dcache_flush_all.
+flush_check:
+	.word   3360
+	
+! _dcache_purge_range can execute up to this amount of loops and 
+! beat execution time of _dcache_purge_all.  This means that 
+! dcache_purge_range can have count param set up to 39936 bytes 
+! and still be faster than dcache_purge_all.
+purge_check:
+	.word   1248        
 

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -1,5 +1,16 @@
 
-.text
+! KallistiOS ##version##
+!
+! arch/dreamcast/kernel/cache.s
+!
+! Copyright (C) 2003 Megan Potter
+! Copyright (C) 2023 Ruslan Rostovtsev
+! Copyright (C) 2023 Andy Barajas
+!
+! Optimized assembler code for managing the cache.
+!
+
+    .text
     .globl _icache_flush_range
     .globl _dcache_inval_range
     .globl _dcache_flush_range
@@ -14,7 +25,7 @@
 !
 ! r4 is starting address
 ! r5 is count
-.align 2
+    .align 2
 _icache_flush_range:
     mov.l    ifr_addr, r0
     mov.l    p2_mask, r1
@@ -77,7 +88,7 @@ _icache_flush_range:
 !
 ! r4 is starting address
 ! r5 is count
-.align 2
+    .align 2
 _dcache_inval_range:
     ! Get ending address from count and align start address
     add      r4, r5
@@ -102,7 +113,7 @@ _dcache_inval_range:
 !
 ! r4 is starting address
 ! r5 is count
-.align 2
+    .align 2
 _dcache_flush_range:
     ! Divide byte count by 32 
     mov      #-5, r1
@@ -132,7 +143,7 @@ _dcache_flush_range:
 ! dcache entries.  It forces a write-back on all dcache entries where
 ! the U bit and V bit are set to 1.  Then updates the entry with
 ! U bit cleared.
-.align 2
+    .align 2
 _dcache_flush_all:
     mov.l    dca_addr, r1
     mov.w    cache_lines, r2
@@ -157,7 +168,7 @@ _dcache_flush_all:
 !
 ! r4 is starting address
 ! r5 is count
-.align 2
+    .align 2
 _dcache_purge_range:
     ! Divide byte count by 32 
     mov      #-5, r1
@@ -186,7 +197,7 @@ _dcache_purge_range:
 ! This routine uses the OC address array to have direct access to the
 ! dcache entries.  It goes through and forces a write-back and invalidate
 ! on all of the dcache.
-.align 2
+    .align 2
 _dcache_purge_all:
     mov.l    dca_addr, r1
     mov.w    cache_lines, r2
@@ -207,7 +218,7 @@ _dcache_purge_all:
 !
 ! r4 is address for temporary buffer 32-byte aligned
 ! r5 is size of temporary buffer (8 KB or 16 KB)
-.align 2
+    .align 2
 _dcache_purge_all_with_buffer:
     mov      #0, r0
     add      r4, r5
@@ -225,7 +236,7 @@ _dcache_purge_all_with_buffer:
 
 
 ! Variables
-.align    2
+    .align    2
 
 ! I-cache (Instruction cache)
 ica_addr:


### PR DESCRIPTION
Renamed dcache_purge_all() to dcache_purge_all_with_buffer().

Add two functions: 

dcache_flush_all(void)
dcache_purge_all(void)

When dcache_flush_range() or dcache_purge_range() have ranges bigger than the dcache 16kb, we use dcache_flush_all()/dcache_purge_all() instead.  This speeds up flushes over ranges 256x256x2 by 2.6x and  512x512x2 by 10.5x.

dcache_purge_all_with_buffer() is still the fastest method but requires a 8/16kb buffer.
