### PR TITLE
Thread Switch copy speed up

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -19,8 +19,6 @@ __BEGIN_DECLS
 #include <sys/reent.h>
 #include <stdint.h>
 
-#include <stdint.h>
-
 /** \file    kos/thread.h
     \brief   Threading support.
     \ingroup kthreads

--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -20,6 +20,7 @@
 #ifndef __ARCH_IRQ_H
 #define __ARCH_IRQ_H
 
+#include <stdint.h>
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
@@ -44,19 +45,20 @@ __BEGIN_DECLS
     \headerfile arch/irq.h
 */
 typedef struct irq_context {
-    uint32  r[16];      /**< \brief 16 general purpose (integer) registers */
-    uint32  pc;         /**< \brief Program counter */
-    uint32  pr;         /**< \brief Procedure register (aka return address) */
-    uint32  gbr;        /**< \brief Global base register */
-    uint32  vbr;        /**< \brief Vector base register */
-    uint32  mach;       /**< \brief Multiply-and-accumulate register (high) */
-    uint32  macl;       /**< \brief Multiply-and-accumulate register (low) */
-    uint32  sr;         /**< \brief Status register */
-    uint32  frbank[16]; /**< \brief Secondary floating poing registers */
-    uint32  fr[16];     /**< \brief Primary floating point registers */
-    uint32  fpscr;      /**< \brief Floating-point status/control register */
-    uint32  fpul;       /**< \brief Floatint-point communication register */
-} irq_context_t;
+    uint32_t  r[16];       /**< \brief 16 general purpose (integer) registers */
+    uint32_t  pc;          /**< \brief Program counter */
+    uint32_t  pr;          /**< \brief Procedure register (aka return address) */
+    uint32_t  gbr;         /**< \brief Global base register */
+    uint32_t  vbr;         /**< \brief Vector base register */
+    uint32_t  mach;        /**< \brief Multiply-and-accumulate register (high) */
+    uint32_t  macl;        /**< \brief Multiply-and-accumulate register (low) */
+    uint32_t  sr;          /**< \brief Status register */
+    uint32_t  fpul;        /**< \brief Floating-point communication register */
+    uint32_t  frbank[16];  /**< \brief Secondary floating poing registers */
+    uint32_t  fr[16];      /**< \brief Primary floating point registers */
+    uint32_t  fpscr;       /**< \brief Floating-point status/control register */
+    uint8_t   padding[28]; /**< \brief Padding to make the struct size 256 bytes */
+} irq_context_t __attribute((aligned(32)));
 
 /* A couple of architecture independent access macros */
 /** \brief  Fetch the program counter from an irq_context_t.
@@ -232,7 +234,7 @@ typedef struct irq_context {
 #define TIMER_IRQ       EXC_TMU0_TUNI0
 
 /** \brief  The type of an interrupt identifier */
-typedef uint32 irq_t;
+typedef uint32_t irq_t;
 
 /** \brief  The type of an IRQ handler
     \param  source          The IRQ that caused the handler to be called.
@@ -330,8 +332,8 @@ irq_context_t *irq_get_context(void);
                             to the architecture maximum.
     \param  usermode        1 to run the routine in user mode, 0 for supervisor.
 */
-void irq_create_context(irq_context_t *context, uint32 stack_pointer,
-                        uint32 routine, uint32 *args, int usermode);
+void irq_create_context(irq_context_t *context, uint32_t stack_pointer,
+                        uint32_t routine, uint32_t *args, int usermode);
 
 /* Enable/Disable interrupts */
 /** \brief  Disable interrupts.

--- a/kernel/arch/dreamcast/kernel/entry.s
+++ b/kernel/arch/dreamcast/kernel/entry.s
@@ -1,7 +1,8 @@
 ! KallistiOS ##version##
 !
 !   arch/dreamcast/kernel/entry.s
-!   (c)2000-2001 Megan Potter
+!   Copyright (c)2003 Megan Potter
+!   Copyright (c)2023 Colton Pawielski
 !
 ! Assembler code for entry and exit to/from the kernel via exceptions
 !
@@ -64,46 +65,31 @@ _irq_save_regs:
 	sts.l		pr,@-r0		! save PR   0x44
 	stc.l		spc,@-r0	! save PC   0x40
 	
-	add		#0x60,r0	! readjust register pointer
-	add		#0x44,r0
-	sts.l		fpul,@-r0	! save FPUL  0xe0
+	add		#0xA4,r0	! readjust register pointer
 	sts.l		fpscr,@-r0	! save FPSCR 0xdc
 	mov		#0,r2		! Set known FP flags
 	lds		r2,fpscr
-	fmov.s		fr15,@-r0	! save FR15  0xd8
-	fmov.s		fr14,@-r0	! save FR14
-	fmov.s		fr13,@-r0	! save FR13
-	fmov.s		fr12,@-r0	! save FR12
-	fmov.s		fr11,@-r0	! save FR11
-	fmov.s		fr10,@-r0	! save FR10
-	fmov.s		fr9,@-r0	! save FR9
-	fmov.s		fr8,@-r0	! save FR8
-	fmov.s		fr7,@-r0	! save FR7
-	fmov.s		fr6,@-r0	! save FR6
-	fmov.s		fr5,@-r0	! save FR5
-	fmov.s		fr4,@-r0	! save FR4
-	fmov.s		fr3,@-r0	! save FR3
-	fmov.s		fr2,@-r0	! save FR2
-	fmov.s		fr1,@-r0	! save FR1
-	fmov.s		fr0,@-r0	! save FR0   0x9c
-	frchg				! Second FP bank
-	fmov.s		fr15,@-r0	! save FR15  0x98
-	fmov.s		fr14,@-r0	! save FR14
-	fmov.s		fr13,@-r0	! save FR13
-	fmov.s		fr12,@-r0	! save FR12
-	fmov.s		fr11,@-r0	! save FR11
-	fmov.s		fr10,@-r0	! save FR10
-	fmov.s		fr9,@-r0	! save FR9
-	fmov.s		fr8,@-r0	! save FR8
-	fmov.s		fr7,@-r0	! save FR7
-	fmov.s		fr6,@-r0	! save FR6
-	fmov.s		fr5,@-r0	! save FR5
-	fmov.s		fr4,@-r0	! save FR4
-	fmov.s		fr3,@-r0	! save FR3
-	fmov.s		fr2,@-r0	! save FR2
-	fmov.s		fr1,@-r0	! save FR1
-	fmov.s		fr0,@-r0	! save FR0   0x5c
-	frchg				! First FP bank again
+	fschg                   ! Switch to pair FP moves
+    fmov.d  dr14,@-r0       ! save FR14 & FR15
+    fmov.d  dr12,@-r0       ! save FR12 & FR13
+    fmov.d  dr10,@-r0       ! save FR10 & FR11
+    fmov.d  dr8,@-r0        ! save FR8 & FR9
+    fmov.d  dr6,@-r0        ! save FR6 & FR7
+    fmov.d  dr4,@-r0        ! save FR4 & FR5
+    fmov.d  dr2,@-r0        ! save FR2 & FR3
+    fmov.d  dr0,@-r0        ! save FR0 & FR1
+    frchg                   ! Second FP bank
+    fmov.d  dr14,@-r0       ! save FR14 & FR15
+    fmov.d  dr12,@-r0       ! save FR12 & FR13
+    fmov.d  dr10,@-r0       ! save FR10 & FR11
+    fmov.d  dr8,@-r0        ! save FR8 & FR9
+    fmov.d  dr6,@-r0        ! save FR6 & FR7
+    fmov.d  dr4,@-r0        ! save FR4 & FR5
+    fmov.d  dr2,@-r0        ! save FR2 & FR3
+    fmov.d  dr0,@-r0        ! save FR0 & FR1
+    fschg                   ! Switch to single FP moves
+    frchg                   ! First FP bank again
+	sts.l		fpul,@-r0	! save FPUL
 
 	! Setup our kernel-mode stack
 	mov.l		stkaddr,r15
@@ -168,44 +154,26 @@ _save_regs_finish:
 	lds.l	@r1+,macl		! restore MACL 0x54	(+0x54)
 	ldc.l	@r1+,ssr		! restore SSR  0x58	(+0x58)
 
+	lds.l	@r1+,fpul		! restore FPUL  
 	mov	#0,r2			! Set known FP flags	(+0x5c)
 	lds	r2,fpscr
-	frchg				! Second FP bank
-	fmov.s	@r1+,fr0		! restore FR0  0x5c
-	fmov.s	@r1+,fr1		! restore FR1
-	fmov.s	@r1+,fr2		! restore FR2
-	fmov.s	@r1+,fr3		! restore FR3
-	fmov.s	@r1+,fr4		! restore FR4
-	fmov.s	@r1+,fr5		! restore FR5
-	fmov.s	@r1+,fr6		! restore FR6
-	fmov.s	@r1+,fr7		! restore FR7
-	fmov.s	@r1+,fr8		! restore FR8
-	fmov.s	@r1+,fr9		! restore FR9
-	fmov.s	@r1+,fr10		! restore FR10
-	fmov.s	@r1+,fr11		! restore FR11
-	fmov.s	@r1+,fr12		! restore FR12
-	fmov.s	@r1+,fr13		! restore FR13
-	fmov.s	@r1+,fr14		! restore FR14
-	fmov.s	@r1+,fr15		! restore FR15 0x98
-	frchg				! First FP bank
-	fmov.s	@r1+,fr0		! restore FR0  0x9c
-	fmov.s	@r1+,fr1		! restore FR1
-	fmov.s	@r1+,fr2		! restore FR2
-	fmov.s	@r1+,fr3		! restore FR3
-	fmov.s	@r1+,fr4		! restore FR4
-	fmov.s	@r1+,fr5		! restore FR5
-	fmov.s	@r1+,fr6		! restore FR6
-	fmov.s	@r1+,fr7		! restore FR7
-	fmov.s	@r1+,fr8		! restore FR8
-	fmov.s	@r1+,fr9		! restore FR9
-	fmov.s	@r1+,fr10		! restore FR10
-	fmov.s	@r1+,fr11		! restore FR11
-	fmov.s	@r1+,fr12		! restore FR12
-	fmov.s	@r1+,fr13		! restore FR13
-	fmov.s	@r1+,fr14		! restore FR14
-	fmov.s	@r1+,fr15		! restore FR15  0xd8
+	frchg                       ! Second FP bank
+    fschg                       ! Switch to pair FP moves
+    fmov.d  @r1+,dr0            ! restore FR0 & FR1
+    fmov.d  @r1+,dr2            ! restore FR2 & FR3
+    fmov.d  @r1+,dr4            ! restore FR4 & FR5
+    fmov.d  @r1+,dr6            ! restore FR6 & FR7
+    fmov.d  @r1+,dr8            ! restore FR8 & FR9
+    fmov.d  @r1+,dr10           ! restore FR10 & FR11
+    fmov.d  @r1+,dr12           ! restore FR12 & FR13
+    fmov.d  @r1+,dr14           ! restore FR14 & FR15
+    frchg                       ! First FP bank
+	add #32, r1
+    fmov.d  @r1+,dr8            ! restore FR8 & FR9
+    fmov.d  @r1+,dr10           ! restore FR10 & FR11
+    fmov.d  @r1+,dr12           ! restore FR12 & FR13
+    fmov.d  @r1+,dr14           ! restore FR14 & FR15
 	lds.l	@r1+,fpscr		! restore FPSCR 0xdc
-	lds.l	@r1+,fpul		! restore FPUL  0xe0
 
 !	add	#-0x70,r1		! jump back to registers
 !	add	#-0x34,r1

--- a/kernel/arch/dreamcast/kernel/entry.s
+++ b/kernel/arch/dreamcast/kernel/entry.s
@@ -1,8 +1,8 @@
 ! KallistiOS ##version##
 !
 !   arch/dreamcast/kernel/entry.s
-!   Copyright (c)2003 Megan Potter
-!   Copyright (c)2023 Colton Pawielski
+!   Copyright (C) 2003 Megan Potter
+!   Copyright (C) 2023 Colton Pawielski
 !
 ! Assembler code for entry and exit to/from the kernel via exceptions
 !

--- a/kernel/arch/dreamcast/kernel/entry.s
+++ b/kernel/arch/dreamcast/kernel/entry.s
@@ -169,6 +169,11 @@ _save_regs_finish:
     fmov.d  @r1+,dr14           ! restore FR14 & FR15
     frchg                       ! First FP bank
 	add #32, r1
+!	fmov.d  @r1+,dr0            ! restore FR0 & FR1
+!   fmov.d  @r1+,dr2            ! restore FR2 & FR3
+!   fmov.d  @r1+,dr4            ! restore FR4 & FR5
+!   fmov.d  @r1+,dr6            ! restore FR6 & FR7
+    fmov.d  @r1+,dr8            ! restore FR8 & FR9
     fmov.d  @r1+,dr8            ! restore FR8 & FR9
     fmov.d  @r1+,dr10           ! restore FR10 & FR11
     fmov.d  @r1+,dr12           ! restore FR12 & FR13

--- a/kernel/arch/dreamcast/kernel/entry.s
+++ b/kernel/arch/dreamcast/kernel/entry.s
@@ -15,12 +15,12 @@
 ! for a context switcher (or especially a timer! =) but it can
 ! be optimized later.
 
-	.text
-	.align		2
-	.globl		_irq_srt_addr
-	.globl		_irq_handle_exception
-	.globl		_irq_save_regs
-	.globl		_irq_force_return
+    .text
+    .align 2
+    .globl  _irq_srt_addr
+    .globl  _irq_handle_exception
+    .globl  _irq_save_regs
+    .globl  _irq_force_return
 
 ! Static kernel-mode stack; we can get away with this because in our
 ! tiny microkernel, only one thread will ever actually be sitting inside
@@ -30,172 +30,171 @@
 ! mis-mapped user-mode stack pointers, etc. It also opens the door for
 ! hard real-time interrupts and exceptions that interrupt the kernel
 ! itself.
-	.space		4096		! One page
+    .space  4096    ! One page
 krn_stack:
 
 ! All exception vectors lead to Rome (i.e., this label).
+    .align 2
 _irq_save_regs:
 ! On the SH4, an exception triggers a toggle of RB in SR. So all
 ! the R0-R7 registers were convienently saved for us.
-	mov.l		_irq_srt_addr,r0	! Grab the location of the reg store
-	add		#0x20,r0	! Start at the top of the BANK regs
-	stc.l		r7_bank,@-r0	! Save R7
-	stc.l		r6_bank,@-r0	! Save R6
-	stc.l		r5_bank,@-r0	! Save R5
-	stc.l		r4_bank,@-r0	! Save R4
-	stc.l		r3_bank,@-r0	! Save R3
-	stc.l		r2_bank,@-r0	! Save R2
-	stc.l		r1_bank,@-r0	! Save R1
-	stc.l		r0_bank,@-r0	! Save R0
-	
-	mov.l		r8,@(0x20,r0)	! save R8
-	mov.l		r9,@(0x24,r0)	! save R9
-	mov.l		r10,@(0x28,r0)	! save R10
-	mov.l		r11,@(0x2c,r0)	! save R11
-	mov.l		r12,@(0x30,r0)	! save R12
-	mov.l		r13,@(0x34,r0)	! save R13
-	mov.l		r14,@(0x38,r0)	! save R14
-	mov.l		r15,@(0x3c,r0)	! save R15 (SP)
-	add		#0x5c,r0	! readjust register pointer
-	stc.l		ssr,@-r0	! save SSR  0x58
-	sts.l		macl,@-r0	! save MACL 0x54
-	sts.l		mach,@-r0	! save MACH 0x50
-	stc.l		vbr,@-r0	! save VBR  0x4c
-	stc.l		gbr,@-r0	! save GBR  0x48
-	sts.l		pr,@-r0		! save PR   0x44
-	stc.l		spc,@-r0	! save PC   0x40
-	
-	add		#0xA4,r0	! readjust register pointer
-	sts.l		fpscr,@-r0	! save FPSCR 0xdc
-	mov		#0,r2		! Set known FP flags
-	lds		r2,fpscr
-	fschg                   ! Switch to pair FP moves
-    fmov.d  dr14,@-r0       ! save FR14 & FR15
-    fmov.d  dr12,@-r0       ! save FR12 & FR13
-    fmov.d  dr10,@-r0       ! save FR10 & FR11
-    fmov.d  dr8,@-r0        ! save FR8 & FR9
-    fmov.d  dr6,@-r0        ! save FR6 & FR7
-    fmov.d  dr4,@-r0        ! save FR4 & FR5
-    fmov.d  dr2,@-r0        ! save FR2 & FR3
-    fmov.d  dr0,@-r0        ! save FR0 & FR1
-    frchg                   ! Second FP bank
-    fmov.d  dr14,@-r0       ! save FR14 & FR15
-    fmov.d  dr12,@-r0       ! save FR12 & FR13
-    fmov.d  dr10,@-r0       ! save FR10 & FR11
-    fmov.d  dr8,@-r0        ! save FR8 & FR9
-    fmov.d  dr6,@-r0        ! save FR6 & FR7
-    fmov.d  dr4,@-r0        ! save FR4 & FR5
-    fmov.d  dr2,@-r0        ! save FR2 & FR3
-    fmov.d  dr0,@-r0        ! save FR0 & FR1
-    fschg                   ! Switch to single FP moves
-    frchg                   ! First FP bank again
-	sts.l		fpul,@-r0	! save FPUL
+    mov.l   _irq_srt_addr, r0    ! Grab the location of the reg store
+    add     #0x20, r0    ! Start at the top of the BANK regs
+    stc.l   r7_bank, @-r0    ! Save R7
+    stc.l   r6_bank, @-r0    ! Save R6
+    stc.l   r5_bank, @-r0    ! Save R5
+    stc.l   r4_bank, @-r0    ! Save R4
+    stc.l   r3_bank, @-r0    ! Save R3
+    stc.l   r2_bank, @-r0    ! Save R2
+    stc.l   r1_bank, @-r0    ! Save R1
+    stc.l   r0_bank, @-r0    ! Save R0
+    
+    mov.l   r8,@(0x20,r0)    ! save R8
+    mov.l   r9,@(0x24,r0)    ! save R9
+    mov.l   r10,@(0x28,r0)   ! save R10
+    mov.l   r11,@(0x2c,r0)   ! save R11
+    mov.l   r12,@(0x30,r0)   ! save R12
+    mov.l   r13,@(0x34,r0)   ! save R13
+    mov.l   r14,@(0x38,r0)   ! save R14
+    mov.l   r15,@(0x3c,r0)   ! save R15 (SP)
+    add     #0x5c,r0     ! readjust register pointer
+    stc.l   ssr,@-r0     ! save SSR  0x58
+    sts.l   macl,@-r0    ! save MACL 0x54
+    sts.l   mach,@-r0    ! save MACH 0x50
+    stc.l   vbr,@-r0     ! save VBR  0x4c
+    stc.l   gbr,@-r0     ! save GBR  0x48
+    sts.l   pr,@-r0      ! save PR   0x44
+    stc.l   spc,@-r0     ! save PC   0x40
+    
+    add     #0xA4, r0    ! readjust register pointer
+    sts.l   fpscr, @-r0  ! save FPSCR 0xdc
+    mov     #0, r2       ! Set known FP flags
+    lds     r2, fpscr
+    fschg                ! Switch to pair FP moves
+    fmov.d  dr14, @-r0   ! save FR14 & FR15
+    fmov.d  dr12, @-r0   ! save FR12 & FR13
+    fmov.d  dr10, @-r0   ! save FR10 & FR11
+    fmov.d  dr8, @-r0    ! save FR8 & FR9
+    fmov.d  dr6, @-r0    ! save FR6 & FR7
+    fmov.d  dr4, @-r0    ! save FR4 & FR5
+    fmov.d  dr2, @-r0    ! save FR2 & FR3
+    fmov.d  dr0, @-r0    ! save FR0 & FR1
+    frchg                ! Second FP bank
+    fmov.d  dr14, @-r0   ! save FR14 & FR15
+    fmov.d  dr12, @-r0   ! save FR12 & FR13
+    fmov.d  dr10, @-r0   ! save FR10 & FR11
+    fmov.d  dr8, @-r0    ! save FR8 & FR9
+    fmov.d  dr6, @-r0    ! save FR6 & FR7
+    fmov.d  dr4, @-r0    ! save FR4 & FR5
+    fmov.d  dr2, @-r0    ! save FR2 & FR3
+    fmov.d  dr0, @-r0    ! save FR0 & FR1
+    fschg                ! Switch to single FP moves
+    frchg                ! First FP bank again
+    sts.l   fpul, @-r0   ! save FPUL
 
-	! Setup our kernel-mode stack
-	mov.l		stkaddr,r15
+    ! Setup our kernel-mode stack
+    mov.l   stkaddr, r15
 
-	! Before we enter the main C code again, re-enable exceptions
-	! (but not interrupts) so we can still debug inside handlers.
-	bsr		_irq_disable
-	nop
+    ! Before we enter the main C code again, re-enable exceptions
+    ! (but not interrupts) so we can still debug inside handlers.
+    bsr     _irq_disable
+    nop
 
-	! R4 still contains the exception code
-	mov.l		hdl_except,r2	! Call handle_exception
-	jsr		@r2
-	nop
-	bra		_save_regs_finish
-	nop
+    ! R4 still contains the exception code
+    mov.l   hdl_except, r2    ! Call handle_exception
+    jsr     @r2
+    nop
+    bra     _save_regs_finish
+    nop
 
 ! irq_force_return() jumps here; make sure we're in register
 ! bank 1 (as opposed to 0)
+    .align 2
 _irq_force_return:
-	mov.l	_irqfr_or,r1
-	stc	sr,r0
-	or	r1,r0
-	ldc	r0,sr
-	bra	_save_regs_finish
-	nop
-	
-	.align 2
+    mov.l   _irqfr_or, r1
+    stc     sr, r0
+    or      r1, r0
+    ldc     r0, sr
+    bra     _save_regs_finish
+    nop
+    
+    .align 2
 _irqfr_or:
-	.long	0x20000000
+    .long   0x20000000
 stkaddr:
-	.long	krn_stack
+    .long   krn_stack
 
 
 ! Now restore all the registers and jump back to the thread
+    .align 2
 _save_regs_finish:
-	mov.l	_irq_srt_addr, r1	! Get register store address
-	ldc.l	@r1+,r0_bank		! restore R0	(r1 is now _irq_srt_addr+0)
-	ldc.l	@r1+,r1_bank		! restore R1
-	ldc.l	@r1+,r2_bank		! restore R2
-	ldc.l	@r1+,r3_bank		! restore R3
-	ldc.l	@r1+,r4_bank		! restore R4
-	ldc.l	@r1+,r5_bank		! restore R5
-	ldc.l	@r1+,r6_bank		! restore R6
-	ldc.l	@r1+,r7_bank		! restore R7
-	add	#-32,r1			! Go back to the front
-	mov.l	@(0x20,r1), r8		! restore R8	(r1 is now ...+0)
-	mov.l	@(0x24,r1), r9		! restore R9
-	mov.l	@(0x28,r1), r10		! restore R10
-	mov.l	@(0x2c,r1), r11		! restore R11
-	mov.l	@(0x30,r1), r12		! restore R12
-	mov.l	@(0x34,r1), r13		! restore R13
-	mov.l	@(0x38,r1), r14		! restore R14
-	mov.l	@(0x3c,r1), r15		! restore program's stack
-	
-	add	#0x40,r1		! jump up to status words
-	ldc.l	@r1+,spc		! restore SPC 0x40	(r1 is now +0x40)
-	lds.l	@r1+,pr			! restore PR  0x44	(+0x44)
-	ldc.l	@r1+,gbr		! restore GBR 0x48	(+0x48)
-!	ldc.l	@r1+,vbr		! restore VBR (don't play with VBR)
-	add	#4,r1			!			(+0x4c)
-	lds.l	@r1+,mach		! restore MACH 0x50	(+0x50)
-	lds.l	@r1+,macl		! restore MACL 0x54	(+0x54)
-	ldc.l	@r1+,ssr		! restore SSR  0x58	(+0x58)
+    mov.l   _irq_srt_addr, r1  ! Get register store address
+    ldc.l   @r1+, r0_bank      ! restore R0    (r1 is now _irq_srt_addr+0)
+    ldc.l   @r1+, r1_bank      ! restore R1
+    ldc.l   @r1+, r2_bank      ! restore R2
+    ldc.l   @r1+, r3_bank      ! restore R3
+    ldc.l   @r1+, r4_bank      ! restore R4
+    ldc.l   @r1+, r5_bank      ! restore R5
+    ldc.l   @r1+, r6_bank      ! restore R6
+    ldc.l   @r1+, r7_bank      ! restore R7
+    add     #-32,r1            ! Go back to the front
+    mov.l   @(0x20,r1), r8     ! restore R8    (r1 is now ...+0)
+    mov.l   @(0x24,r1), r9     ! restore R9
+    mov.l   @(0x28,r1), r10    ! restore R10
+    mov.l   @(0x2c,r1), r11    ! restore R11
+    mov.l   @(0x30,r1), r12    ! restore R12
+    mov.l   @(0x34,r1), r13    ! restore R13
+    mov.l   @(0x38,r1), r14    ! restore R14
+    mov.l   @(0x3c,r1), r15    ! restore program's stack
+    
+    add     #0x40, r1    ! jump up to status words
+    ldc.l   @r1+, spc    ! restore SPC 0x40    (r1 is now +0x40)
+    lds.l   @r1+, pr     ! restore PR  0x44    (+0x44)
+    ldc.l   @r1+, gbr    ! restore GBR 0x48    (+0x48)
+!   ldc.l   @r1+, vbr    ! restore VBR (don't play with VBR)
+    add     #4, r1       !            (+0x4c)
+    lds.l   @r1+, mach   ! restore MACH 0x50    (+0x50)
+    lds.l   @r1+, macl   ! restore MACL 0x54    (+0x54)
+    ldc.l   @r1+, ssr    ! restore SSR  0x58    (+0x58)
 
-	lds.l	@r1+,fpul		! restore FPUL  
-	mov	#0,r2			! Set known FP flags	(+0x5c)
-	lds	r2,fpscr
-	frchg                       ! Second FP bank
-    fschg                       ! Switch to pair FP moves
-    fmov.d  @r1+,dr0            ! restore FR0 & FR1
-    fmov.d  @r1+,dr2            ! restore FR2 & FR3
-    fmov.d  @r1+,dr4            ! restore FR4 & FR5
-    fmov.d  @r1+,dr6            ! restore FR6 & FR7
-    fmov.d  @r1+,dr8            ! restore FR8 & FR9
-    fmov.d  @r1+,dr10           ! restore FR10 & FR11
-    fmov.d  @r1+,dr12           ! restore FR12 & FR13
-    fmov.d  @r1+,dr14           ! restore FR14 & FR15
-    frchg                       ! First FP bank
-	add #32, r1
-!	fmov.d  @r1+,dr0            ! restore FR0 & FR1
-!   fmov.d  @r1+,dr2            ! restore FR2 & FR3
-!   fmov.d  @r1+,dr4            ! restore FR4 & FR5
-!   fmov.d  @r1+,dr6            ! restore FR6 & FR7
-    fmov.d  @r1+,dr8            ! restore FR8 & FR9
-    fmov.d  @r1+,dr8            ! restore FR8 & FR9
-    fmov.d  @r1+,dr10           ! restore FR10 & FR11
-    fmov.d  @r1+,dr12           ! restore FR12 & FR13
-    fmov.d  @r1+,dr14           ! restore FR14 & FR15
-	lds.l	@r1+,fpscr		! restore FPSCR 0xdc
+    lds.l   @r1+, fpul   ! restore FPUL  
+    mov     #0, r2       ! Set known FP flags    (+0x5c)
+    lds     r2, fpscr
+    frchg                ! Second FP bank
+    fschg                ! Switch to pair FP moves
+    fmov.d  @r1+, dr0    ! restore FR0 & FR1
+    fmov.d  @r1+, dr2    ! restore FR2 & FR3
+    fmov.d  @r1+, dr4    ! restore FR4 & FR5
+    fmov.d  @r1+, dr6    ! restore FR6 & FR7
+    fmov.d  @r1+, dr8    ! restore FR8 & FR9
+    fmov.d  @r1+, dr10   ! restore FR10 & FR11
+    fmov.d  @r1+, dr12   ! restore FR12 & FR13
+    fmov.d  @r1+, dr14   ! restore FR14 & FR15
+    frchg                ! First FP bank
+    add     #32, r1
+    fmov.d  @r1+, dr0    ! restore FR0 & FR1
+    fmov.d  @r1+, dr2    ! restore FR2 & FR3
+    fmov.d  @r1+, dr4    ! restore FR4 & FR5
+    fmov.d  @r1+, dr6    ! restore FR6 & FR7
+    fmov.d  @r1+, dr8    ! restore FR8 & FR9
+    fmov.d  @r1+, dr8    ! restore FR8 & FR9
+    fmov.d  @r1+, dr10   ! restore FR10 & FR11
+    fmov.d  @r1+, dr12   ! restore FR12 & FR13
+    fmov.d  @r1+, dr14   ! restore FR14 & FR15
+    lds.l   @r1+, fpscr  ! restore FPSCR 0xdc
 
-!	add	#-0x70,r1		! jump back to registers
-!	add	#-0x34,r1
-!	mov.l	@(0,r1),r0		! restore R0
-!	mov.l	@(4,r1),r1		! restore R1
-	mov	#2,r0
+    mov     #2, r0
 
-	rte				! return
-	nop
-	
-	.align 2
+    rte                  ! return
+    nop
+    
+    .align 2
 _irq_srt_addr:
-	.long	0	! Save Regs Table -- this is an indirection
-			! so we can easily swap out pointers during a
-			! context switch.
+    .long    0    ! Save Regs Table -- this is an indirection
+            ! so we can easily swap out pointers during a
+            ! context switch.
 hdl_except:
-	.long	_irq_handle_exception
+    .long   _irq_handle_exception
 
 
 ! Special case handler for TLB miss exceptions. There are two reasons
@@ -211,80 +210,80 @@ hdl_except:
 ! !!NOTE!! This is highly dependent on the structure of the MMU tables
 ! in mmu.h and the MMU code in mmu.c. If either of those change, this will
 ! likely need to change as well.
-	.text
-	.align 2
+    .text
+    .align 2
 tlb_miss_hnd:
-	! Get the exception event code; we want to handle only
-	! 0x0040 (ITLB_MISS/DTLB_MISS_READ) or 0x0060 (DTLB_MISS_WRITE)
-	mov	#-1,r3		! 0xff000024 (EXPEVT) -> r3
-	shll16	r3
-	shll8	r3
-	add	#0x24,r3
-	mov.l	@r3,r0		! Get EXPEVT
+    ! Get the exception event code; we want to handle only
+    ! 0x0040 (ITLB_MISS/DTLB_MISS_READ) or 0x0060 (DTLB_MISS_WRITE)
+    mov     #-1, r3      ! 0xff000024 (EXPEVT) -> r3
+    shll16  r3
+    shll8   r3
+    add     #0x24, r3
+    mov.l   @r3, r0      ! Get EXPEVT
 
-	mov	#0x40,r1	! 0x0040 -> r1
+    mov     #0x40, r1    ! 0x0040 -> r1
 
-	cmp/eq	r0,r1
-	bt.s	tmh_doit
-	mov	#0x60,r1
+    cmp/eq  r0, r1
+    bt.s    tmh_doit
+    mov     #0x60, r1
 
-	cmp/eq	r0,r1
-	bt	tmh_doit
+    cmp/eq  r0, r1
+    bt      tmh_doit
 
-	! It's not one of the MISS codes, just send it on to the normal
-	! irq processing.
-	bra	_irq_save_regs
-	mov	#2,r4
+    ! It's not one of the MISS codes, just send it on to the normal
+    ! irq processing.
+    bra     _irq_save_regs
+    mov     #2, r4
 
 tmh_doit:
-	! So it's an ITLB or DTLB_MISS code. Look at the MMU module's
-	! shortcut flag. If that's set, it's safe to pass on processing
-	! directly to the mapping function.
+    ! So it's an ITLB or DTLB_MISS code. Look at the MMU module's
+    ! shortcut flag. If that's set, it's safe to pass on processing
+    ! directly to the mapping function.
 
-	! Check the shortcut flag
-	mov.l	tmh_shortcut_addr,r0
-	mov.l	@r0,r0
-	cmp/pz	r0
-	bt	tmh_clear
-	bra	_irq_save_regs
-	mov	#2,r4
+    ! Check the shortcut flag
+    mov.l   tmh_shortcut_addr, r0
+    mov.l   @r0, r0
+    cmp/pz  r0
+    bt      tmh_clear
+    bra     _irq_save_regs
+    mov     #2, r4
 
 tmh_clear:
-	! Coast is clear -- setup the args and call the C function. Regs R0-R7
-	! are volatile on SH-4 anyway, and R8-R14 will be saved if needed
-	! onto our temp stack. So all we need to worry about here, at least
-	! for this small C call, is the stack. To faciliate the stack, we'll
-	! save R15 and setup a small temp stack.
-	mov.l	tmh_stack_save_addr,r0		! Setup stack
-	mov.l	r15,@r0
-	mov.l	tmh_temp_stack_addr,r15
+    ! Coast is clear -- setup the args and call the C function. Regs R0-R7
+    ! are volatile on SH-4 anyway, and R8-R14 will be saved if needed
+    ! onto our temp stack. So all we need to worry about here, at least
+    ! for this small C call, is the stack. To faciliate the stack, we'll
+    ! save R15 and setup a small temp stack.
+    mov.l   tmh_stack_save_addr, r0   ! Setup stack
+    mov.l   r15, @r0
+    mov.l   tmh_temp_stack_addr, r15
 
-	mov	#0,r4				! Call gen_miss
-	mov	#0,r5
-	mov.l	tmh_gen_miss_addr,r0
-	jsr	@r0
-	mov	#0,r6
+    mov     #0, r4               ! Call gen_miss
+    mov     #0, r5
+    mov.l   tmh_gen_miss_addr, r0
+    jsr     @r0
+    mov     #0, r6
 
-	mov.l	tmh_stack_save,r15		! Fix stack back
+    mov.l   tmh_stack_save, r15  ! Fix stack back
 
-	! Return back from the exception
-	rte
-	nop
+    ! Return back from the exception
+    rte
+    nop
 
-	.align	2
+    .align 2
 tmh_shortcut_addr:
-	.long	_mmu_shortcut_ok
+    .long   _mmu_shortcut_ok
 tmh_stack_save_addr:
-	.long	tmh_stack_save
+    .long   tmh_stack_save
 tmh_stack_save:
-	.long	0
+    .long   0
 tmh_temp_stack_addr:
-	.long	tmh_temp_stack
+    .long   tmh_temp_stack
 tmh_gen_miss_addr:
-	.long	_mmu_gen_tlb_miss
+    .long   _mmu_gen_tlb_miss
 
-	.data
-	.space	256
+    .data
+    .space  256
 tmh_temp_stack:
 
 
@@ -292,38 +291,38 @@ tmh_temp_stack:
 ! table like a sensible processor, it has a vector code block. *sigh*
 ! Thus this table of assembly code. Note that we can't catch reset
 ! exceptions at all, but that really shouldn't matter.
-	.text
-	.align 2
-	.globl _irq_vma_table
+    .text
+    .align 2
+    .globl _irq_vma_table
 _irq_vma_table:
-	.rep	0x100
-	.byte	0
-	.endr
-	
-_vma_table_100:		! General exceptions
-	nop				! Can't have a branch as the first instr
-	bra	_irq_save_regs
-	mov	#1,r4			! Set exception code
-	
-	.rep	0x300 - 6
-	.byte	0
-	.endr
+    .rep    0x100
+    .byte   0
+    .endr
+    
+_vma_table_100:        ! General exceptions
+    nop                ! Can't have a branch as the first instr
+    bra     _irq_save_regs
+    mov     #1, r4     ! Set exception code
+    
+    .rep    0x300 - 6
+    .byte   0
+    .endr
 
-_vma_table_400:		! TLB miss exceptions (MMU)
-	nop
-!	bra	tlb_miss_hnd
-!	nop
-	bra	_irq_save_regs
-	mov	#2,r4			! Set exception code
+_vma_table_400:        ! TLB miss exceptions (MMU)
+    nop
+!    bra    tlb_miss_hnd
+!    nop
+    bra     _irq_save_regs
+    mov     #2, r4     ! Set exception code
 
-	.rep	0x200 - 6
-	.byte	0
-	.endr
+    .rep    0x200 - 6
+    .byte   0
+    .endr
 
-_vma_table_600:		! IRQs
-	nop
-	bra	_irq_save_regs
-	mov	#3,r4			! Set exception code
+_vma_table_600:        ! IRQs
+    nop
+    bra     _irq_save_regs
+    mov     #3, r4     ! Set exception code
 
 
 ! Disable interrupts, but leave exceptions enabled. Returns the old
@@ -332,53 +331,57 @@ _vma_table_600:		! IRQs
 ! Calling this inside an exception/interrupt handler will generally not have
 ! any effect.
 !
-	.globl	_irq_disable
+    .align 2
+    .globl  _irq_disable
 _irq_disable:
-	mov.l	_irqd_and,r1
-	mov.l	_irqd_or,r2
-	stc	sr,r0
-	and	r0,r1
-	or	r2,r1
-	ldc	r1,sr
-	rts
-	nop
-	
-	.align 2
+    mov.l   _irqd_and, r1
+    mov.l   _irqd_or, r2
+    stc     sr, r0
+    and     r0, r1
+    or      r2, r1
+    ldc     r1, sr
+    rts
+    nop
+    
+    .align 2
 _irqd_and:
-	.long	0xefffff0f
+    .long   0xefffff0f
 _irqd_or:
-	.long	0x000000f0
+    .long   0x000000f0
 
 
 ! Enable interrupts and exceptions. Returns the old interrupt status.
 !
 ! Call this inside an exception/interrupt handler only with GREAT CARE.
 !
-	.globl	_irq_enable
+    .align 2
+    .globl  _irq_enable
 _irq_enable:
-	mov.l	_irqe_and,r1
-	stc	sr,r0
-	and	r0,r1
-	ldc	r1,sr
-	rts
-	nop
-	
-	.align 2
+    mov.l   _irqe_and, r1
+    stc     sr, r0
+    and     r0, r1
+    ldc     r1, sr
+    rts
+    nop
+    
+    .align 2
 _irqe_and:
-	.long	0xefffff0f
+    .long   0xefffff0f
 
 
 ! Restore interrupts to the state returned by irq_disable()
 ! or irq_enable().
-	.globl	_irq_restore
+    .align 2
+    .globl  _irq_restore
 _irq_restore:
-	ldc	r4,sr
-	rts
-	nop
+    ldc     r4, sr
+    rts
+    nop
 
 
 ! Retrieve SR
-	.globl	_irq_get_sr
+    .align 2
+    .globl  _irq_get_sr
 _irq_get_sr:
-	rts
-	stc	sr,r0
+    rts
+    stc     sr, r0

--- a/kernel/arch/dreamcast/kernel/entry.s
+++ b/kernel/arch/dreamcast/kernel/entry.s
@@ -57,14 +57,14 @@ _irq_save_regs:
     mov.l   r13,@(0x34,r0)   ! save R13
     mov.l   r14,@(0x38,r0)   ! save R14
     mov.l   r15,@(0x3c,r0)   ! save R15 (SP)
-    add     #0x5c,r0     ! readjust register pointer
-    stc.l   ssr,@-r0     ! save SSR  0x58
-    sts.l   macl,@-r0    ! save MACL 0x54
-    sts.l   mach,@-r0    ! save MACH 0x50
-    stc.l   vbr,@-r0     ! save VBR  0x4c
-    stc.l   gbr,@-r0     ! save GBR  0x48
-    sts.l   pr,@-r0      ! save PR   0x44
-    stc.l   spc,@-r0     ! save PC   0x40
+    add     #0x5c, r0    ! readjust register pointer
+    stc.l   ssr, @-r0    ! save SSR  0x58
+    sts.l   macl, @-r0   ! save MACL 0x54
+    sts.l   mach, @-r0   ! save MACH 0x50
+    stc.l   vbr, @-r0    ! save VBR  0x4c
+    stc.l   gbr, @-r0    ! save GBR  0x48
+    sts.l   pr, @-r0     ! save PR   0x44
+    stc.l   spc, @-r0    ! save PC   0x40
     
     add     #0xA4, r0    ! readjust register pointer
     sts.l   fpscr, @-r0  ! save FPSCR 0xdc
@@ -137,7 +137,7 @@ _save_regs_finish:
     ldc.l   @r1+, r5_bank      ! restore R5
     ldc.l   @r1+, r6_bank      ! restore R6
     ldc.l   @r1+, r7_bank      ! restore R7
-    add     #-32,r1            ! Go back to the front
+    add     #-32, r1           ! Go back to the front
     mov.l   @(0x20,r1), r8     ! restore R8    (r1 is now ...+0)
     mov.l   @(0x24,r1), r9     ! restore R9
     mov.l   @(0x28,r1), r10    ! restore R10

--- a/kernel/arch/dreamcast/kernel/entry.s
+++ b/kernel/arch/dreamcast/kernel/entry.s
@@ -171,7 +171,6 @@ _save_regs_finish:
     fmov.d  @r1+, dr12   ! restore FR12 & FR13
     fmov.d  @r1+, dr14   ! restore FR14 & FR15
     frchg                ! First FP bank
-    add     #32, r1
     fmov.d  @r1+, dr0    ! restore FR0 & FR1
     fmov.d  @r1+, dr2    ! restore FR2 & FR3
     fmov.d  @r1+, dr4    ! restore FR4 & FR5

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -97,13 +97,13 @@ void irq_dump_regs(int code, int evt) {
 /* The C-level routine that processes context switching and other
    types of interrupts. NOTE: We are running on the stack of the process
    that was interrupted! */
-volatile uint32 jiffies = 0;
+volatile uint32_t jiffies = 0;
 void irq_handle_exception(int code) {
     /* Get the exception code */
     /* volatile uint32 *tra = (uint32*)0xff000020; */
-    volatile uint32 *expevt = (uint32*)0xff000024;
-    volatile uint32 *intevt = (uint32*)0xff000028;
-    uint32 evt = 0;
+    volatile uint32_t *expevt = (uint32_t *)0xff000024;
+    volatile uint32_t *intevt = (uint32_t *)0xff000028;
+    uint32_t evt = 0;
     int handled = 0;
 
     /* If it's a code 0, well, we shouldn't be here. */
@@ -186,9 +186,9 @@ void irq_handle_exception(int code) {
 
 void irq_handle_trapa(irq_t code, irq_context_t *context) {
     /* Get the exception code */
-    volatile uint32 *tra = (uint32*)0xff000020;
+    volatile uint32_t *tra = (uint32_t *)0xff000020;
     irq_handler hnd;
-    uint32 vec;
+    uint32_t vec;
 
     (void)code;
 
@@ -223,8 +223,8 @@ irq_context_t *irq_get_context(void) {
 /* Fill a newly allocated context block for usage with supervisor/kernel
    or user mode. The given parameters will be passed to the called routine (up
    to the architecture maximum). */
-void irq_create_context(irq_context_t *context, uint32 stkpntr,
-                        uint32 routine, uint32 *args, int usermode) {
+void irq_create_context(irq_context_t *context, uint32_t stkpntr,
+                        uint32_t routine, uint32_t *args, int usermode) {
     int i;
 
     /* Clear out user and FP regs */
@@ -244,7 +244,7 @@ void irq_create_context(irq_context_t *context, uint32 stkpntr,
     context->fpul = 0;
 
     /* Setup the program frame */
-    context->pc = (uint32)routine;
+    context->pc = (uint32_t)routine;
     context->pr = 0;
     context->sr = 0x40000000;   /* note: need to handle IMASK */
     context->r[15] = stkpntr;

--- a/kernel/arch/dreamcast/kernel/thdswitch.s
+++ b/kernel/arch/dreamcast/kernel/thdswitch.s
@@ -73,6 +73,11 @@ _thd_block_now:
 	fmov.d   dr12, @-r4   ! save FR12 & FR13
 	fmov.d   dr10, @-r4   ! save FR10 & FR11
 	fmov.d   dr8, @-r4    ! save FR8 & FR9
+!	fmov.d   dr6, @-r4    ! save FR6 & FR7
+!	fmov.d   dr4, @-r4    ! save FR4 & FR5
+!	fmov.d   dr2, @-r4    ! save FR2 & FR3
+!	fmov.d   dr0, @-r4    ! save FR0 & FR1    0x9c
+	add      #-32, r4
 	frchg                 ! Second FP bank
 	fmov.d   dr14, @-r4   ! save FR14 & FR15  0x98
 	fmov.d   dr12, @-r4   ! save FR12 & FR13

--- a/kernel/arch/dreamcast/kernel/thdswitch.s
+++ b/kernel/arch/dreamcast/kernel/thdswitch.s
@@ -9,7 +9,6 @@
 
 	.text
 	.globl		_thd_block_now
-	.globl		_thd_block_now2
 
 ! Call this function to save the current task state (with one small
 ! exception -- PC will be moved forwards to the "restore" code) and

--- a/kernel/arch/dreamcast/kernel/thdswitch.s
+++ b/kernel/arch/dreamcast/kernel/thdswitch.s
@@ -1,8 +1,8 @@
 ! KallistiOS ##version##
 !
 !   arch/dreamcast/kernel/thdswitch.s
-!   Copyright (c)2003 Megan Potter
-!   Copyright (c)2023 Andy Barajas
+!   Copyright (C) 2003 Megan Potter
+!   Copyright (C) 2023 Andy Barajas
 !
 ! Assembler code for swapping out running threads
 !

--- a/kernel/arch/dreamcast/kernel/thdswitch.s
+++ b/kernel/arch/dreamcast/kernel/thdswitch.s
@@ -7,8 +7,8 @@
 ! Assembler code for swapping out running threads
 !
 
-	.text
-	.globl		_thd_block_now
+    .text
+    .globl  _thd_block_now
 
 ! Call this function to save the current task state (with one small
 ! exception -- PC will be moved forwards to the "restore" code) and
@@ -26,89 +26,88 @@
 ! No explicit return value, though R0 might be changed while the
 ! called is blocked. Returns when we are woken again later.
 !
-	.align 2
+    .align 2
 _thd_block_now:
-	! There's no need to save R0-R7 since these are not guaranteed
-	! to persist across calls. So we'll put our temps down there
-	! and start at R8.
+    ! There's no need to save R0-R7 since these are not guaranteed
+    ! to persist across calls. So we'll put our temps down there
+    ! and start at R8.
 
-	! Save SR and disable interrupts
-	sts.l		pr,@-r15
-	mov.l		idaddr,r0
-	jsr		@r0
-	nop
-	lds.l		@r15+,pr
+    ! Save SR and disable interrupts
+    sts.l   pr, @-r15
+    mov.l   idaddr, r0
+    jsr     @r0
+    nop
+    lds.l   @r15+, pr
 
-	! Ok save the "permanent" GPRs
-	mov.l		r8,@(0x20,r4)	! Save R8
-	mov.l		r9,@(0x24,r4)	! Save R9
-	mov.l		r10,@(0x28,r4)	! Save R10
-	mov.l		r11,@(0x2c,r4)	! Save R11
-	mov.l		r12,@(0x30,r4)	! Save R12
-	mov.l		r13,@(0x34,r4)	! Save R13
-	mov.l		r14,@(0x38,r4)	! Save R14 (FP maybe)
-	mov.l		r15,@(0x3c,r4)	! Save R15 (SP)
+    ! Ok save the "permanent" GPRs
+    mov.l   r8, @(0x20,r4)    ! Save R8
+    mov.l   r9, @(0x24,r4)    ! Save R9
+    mov.l   r10, @(0x28,r4)   ! Save R10
+    mov.l   r11, @(0x2c,r4)   ! Save R11
+    mov.l   r12, @(0x30,r4)   ! Save R12
+    mov.l   r13, @(0x34,r4)   ! Save R13
+    mov.l   r14, @(0x38,r4)   ! Save R14 (FP maybe)
+    mov.l   r15, @(0x3c,r4)   ! Save R15 (SP)
 
-	! Save any machine words. We want the swapping-in of this task
-	! to simulate returning from this function, so what we'll do is
-	! put PR as PC. Everything else can stay the same.
-	add		#0x5c,r4	! readjust register ptr
-	mov.l		r0,@-r4		! save SR   0x58
-	sts.l		macl,@-r4	! save MACL 0x54
-	sts.l		mach,@-r4	! save MACH 0x50
-	stc.l		vbr,@-r4	! save VBR  0x4c
-	stc.l		gbr,@-r4	! save GBR  0x48
-	sts.l		pr,@-r4		! save PR   0x44
-	sts.l		pr,@-r4		! save "PC" 0x40
+    ! Save any machine words. We want the swapping-in of this task
+    ! to simulate returning from this function, so what we'll do is
+    ! put PR as PC. Everything else can stay the same.
+    add     #0x5c, r4    ! readjust register ptr
+    mov.l   r0, @-r4     ! save SR   0x58
+    sts.l   macl, @-r4   ! save MACL 0x54
+    sts.l   mach, @-r4   ! save MACH 0x50
+    stc.l   vbr, @-r4    ! save VBR  0x4c
+    stc.l   gbr, @-r4    ! save GBR  0x48
+    sts.l   pr, @-r4     ! save PR   0x44
+    sts.l   pr, @-r4     ! save "PC" 0x40
 
-	! Save FPRs. We could probably skimp on FR0-FR7 but it'd probably
-	! be more trouble than it's worth to figure out which bank we're
-	! currently on, etc.
-	add		#0xA4,r4	! readjust register pointer
-	sts.l		fpscr,@-r4	! save FPSCR 0xdc
-	mov		#0,r2		! Set known FP flags
-	lds		r2,fpscr
-	fschg                 ! Switch to pair FP moves
-	fmov.d   dr14, @-r4   ! save FR14 & FR15  0xd8
-	fmov.d   dr12, @-r4   ! save FR12 & FR13
-	fmov.d   dr10, @-r4   ! save FR10 & FR11
-	fmov.d   dr8, @-r4    ! save FR8 & FR9
-!	fmov.d   dr6, @-r4    ! save FR6 & FR7
-!	fmov.d   dr4, @-r4    ! save FR4 & FR5
-!	fmov.d   dr2, @-r4    ! save FR2 & FR3
-!	fmov.d   dr0, @-r4    ! save FR0 & FR1    0x9c
-	add      #-32, r4
-	frchg                 ! Second FP bank
-	fmov.d   dr14, @-r4   ! save FR14 & FR15  0x98
-	fmov.d   dr12, @-r4   ! save FR12 & FR13
-	fmov.d   dr10, @-r4   ! save FR10 & FR11
-	fmov.d   dr8, @-r4    ! save FR8 & FR9
-	fmov.d   dr6, @-r4    ! save FR6 & FR7
-	fmov.d   dr4, @-r4    ! save FR4 & FR5
-	fmov.d   dr2, @-r4    ! save FR2 & FR3
-	fmov.d   dr0, @-r4    ! save FR0 & FR1    0x5c
-	frchg                 ! First FP bank again
-	fschg                 ! Switch to single FP moves
-	sts.l		fpul,@-r4	! save FPUL  0xe0
+    ! Save FPRs. We could probably skimp on FR0-FR7 but it'd probably
+    ! be more trouble than it's worth to figure out which bank we're
+    ! currently on, etc.
+    add     #0xA4, r4    ! readjust register pointer
+    sts.l   fpscr, @-r4  ! save FPSCR 0xdc
+    mov     #0, r2       ! Set known FP flags
+    lds     r2, fpscr
+    fschg                ! Switch to pair FP moves
+    fmov.d  dr14, @-r4   ! save FR14 & FR15  0xd8
+    fmov.d  dr12, @-r4   ! save FR12 & FR13
+    fmov.d  dr10, @-r4   ! save FR10 & FR11
+    fmov.d  dr8, @-r4    ! save FR8 & FR9
+    fmov.d  dr6, @-r4    ! save FR6 & FR7
+    fmov.d  dr4, @-r4    ! save FR4 & FR5
+    fmov.d  dr2, @-r4    ! save FR2 & FR3
+    fmov.d  dr0, @-r4    ! save FR0 & FR1    0x9c
+    frchg                ! Second FP bank
+    fmov.d  dr14, @-r4   ! save FR14 & FR15  0x98
+    fmov.d  dr12, @-r4   ! save FR12 & FR13
+    fmov.d  dr10, @-r4   ! save FR10 & FR11
+    fmov.d  dr8, @-r4    ! save FR8 & FR9
+    fmov.d  dr6, @-r4    ! save FR6 & FR7
+    fmov.d  dr4, @-r4    ! save FR4 & FR5
+    fmov.d  dr2, @-r4    ! save FR2 & FR3
+    fmov.d  dr0, @-r4    ! save FR0 & FR1    0x5c
+    frchg                ! First FP bank again
+    fschg                ! Switch to single FP moves
+    sts.l   fpul, @-r4   ! save FPUL  0xe0
 
-	! Ok, everything is saved now. There's no need to switch stacks or
-	! anything, because any stack usage by the thread scheduler will not
-	! disturb the saved task (assuming it doesn't overrun its stack anyway).
-	mov.l		tcnaddr,r0
-	jsr		@r0
-	nop
+    ! Ok, everything is saved now. There's no need to switch stacks or
+    ! anything, because any stack usage by the thread scheduler will not
+    ! disturb the saved task (assuming it doesn't overrun its stack anyway).
+    mov.l   tcnaddr, r0
+    jsr     @r0
+    nop
 
-	! To swap in the new task, we'll just force an interrupt return. That will
-	! cover all the contingencies.
-	mov.l		ifraddr,r1
-	jmp		@r1
-	mov		r0,r4
+    ! To swap in the new task, we'll just force an interrupt return. That will
+    ! cover all the contingencies.
+    mov.l   ifraddr, r1
+    jmp     @r1
+    mov     r0, r4
 
 
-	.balign	4
+    .align 2
 idaddr:
-	.long	_irq_disable
+    .long    _irq_disable
 ifraddr:
-	.long	_irq_force_return
+    .long    _irq_force_return
 tcnaddr:
-	.long	_thd_choose_new
+    .long    _thd_choose_new


### PR DESCRIPTION
Uses double precision mode to speed up copying of thread switch context.

## IMPORTANT
Fixing the formatting/spacing inside the assembly files will be in a future commit after all code changes are finalized.