### PR TITLE
Fix built-in romdisks not mounting properly

### DIFF
--- a/kernel/romdisk/romdiskbase.c
+++ b/kernel/romdisk/romdiskbase.c
@@ -10,7 +10,9 @@ extern unsigned char romdisk[];
 
 void *__kos_romdisk = romdisk;
 
-int fs_romdisk_mount_weak(void)
+static int do_fs_romdisk_mount(void)
 {
     return fs_romdisk_mount("/rd", __kos_romdisk, 0);
 }
+
+int (*fs_romdisk_mount_weak)(void) = do_fs_romdisk_mount;


### PR DESCRIPTION
Fix kernel crash that happened when the init code was trying to execute fs_romdisk_mount_weak().