### PR TITLE
Implement SO_RCVBUF and SO_SNDBUF for setsockopt()

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -271,18 +271,13 @@ typedef struct kthread_attr {
     @{
 */
 #define THD_MODE_NONE       -1  /**< \brief Threads not running */
-#define THD_MODE_COOP       0   /**< \brief Cooperative mode (deprecated) */
+#define THD_MODE_COOP       0   /**< \brief Cooperative mode \deprecated */
 #define THD_MODE_PREEMPT    1   /**< \brief Preemptive threading mode */
 /** @} */
 
-/** \brief   The currently executing thread.
-
-    \warning
-    Do not manipulate this variable directly!
-
-    \sa thd_get_current
-*/
+/** \cond The currently executing thread -- Do not manipulate directly! */
 extern kthread_t *thd_current;
+/** \endcond */
 
 /** \brief   Block the current thread.
 

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -26,6 +26,7 @@
 __BEGIN_DECLS
 
 #include <arch/types.h>
+#include <stdint.h>
 
 /** \brief  Sound effect handle type.
 

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -139,11 +139,6 @@ int  __attribute__((weak)) arch_auto_init(void) {
     timer_ms_enable();
     rtc_init();
 
-    /* Threads */
-    if(!(__kos_init_flags & INIT_THD_PREEMPT))
-        dbglog(DBG_WARNING, "Cooperative threading mode is deprecated. KOS is \
-        always in pre-emptive threading mode. \n");
-
     thd_init();
 
     nmmgr_init();


### PR DESCRIPTION
This PR implements the SO_RCVBUF and SO_SNDBUF options in setsockopt(). This allows the send and receive buffer sizes to be increased for a socket. Currently attempting to do so with setsockopt() results in a silent failure. 

Increasing the send and receive buffers from the default 8192 to the maximum 65535 results in a doubling in throughput for my application. 