### PR TITLE
Modularizing KOS, my take

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -208,6 +208,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added <netinet/udp.h> and <netinet/udplite.h> headers and move the related
       content from <netinet/in.h> [LS]
 - *** Added __weak, __used, likely() and unlikely() [FG]
+- DC  Added Maple-specific KOS_INIT_FLAGS() which allow for GC-ing unused drivers [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -207,6 +207,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added <netinet/tcp.h> header file and required option [LS]
 - *** Added <netinet/udp.h> and <netinet/udplite.h> headers and move the related
       content from <netinet/in.h> [LS]
+- *** Added __weak, __used, likely() and unlikely() [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -3,18 +3,21 @@
    kos/cdefs.h
    Copyright (C) 2002, 2004 Megan Potter
    Copyright (C) 2020, 2023 Lawrence Sebald
+   Copyright (C) 2023 Falco Girgis
 
    Based loosely around some stuff in BSD's sys/cdefs.h
 */
 
 /** \file   kos/cdefs.h
-    \brief  Potentially useful definitions for C Programs.
+    \brief  Definitions for builtin attributes and compiler directives
 
     This file contains definitions of various __attribute__ directives in
-    shorter forms for use in programs (to aid in optimization, mainly).
+    shorter forms for use in programs. These typically aid  in optimizations
+    or provide the compiler with extra information about a symbol.
 
     \author Megan Potter
     \author Lawrence Sebald
+    \author Falco Girgis
 */
 
 #ifndef __KOS_CDEFS_H
@@ -45,6 +48,16 @@
 #define __unused    __attribute__((__unused__))
 #endif
 
+#ifndef __used
+/** \brief  Prevent a symbol from being removed from the binary. */
+#define __used      __attribute__((used))
+#endif
+
+#ifndef __weak
+/** \brief  Identify a function or variable that may be overriden by another symbol. */
+#define __weak      __attribute__((weak))
+#endif
+
 #ifndef __dead2
 /** \brief  Alias for \ref __noreturn. For BSD compatibility. */
 #define __dead2     __noreturn  /* BSD compat */
@@ -53,6 +66,32 @@
 #ifndef __pure2
 /** \brief  Alias for \ref __pure. For BSD compatibility. */
 #define __pure2     __pure      /* ditto */
+#endif
+
+#ifndef likely
+/** \brief  Directive to inform the compiler the condition is in the likely path.
+
+    This can be used around conditionals or loops to help inform the
+    compiler which path to optimize for as the common-case.
+
+    \param  exp     Boolean expression which expected to be true.
+
+    \sa unlikely()
+*/
+#define likely(exp)   __builtin_expect(!!(exp), 1)
+#endif
+
+#ifndef unlikely
+/** \brief  Directive to inform the compiler the condition is in the unlikely path.
+
+    This can be used around conditionals or loops to help inform the
+    compiler which path to optimize against as the infrequent-case.
+
+    \param  exp     Boolean expression which is expected to be false.
+
+    \sa likely()
+*/
+#define unlikely(exp) __builtin_expect(!!(exp), 0)
 #endif
 
 #ifndef __deprecated

--- a/include/kos/exports.h
+++ b/include/kos/exports.h
@@ -55,11 +55,8 @@ typedef struct symtab_handler {
 } symtab_handler_t;
 #endif
 
-/** \brief  Setup initial kernel exports.
-    \retval 0               On success
-    \retval -1              On error
-*/
-int export_init(void);
+/** \brief  Setup initial kernel exports. */
+void export_init(void);
 
 /** \brief  Look up a symbol by name.
     \param  name            The symbol to look up

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -32,10 +32,10 @@ __BEGIN_DECLS
 
 /** \cond */
 /* Initialize the file system */
-int fs_romdisk_init(void);
+void fs_romdisk_init(void);
 
 /* De-init the file system; also unmounts any mounted images. */
-int fs_romdisk_shutdown(void);
+void fs_romdisk_shutdown(void);
 /** \endcond */
 
 /* NOTE: the mount/unmount are _not_ thread safe as regards doing multiple

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -48,10 +48,10 @@ __BEGIN_DECLS
     void (*bba_la_init_weak)(void) = ((flags) & INIT_NET) ? bba_la_init : NULL; \
     extern void bba_la_shutdown(void); \
     void (*bba_la_shutdown_weak)(void) = ((flags) & INIT_NET) ? bba_la_shutdown : NULL; \
-    extern int fs_romdisk_init(void); \
-    int (*fs_romdisk_init_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_init : NULL; \
-    extern int fs_romdisk_shutdown(void); \
-    int (*fs_romdisk_shutdown_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_shutdown : NULL; \
+    extern void fs_romdisk_init(void); \
+    void (*fs_romdisk_init_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_init : NULL; \
+    extern void fs_romdisk_shutdown(void); \
+    void (*fs_romdisk_shutdown_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_shutdown : NULL; \
     extern int export_init(void); \
     int (*export_init_weak)(void) = ((flags) & INIT_EXPORT) ? export_init : NULL
 

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -3,6 +3,8 @@
    include/kos/init.h
    Copyright (C) 2001 Megan Potter
    Copyright (C) 2023 Lawrence Sebald
+   Copyright (C) 2023 Paul Cercueil
+   Copyright (C) 2023 Falco Girgis
 
 */
 
@@ -14,9 +16,13 @@
     architecture-independent are specified here, however this file also includes
     the architecture-specific file to bring in those flags as well.
 
-    \author Lawrence Sebald
+    \sa     arch/init_flags.h
+    \sa     kos/init_base.h
+
     \author Megan Potter
-    \see    arch/init_flags.h
+    \author Lawrence Sebald
+    \author Paul Cercueil
+    \author Falco Girgis
 */
 
 #ifndef __KOS_INIT_H
@@ -25,35 +31,31 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <arch/init_flags.h>
+#include <kos/init_base.h>
+#include <stdint.h>
 
-/** \brief  Use this macro to determine the level of initialization you'd like
-            in your program by default.
+/** \brief  Exports and initializes the given KOS subsystems.
 
-    The defaults will be fine for most things, and will be used if you do not
-    specify any init flags yourself.
+    KOS_INIT_FLAGS() provides a mechanism through which various components
+    of KOS can be enabled and initialized depending on whether their flag
+    has been included within the list.
+
+    \note
+    When no KOS_INIT_FLAGS() have been explicitly provided, the default
+    flags used by KOS are equivalent to KOS_INIT_FLAGS(INIT_DEFAULT).
 
     \param  flags           Parts of KOS to init.
-    \see    kos_initflags
-    \see    dreamcast_initflags
-*/
-#define KOS_INIT_FLAGS(flags) \
-    const uint32_t __kos_init_flags = (flags); \
-    extern void arch_init_net(void); \
-    void (*init_net_weak)(void) = ((flags) & INIT_NET) ? arch_init_net : NULL; \
-    extern void net_shutdown(void); \
-    void (*net_shutdown_weak)(void) = ((flags) & INIT_NET) ? net_shutdown : NULL; \
-    extern void bba_la_init(void); \
-    void (*bba_la_init_weak)(void) = ((flags) & INIT_NET) ? bba_la_init : NULL; \
-    extern void bba_la_shutdown(void); \
-    void (*bba_la_shutdown_weak)(void) = ((flags) & INIT_NET) ? bba_la_shutdown : NULL; \
-    extern void fs_romdisk_init(void); \
-    void (*fs_romdisk_init_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_init : NULL; \
-    extern void fs_romdisk_shutdown(void); \
-    void (*fs_romdisk_shutdown_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_shutdown : NULL; \
-    extern void export_init(void); \
-    void (*export_init_weak)(void) = ((flags) & INIT_EXPORT) ? export_init : NULL
+ */
+ #define KOS_INIT_FLAGS(flags) \
+     const uint32_t __kos_init_flags = (flags); \
+     KOS_INIT_FLAG(flags, INIT_NET, arch_init_net); \
+     KOS_INIT_FLAG(flags, INIT_NET, net_shutdown); \
+     KOS_INIT_FLAG(flags, INIT_NET, bba_la_init); \
+     KOS_INIT_FLAG(flags, INIT_NET, bba_la_shutdown); \
+     KOS_INIT_FLAG(flags, INIT_FS_ROMDISK, fs_romdisk_init); \
+     KOS_INIT_FLAG(flags, INIT_FS_ROMDISK, fs_romdisk_shutdown); \
+     KOS_INIT_FLAG(flags, INIT_EXPORT, export_init)
 
 /** \cond */
 extern const uint32_t __kos_init_flags;
@@ -62,8 +64,9 @@ extern const uint32_t __kos_init_flags;
 /** \brief  Deprecated and not useful anymore. */
 #define KOS_INIT_ROMDISK(rd) \
     void *__kos_romdisk = (rd); \
-    extern void fs_romdisk_mount_builtin(void); \
-    void (*fs_romdisk_mount_builtin_weak_legacy)(void) = fs_romdisk_mount_builtin
+    extern void fs_romdisk_mount_builtin_legacy(void); \
+    void (*fs_romdisk_mount_builtin_legacy_weak)(void) = fs_romdisk_mount_builtin_legacy
+
 
 /** \brief  Built-in romdisk. Do not modify this directly! */
 extern void * __kos_romdisk;

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -39,7 +39,7 @@ __BEGIN_DECLS
     \see    dreamcast_initflags
 */
 #define KOS_INIT_FLAGS(flags) \
-    uint32 __kos_init_flags = (flags); \
+    const uint32_t __kos_init_flags = (flags); \
     extern void arch_init_net(void); \
     void (*init_net_weak)(void) = ((flags) & INIT_NET) ? arch_init_net : NULL; \
     extern void net_shutdown(void); \
@@ -55,8 +55,9 @@ __BEGIN_DECLS
     extern void export_init(void); \
     void (*export_init_weak)(void) = ((flags) & INIT_EXPORT) ? export_init : NULL
 
-/** \brief  The init flags. Do not modify this directly! */
-extern uint32 __kos_init_flags;
+/** \cond */
+extern const uint32_t __kos_init_flags;
+/** \endcond */
 
 /** \brief  Deprecated and not useful anymore. */
 #define KOS_INIT_ROMDISK(rd) \

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -55,7 +55,8 @@ __BEGIN_DECLS
      KOS_INIT_FLAG(flags, INIT_NET, bba_la_shutdown); \
      KOS_INIT_FLAG(flags, INIT_FS_ROMDISK, fs_romdisk_init); \
      KOS_INIT_FLAG(flags, INIT_FS_ROMDISK, fs_romdisk_shutdown); \
-     KOS_INIT_FLAG(flags, INIT_EXPORT, export_init)
+     KOS_INIT_FLAG(flags, INIT_EXPORT, export_init); \
+     KOS_INIT_FLAGS_ARCH(flags)
 
 /** \cond */
 extern const uint32_t __kos_init_flags;
@@ -91,18 +92,18 @@ extern void * __kos_romdisk;
     @{
 */
 /** \brief  Default init flags (IRQs on, preemption enabled, romdisks). */
-#define INIT_DEFAULT \
-    (INIT_IRQ | INIT_THD_PREEMPT | INIT_FS_ROMDISK)
+#define INIT_DEFAULT    (INIT_IRQ | INIT_THD_PREEMPT | INIT_FS_ROMDISK | \
+                         INIT_DEFAULT_ARCH)
 
-#define INIT_NONE           0x0000  /**< \brief Don't init optional things */
-#define INIT_IRQ            0x0001  /**< \brief Enable IRQs at startup */
+#define INIT_NONE        0x00000000  /**< \brief Don't init optional things */
+#define INIT_IRQ         0x00000001  /**< \brief Enable IRQs at startup */
 /* Preemptive mode is the only mode now. Keeping define for compatability. */
-#define INIT_THD_PREEMPT    0x0002  /**< \brief Enable thread preemption */
-#define INIT_NET            0x0004  /**< \brief Enable built-in networking */
-#define INIT_MALLOCSTATS    0x0008  /**< \brief Enable malloc statistics */
-#define INIT_QUIET          0x0010  /**< \brief Disable dbgio */
-#define INIT_EXPORT         0x0020  /**< \brief Export kernel symbols */
-#define INIT_FS_ROMDISK     0x0040  /**< \brief Enable support for romdisks */
+#define INIT_THD_PREEMPT 0x00000002  /**< \deprecated Already default mode */
+#define INIT_NET         0x00000004  /**< \brief Enable built-in networking */
+#define INIT_MALLOCSTATS 0x00000008  /**< \brief Enable malloc statistics */
+#define INIT_QUIET       0x00000010  /**< \brief Disable dbgio */
+#define INIT_EXPORT      0x00000020  /**< \brief Export kernel symbols */
+#define INIT_FS_ROMDISK  0x00000040  /**< \brief Enable support for romdisks */
 /** @} */
 
 __END_DECLS

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -61,8 +61,8 @@ extern uint32 __kos_init_flags;
 /** \brief  Deprecated and not useful anymore. */
 #define KOS_INIT_ROMDISK(rd) \
     void *__kos_romdisk = (rd); \
-    extern int fs_romdisk_mount_builtin(void); \
-    int (*fs_romdisk_mount_builtin_weak_legacy)(void) = fs_romdisk_mount_builtin
+    extern void fs_romdisk_mount_builtin(void); \
+    void (*fs_romdisk_mount_builtin_weak_legacy)(void) = fs_romdisk_mount_builtin
 
 /** \brief  Built-in romdisk. Do not modify this directly! */
 extern void * __kos_romdisk;

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -52,8 +52,8 @@ __BEGIN_DECLS
     void (*fs_romdisk_init_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_init : NULL; \
     extern void fs_romdisk_shutdown(void); \
     void (*fs_romdisk_shutdown_weak)(void) = ((flags) & INIT_FS_ROMDISK) ? fs_romdisk_shutdown : NULL; \
-    extern int export_init(void); \
-    int (*export_init_weak)(void) = ((flags) & INIT_EXPORT) ? export_init : NULL
+    extern void export_init(void); \
+    void (*export_init_weak)(void) = ((flags) & INIT_EXPORT) ? export_init : NULL
 
 /** \brief  The init flags. Do not modify this directly! */
 extern uint32 __kos_init_flags;

--- a/include/kos/init_base.h
+++ b/include/kos/init_base.h
@@ -1,0 +1,67 @@
+/* KallistiOS ##version##
+
+   include/kos/init_base.h
+   Copyright (C) 2023 Falco Girgis
+
+*/
+
+/** \file   kos/init_base.h
+    \brief  Shared initialization macros and utilities
+
+   This file contains common utilities which can be included within
+   architecture-specific `init_flags.h` files, providing a base
+   layer of infrastructure for managing initialization flags.
+
+    \sa    kos/init.h
+    \sa    arch/init_flags.h
+
+    \author Falco Girgis
+*/
+
+#ifndef __KOS_INIT_BASE_H
+#define __KOS_INIT_BASE_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+/** \cond */
+
+/* Declares a weak function pointer which can be optionally
+   overridden and given a value later. */
+#define KOS_INIT_FLAG_WEAK(func, dft_on) \
+    void (*func##_weak)(void) __weak = (dft_on) ? func : NULL
+
+/* Invokes the given function if its weak function pointer
+   has been overridden to point to a valid function. */
+#define KOS_INIT_FLAG_CALL(func) ({ \
+    int ret = 0; \
+    if(func##_weak) { \
+        (*func##_weak)(); \
+        ret = 1; \
+    } \
+    ret; \
+})
+
+/* Export the given function pointer by assigning it to the weak function
+ * pointer if the given flags value contains all the flags set in the mask. */
+#define KOS_INIT_FLAG_ALL(flags, mask, func) \
+    extern void func(void); \
+    void (*func##_weak)(void) = ((flags) & (mask)) == (mask) ? func : NULL
+
+/* Export the given function by assigning it to the weak function pointer if the
+   given flags value contains none of the flags set in the mask. */
+#define KOS_INIT_FLAG_NONE(flags, mask, func) \
+    extern void func(void); \
+    void (*func##_weak)(void) = ((flags) & (mask)) ? NULL : func
+
+/* Export the given function by assigning it to the weak function pointer if the
+   given flags value contains the selected flag */
+#define KOS_INIT_FLAG(flags, mask, func) \
+    extern void func(void); \
+    void (*func##_weak)(void) = ((flags) & (mask)) ? func : NULL
+
+/** \endcond */
+
+__END_DECLS
+
+#endif /* !__ARCH_INIT_BASE_H */

--- a/include/kos/nmmgr.h
+++ b/include/kos/nmmgr.h
@@ -127,7 +127,7 @@ int nmmgr_handler_remove(nmmgr_handler_t *hnd);
 
 /** \cond */
 /* Name manager init */
-int nmmgr_init(void);
+void nmmgr_init(void);
 void nmmgr_shutdown(void);
 /** \endcond */
 

--- a/kernel/arch/dreamcast/hardware/hardware.c
+++ b/kernel/arch/dreamcast/hardware/hardware.c
@@ -5,7 +5,9 @@
    Copyright (C) 2013 Lawrence Sebald
 */
 
+#include <stdbool.h>
 #include <arch/arch.h>
+#include <kos/init.h>
 #include <dc/spu.h>
 #include <dc/video.h>
 #include <dc/cdrom.h>
@@ -40,8 +42,6 @@ int hardware_sys_init(void) {
     return 0;
 }
 
-void (*bba_la_init_weak)(void) __attribute__((weak));
-void (*bba_la_shutdown_weak)(void) __attribute__((weak));
 
 void bba_la_init(void) {
     /* Setup network (this won't do anything unless we enable netcore) */
@@ -53,6 +53,9 @@ void bba_la_shutdown(void) {
     la_shutdown();
     bba_shutdown();
 }
+
+KOS_INIT_FLAG_WEAK(bba_la_init, false);
+KOS_INIT_FLAG_WEAK(bba_la_shutdown, false);
 
 int hardware_periph_init(void) {
     /* Init sound */
@@ -71,8 +74,7 @@ int hardware_periph_init(void) {
     vid_init(DEFAULT_VID_MODE, DEFAULT_PIXEL_MODE);
 
 #ifndef _arch_sub_naomi
-    if(bba_la_init_weak)
-        (*bba_la_init_weak)();
+    KOS_INIT_FLAG_CALL(bba_la_init);
 #endif
 
     initted = 2;
@@ -84,8 +86,7 @@ void hardware_shutdown(void) {
     switch(initted) {
         case 2:
 #ifndef _arch_sub_naomi
-            if(bba_la_shutdown_weak)
-                (*bba_la_shutdown_weak)();
+            KOS_INIT_FLAG_CALL(bba_la_shutdown);
 #endif
             maple_shutdown();
 #if 0

--- a/kernel/arch/dreamcast/hardware/hardware.c
+++ b/kernel/arch/dreamcast/hardware/hardware.c
@@ -56,6 +56,7 @@ void bba_la_shutdown(void) {
 
 KOS_INIT_FLAG_WEAK(bba_la_init, false);
 KOS_INIT_FLAG_WEAK(bba_la_shutdown, false);
+KOS_INIT_FLAG_WEAK(maple_init, true);
 
 int hardware_periph_init(void) {
     /* Init sound */
@@ -68,7 +69,7 @@ int hardware_periph_init(void) {
 #endif
 
     /* Setup maple bus */
-    maple_init();
+    KOS_INIT_FLAG_CALL(maple_init);
 
     /* Init video */
     vid_init(DEFAULT_VID_MODE, DEFAULT_PIXEL_MODE);
@@ -82,13 +83,15 @@ int hardware_periph_init(void) {
     return 0;
 }
 
+KOS_INIT_FLAG_WEAK(maple_shutdown, true);
+
 void hardware_shutdown(void) {
     switch(initted) {
         case 2:
 #ifndef _arch_sub_naomi
             KOS_INIT_FLAG_CALL(bba_la_shutdown);
 #endif
-            maple_shutdown();
+            KOS_INIT_FLAG_CALL(maple_shutdown);
 #if 0
             cdrom_shutdown();
 #endif

--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -134,10 +134,9 @@ static maple_driver_t controller_drv = {
 };
 
 /* Add the controller to the driver chain */
-int cont_init(void) {
+void cont_init(void) {
     if(!controller_drv.drv_list.le_prev)
-        return maple_driver_reg(&controller_drv);
-    return -1;
+        maple_driver_reg(&controller_drv);
 }
 
 void cont_shutdown(void) {

--- a/kernel/arch/dreamcast/hardware/maple/dreameye.c
+++ b/kernel/arch/dreamcast/hardware/maple/dreameye.c
@@ -430,10 +430,9 @@ static maple_driver_t dreameye_drv = {
 };
 
 /* Add the Dreameye to the driver chain */
-int dreameye_init(void) {
+void dreameye_init(void) {
     if(!dreameye_drv.drv_list.le_prev)
-        return maple_driver_reg(&dreameye_drv);
-    return -1;
+        maple_driver_reg(&dreameye_drv);
 }
 
 void dreameye_shutdown(void) {

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -612,10 +612,9 @@ static maple_driver_t kbd_drv = {
 };
 
 /* Add the keyboard to the driver chain */
-int kbd_init(void) {
+void kbd_init(void) {
     if(!kbd_drv.drv_list.le_prev)
-        return maple_driver_reg(&kbd_drv);
-    return -1;
+        maple_driver_reg(&kbd_drv);
 }
 
 void kbd_shutdown(void) {

--- a/kernel/arch/dreamcast/hardware/maple/lightgun.c
+++ b/kernel/arch/dreamcast/hardware/maple/lightgun.c
@@ -26,10 +26,9 @@ static maple_driver_t lightgun_drv = {
 };
 
 /* Add the lightgun to the driver chain */
-int lightgun_init(void) {
+void lightgun_init(void) {
     if(!lightgun_drv.drv_list.le_prev)
-        return maple_driver_reg(&lightgun_drv);
-    return -1;
+        maple_driver_reg(&lightgun_drv);
 }
 
 void lightgun_shutdown(void) {

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -35,7 +35,7 @@
 */
 
 /* Initialize Hardware (call after driver inits) */
-int maple_hw_init(void) {
+static void maple_hw_init(void) {
     maple_driver_t *drv;
     int p, u;
 
@@ -98,8 +98,6 @@ int maple_hw_init(void) {
     maple_state.vbl_handle = vblank_handler_add(maple_vbl_irq_hnd);
     asic_evt_set_handler(ASIC_EVT_MAPLE_DMA, maple_dma_irq_hnd);
     asic_evt_enable(ASIC_EVT_MAPLE_DMA, ASIC_IRQ_DEFAULT);
-
-    return 0;
 }
 
 /* Turn off the maple bus, free mem */
@@ -182,7 +180,7 @@ KOS_INIT_FLAG_WEAK(sip_init, true);
 KOS_INIT_FLAG_WEAK(dreameye_init, true);
 
 /* Full init: initialize known drivers and start maple operations */
-int maple_init(void) {
+void maple_init(void) {
     KOS_INIT_FLAG_CALL(lightgun_init);
     KOS_INIT_FLAG_CALL(cont_init);
     KOS_INIT_FLAG_CALL(kbd_init);
@@ -192,7 +190,7 @@ int maple_init(void) {
     KOS_INIT_FLAG_CALL(sip_init);
     KOS_INIT_FLAG_CALL(dreameye_init);
 
-    return maple_hw_init();
+    maple_hw_init();
 }
 
 KOS_INIT_FLAG_WEAK(cont_shutdown, true);

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -5,6 +5,7 @@
  */
 
 #include <malloc.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <assert.h>
 #include <arch/memory.h>
@@ -12,6 +13,7 @@
 #include <dc/asic.h>
 #include <dc/vblank.h>
 #include <kos/thread.h>
+#include <kos/init.h>
 
 #include <dc/maple/controller.h>
 #include <dc/maple/keyboard.h>
@@ -170,30 +172,48 @@ void maple_wait_scan(void) {
     }
 }
 
+KOS_INIT_FLAG_WEAK(cont_init, true);
+KOS_INIT_FLAG_WEAK(kbd_init, true);
+KOS_INIT_FLAG_WEAK(mouse_init, true);
+KOS_INIT_FLAG_WEAK(lightgun_init, true);
+KOS_INIT_FLAG_WEAK(vmu_init, true);
+KOS_INIT_FLAG_WEAK(purupuru_init, true);
+KOS_INIT_FLAG_WEAK(sip_init, true);
+KOS_INIT_FLAG_WEAK(dreameye_init, true);
+
 /* Full init: initialize known drivers and start maple operations */
 int maple_init(void) {
-    lightgun_init();
-    cont_init();
-    kbd_init();
-    mouse_init();
-    vmu_init();
-    purupuru_init();
-    sip_init();
-    dreameye_init();
+    KOS_INIT_FLAG_CALL(lightgun_init);
+    KOS_INIT_FLAG_CALL(cont_init);
+    KOS_INIT_FLAG_CALL(kbd_init);
+    KOS_INIT_FLAG_CALL(mouse_init);
+    KOS_INIT_FLAG_CALL(vmu_init);
+    KOS_INIT_FLAG_CALL(purupuru_init);
+    KOS_INIT_FLAG_CALL(sip_init);
+    KOS_INIT_FLAG_CALL(dreameye_init);
 
     return maple_hw_init();
 }
+
+KOS_INIT_FLAG_WEAK(cont_shutdown, true);
+KOS_INIT_FLAG_WEAK(kbd_shutdown, true);
+KOS_INIT_FLAG_WEAK(mouse_shutdown, true);
+KOS_INIT_FLAG_WEAK(lightgun_shutdown, true);
+KOS_INIT_FLAG_WEAK(vmu_shutdown, true);
+KOS_INIT_FLAG_WEAK(purupuru_shutdown, true);
+KOS_INIT_FLAG_WEAK(sip_shutdown, true);
+KOS_INIT_FLAG_WEAK(dreameye_shutdown, true);
 
 /* Full shutdown: shutdown maple operations and known drivers */
 void maple_shutdown(void) {
     maple_hw_shutdown();
 
-    dreameye_shutdown();
-    sip_shutdown();
-    purupuru_shutdown();
-    vmu_shutdown();
-    mouse_shutdown();
-    kbd_shutdown();
-    cont_shutdown();
-    lightgun_shutdown();
+    KOS_INIT_FLAG_CALL(dreameye_shutdown);
+    KOS_INIT_FLAG_CALL(sip_shutdown);
+    KOS_INIT_FLAG_CALL(purupuru_shutdown);
+    KOS_INIT_FLAG_CALL(vmu_shutdown);
+    KOS_INIT_FLAG_CALL(mouse_shutdown);
+    KOS_INIT_FLAG_CALL(kbd_shutdown);
+    KOS_INIT_FLAG_CALL(cont_shutdown);
+    KOS_INIT_FLAG_CALL(lightgun_shutdown);
 }

--- a/kernel/arch/dreamcast/hardware/maple/mouse.c
+++ b/kernel/arch/dreamcast/hardware/maple/mouse.c
@@ -79,10 +79,9 @@ static maple_driver_t mouse_drv = {
 };
 
 /* Add the mouse to the driver chain */
-int mouse_init(void) {
+void mouse_init(void) {
     if(!mouse_drv.drv_list.le_prev)
-        return maple_driver_reg(&mouse_drv);
-    return -1;
+        maple_driver_reg(&mouse_drv);
 }
 
 void mouse_shutdown(void) {

--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -91,10 +91,9 @@ static maple_driver_t purupuru_drv = {
 };
 
 /* Add the purupuru to the driver chain */
-int purupuru_init(void) {
+void purupuru_init(void) {
     if(!purupuru_drv.drv_list.le_prev)
-        return maple_driver_reg(&purupuru_drv);
-    return -1;
+        maple_driver_reg(&purupuru_drv);
 }
 
 void purupuru_shutdown(void) {

--- a/kernel/arch/dreamcast/hardware/maple/sip.c
+++ b/kernel/arch/dreamcast/hardware/maple/sip.c
@@ -297,10 +297,9 @@ static maple_driver_t sip_drv = {
 };
 
 /* Add the SIP to the driver chain */
-int sip_init(void) {
+void sip_init(void) {
     if(!sip_drv.drv_list.le_prev)
-        return maple_driver_reg(&sip_drv);
-    return -1;
+        maple_driver_reg(&sip_drv);
 }
 
 void sip_shutdown(void) {

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -150,10 +150,9 @@ static maple_driver_t vmu_drv = {
 };
 
 /* Add the VMU to the driver chain */
-int vmu_init(void) {
+void vmu_init(void) {
     if(!vmu_drv.drv_list.le_prev)
-        return maple_driver_reg(&vmu_drv);
-    return -1;
+        maple_driver_reg(&vmu_drv);
 }
 
 void vmu_shutdown(void) {

--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -44,6 +44,22 @@ __BEGIN_DECLS
     \sa KOS_INIT_FLAGS()
 */
 #define KOS_INIT_FLAGS_ARCH(flags) \
+    KOS_INIT_FLAG(flags, INIT_CONTROLLER, cont_init); \
+    KOS_INIT_FLAG(flags, INIT_CONTROLLER, cont_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_KEYBOARD, kbd_init); \
+    KOS_INIT_FLAG(flags, INIT_KEYBOARD, kbd_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_MOUSE, mouse_init); \
+    KOS_INIT_FLAG(flags, INIT_MOUSE, mouse_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_LIGHTGUN, lightgun_init); \
+    KOS_INIT_FLAG(flags, INIT_LIGHTGUN, lightgun_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_VMU, vmu_init); \
+    KOS_INIT_FLAG(flags, INIT_VMU, vmu_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_PURUPURU, purupuru_init); \
+    KOS_INIT_FLAG(flags, INIT_PURUPURU, purupuru_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_SIP, sip_init); \
+    KOS_INIT_FLAG(flags, INIT_SIP, sip_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_DREAMEYE, dreameye_init); \
+    KOS_INIT_FLAG(flags, INIT_DREAMEYE, dreameye_shutdown)
 
 
 /** \name  Init Flags
@@ -57,7 +73,17 @@ __BEGIN_DECLS
 */
 
 /** \brief Default init flags for the Dreamcast. */
-#define INIT_DEFAULT_ARCH   (0)
+#define INIT_DEFAULT_ARCH   (INIT_MAPLE_ALL)
+
+#define INIT_CONTROLLER     0x00001000  /**< \brief Enable Controller maple driver */
+#define INIT_KEYBOARD       0x00002000  /**< \brief Enable Keyboard maple driver */
+#define INIT_MOUSE          0x00004000  /**< \brief Enable Mouse maple driver */
+#define INIT_LIGHTGUN       0x00008000  /**< \brief Enable Lightgun maple driver */
+#define INIT_VMU            0x00010000  /**< \brief Enable VMU maple driver */
+#define INIT_PURUPURU       0x00020000  /**< \brief Enable Puru Puru maple driver */
+#define INIT_SIP            0x00040000  /**< \brief Enable Sound input maple driver */
+#define INIT_DREAMEYE       0x00080000  /**< \brief Enable DreamEye maple driver */
+#define INIT_MAPLE_ALL      0x000ff000  /**< \brief Enable all Maple drivers */
 
 #define INIT_OCRAM          0x10000000  /**< \brief Use half of the dcache as RAM */
 #define INIT_NO_DCLOAD      0x20000000  /**< \brief Disable dcload */

--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -59,7 +59,10 @@ __BEGIN_DECLS
     KOS_INIT_FLAG(flags, INIT_SIP, sip_init); \
     KOS_INIT_FLAG(flags, INIT_SIP, sip_shutdown); \
     KOS_INIT_FLAG(flags, INIT_DREAMEYE, dreameye_init); \
-    KOS_INIT_FLAG(flags, INIT_DREAMEYE, dreameye_shutdown)
+    KOS_INIT_FLAG(flags, INIT_DREAMEYE, dreameye_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_MAPLE_ALL, maple_wait_scan); \
+    KOS_INIT_FLAG(flags, INIT_MAPLE_ALL, maple_init); \
+    KOS_INIT_FLAG(flags, INIT_MAPLE_ALL, maple_shutdown)
 
 
 /** \name  Init Flags

--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -3,6 +3,7 @@
    arch/dreamcast/include/arch/init_flags.h
    Copyright (C) 2001 Megan Potter
    Copyright (C) 2023 Lawrence Sebald
+   Copyright (C) 2023 Falco Girgis
 
 */
 
@@ -12,18 +13,41 @@
     This file provides initialization-related flags that are specific to the
     Dreamcast architecture.
 
+    \sa    kos/init.h
+    \sa    kos/init_base.h
+
     \author Lawrence Sebald
     \author Megan Potter
-    \see    kos/init.h
+    \author Falco Girgis
 */
 
 #ifndef __ARCH_INIT_FLAGS_H
 #define __ARCH_INIT_FLAGS_H
 
 #include <kos/cdefs.h>
+#include <kos/init_base.h>
 __BEGIN_DECLS
 
 /** \defgroup dreamcast_initflags   Dreamcast-specific initialization flags.
+
+    \brief Dreamcast-specific KOS_INIT Exports
+
+    This macro contains a list of all of the possible DC-specific
+    exported functions based on their associated initialization flags.
+
+    \note
+    This is not typically used directly and is instead included within
+    the top-level architecture-independent KOS_INIT_FLAGS() macro.
+
+    \param flags    Parts of KOS to initialize.
+
+    \sa KOS_INIT_FLAGS()
+*/
+#define KOS_INIT_FLAGS_ARCH(flags) \
+
+
+/** \name  Init Flags
+    \brief Dreamcast-specific initialization flags.
 
     These are the Dreamcast-specific flags that can be specified with
     KOS_INIT_FLAGS.
@@ -31,8 +55,12 @@ __BEGIN_DECLS
     \see    kos_initflags
     @{
 */
-#define INIT_OCRAM          0x10000 /**< \brief Use half of the dcache as RAM */
-#define INIT_NO_DCLOAD      0x20000 /**< \brief Disable dcload */
+
+/** \brief Default init flags for the Dreamcast. */
+#define INIT_DEFAULT_ARCH   (0)
+
+#define INIT_OCRAM          0x10000000  /**< \brief Use half of the dcache as RAM */
+#define INIT_NO_DCLOAD      0x20000000  /**< \brief Disable dcload */
 
 /** @} */
 

--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -54,6 +54,8 @@ __BEGIN_DECLS
     KOS_INIT_FLAG(flags, INIT_LIGHTGUN, lightgun_shutdown); \
     KOS_INIT_FLAG(flags, INIT_VMU, vmu_init); \
     KOS_INIT_FLAG(flags, INIT_VMU, vmu_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_VMU, vmu_fs_init); \
+    KOS_INIT_FLAG(flags, INIT_VMU, vmu_fs_shutdown); \
     KOS_INIT_FLAG(flags, INIT_PURUPURU, purupuru_init); \
     KOS_INIT_FLAG(flags, INIT_PURUPURU, purupuru_shutdown); \
     KOS_INIT_FLAG(flags, INIT_SIP, sip_init); \

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -739,10 +739,8 @@ void * maple_dev_status(maple_device_t *dev);
 /**************************************************************************/
 /* maple_init.c */
 
-/** \brief  Initialize Maple.
-    \return                 0 on success, <0 on failure.
-*/
-int maple_init(void);
+/** \brief  Initialize Maple. */
+void maple_init(void);
 
 /** \brief  Shutdown Maple. */
 void maple_shutdown(void);

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -512,7 +512,7 @@ int cont_is_type(const struct maple_device *cont, uint32_t type);
 
 /* \cond */
 /* Init / Shutdown */
-int cont_init(void);
+void cont_init(void);
 void cont_shutdown(void);
 /* \endcond */
 

--- a/kernel/arch/dreamcast/include/dc/maple/dreameye.h
+++ b/kernel/arch/dreamcast/include/dc/maple/dreameye.h
@@ -154,7 +154,7 @@ int dreameye_erase_image(maple_device_t *dev, uint8 image, int block);
 
 /* \cond */
 /* Init / Shutdown */
-int dreameye_init(void);
+void dreameye_init(void);
 void dreameye_shutdown(void);
 /* \endcond */
 

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -349,7 +349,7 @@ int kbd_queue_pop(maple_device_t *dev, int xlat);
 
 /* \cond */
 /* Init / Shutdown */
-int kbd_init(void);
+void kbd_init(void);
 void kbd_shutdown(void);
 /* \endcond */
 

--- a/kernel/arch/dreamcast/include/dc/maple/lightgun.h
+++ b/kernel/arch/dreamcast/include/dc/maple/lightgun.h
@@ -23,7 +23,7 @@ __BEGIN_DECLS
 
 /* \cond */
 /* Init / Shutdown */
-int lightgun_init(void);
+void lightgun_init(void);
 void lightgun_shutdown(void);
 /* \endcond */
 

--- a/kernel/arch/dreamcast/include/dc/maple/mouse.h
+++ b/kernel/arch/dreamcast/include/dc/maple/mouse.h
@@ -84,7 +84,7 @@ typedef struct {
 
 /* \cond */
 /* Init / Shutdown */
-int mouse_init(void);
+void mouse_init(void);
 void mouse_shutdown(void);
 /* \endcond */
 

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -179,7 +179,7 @@ int purupuru_rumble_raw(maple_device_t *dev, uint32 effect);
 
 /* \cond */
 /* Init / Shutdown */
-int purupuru_init(void);
+void purupuru_init(void);
 void purupuru_shutdown(void);
 /* \endcond */
 

--- a/kernel/arch/dreamcast/include/dc/maple/sip.h
+++ b/kernel/arch/dreamcast/include/dc/maple/sip.h
@@ -196,7 +196,7 @@ int sip_stop_sampling(maple_device_t *dev, int block);
 
 /* \cond */
 /* Init / Shutdown */
-int sip_init(void);
+void sip_init(void);
 void sip_shutdown(void);
 /* \endcond */
 

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -614,7 +614,7 @@ int vmu_get_buttons_enabled(void);
 
 /** \cond */
 /* Init / Shutdown -- Managed internally by KOS */
-int vmu_init(void);
+void vmu_init(void);
 void vmu_shutdown(void);
 /** \endcond */
 

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -88,6 +88,16 @@ void arch_init_net(void) {
     }
 }
 
+void vmu_fs_init(void) {
+    fs_vmu_init();
+    vmufs_init();
+}
+
+void vmu_fs_shutdown(void) {
+    fs_vmu_shutdown();
+    vmufs_shutdown();
+}
+
 /* Mount the built-in romdisk to /rd. */
 void fs_romdisk_mount_builtin(void) {
     fs_romdisk_mount("/rd", __kos_romdisk, 0);
@@ -104,6 +114,8 @@ KOS_INIT_FLAG_WEAK(fs_romdisk_init, true);
 KOS_INIT_FLAG_WEAK(fs_romdisk_shutdown, true);
 KOS_INIT_FLAG_WEAK(fs_romdisk_mount_builtin, false);
 KOS_INIT_FLAG_WEAK(fs_romdisk_mount_builtin_legacy, false);
+KOS_INIT_FLAG_WEAK(vmu_fs_init, true);
+KOS_INIT_FLAG_WEAK(vmu_fs_shutdown, true);
 
 /* Auto-init stuff: override with a non-weak symbol if you don't want all of
    this to be linked into your code (and do the same with the
@@ -175,8 +187,8 @@ int  __weak arch_auto_init(void) {
 
     fs_iso9660_init();
 #endif
-    vmufs_init();
-    fs_vmu_init();
+
+    KOS_INIT_FLAG_CALL(vmu_fs_init);
 
     /* Initialize library handling */
     library_init();
@@ -209,8 +221,7 @@ void  __weak arch_auto_shutdown(void) {
 #ifndef _arch_sub_naomi
     fs_dcload_shutdown();
 #endif
-    fs_vmu_shutdown();
-    vmufs_shutdown();
+    KOS_INIT_FLAG_CALL(vmu_fs_shutdown);
 #ifndef _arch_sub_naomi
     fs_iso9660_shutdown();
 #endif

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -99,6 +99,7 @@ void fs_romdisk_mount_builtin_legacy(void) {
 
 KOS_INIT_FLAG_WEAK(arch_init_net, false);
 KOS_INIT_FLAG_WEAK(net_shutdown, false);
+KOS_INIT_FLAG_WEAK(maple_wait_scan, true);
 KOS_INIT_FLAG_WEAK(fs_romdisk_init, true);
 KOS_INIT_FLAG_WEAK(fs_romdisk_shutdown, true);
 KOS_INIT_FLAG_WEAK(fs_romdisk_mount_builtin, false);
@@ -183,7 +184,7 @@ int  __weak arch_auto_init(void) {
     /* Now comes the optional stuff */
     if(__kos_init_flags & INIT_IRQ) {
         irq_enable();       /* Turn on IRQs */
-        maple_wait_scan();  /* Wait for the maple scan to complete */
+        KOS_INIT_FLAG_CALL(maple_wait_scan);  /* Wait for the maple scan to complete */
     }
 
 #ifndef _arch_sub_naomi

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -91,12 +91,12 @@ void (*net_shutdown_weak)(void) __attribute__((weak));
 
 void (*fs_romdisk_init_weak)(void) __attribute__((weak));
 void (*fs_romdisk_shutdown_weak)(void) __attribute__((weak));
-int (*fs_romdisk_mount_builtin_weak)(void) __attribute__((weak));
-int (*fs_romdisk_mount_builtin_weak_legacy)(void) __attribute__((weak));
+void (*fs_romdisk_mount_builtin_weak)(void) __attribute__((weak));
+void (*fs_romdisk_mount_builtin_weak_legacy)(void) __attribute__((weak));
 
 /* Mount the built-in romdisk to /rd. */
-int fs_romdisk_mount_builtin(void) {
-    return fs_romdisk_mount("/rd", __kos_romdisk, 0);
+void fs_romdisk_mount_builtin(void) {
+    fs_romdisk_mount("/rd", __kos_romdisk, 0);
 }
 
 /* Auto-init stuff: override with a non-weak symbol if you don't want all of

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -102,7 +102,7 @@ int fs_romdisk_mount_builtin(void) {
 /* Auto-init stuff: override with a non-weak symbol if you don't want all of
    this to be linked into your code (and do the same with the
    arch_auto_shutdown function too). */
-int  __attribute__((weak)) arch_auto_init(void) {
+int  __weak arch_auto_init(void) {
     /* Initialize memory management */
     mm_init();
 
@@ -194,7 +194,7 @@ int  __attribute__((weak)) arch_auto_init(void) {
     return 0;
 }
 
-void  __attribute__((weak)) arch_auto_shutdown(void) {
+void  __weak arch_auto_shutdown(void) {
 #ifndef _arch_sub_naomi
     fs_dclsocket_shutdown();
     if(net_shutdown_weak)

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -89,8 +89,8 @@ void arch_init_net(void) {
 void (*init_net_weak)(void) __attribute__((weak));
 void (*net_shutdown_weak)(void) __attribute__((weak));
 
-int (*fs_romdisk_init_weak)(void) __attribute__((weak));
-int (*fs_romdisk_shutdown_weak)(void) __attribute__((weak));
+void (*fs_romdisk_init_weak)(void) __attribute__((weak));
+void (*fs_romdisk_shutdown_weak)(void) __attribute__((weak));
 int (*fs_romdisk_mount_builtin_weak)(void) __attribute__((weak));
 int (*fs_romdisk_mount_builtin_weak_legacy)(void) __attribute__((weak));
 

--- a/kernel/exports/exports.c
+++ b/kernel/exports/exports.c
@@ -43,15 +43,10 @@ static symtab_handler_t st_arch = {
     arch_symtab
 };
 
-int export_init(void) {
+void export_init(void) {
     /* Add our two export tables */
-    if(nmmgr_handler_add(&st_kern.nmmgr) < 0)
-        return -1;
-
-    if(nmmgr_handler_add(&st_arch.nmmgr) < 0)
-        return -1;
-
-    return 0;
+    nmmgr_handler_add(&st_kern.nmmgr);
+    nmmgr_handler_add(&st_arch.nmmgr);
 }
 
 export_sym_t * export_lookup(const char * name) {

--- a/kernel/exports/nmmgr.c
+++ b/kernel/exports/nmmgr.c
@@ -15,10 +15,12 @@ interface at the front of their struct.
 
 */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <malloc.h>
 #include <string.h>
 #include <strings.h>
+#include <kos/init_base.h>
 #include <kos/nmmgr.h>
 #include <kos/mutex.h>
 #include <kos/exports.h>
@@ -88,7 +90,7 @@ int nmmgr_handler_remove(nmmgr_handler_t *hnd) {
     return rv;
 }
 
-void (*export_init_weak)(void) __attribute__((weak));
+KOS_INIT_FLAG_WEAK(export_init, false);
 
 /* Initialize structures */
 void nmmgr_init(void) {
@@ -96,8 +98,7 @@ void nmmgr_init(void) {
     LIST_INIT(&nmmgr_handlers);
 
     /* Initialize our internal exports */
-    if(export_init_weak)
-        (*export_init_weak)();
+    KOS_INIT_FLAG_CALL(export_init);
 }
 
 void nmmgr_shutdown(void) {

--- a/kernel/exports/nmmgr.c
+++ b/kernel/exports/nmmgr.c
@@ -88,20 +88,16 @@ int nmmgr_handler_remove(nmmgr_handler_t *hnd) {
     return rv;
 }
 
-int (*export_init_weak)(void) __attribute__((weak));
+void (*export_init_weak)(void) __attribute__((weak));
 
 /* Initialize structures */
-int nmmgr_init(void) {
-    int rv = 0;
-
+void nmmgr_init(void) {
     /* Start with no handlers */
     LIST_INIT(&nmmgr_handlers);
 
     /* Initialize our internal exports */
     if(export_init_weak)
         (*export_init_weak)();
-
-    return rv;
 }
 
 void nmmgr_shutdown(void) {

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -525,9 +525,9 @@ static vfs_handler_t vh = {
 static int initted = 0;
 
 /* Initialize the file system */
-int fs_romdisk_init(void) {
+void fs_romdisk_init(void) {
     if(initted)
-        return 0;
+        return;
 
     /* Init our list of mounted images */
     LIST_INIT(&romdisks);
@@ -542,16 +542,14 @@ int fs_romdisk_init(void) {
     mutex_init(&fh_mutex, MUTEX_TYPE_NORMAL);
 
     initted = 1;
-
-    return 0;
 }
 
 /* De-init the file system; also unmounts any mounted images. */
-int fs_romdisk_shutdown(void) {
+void fs_romdisk_shutdown(void) {
     rd_image_t *n, *c;
 
     if(!initted)
-        return 0;
+        return;
 
     /* Go through and free all the romdisk mount entries */
     c = LIST_FIRST(&romdisks);
@@ -581,8 +579,6 @@ int fs_romdisk_shutdown(void) {
     mutex_destroy(&fh_mutex);
 
     initted = 0;
-
-    return 0;
 }
 
 /* Mount a romdisk image; must have called fs_romdisk_init() earlier.

--- a/kernel/libc/koslib/abort.c
+++ b/kernel/libc/koslib/abort.c
@@ -9,7 +9,7 @@
 #include <arch/arch.h>
 
 /* This is probably the closest mapping we've got for abort() */
-__attribute__((used)) void abort(void) {
+__used void abort(void) {
     arch_exit();
 }
 

--- a/kernel/romdisk/romdiskbase.c
+++ b/kernel/romdisk/romdiskbase.c
@@ -10,6 +10,6 @@ extern unsigned char romdisk[];
 
 void *__kos_romdisk = romdisk;
 
-extern int fs_romdisk_mount_builtin(void);
+extern void fs_romdisk_mount_builtin(void);
 
-int (*fs_romdisk_mount_builtin_weak)(void) = fs_romdisk_mount_builtin;
+void (*fs_romdisk_mount_builtin_weak)(void) = fs_romdisk_mount_builtin;


### PR DESCRIPTION
A rewrite of https://github.com/KallistiOS/KallistiOS/pull/335.

The bulk of the changes are by GyroVorbis, so he should probably sign-off the commits as well (or give me the permission to add his sign-off).

Compiling the "hello" example with just `KOS_INIT_FLAGS(INIT_IRQ | INIT_THD_PREEMPT | INIT_MALLOCSTATS | INIT_FS_ROMDISK);`, in which case the maple code and VMU FS code are garbage-collected, the resulting (stripped) hello.elf drops from 156 KiB to 116 KiB.