### PR TITLE
getsockopt(): add no-op handling for SO_ERROR

### DIFF
--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -1688,6 +1688,10 @@ static int net_tcp_getsockopt(net_socket_t *hnd, int level, int option_name,
                     tmp = sock->state == TCP_STATE_LISTEN;
                     goto copy_int;
 
+                case SO_ERROR:
+                    // Checking/resetting errors not implemented
+                    goto simply_return;
+
                 case SO_RCVBUF:
                     tmp = sock->rcvbuf_sz;
                     goto copy_int;
@@ -1753,6 +1757,7 @@ copy_int:
         memcpy(option_value, &tmp, *option_len);
     }
 
+simply_return:
     mutex_unlock(&sock->mutex);
     rwsem_read_unlock(&tcp_sem);
     return 0;


### PR DESCRIPTION
getsockopt() is supposed to return and clear errors when passed SO_ERROR option.
As it's not currently handled it always returns a "Protocol not available" error when called which signals to the calling code to kill the connection regardless of whether it's established or not.

This change adds a no-op handler for SO_ERROR so that the calls to getsockopt() return successfully.

It's not exactly correct, but given that we don't seem to have error info on the socket
structure I'm not sure it can be implemented easily. In any case, this at least makes it
possible for calling code to work normally.