### PR TITLE
SPU Clean

### DIFF
--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -79,7 +79,6 @@ void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
 
     /* Make sure the FIFOs are empty */
     ctx = g2_lock();
-    g2_fifo_wait();
 
     sq_cpy((void *)dst, src, aligned_len);
 

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -8,7 +8,6 @@
 #include <dc/spu.h>
 #include <dc/g2bus.h>
 #include <dc/sq.h>
-#include <arch/memory.h>
 #include <arch/timer.h>
 
 /*
@@ -36,22 +35,19 @@ kernel; so don't use them if you don't need to =).
 /* memcpy and memset designed for sound RAM; for addresses, don't
    bother to include the 0xa0800000 offset that is implied. 'length'
    must be a multiple of 4, but if it is not it will be rounded up. */
-void spu_memload(uint32 dst, void *src_void, int length) {
-    uint8 *src = (uint8*)src_void;
+void spu_memload(uintptr_t dst, void *src_void, size_t length) {
+    uint8_t *src = (uint8_t *)src_void;
 
     /* Make sure it's an even number of 32-bit words and convert the
        count to a 32-bit word count */
-    if(length % 4)
-        length = (length / 4) + 1;
-    else
-        length = length / 4;
+    length = (length + 3) >> 2;
 
     /* Add in the SPU RAM base */
-    dst += 0xa0800000;
+    dst += SPU_RAM_UNCACHED_BASE;
 
     while(length > 8) {
         g2_fifo_wait();
-        g2_write_block_32((uint32*)src, dst, 8);
+        g2_write_block_32((uint32_t *)src, dst, 8);
 
         src += 8 * 4;
         dst += 8 * 4;
@@ -60,30 +56,28 @@ void spu_memload(uint32 dst, void *src_void, int length) {
 
     if(length > 0) {
         g2_fifo_wait();
-        g2_write_block_32((uint32*)src, dst, length);
+        g2_write_block_32((uint32_t *)src, dst, length);
     }
 }
 
-void spu_memload_sq(uint32 dst, void *src_void, int length) {
-    uint8 *src = (uint8 *)src_void;
+void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
+    uint8_t *src = (uint8_t *)src_void;
     int aligned_len, old;
 
-    /* Make sure it's an even number of 32-bit words and convert the
-       count to a 32-bit word count */
+    /* Round up to the nearest multiple of 4 */
     if(length & 3) {
         length = (length + 4) & ~3;
     }
-
-    /* Add in the SPU RAM base (cached area) */
-    dst += 0x00800000;
 
     /* Using SQs for all that is divisible by 32 */
     aligned_len = length & ~31;
     length &= 31;
 
+    /* Add in the SPU RAM base (cached area) */
+    dst += SPU_RAM_BASE;
+
     old = irq_disable();
-    do { } while(*(vuint32 *)0xa05f688c & (1 << 5)); /* FIFO_SH4 */
-    do { } while(*(vuint32 *)0xa05f688c & (1 << 4)); /* FIFO_G2 */
+    do { } while(FIFO_STATUS & (FIFO_SH4 | FIFO_G2));
     sq_cpy((void *)dst, src, aligned_len);
     irq_restore(old);
 
@@ -93,26 +87,23 @@ void spu_memload_sq(uint32 dst, void *src_void, int length) {
         dst += aligned_len;
         src += aligned_len;
         g2_fifo_wait();
-        g2_write_block_32((uint32 *)src, dst, length >> 2);
+        g2_write_block_32((uint32_t *)src, dst, length >> 2);
     }
 }
 
-void spu_memread(void *dst_void, uint32 src, int length) {
-    uint8 *dst = (uint8*)dst_void;
+void spu_memread(void *dst_void, uintptr_t src, size_t length) {
+    uint8_t *dst = (uint8_t *)dst_void;
 
     /* Make sure it's an even number of 32-bit words and convert the
        count to a 32-bit word count */
-    if(length % 4)
-        length = (length / 4) + 1;
-    else
-        length = length / 4;
+    length = (length + 3) >> 2;
 
     /* Add in the SPU RAM base */
-    src += 0xa0800000;
+    src += SPU_RAM_UNCACHED_BASE;
 
     while(length > 8) {
         g2_fifo_wait();
-        g2_read_block_32((uint32*)dst, src, 8);
+        g2_read_block_32((uint32_t *)dst, src, 8);
 
         src += 8 * 4;
         dst += 8 * 4;
@@ -121,27 +112,24 @@ void spu_memread(void *dst_void, uint32 src, int length) {
 
     if(length > 0) {
         g2_fifo_wait();
-        g2_read_block_32((uint32*)dst, src, length);
+        g2_read_block_32((uint32_t *)dst, src, length);
     }
 }
 
-void spu_memset(uint32 dst, unsigned long what, int length) {
-    uint32  blank[8];
+void spu_memset(uintptr_t dst, uint32_t what, size_t length) {
+    uint32_t  blank[8];
     int i;
 
     /* Make sure it's an even number of 32-bit words and convert the
        count to a 32-bit word count */
-    if(length % 4)
-        length = (length / 4) + 1;
-    else
-        length = length / 4;
+    length = (length + 3) >> 2;
 
     /* Initialize the array */
     for(i = 0; i < 8; i++)
         blank[i] = what;
 
     /* Add in the SPU RAM base */
-    dst += 0xa0800000;
+    dst += SPU_RAM_UNCACHED_BASE;
 
     while(length > 8) {
         g2_fifo_wait();
@@ -249,7 +237,7 @@ int spu_init(void) {
     /* Load a default "program" into the SPU that just executes
        an infinite loop, so that CD audio works. */
     g2_fifo_wait();
-    g2_write_32(0xa0800000, 0xeafffff8);
+    g2_write_32(SPU_RAM_UNCACHED_BASE, 0xeafffff8);
 
     /* Start the SPU again */
     spu_enable();
@@ -273,7 +261,7 @@ int spu_shutdown(void) {
 int spu_dma_transfer(void *from, uintptr_t dest, size_t length, int block,
                      g2_dma_callback_t callback, void *cbdata) {
     /* Adjust destination to SPU RAM */
-    dest += 0x00800000;
+    dest += SPU_RAM_BASE;
 
     return g2_dma_transfer(from, (void *) dest, length, block, callback, cbdata, 0,
                            0, G2_DMA_CHAN_SPU, 0);

--- a/kernel/arch/dreamcast/include/dc/g2bus.h
+++ b/kernel/arch/dreamcast/include/dc/g2bus.h
@@ -161,7 +161,7 @@ static inline g2_ctx_t g2_lock(void) {
     G2_DMA_SUSPEND_BBA = 1;
     G2_DMA_SUSPEND_CH2 = 1;
 
-    while(FIFO_STATUS & FIFO_SH4);
+    while(FIFO_STATUS & (FIFO_SH4 | FIFO_G2));
 
     return ctx;
 }

--- a/kernel/arch/dreamcast/include/dc/spu.h
+++ b/kernel/arch/dreamcast/include/dc/spu.h
@@ -22,10 +22,12 @@
 __BEGIN_DECLS
 
 #include <arch/types.h>
+#include <arch/memory.h>
 #include <dc/g2bus.h>
 
-/** \brief  Waits for the sound FIFO to empty. */
-void spu_write_wait(void);
+/** \brief  Sound ram address from the SH4 side */
+#define SPU_RAM_BASE 0x00800000
+#define SPU_RAM_UNCACHED_BASE (MEM_AREA_P2_BASE | SPU_RAM_BASE)
 
 /** \brief  Copy a block of data to sound RAM.
 
@@ -37,7 +39,7 @@ void spu_write_wait(void);
     \param  length          The number of bytes to copy. Automatically rounded
                             up to be a multiple of 4.
 */
-void spu_memload(uint32 to, void *from, int length);
+void spu_memload(uintptr_t to, void *from, size_t length);
 
 
 /** \brief  Copy a block of data to sound RAM.
@@ -51,7 +53,7 @@ void spu_memload(uint32 to, void *from, int length);
     \param  length          The number of bytes to copy. Automatically rounded
                             up to be a multiple of 4.
 */
-void spu_memload_sq(uint32 to, void *from, int length);
+void spu_memload_sq(uintptr_t to, void *from, size_t length);
 
 /** \brief  Copy a block of data from sound RAM.
 
@@ -63,7 +65,7 @@ void spu_memload_sq(uint32 to, void *from, int length);
     \param  length          The number of bytes to copy. Automatically rounded
                             up to be a multiple of 4.
 */
-void spu_memread(void *to, uint32 from, int length);
+void spu_memread(void *to, uintptr_t from, size_t length);
 
 /** \brief  Set a block of sound RAM to the specified value.
 
@@ -76,7 +78,7 @@ void spu_memread(void *to, uint32 from, int length);
     \param  length          The number of bytes to copy. Automatically rounded
                             up to be a multiple of 4.
 */
-void spu_memset(uint32 to, uint32 what, int length);
+void spu_memset(uintptr_t to, uint32_t what, size_t length);
 
 /* DMA copy from SH-4 RAM to SPU RAM; length must be a multiple of 32,
    and the source and destination addresses must be aligned on 32-byte

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -235,7 +235,6 @@ void snd_pcm16_split_sq(uint32_t *data, uintptr_t left, uintptr_t right, size_t 
 
     /* Make sure the FIFOs are empty */
     ctx = g2_lock();
-    g2_fifo_wait();
 
     /* Separating channels and do fill/write queues as many times necessary. */
     snd_pcm16_split_sq_start(data, masked_left, masked_right, size);

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -331,6 +331,8 @@ snd_stream_hnd_t snd_stream_alloc(snd_stream_callback_t cb, int bufsize) {
     int i, old;
     snd_stream_hnd_t hnd;
 
+    mutex_lock(&stream_mutex);
+
     /* Get an unused handle */
     hnd = -1;
     old = irq_disable();
@@ -371,6 +373,8 @@ snd_stream_hnd_t snd_stream_alloc(snd_stream_callback_t cb, int bufsize) {
     streams[hnd].ch[1] = snd_sfx_chn_alloc();
     dbglog(DBG_INFO, "snd_stream: alloc'd channels %d/%d\n", streams[hnd].ch[0], streams[hnd].ch[1]);
 
+    mutex_unlock(&stream_mutex);
+
     return hnd;
 }
 
@@ -388,6 +392,8 @@ snd_stream_hnd_t snd_stream_reinit(snd_stream_hnd_t hnd, snd_stream_callback_t c
 
 void snd_stream_destroy(snd_stream_hnd_t hnd) {
     filter_t *c, *n;
+
+    mutex_lock(&stream_mutex);
 
     CHECK_HND(hnd);
 
@@ -411,6 +417,8 @@ void snd_stream_destroy(snd_stream_hnd_t hnd) {
     snd_mem_free(streams[hnd].spu_ram_sch[0]);
     dbglog(DBG_INFO, "snd_stream: dealloc'd channels %d/%d\n", streams[hnd].ch[0], streams[hnd].ch[1]);
     memset(streams + hnd, 0, sizeof(streams[0]));
+
+    mutex_unlock(&stream_mutex);
 }
 
 /* Shut everything down and free mem */

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -409,6 +409,7 @@ void snd_stream_destroy(snd_stream_hnd_t hnd) {
 
     snd_stream_stop(hnd);
     snd_mem_free(streams[hnd].spu_ram_sch[0]);
+    dbglog(DBG_INFO, "snd_stream: dealloc'd channels %d/%d\n", streams[hnd].ch[0], streams[hnd].ch[1]);
     memset(streams + hnd, 0, sizeof(streams[0]));
 }
 


### PR DESCRIPTION
Added these constants to spu.h and replaced redefined values across spu.c, snd_stream.c, and snd_iface.c:

#define SPU_RAM_BASE 0x00800000
#define SPU_RAM_UNCACHED_BASE (MEM_AREA_P2_BASE | SPU_RAM_BASE)

Replaced uint8, uint16, uint32 types.

Corrected comment that rounds to the nearest 4 for SQ transfer and reduced logic to calculate number of 32-bit words for other transfers:
https://godbolt.org/z/d5xjs4aWz