### PR TITLE
`elf2bin`: adding script to the `utils` directory

### DIFF
--- a/utils/elf2bin/elf2bin
+++ b/utils/elf2bin/elf2bin
@@ -49,7 +49,6 @@ tmpfile="$workdir/$(basename $0).$$.tmp"
 
 # Do the conversion
 cp "$source" "$tmpfile"
-kos-strip "$tmpfile"
 kos-objcopy -O binary "$tmpfile" "$destination"
 
 # Remove the temporary directory

--- a/utils/elf2bin/elf2bin
+++ b/utils/elf2bin/elf2bin
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# elf2bin
+# script to convert an elf program to a bin(ary) program
+# then you can use 'scramble' to generate a '1ST_READ.BIN' file
+# this script is basically using 'strip' and 'objcopy'.
+
+me=`basename "$0"`
+
+# Retrieve args
+source=$1
+destination=$2
+
+# Check if we want to overwrite (force) the destination file
+force_switch=$3
+if [ "$destination" = "-f" ] || [ "$force_switch" = "-f" ]; then
+  force_switch=1
+  unset destination
+else
+  force_switch=0
+fi
+
+# Check for args
+if [ -z "$source" ]; then
+  echo "usage: $me <binary.elf> [binary.bin] [-f]";
+  exit 1
+fi
+
+# Check for source file existence
+if [ ! -f "$source" ]; then
+  echo "$me: error: file not found: $source";
+  exit 2
+fi
+
+# Compute destination file if destination arg is not passed
+if [ -z "$destination" ]; then
+  destination="${source%.*}.bin"
+fi
+
+# Check if destination file exists (or ignore if requested)
+if [ -f "$destination" ] && [ "$force_switch" = "0" ]; then
+  echo "$me: error: file already exists: $destination";
+  exit 3
+fi
+
+# Compute a temporary filename used to work on the elf file
+workdir=$(mktemp -d)
+tmpfile="$workdir/$(basename $0).$$.tmp"
+
+# Do the conversion
+cp "$source" "$tmpfile"
+kos-strip "$tmpfile"
+kos-objcopy -O binary "$tmpfile" "$destination"
+
+# Remove the temporary directory
+if [ -d "$workdir" ]; then
+  rm -r "$workdir"
+fi


### PR DESCRIPTION
This is basically a simple script using `strip` and `kos-objcopy`; basically this makes the conversion "explicit".
Indeed, this script is just an assembly of existing tools but it guides the KallistiOS user for having a clear meaning, secured and tested "workflow step" for generating a valid [Sega Dreamcast Mil-CD image](https://segaretro.org/Mil-CD) - in clear, a selfboot CD image.

This means that the workflow for generating a Sega Dreamcast disc would be (supposing the user project is using a standard KallistiOS `Makefile`):

1. `make` - this generate `program.elf`
2. `elf2bin` - this convert `program.elf` to `program.bin`
3. `scramble` - this generate `1ST_READ.BIN` from `program.bin`
4. `makeip` - this generate the Initial Program bootloader (`IP.BIN`)
5. `img4dc` - this generate the final CD image

This utility is coming from [DreamSDK](https://www.dreamsdk.org) (but improved here), so if this PR is accepted, `elf2bin` will be removed from DreamSDK.

**Note:** An alternative could be [mkdcdisc](https://gitlab.com/simulant/mkdcdisc) which handles a lot of those steps.