### PR TITLE
Removed INIT_THD_PREEMPT startup warning

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -271,18 +271,13 @@ typedef struct kthread_attr {
     @{
 */
 #define THD_MODE_NONE       -1  /**< \brief Threads not running */
-#define THD_MODE_COOP       0   /**< \brief Cooperative mode (deprecated) */
+#define THD_MODE_COOP       0   /**< \brief Cooperative mode \deprecated */
 #define THD_MODE_PREEMPT    1   /**< \brief Preemptive threading mode */
 /** @} */
 
-/** \brief   The currently executing thread.
-
-    \warning
-    Do not manipulate this variable directly!
-
-    \sa thd_get_current
-*/
+/** \cond The currently executing thread -- Do not manipulate directly! */
 extern kthread_t *thd_current;
+/** \endcond */
 
 /** \brief   Block the current thread.
 

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -139,11 +139,6 @@ int  __attribute__((weak)) arch_auto_init(void) {
     timer_ms_enable();
     rtc_init();
 
-    /* Threads */
-    if(!(__kos_init_flags & INIT_THD_PREEMPT))
-        dbglog(DBG_WARNING, "Cooperative threading mode is deprecated. KOS is \
-        always in pre-emptive threading mode. \n");
-
     thd_init();
 
     nmmgr_init();


### PR DESCRIPTION
- Removed warning from init.c that gets printed when the INIT_THD_PREEMPT flag gets used 
    - this flag is always used by default, so the warning is just clutter and is confusing when the flag wasn't explicitly added
- Hid extern variable for current thread pointer from the Doxygen in thread.h

Here's a screenshot of the clutter that was being displayed by default with any example using no explicit `KOS_INIT_FLAGS()` or the `INIT_DEFAULT` flag: 

![Screenshot from 2023-11-16 08-35-42](https://github.com/KallistiOS/KallistiOS/assets/5545520/eb4b036b-c425-43b9-92d7-fbb3dc4af697)
