### PR TITLE
Watchdog Timer Documentation Improvements

### DIFF
--- a/kernel/arch/dreamcast/include/arch/rtc.h
+++ b/kernel/arch/dreamcast/include/arch/rtc.h
@@ -15,6 +15,8 @@
     standard C functions, like time(), rather than these when simply needing
     to fetch the current system time.
 
+    \sa arch/wdt.h
+
     \author Megan Potter
     \author Falco Girgis
 */
@@ -53,6 +55,8 @@ __BEGIN_DECLS
     with an epoch of January 1, 1950 00:00. Because of this, the Dreamcast's
     Y2K and the last timestamp it can represent before rolling over is 
     February 06 2086 06:28:15.
+
+    \sa wdt
 */
 
 /** \defgroup rtc_regs Registers

--- a/kernel/arch/dreamcast/include/arch/wdt.h
+++ b/kernel/arch/dreamcast/include/arch/wdt.h
@@ -1,29 +1,16 @@
 /* KallistiOS ##version##
 
    arch/dreamcast/include/wdt.h
-   Copyright (c) 2023 Falco Girgis
+   Copyright (C) 2023 Falco Girgis
 
 */
 
-/** \file   arch/wdt.h
-    \brief  Watchdog Timer API
+/** \file    arch/wdt.h
+    \brief   Watchdog Timer API
+    \ingroup wdt
 
-    This file provides an API built around utilizing the SH4's watchdog timer.
-    There are two different modes of operation which are supported:
-        - watchdog mode: counter overflow causes a reset interrupt
-        - interval timer mode: counter overflow invokes a callback function
-
-    To start the WDT in watchdog mode, use wdt_enable_watchdog(). To use the 
-    WDT as a general-purpose interval timer, use wdt_enable_timer().
-
-    The timer can be stopped in either mode by calling wdt_disable_timer().
-
-    \warning
-    Once the WDT has been enabled, special care must be taken to disable it
-    when exiting from the application. If left enabled, the WDT will continue
-    running beyond the lifetime of the application, causing either a reset or
-    an unhandled exception (depending on which mode was used), preventing you
-    from gracefully returning to a DC-Load session when testing.
+    This file provides an API for configuring and utilizing the SH4's watchdog
+    timer as either a reset or an interval timer.
 
     \sa timer.h, rtc.h
 
@@ -38,36 +25,73 @@ __BEGIN_DECLS
 
 #include <stdint.h>
 
-/** \brief Clock divider settings 
+/** \defgroup wdt   Watchdog Timer
+    \brief          Driver for using the WDT as a reset or interval timer
+
+    The watchdog timer (WDT) is a special-purpose timer peripheral integrated
+    within the Dreamcast's SH4 CPU.
+
+    \warning
+    At this time, there are no known emulators which are emulating the WDT,
+    as it was never used in commercial games; however, it works perfectly fine
+    on real hardware.
+
+    There are two different modes of operation which are supported:
+        - watchdog mode: counter overflow causes a reset interrupt
+        - interval timer mode: counter overflow invokes a callback function
+
+    To start the WDT in watchdog mode, use wdt_enable_watchdog(). To use the 
+    WDT as a general-purpose interval timer, use wdt_enable_timer().
+
+    The timer can be stopped in either mode by calling wdt_disable().
+
+    \warning
+    Once the WDT has been enabled, special care must be taken to disable it
+    when exiting from the application. If left enabled, the WDT will continue
+    running beyond the lifetime of the application, causing either a reset or
+    an unhandled exception (depending on which mode was used), preventing you
+    from gracefully returning to a DC-Load session when testing.
+
+    \sa rtc
+*/
+
+/** \brief   Clock divider settings
+    \ingroup wdt
  
     Denominators used to set the frequency divider
     for the input clock to the WDT.
  */
 typedef enum WDT_CLK_DIV {
-    WDT_CLK_DIV_32,     /** \brief Period: 41us */
-    WDT_CLK_DIV_64,     /** \brief Period: 82us */
-    WDT_CLK_DIV_128,    /** \brief Period: 164us */
-    WDT_CLK_DIV_256,    /** \brief Period: 328us */
-    WDT_CLK_DIV_512,    /** \brief Period: 656us */
-    WDT_CLK_DIV_1024,   /** \brief Period: 1.31ms */
-    WDT_CLK_DIV_2048,   /** \brief Period: 2.62ms */
-    WDT_CLK_DIV_4096    /** \brief Period: 5.25ms */
+    WDT_CLK_DIV_32,     /**< \brief Period: 41us */
+    WDT_CLK_DIV_64,     /**< \brief Period: 82us */
+    WDT_CLK_DIV_128,    /**< \brief Period: 164us */
+    WDT_CLK_DIV_256,    /**< \brief Period: 328us */
+    WDT_CLK_DIV_512,    /**< \brief Period: 656us */
+    WDT_CLK_DIV_1024,   /**< \brief Period: 1.31ms */
+    WDT_CLK_DIV_2048,   /**< \brief Period: 2.62ms */
+    WDT_CLK_DIV_4096    /**< \brief Period: 5.25ms */
 } WDT_CLK_DIV;
 
-/** \brief Reset signal type
- 
+/** \brief   Reset signal type
+    \ingroup wdt
+
     Specifies the kind of reset to be performed when the WDT
     overflows in watchdog mode.
 */
 typedef enum WDT_RST {
-    WDT_RST_POWER_ON,   /** \brief Power-On Reset */
-    WDT_RST_MANUAL      /** \brief Manual Reset */
+    WDT_RST_POWER_ON,   /**< \brief Power-On Reset */
+    WDT_RST_MANUAL      /**< \brief Manual Reset */
 } WDT_RST;
 
-/* \brief WDT interval timer callback function type */
+/* \brief   WDT interval timer callback function type
+   \ingroup wdt
+
+   Type of the callback function to be passed to wdt_enable_timer().
+*/
 typedef void (*wdt_callback)(void *user_data);
 
-/** \brief  Enables the WDT as an interval timer
+/** \brief   Enables the WDT as an interval timer
+    \ingroup wdt
 
     Stops the WDT if it was previously running and reconfigures it 
     to be used as a generic interval timer, calling the given callback
@@ -100,7 +124,8 @@ void wdt_enable_timer(uint8_t initial_count,
                       wdt_callback callback,
                       void *user_data);
 
-/** \brief  Enables the WDT in watchdog mode
+/** \brief   Enables the WDT in watchdog mode
+    \ingroup wdt
 
     Stops the WDT if it was previously running and reconfigures it 
     to be used as a typical watchdog timer, generating a resest 
@@ -121,7 +146,8 @@ void wdt_enable_watchdog(uint8_t initial_count,
                          WDT_CLK_DIV clk_config,
                          WDT_RST reset_select);
 
-/** \brief  Fetches the counter value
+/** \brief   Fetches the counter value
+    \ingroup wdt
  
     Returns the current 8-bit value of the WDT counter. 
 
@@ -131,7 +157,8 @@ void wdt_enable_watchdog(uint8_t initial_count,
 */
 uint8_t wdt_get_counter(void);
 
-/** \brief  Sets the counter value
+/** \brief   Sets the counter value
+    \ingroup wdt
  
     Sets the current 8-bit value of the WDT counter.
 
@@ -141,7 +168,8 @@ uint8_t wdt_get_counter(void);
 */
 void wdt_set_counter(uint8_t value);
 
-/** \brief  Resets the counter value 
+/** \brief   Resets the counter value
+    \ingroup wdt
  
     "Petting" or "kicking" the WDT is the same thing as
     resetting its counter value to 0.
@@ -150,7 +178,8 @@ void wdt_set_counter(uint8_t value);
 */
 void wdt_pet(void);
 
-/** \brief Disables the WDT
+/** \brief   Disables the WDT
+    \ingroup wdt
     
     Disables the WDT if it was previously enabled, 
     otherwise does nothing. 
@@ -159,7 +188,8 @@ void wdt_pet(void);
 */
 void wdt_disable(void);
 
-/** \brief  Returns whether the WDT is enabled
+/** \brief   Returns whether the WDT is enabled
+    \ingroup wdt
 
     Checks to see whether the WDT has been enabled.
 


### PR DESCRIPTION
After working on the Timer driver and a bunch of other Doxygen stuff, I came to the realization that the WDT docs were a bit lacking and weren't up to my own standards... Whoops. 

- Watchdog timer documentation had a few errors within it
- Watchdog timer documentation lacked a proper top-level group defined to put it in the main module index
- Added a reference to the WDT from the RTC