### PR TITLE
Enable C99 printf() Formatters in Toolchain Config Samples

### DIFF
--- a/utils/dc-chain/config/config.mk.10.5.0.sample
+++ b/utils/dc-chain/config/config.mk.10.5.0.sample
@@ -136,7 +136,7 @@ thread_model=kos
 # Define this to build SH4 Newlib with additional support for the C99 format
 # specifiers, used by printf and friends. These include support for size_t,
 # ptrdiff_t, intmax_t, and sized integral types.
-#newlib_c99_formats=1
+newlib_c99_formats=1
 
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will

--- a/utils/dc-chain/config/config.mk.11.4.0.sample
+++ b/utils/dc-chain/config/config.mk.11.4.0.sample
@@ -136,7 +136,7 @@ thread_model=kos
 # Define this to build SH4 Newlib with additional support for the C99 format
 # specifiers, used by printf and friends. These include support for size_t,
 # ptrdiff_t, intmax_t, and sized integral types.
-#newlib_c99_formats=1
+newlib_c99_formats=1
 
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will

--- a/utils/dc-chain/config/config.mk.12.3.0.sample
+++ b/utils/dc-chain/config/config.mk.12.3.0.sample
@@ -136,7 +136,7 @@ thread_model=kos
 # Define this to build SH4 Newlib with additional support for the C99 format
 # specifiers, used by printf and friends. These include support for size_t,
 # ptrdiff_t, intmax_t, and sized integral types.
-#newlib_c99_formats=1
+newlib_c99_formats=1
 
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will

--- a/utils/dc-chain/config/config.mk.9.3.0.sample
+++ b/utils/dc-chain/config/config.mk.9.3.0.sample
@@ -136,7 +136,7 @@ thread_model=kos
 # Define this to build SH4 Newlib with additional support for the C99 format
 # specifiers, used by printf and friends. These include support for size_t,
 # ptrdiff_t, intmax_t, and sized integral types.
-#newlib_c99_formats=1
+newlib_c99_formats=1
 
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will

--- a/utils/dc-chain/config/config.mk.devel.sample
+++ b/utils/dc-chain/config/config.mk.devel.sample
@@ -146,7 +146,7 @@ thread_model=kos
 # Define this to build SH4 Newlib with additional support for the C99 format
 # specifiers, used by printf and friends. These include support for size_t,
 # ptrdiff_t, intmax_t, and sized integral types.
-#newlib_c99_formats=1
+newlib_c99_formats=1
 
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will

--- a/utils/dc-chain/config/config.mk.legacy.sample
+++ b/utils/dc-chain/config/config.mk.legacy.sample
@@ -136,7 +136,7 @@ thread_model=kos
 # Define this to build SH4 Newlib with additional support for the C99 format
 # specifiers, used by printf and friends. These include support for size_t,
 # ptrdiff_t, intmax_t, and sized integral types.
-#newlib_c99_formats=1
+newlib_c99_formats=1
 
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will

--- a/utils/dc-chain/config/config.mk.stable.sample
+++ b/utils/dc-chain/config/config.mk.stable.sample
@@ -136,7 +136,7 @@ thread_model=kos
 # Define this to build SH4 Newlib with additional support for the C99 format
 # specifiers, used by printf and friends. These include support for size_t,
 # ptrdiff_t, intmax_t, and sized integral types.
-#newlib_c99_formats=1
+newlib_c99_formats=1
 
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will

--- a/utils/dc-chain/config/config.mk.winxp-latest.sample
+++ b/utils/dc-chain/config/config.mk.winxp-latest.sample
@@ -136,7 +136,7 @@ thread_model=kos
 # Define this to build SH4 Newlib with additional support for the C99 format
 # specifiers, used by printf and friends. These include support for size_t,
 # ptrdiff_t, intmax_t, and sized integral types.
-#newlib_c99_formats=1
+newlib_c99_formats=1
 
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will


### PR DESCRIPTION
- Modified all of the sample configuration files in dc-chain to enable the C99 printf formatter option by default.

When I first implemented the option to enable the C99 `printf()` formatters, I thought it seemed too audacious to enable them by default, so I made them opt-in... This was because they hadn't been thoroughly tested, and I had no idea how they impacted binary sizes...

Fast forward a few months, and I along with several others have been using the crap out of them and haven't noticed any changes in binary sizes or `printf()` performance... Every time I mention these formatters to people, they seem to not even be aware of the fact that they could be enabled, and almost unanimously everyone regrets not enabling them when they built the toolchain....

Combine that with the fact that we give crazy C++20 `std::regex` and `std::format` insanity that can log anything, but we don't default to giving people a way to simply log a `size_t` or `uint32_t` in a standard manner with KOS? Seems janky...

Also, also, we convinced the PSP scene to enable these formatters as well, and they don't even give you the option to opt out of them like we do... 