### PR TITLE
Fixed Thread-Related Doxygen Warnings

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -573,7 +573,7 @@ struct _reent *thd_get_reent(kthread_t *thd);
     \deprecated
     This is now deprecated.
 
-    \param  mode            One of the \ref thd_modes values.
+    \param  mode            One of the THD_MODE values.
     \return                 The old mode of the threading system.
 
     \sa thd_get_mode

--- a/include/threads.h
+++ b/include/threads.h
@@ -114,8 +114,7 @@ extern void mtx_destroy(mtx_t *mtx);
     protect critical sections of code.
 
     \param  mtx             The mutex to initialize.
-    \param  type            The type of mutex desired (see
-                            \ref c11_mutex_types).
+    \param  type            The type of mutex desired
     \retval thrd_success    On success.
     \retval thrd_error      If the request could not be honored.
 */


### PR DESCRIPTION
Both were for top-level groups that I removed to prevent them from polluting the global namespace.

- 1 in kthreads: kos/thread.h
- 1 in C11 threads: threads.h