### PR TITLE
Fix GCC 13.2.0 Toolchain Compilation on Cygwin

### DIFF
--- a/utils/dc-chain/patches/gcc-13.2.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-13.2.0-kos.diff
@@ -160,20 +160,3 @@ diff --color -ruN gcc-13.2.0/libstdc++-v3/configure gcc-13.2.0-kos/libstdc++-v3/
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
-diff --color -ruN gcc-13.2.0/gcc/config/sh/sh.cc gcc-13.2.0-kos/gcc/config/sh/sh.cc
---- gcc-13.2.0/gcc/config/sh/sh.cc	2023-11-26 08:34:56.426962700 +0900
-+++ gcc-13.2.0-kos/gcc/config/sh/sh.cc	2023-11-26 08:40:20.067698600 +0900
-@@ -71,6 +71,12 @@
- /* This file should be included last.  */
- #include "target-def.h"
- 
-+/* Fix fputs_unlocked not declared issue in Cygwin */
-+#ifdef __CYGWIN__
-+#undef fputs
-+#undef fprintf
-+#endif
-+
- int code_for_indirect_jump_scratch = CODE_FOR_indirect_jump_scratch;
- 
- #define CONST_OK_FOR_ADD(size) CONST_OK_FOR_I08 (size)
- 

--- a/utils/dc-chain/patches/gcc-13.2.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-13.2.0-kos.diff
@@ -160,3 +160,20 @@ diff --color -ruN gcc-13.2.0/libstdc++-v3/configure gcc-13.2.0-kos/libstdc++-v3/
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+diff --color -ruN gcc-13.2.0/gcc/config/sh/sh.cc gcc-13.2.0-kos/gcc/config/sh/sh.cc
+--- gcc-13.2.0/gcc/config/sh/sh.cc	2023-11-26 08:34:56.426962700 +0900
++++ gcc-13.2.0-kos/gcc/config/sh/sh.cc	2023-11-26 08:40:20.067698600 +0900
+@@ -71,6 +71,12 @@
+ /* This file should be included last.  */
+ #include "target-def.h"
+ 
++/* Fix fputs_unlocked not declared issue in Cygwin */
++#ifdef __CYGWIN__
++#undef fputs
++#undef fprintf
++#endif
++
+ int code_for_indirect_jump_scratch = CODE_FOR_indirect_jump_scratch;
+ 
+ #define CONST_OK_FOR_ADD(size) CONST_OK_FOR_I08 (size)
+ 

--- a/utils/dc-chain/patches/x86_64-pc-cygwin/gcc-13.2.0.diff
+++ b/utils/dc-chain/patches/x86_64-pc-cygwin/gcc-13.2.0.diff
@@ -1,0 +1,18 @@
+diff --color -ruN gcc-13.2.0/gcc/config/sh/sh.cc gcc-13.2.0-kos/gcc/config/sh/sh.cc
+--- gcc-13.2.0/gcc/config/sh/sh.cc	2023-11-26 08:34:56.426962700 +0900
++++ gcc-13.2.0-kos/gcc/config/sh/sh.cc	2023-11-26 08:40:20.067698600 +0900
+@@ -71,6 +71,14 @@
+ /* This file should be included last.  */
+ #include "target-def.h"
+ 
++/* fputs() and related are redefined in system.h to their unlocked version. */
++/* On Cygwin, compilation errors with 'fputs_unlocked() was not declared'  */
++/* Therefore, on Cygwin, undefine these problematic symbols.               */
++#ifdef __CYGWIN__
++#undef fputs
++#undef fprintf
++#endif
++
+ int code_for_indirect_jump_scratch = CODE_FOR_indirect_jump_scratch;
+ 
+ #define CONST_OK_FOR_ADD(size) CONST_OK_FOR_I08 (size)


### PR DESCRIPTION
Building dc-chain on Cygwin fails in gcc-13.2.0/gcc/config/sh/sh.cc, with the following error:

> build-gcc-sh-elf-13.2.0-pass1.log:../../gcc-13.2.0/gcc/system.h:150:33: エラー: ‘fputs_unlocked’ was not declared in this scope; did you mean ‘fputc_unlocked’?

In gcc-13.2.0/gcc/system.h, fputs() and similar functions are redefined to use their unlocked counterpart, like fputs_unlocked().

However, for whatever reason, this causes the build to fail on Cygwin.

As a workaround, I have added a patch, which will add a preprocessor conditional inside sh.cc to check for Cygwin and undefine the problematic symbols.

After the patch, the build process completes successfully.