### PR TITLE
Removed GD drive status checks at startup.

### DIFF
--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -501,16 +501,7 @@ int cdrom_init(void) {
     gdc_init_system();
     mutex_unlock(&_g1_ata_mutex);
 
-    cdrom_get_status(&status, &disc_type);
-
-    if(status < CD_STATUS_OPEN && disc_type > CD_CDDA && disc_type < CD_FAIL) {
-        /* Do an initial initialization */
-        cdrom_reinit();
-    } else {
-        dbglog(DBG_INFO, "cdrom_init: No disc inserted\n");
-    }
-
-    return 0;
+    return cdrom_reinit();
 }
 
 void cdrom_shutdown(void) {


### PR DESCRIPTION
I figured out what my initial problem is.
I have flashed the BIOS with a bootloader builded on old KOS where the IDE driver does not return the master!
That's why I was stuck at INIT first time. After IDE driver works in new KOS it's all normalized.
So I remove these checks, they are not needed.