### PR TITLE
Add <netinet/tcp.h> header

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -192,7 +192,8 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added toolchain and KOS support for C/C++ compiler-level TLS [CP && FG]
 - DC  Added vmu functions to check/enable/disable the extra 41 blocks [AB]
 - *** Added driver for the SH4's Watchdog Timer peripheral [FG]
-- DC  Added Moop powered fast path to sq_cpy, added TapamN pvr related sq functions [AB]
+- DC  Added Moop powered fast path to sq_cpy, added TapamN pvr related sq
+      functions [AB]
 - DC  Garbage-collect network stack [PC]
 - DC  Rework romdisks [PC]
 - DC  Refactored g2bus API, converted magic values to macros, added
@@ -203,6 +204,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Optimized separating stereo PCM [RR]
 - DC  Refactored sfx and streaming to add SQ fast path [RR]
 - DC  Added 4/8-bit wav support to sfx and streaming [RR]
+- *** Added <netinet/tcp.h> header file and required option [LS]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -197,6 +197,7 @@ extern const struct in6_addr in6addr_loopback;
     \see                ipv6_opts
     \see                udp_opts
     \see                udplite_opts
+    \see                tcp_opts
 
     @{
 */
@@ -215,6 +216,7 @@ extern const struct in6_addr in6addr_loopback;
     \see                ipv4_opts
     \see                udp_opts
     \see                udplite_opts
+    \see                tcp_opts
 
     @{
 */
@@ -236,6 +238,7 @@ extern const struct in6_addr in6addr_loopback;
     \see                ipv4_opts
     \see                ipv6_opts
     \see                udplite_opts
+    \see                tcp_opts
 
     @{
 */
@@ -251,6 +254,7 @@ extern const struct in6_addr in6addr_loopback;
     \see                ipv4_opts
     \see                ipv6_opts
     \see                udp_opts
+    \see                tcp_opts
 
     @{
 */

--- a/include/netinet/tcp.h
+++ b/include/netinet/tcp.h
@@ -1,0 +1,51 @@
+/* KallistiOS ##version##
+
+   netinet/tcp.h
+   Copyright (C) 2023 Lawrence Sebald
+
+*/
+
+/** \file   netinet/tcp.h
+    \brief  Definitions for the Transmission Control Protocol.
+
+    This file contains the standard definitions (as directed by the Open Group
+    Base Specifications Issue 7, 2018 Edition aka POSIX 2017) for  functionality
+    of the Transmission Control Protocol.
+    This does is not guaranteed to have everything that one might have in a
+    fully-standard compliant implementation of the POSIX standard.
+
+    \author Lawrence Sebald
+*/
+
+#ifndef __NETINET_TCP_H
+#define __NETINET_TCP_H
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+/** \defgroup tcp_opts                  TCP protocol level options
+
+    These are the various socket-level optoins that can be accessed with the
+    setsockopt() and getsockopt() fnctions for the IPPROTO_TCP level value.
+
+    All options listed here are at least guaranteed to be accepted by
+    setsockopt() and getsockopt() for IPPROTO_TCP, however they are not
+    guaranteed to be implemented in any meaningful way.
+
+    \see                so_opts
+    \see                ipv4_opts
+    \see                ipv6_opts
+    \see                udp_opts
+    \see                udplite_opts
+
+    @{
+*/
+
+#define TCP_NODELAY             1 /**< \brief Don't delay to coalesce. */
+
+/** @} */
+
+__END_DECLS
+
+#endif /* !__NETINET_TCP_H */


### PR DESCRIPTION
- Add the `<netinet/tcp.h>` header called for in POSIX, with the required (single) macro defined in it.
- Add "support" for `TCP_NODELAY` in setsockopt() and getsockopt() -- Note, we don't implement Nagle's algorithm, so the options are effectively ignored.
- Clean up some formatting in net_tcp.c.