### PR TITLE
Ensure getaddrinfo() handles IP adddress inputs without using DNS

### DIFF
--- a/kernel/libc/koslib/getaddrinfo.c
+++ b/kernel/libc/koslib/getaddrinfo.c
@@ -706,12 +706,15 @@ int getaddrinfo(const char *nodename, const char *servname,
         return 0;
     }
 
-    // Try to handle input as IPv4 address
-    uint32_t ip4_addr;
-    if (inet_pton(AF_INET, nodename, &ip4_addr) > 0) {
-        ihints.ai_family = AF_INET;
-        *res = add_ipv4_ai(ip4_addr, port, &ihints, NULL);
-        return 0;
+    /* Try to handle input as an IPv4 address */
+    if(ihints.ai_family == AI_INET || ihints.ai_family == AF_UNSPEC) {
+        uint32_t ip4_addr;
+
+        if(inet_pton(AF_INET, nodename, &ip4_addr) > 0) {
+            ihints.ai_family = AF_INET;
+            *res = add_ipv4_ai(ip4_addr, port, &ihints, NULL);
+            return 0;
+        }
     }
 
     // Try to handle input as IPv6 address

--- a/kernel/libc/koslib/getaddrinfo.c
+++ b/kernel/libc/koslib/getaddrinfo.c
@@ -717,12 +717,15 @@ int getaddrinfo(const char *nodename, const char *servname,
         }
     }
 
-    // Try to handle input as IPv6 address
-    struct in6_addr addr;
-    if (inet_pton(AF_INET6, nodename, &addr.s6_addr) > 0) {
-        ihints.ai_family = AF_INET6;
-        *res = add_ipv6_ai(&addr, port, &ihints, NULL);
-        return 0;
+    /* Try to handle input as an IPv6 address */
+    if(ihints.ai_family == AF_INET6 || ihints.ai_family == AF_UNSPEC) {
+        struct in6_addr addr;
+
+        if(inet_pton(AF_INET6, nodename, &addr.s6_addr) > 0) {
+            ihints.ai_family = AF_INET6;
+            *res = add_ipv6_ai(&addr, port, &ihints, NULL);
+            return 0;
+        }
     }
 
     /* If we've gotten this far, do the lookup. */

--- a/kernel/libc/koslib/getaddrinfo.c
+++ b/kernel/libc/koslib/getaddrinfo.c
@@ -706,6 +706,22 @@ int getaddrinfo(const char *nodename, const char *servname,
         return 0;
     }
 
+    // Try to handle input as IPv4 address
+    uint32_t ip4_addr;
+    if (inet_pton(AF_INET, nodename, &ip4_addr) > 0) {
+        ihints.ai_family = AF_INET;
+        *res = add_ipv4_ai(ip4_addr, port, &ihints, NULL);
+        return 0;
+    }
+
+    // Try to handle input as IPv6 address
+    struct in6_addr addr;
+    if (inet_pton(AF_INET6, nodename, &addr.s6_addr) > 0) {
+        ihints.ai_family = AF_INET6;
+        *res = add_ipv6_ai(&addr, port, &ihints, NULL);
+        return 0;
+    }
+
     /* If we've gotten this far, do the lookup. */
     if(ihints.ai_family == AF_UNSPEC) {
         /* It seems that some resolvers really don't like multi-part questions.


### PR DESCRIPTION
Currently any input to getaddrinfo() gets resolved using DNS, including raw IP addresses. This is not ideal but tends to work when your DNS server is local, however it flat out fails when the DNS server is an external/public one and you're trying to connect to a local IP.

This change parses the hostname input string and fills relevant structures without making a DNS call when the input matches IPv4 or IPv6 address.