### PR TITLE
Threaded ASIC IRQ handlers

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -1078,7 +1078,7 @@ int fs_iso9660_init(void) {
     iso_last_status = -1;
 
     /* Register with the vblank */
-    iso_vblank_hnd = vblank_handler_add(iso_vblank);
+    iso_vblank_hnd = vblank_handler_add(iso_vblank, NULL);
 
     /* Register with VFS */
     return nmmgr_handler_add(&vh.nmmgr);

--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -928,10 +928,11 @@ int iso_reset(void) {
    time someone calls in it'll get reset. */
 static int iso_last_status;
 static int iso_vblank_hnd;
-static void iso_vblank(uint32 evt) {
+static void iso_vblank(uint32 evt, void *data) {
     int status, disc_type;
 
     (void)evt;
+    (void)data;
 
     /* Get the status. This may fail if a CD operation is in
        progress in the foreground. */

--- a/kernel/arch/dreamcast/hardware/asic.c
+++ b/kernel/arch/dreamcast/hardware/asic.c
@@ -229,3 +229,8 @@ void asic_init(void) {
 void asic_shutdown(void) {
     asic_evt_shutdown();
 }
+
+void asic_evt_remove_handler(uint16_t code)
+{
+    asic_evt_set_handler(code, NULL);
+}

--- a/kernel/arch/dreamcast/hardware/asic.c
+++ b/kernel/arch/dreamcast/hardware/asic.c
@@ -110,13 +110,19 @@
 #define ASIC_EVT_REGS 3
 #define ASIC_EVT_REG_HNDS 32
 
+typedef struct {
+    asic_evt_handler hdl;
+    void *data;
+} asic_evt_handler_entry_t;
+
 /* Exception table -- this table matches each potential G2 event to a function
    pointer. If the pointer is null, then nothing happens. Otherwise, the
    function will handle the exception. */
-static asic_evt_handler asic_evt_handlers[ASIC_EVT_REGS][ASIC_EVT_REG_HNDS];
+static asic_evt_handler_entry_t
+asic_evt_handlers[ASIC_EVT_REGS][ASIC_EVT_REG_HNDS];
 
 /* Set a handler, or remove a handler */
-void asic_evt_set_handler(uint16_t code, asic_evt_handler hnd) {
+void asic_evt_set_handler(uint16_t code, asic_evt_handler hnd, void *data) {
     uint8_t evtreg, evt;
 
     evtreg = (code >> 8) & 0xff;
@@ -124,13 +130,14 @@ void asic_evt_set_handler(uint16_t code, asic_evt_handler hnd) {
 
     assert((evtreg < ASIC_EVT_REGS) && (evt < ASIC_EVT_REG_HNDS));
 
-    asic_evt_handlers[evtreg][evt] = hnd;
+    asic_evt_handlers[evtreg][evt] = (asic_evt_handler_entry_t){ hnd, data };
 }
 
 /* The ASIC event handler; this is called from the global IRQ handler
    to handle external IRQ 9. */
 static void handler_irq9(irq_t source, irq_context_t *context, void *data) {
-    const asic_evt_handler (*const handlers)[ASIC_EVT_REG_HNDS] = data;
+    const asic_evt_handler_entry_t (*const handlers)[ASIC_EVT_REG_HNDS] = data;
+    const asic_evt_handler_entry_t *entry;
     uint8_t reg, i;
 
     (void)source;
@@ -147,9 +154,10 @@ static void handler_irq9(irq_t source, irq_context_t *context, void *data) {
 
         /* Search for relevant handlers */
         for(i = 0; i < ASIC_EVT_REG_HNDS; i++) {
-            if((mask & (1 << i)) && handlers[reg][i] != NULL) {
-                handlers[reg][i]((reg << 8) | i);
-            }
+            entry = &handlers[reg][i];
+
+            if((mask & (1 << i)) && entry->hdl != NULL)
+                entry->hdl((reg << 8) | i, entry->data);
         }
     }
 }
@@ -232,5 +240,5 @@ void asic_shutdown(void) {
 
 void asic_evt_remove_handler(uint16_t code)
 {
-    asic_evt_set_handler(code, NULL);
+    asic_evt_set_handler(code, NULL, NULL);
 }

--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -211,9 +211,10 @@ inline int g1_ata_mutex_unlock(void) {
     return mutex_unlock(&_g1_ata_mutex);
 }
 
-static void g1_dma_irq_hnd(uint32 code) {
+static void g1_dma_irq_hnd(uint32 code, void *data) {
     /* XXXX: Probably should look at the code to make sure it isn't an error. */
     (void)code;
+    (void)data;
 
     if(dma_in_progress) {
         /* Signal the calling thread to continue, if it is blocking. */
@@ -1388,11 +1389,11 @@ int g1_ata_init(void) {
     }
 
     /* Hook all the DMA related events. */
-    asic_evt_set_handler(ASIC_EVT_GD_DMA, g1_dma_irq_hnd);
+    asic_evt_set_handler(ASIC_EVT_GD_DMA, g1_dma_irq_hnd, NULL);
     asic_evt_enable(ASIC_EVT_GD_DMA, ASIC_IRQB);
-    asic_evt_set_handler(ASIC_EVT_GD_DMA_OVERRUN, g1_dma_irq_hnd);
+    asic_evt_set_handler(ASIC_EVT_GD_DMA_OVERRUN, g1_dma_irq_hnd, NULL);
     asic_evt_enable(ASIC_EVT_GD_DMA_OVERRUN, ASIC_IRQB);
-    asic_evt_set_handler(ASIC_EVT_GD_DMA_ILLADDR, g1_dma_irq_hnd);
+    asic_evt_set_handler(ASIC_EVT_GD_DMA_ILLADDR, g1_dma_irq_hnd, NULL);
     asic_evt_enable(ASIC_EVT_GD_DMA_ILLADDR, ASIC_IRQB);
 
     initted = 1;
@@ -1415,9 +1416,9 @@ void g1_ata_shutdown(void) {
 
     /* Unhook the events and disable the IRQs. */
     asic_evt_disable(ASIC_EVT_GD_DMA, ASIC_IRQB);
-    asic_evt_set_handler(ASIC_EVT_GD_DMA, NULL);
+    asic_evt_remove_handler(ASIC_EVT_GD_DMA);
     asic_evt_disable(ASIC_EVT_GD_DMA_OVERRUN, ASIC_IRQB);
-    asic_evt_set_handler(ASIC_EVT_GD_DMA_OVERRUN, NULL);
+    asic_evt_remove_handler(ASIC_EVT_GD_DMA_OVERRUN);
     asic_evt_disable(ASIC_EVT_GD_DMA_ILLADDR, ASIC_IRQB);
-    asic_evt_set_handler(ASIC_EVT_GD_DMA_ILLADDR, NULL);
+    asic_evt_remove_handler(ASIC_EVT_GD_DMA_ILLADDR);
 }

--- a/kernel/arch/dreamcast/hardware/g2dma.c
+++ b/kernel/arch/dreamcast/hardware/g2dma.c
@@ -128,8 +128,10 @@ inline static void dma_disable(uint32_t chn) {
     g2_dma->dma[chn].start = 0;
 }
 
-static void g2_dma_irq_hnd(uint32_t code) {
+static void g2_dma_irq_hnd(uint32_t code, void *data) {
     int chn = code - ASIC_EVT_G2_DMA0;
+
+    (void)data;
 
     if(chn < G2_DMA_CHAN_SPU || chn > G2_DMA_CHAN_CH3) {
         dbglog(DBG_ERROR, "g2_dma: Wrong channel received in g2_dma_irq_hnd");
@@ -224,7 +226,7 @@ int g2_dma_init(void) {
         dma_cbdata[i] = 0;
 
         /* Hook the interrupt */
-        asic_evt_set_handler(ASIC_EVT_G2_DMA0 + i, g2_dma_irq_hnd);
+        asic_evt_set_handler(ASIC_EVT_G2_DMA0 + i, g2_dma_irq_hnd, NULL);
         asic_evt_enable(ASIC_EVT_G2_DMA0 + i, ASIC_IRQB);
     }
 
@@ -246,7 +248,7 @@ void g2_dma_shutdown(void) {
     for(i = 0; i < 4; i++) {
         /* Unhook the G2 interrupt */
         asic_evt_disable(ASIC_EVT_G2_DMA0 + i, ASIC_IRQB);
-        asic_evt_set_handler(ASIC_EVT_G2_DMA0 + i, NULL);
+        asic_evt_remove_handler(ASIC_EVT_G2_DMA0 + i);
 
         /* Destroy the semaphore */
         sem_destroy(&dma_done[i]);

--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -49,7 +49,7 @@ void cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb) {
 }
 
 /* Response callback for the GETCOND Maple command. */
-static void cont_reply(maple_frame_t *frm) {
+static void cont_reply(maple_state_t *, maple_frame_t *frm) {
     maple_response_t *resp;
     uint32_t         *respbuf;
     cont_cond_t      *raw;

--- a/kernel/arch/dreamcast/hardware/maple/dreameye.c
+++ b/kernel/arch/dreamcast/hardware/maple/dreameye.c
@@ -19,7 +19,7 @@ static int dreameye_send_get_image(maple_device_t *dev,
 
 static dreameye_state_t *first_state = NULL;
 
-static void dreameye_get_image_count_cb(maple_frame_t *frame) {
+static void dreameye_get_image_count_cb(maple_state_t *, maple_frame_t *frame) {
     dreameye_state_t *de;
     maple_response_t *resp;
     uint32 *respbuf32;
@@ -59,7 +59,7 @@ static void dreameye_get_image_count_cb(maple_frame_t *frame) {
     genwait_wake_all(frame);
 }
 
-static void dreameye_get_transfer_count_cb(maple_frame_t *frame) {
+static void dreameye_get_transfer_count_cb(maple_state_t *, maple_frame_t *frame) {
     dreameye_state_t *de;
     maple_response_t *resp;
     uint32 *respbuf32;
@@ -139,7 +139,7 @@ int dreameye_get_image_count(maple_device_t *dev, int block) {
     return MAPLE_EOK;
 }
 
-static void dreameye_get_image_cb(maple_frame_t *frame) {
+static void dreameye_get_image_cb(maple_state_t *, maple_frame_t *frame) {
     maple_device_t *dev;
     maple_response_t *resp;
     uint32 *respbuf32;
@@ -327,7 +327,7 @@ fail:
     return MAPLE_EFAIL;
 }
 
-static void dreameye_erase_cb(maple_frame_t *frame) {
+static void dreameye_erase_cb(maple_state_t *, maple_frame_t *frame) {
     maple_response_t *resp;
     uint8 *respbuf;
 

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -521,7 +521,7 @@ static void kbd_check_poll(maple_frame_t *frm) {
     }
 }
 
-static void kbd_reply(maple_frame_t *frm) {
+static void kbd_reply(maple_state_t *, maple_frame_t *frm) {
     maple_response_t *resp;
     uint32 *respbuf;
     kbd_state_t *state;

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -95,7 +95,7 @@ static void maple_hw_init(void) {
     maple_bus_enable();
 
     /* Hook the necessary interrupts */
-    maple_state.vbl_handle = vblank_handler_add(maple_vbl_irq_hnd);
+    maple_state.vbl_handle = vblank_handler_add(maple_vbl_irq_hnd, NULL);
     asic_evt_set_handler(ASIC_EVT_MAPLE_DMA, maple_dma_irq_hnd, NULL);
     asic_evt_enable(ASIC_EVT_MAPLE_DMA, ASIC_IRQ_DEFAULT);
 }

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -96,7 +96,7 @@ static void maple_hw_init(void) {
 
     /* Hook the necessary interrupts */
     maple_state.vbl_handle = vblank_handler_add(maple_vbl_irq_hnd);
-    asic_evt_set_handler(ASIC_EVT_MAPLE_DMA, maple_dma_irq_hnd);
+    asic_evt_set_handler(ASIC_EVT_MAPLE_DMA, maple_dma_irq_hnd, NULL);
     asic_evt_enable(ASIC_EVT_MAPLE_DMA, ASIC_IRQ_DEFAULT);
 }
 
@@ -108,7 +108,7 @@ void maple_hw_shutdown(void) {
 
     /* Unhook interrupts */
     vblank_handler_remove(maple_state.vbl_handle);
-    asic_evt_set_handler(ASIC_EVT_MAPLE_DMA, NULL);
+    asic_evt_remove_handler(ASIC_EVT_MAPLE_DMA);
     asic_evt_disable(ASIC_EVT_MAPLE_DMA, ASIC_IRQ_DEFAULT);
 
     /* Stop any existing maple DMA and shut down the bus */

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -95,8 +95,8 @@ static void maple_hw_init(void) {
     maple_bus_enable();
 
     /* Hook the necessary interrupts */
-    maple_state.vbl_handle = vblank_handler_add(maple_vbl_irq_hnd, NULL);
-    asic_evt_set_handler(ASIC_EVT_MAPLE_DMA, maple_dma_irq_hnd, NULL);
+    maple_state.vbl_handle = vblank_handler_add(maple_vbl_irq_hnd, &maple_state);
+    asic_evt_set_handler(ASIC_EVT_MAPLE_DMA, maple_dma_irq_hnd, &maple_state);
     asic_evt_enable(ASIC_EVT_MAPLE_DMA, ASIC_IRQ_DEFAULT);
 }
 

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -19,13 +19,13 @@
 /* VBlank IRQ handler */
 
 /* Fwd declare */
-static void vbl_autodet_callback(maple_frame_t *);
+static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm);
 
 /* Send a DEVINFO command for the given port/unit */
-static void vbl_send_devinfo(int p, int u) {
+static void vbl_send_devinfo(maple_state_t *state, int p, int u) {
     maple_device_t * dev;
 
-    dev = &maple_state.ports[p].units[u];
+    dev = &state->ports[p].units[u];
 
     /* Reserve access; if we don't get it, forget about it */
     if(maple_frame_lock(&dev->frame) < 0)
@@ -42,25 +42,25 @@ static void vbl_send_devinfo(int p, int u) {
 
 /* Do a potential disconnect on the named device (check to make sure it
    was connected first) */
-static void vbl_chk_disconnect(int p, int u) {
-    if(maple_state.ports[p].units[u].valid) {
+static void vbl_chk_disconnect(maple_state_t *state, int p, int u) {
+    if(state->ports[p].units[u].valid) {
 #if MAPLE_IRQ_DEBUG
         dbglog(DBG_KDEBUG, "maple: detach on device %c%c\n",
                'A' + p, '0' + u);
 #endif
 
         if(maple_driver_detach(p, u) >= 0) {
-            assert(!maple_state.ports[p].units[u].valid);
+            assert(!state->ports[p].units[u].valid);
         }
     }
 }
 
 /* Check the sub-devices for a top-level port */
-static void vbl_chk_subdevs(int p, uint8 newmask) {
+static void vbl_chk_subdevs(maple_state_t *state, int p, uint8 newmask) {
     int oldmask, chkmask, u;
 
     /* Get the old mask */
-    oldmask = maple_state.ports[p].units[0].dev_mask;
+    oldmask = state->ports[p].units[0].dev_mask;
 
     /* Is it different from the new mask? */
     if(oldmask != newmask) {
@@ -73,16 +73,16 @@ static void vbl_chk_subdevs(int p, uint8 newmask) {
                device. Do a driver detach on it. */
             if(!(oldmask & chkmask) && (newmask & chkmask)) {
                 /* Send a further query */
-                vbl_send_devinfo(p, u);
+                vbl_send_devinfo(state, p, u);
             }
             else if((oldmask & chkmask) && !(newmask & chkmask)) {
                 /* Do a disconnect */
-                vbl_chk_disconnect(p, u);
+                vbl_chk_disconnect(state, p, u);
             }
         }
 
         /* Update with the new sub-dev mask */
-        maple_state.ports[p].units[0].dev_mask = newmask;
+        state->ports[p].units[0].dev_mask = newmask;
     }
 }
 
@@ -96,7 +96,7 @@ static void vbl_chk_subdevs(int p, uint8 newmask) {
    but that might complicate things if we're swapping device structures
    around in the middle of a list traversal, so we do it here as a
    special case instead. */
-static void vbl_autodet_callback(maple_frame_t * frm) {
+static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     maple_response_t    *resp;
     int         p, u;
 
@@ -110,26 +110,26 @@ static void vbl_autodet_callback(maple_frame_t * frm) {
         if(u == 0) {
             /* Top-level device -- detach all sub-devices as well */
             for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-                vbl_chk_disconnect(p, u);
+                vbl_chk_disconnect(state, p, u);
             }
 
-            maple_state.ports[p].units[0].dev_mask = 0;
+            state->ports[p].units[0].dev_mask = 0;
         }
         else {
             /* Not a top-level device -- only detach this device */
-            vbl_chk_disconnect(p, u);
+            vbl_chk_disconnect(state, p, u);
         }
     }
     else if(resp->response == MAPLE_RESPONSE_DEVINFO) {
         /* Device is present, check for connections */
-        if(!maple_state.ports[p].units[u].valid) {
+        if(!state->ports[p].units[u].valid) {
 #if MAPLE_IRQ_DEBUG
             dbglog(DBG_KDEBUG, "maple: attach on device %c%c\n",
                    'A' + p, '0' + u);
 #endif
 
             if(maple_driver_attach(frm) >= 0) {
-                assert(maple_state.ports[p].units[u].valid);
+                assert(state->ports[p].units[u].valid);
             }
         }
         else {
@@ -137,7 +137,7 @@ static void vbl_autodet_callback(maple_frame_t * frm) {
             maple_device_t      *dev;
             /* Device already connected, update function data (caps) */
             devinfo = (maple_devinfo_t *)resp->data;
-            dev = &maple_state.ports[p].units[u];
+            dev = &state->ports[p].units[u];
             dev->info.function_data[0] = devinfo->function_data[0];
             dev->info.function_data[1] = devinfo->function_data[1];
             dev->info.function_data[2] = devinfo->function_data[2];
@@ -146,7 +146,7 @@ static void vbl_autodet_callback(maple_frame_t * frm) {
         /* If this is a top-level port, then also check any
            sub-devices that claim to be attached */
         if(u == 0)
-            vbl_chk_subdevs(p, resp->src_addr);
+            vbl_chk_subdevs(state, p, resp->src_addr);
     }
     else {
         /* dbglog(DBG_KDEBUG, "maple: unknown response %d on device %c%c\n",
@@ -157,50 +157,50 @@ static void vbl_autodet_callback(maple_frame_t * frm) {
 }
 
 /* Move on to the next device for next time */
-static void vbl_ad_advance(void) {
-    maple_state.detect_port_next++;
+static void vbl_ad_advance(maple_state_t *state) {
+    state->detect_port_next++;
 
-    if(maple_state.detect_port_next >= MAPLE_PORT_COUNT) {
-        maple_state.detect_port_next = 0;
-        maple_state.detect_wrapped++;
+    if(state->detect_port_next >= MAPLE_PORT_COUNT) {
+        state->detect_port_next = 0;
+        state->detect_wrapped++;
     }
 }
 
-static void vbl_autodetect(void) {
+static void vbl_autodetect(maple_state_t *state) {
     int p, u;
 
     /* Queue a detection on the next device */
-    p = maple_state.detect_port_next;
-    u = maple_state.detect_unit_next;
-    vbl_send_devinfo(p, u);
+    p = state->detect_port_next;
+    u = state->detect_unit_next;
+    vbl_send_devinfo(state, p, u);
 
     /* Move to the next device */
-    vbl_ad_advance();
+    vbl_ad_advance(state);
 }
 
 /* Called on every VBL (~60fps) */
 void maple_vbl_irq_hnd(uint32 code, void *data) {
+    maple_state_t *state = data;
     maple_driver_t *drv;
 
     (void)code;
-    (void)data;
 
     /* dbgio_write_str("inside vbl_irq_hnd\n"); */
 
     /* Count, for fun and profit */
-    maple_state.vbl_cntr++;
+    state->vbl_cntr++;
 
     /* Autodetect changed devices */
-    vbl_autodetect();
+    vbl_autodetect(state);
 
     /* Call all registered drivers' periodic callbacks */
-    LIST_FOREACH(drv, &maple_state.driver_list, drv_list) {
+    LIST_FOREACH(drv, &state->driver_list, drv_list) {
         if(drv->periodic != NULL)
             drv->periodic(drv);
     }
 
     /* Send any queued data */
-    if(!maple_state.dma_in_progress)
+    if(!state->dma_in_progress)
         maple_queue_flush();
 
     /* dbgio_write_str("finish vbl_irq_hnd\n"); */
@@ -211,27 +211,27 @@ void maple_vbl_irq_hnd(uint32 code, void *data) {
 
 /* Called after a Maple DMA send / receive pair completes */
 void maple_dma_irq_hnd(uint32 code, void *data) {
+    maple_state_t *state = data;
     maple_frame_t   *i;
     int8        resp;
     uint32 gun;
 
     (void)code;
-    (void)data;
 
     /* dbgio_write_str("start dma_irq_hnd\n"); */
 
     /* Count, for fun and profit */
-    maple_state.dma_cntr++;
+    state->dma_cntr++;
 
     /* ACK the receipt */
-    maple_state.dma_in_progress = 0;
+    state->dma_in_progress = 0;
 
 #if MAPLE_DMA_DEBUG
-    maple_sentinel_verify("maple_state.dma_buffer", maple_state.dma_buffer, MAPLE_DMA_SIZE);
+    maple_sentinel_verify("state->dma_buffer", state->dma_buffer, MAPLE_DMA_SIZE);
 #endif
 
     /* For each queued frame, call its callback if it's done */
-    TAILQ_FOREACH(i, &maple_state.frame_queue, frameq) {
+    TAILQ_FOREACH(i, &state->frame_queue, frameq) {
         /* Skip any unsent or stale items */
         if(i->state != MAPLE_FRAME_SENT)
             continue;
@@ -259,17 +259,17 @@ void maple_dma_irq_hnd(uint32 code, void *data) {
         /* If it's got a callback, call it; otherwise unlock
            it manually (or it'll never get used again) */
         if(i->callback != NULL)
-            i->callback(i);
+            i->callback(state, i);
         else
             maple_frame_unlock(i);
     }
 
     /* If gun mode is enabled, read the latched H/V counter values. */
-    if(maple_state.gun_port > -1) {
+    if(state->gun_port > -1) {
         gun = PVR_GET(PVR_GUN_POS);
-        maple_state.gun_x = gun & 0x3ff;
-        maple_state.gun_y = (gun >> 16) & 0x3ff;
-        maple_state.gun_port = -1;
+        state->gun_x = gun & 0x3ff;
+        state->gun_y = (gun >> 16) & 0x3ff;
+        state->gun_port = -1;
     }
 
     /* dbgio_write_str("finish dma_irq_hnd\n"); */

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -179,10 +179,11 @@ static void vbl_autodetect(void) {
 }
 
 /* Called on every VBL (~60fps) */
-void maple_vbl_irq_hnd(uint32 code) {
+void maple_vbl_irq_hnd(uint32 code, void *data) {
     maple_driver_t *drv;
 
     (void)code;
+    (void)data;
 
     /* dbgio_write_str("inside vbl_irq_hnd\n"); */
 
@@ -209,12 +210,13 @@ void maple_vbl_irq_hnd(uint32 code) {
 /* Maple DMA completion handler */
 
 /* Called after a Maple DMA send / receive pair completes */
-void maple_dma_irq_hnd(uint32 code) {
+void maple_dma_irq_hnd(uint32 code, void *data) {
     maple_frame_t   *i;
     int8        resp;
     uint32 gun;
 
     (void)code;
+    (void)data;
 
     /* dbgio_write_str("start dma_irq_hnd\n"); */
 

--- a/kernel/arch/dreamcast/hardware/maple/mouse.c
+++ b/kernel/arch/dreamcast/hardware/maple/mouse.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <assert.h>
 
-static void mouse_reply(maple_frame_t *frm) {
+static void mouse_reply(maple_state_t *, maple_frame_t *frm) {
     maple_response_t    *resp;
     uint32          *respbuf;
     mouse_cond_t        *raw;

--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -14,7 +14,7 @@
 /* Be warned, not all purus are created equal, in fact, most of
    them act different for just about everything you feed to them. */
 
-static void purupuru_rumble_cb(maple_frame_t *frame) {
+static void purupuru_rumble_cb(maple_state_t *, maple_frame_t *frame) {
     /* Unlock the frame */
     maple_frame_unlock(frame);
 

--- a/kernel/arch/dreamcast/hardware/maple/sip.c
+++ b/kernel/arch/dreamcast/hardware/maple/sip.c
@@ -15,7 +15,7 @@
 
 #define SIP_START_SAMPLING 0x80
 
-static void sip_start_sampling_cb(maple_frame_t *frame) {
+static void sip_start_sampling_cb(maple_state_t *, maple_frame_t *frame) {
     sip_state_t *sip;
     maple_response_t *resp;
 
@@ -36,7 +36,7 @@ static void sip_start_sampling_cb(maple_frame_t *frame) {
     genwait_wake_all(frame);
 }
 
-static void sip_stop_sampling_cb(maple_frame_t *frame) {
+static void sip_stop_sampling_cb(maple_state_t *, maple_frame_t *frame) {
     sip_state_t *sip;
     maple_response_t *resp;
 
@@ -207,7 +207,7 @@ int sip_stop_sampling(maple_device_t *dev, int block) {
     return MAPLE_EOK;
 }
 
-static void sip_reply(maple_frame_t *frm) {
+static void sip_reply(maple_state_t *, maple_frame_t *frm) {
     maple_response_t *resp;
     uint32 *respbuf;
     sip_state_t *sip;

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -63,7 +63,7 @@ static int vmu_attach(maple_driver_t *drv, maple_device_t *dev) {
     return 0;
 }
 
-static void vmu_poll_reply(maple_frame_t *frm) { 
+static void vmu_poll_reply(maple_state_t *, maple_frame_t *frm) {
     maple_response_t   *resp;
     uint32_t           *respbuf;
     vmu_cond_t         *raw;
@@ -264,7 +264,7 @@ int vmu_set_icon_shape(maple_device_t *dev, uint8_t icon_shape) {
    can stay the same */
 
 /* Callback that unlocks the frame, general use */
-static void vmu_gen_callback(maple_frame_t *frame) {
+static void vmu_gen_callback(maple_state_t *, maple_frame_t *frame) {
     /* Unlock the frame for the next usage */
     maple_frame_unlock(frame);
 
@@ -412,7 +412,7 @@ void vmu_set_icon(const char *vmu_icon) {
 /* Read the data in block blocknum into buffer, return a -1
    if an error occurs, for now we ignore MAPLE_RESPONSE_FILEERR,
    which will be changed shortly */
-static void vmu_block_read_callback(maple_frame_t *frm) {
+static void vmu_block_read_callback(maple_state_t *, maple_frame_t *frm) {
     /* Wakey, wakey! */
     genwait_wake_all(frm);
 }
@@ -486,7 +486,7 @@ int vmu_block_read(maple_device_t *dev, uint16_t blocknum, uint8_t *buffer) {
 
 /* writes buffer into block blocknum.  ret a -1 on error.  We don't do anything about the
    maple bus returning file errors, etc, right now, but that will change soon. */
-static void vmu_block_write_callback(maple_frame_t *frm) {
+static void vmu_block_write_callback(maple_state_t *, maple_frame_t *frm) {
     /* Reset the frame status (but still keep it for us to use) */
     frm->state = MAPLE_FRAME_UNSENT;
 
@@ -661,7 +661,7 @@ int vmu_set_datetime(maple_device_t *dev, time_t unix) {
     return MAPLE_EOK;
 }
 
-static void vmu_get_datetime_callback(maple_frame_t *frm) {
+static void vmu_get_datetime_callback(maple_state_t *, maple_frame_t *frm) {
     /* Wakey, wakey! */
     genwait_wake_all(frm);
 }

--- a/kernel/arch/dreamcast/hardware/modem/mintr.c
+++ b/kernel/arch/dreamcast/hardware/modem/mintr.c
@@ -577,8 +577,9 @@ void modemConnection(void) {
     }
 }
 
-static void modemCallback(uint32 code) {
+static void modemCallback(uint32 code, void *data) {
     (void)code;
+    (void)data;
 
     if(modemCallbackCode != NULL)
         modemCallbackCode();
@@ -597,13 +598,13 @@ void modemIntInit(void) {
 
     /* Set the default IRQ handler */
     modemCallbackCode = NULL;
-    asic_evt_set_handler(ASIC_EVT_EXP_8BIT, modemCallback);
+    asic_evt_set_handler(ASIC_EVT_EXP_8BIT, modemCallback, NULL);
     asic_evt_enable(ASIC_EVT_EXP_8BIT, ASIC_IRQB);
 }
 
 void modemIntShutdown(void) {
     asic_evt_disable(ASIC_EVT_EXP_8BIT, ASIC_IRQB);
-    asic_evt_set_handler(ASIC_EVT_EXP_8BIT, NULL);
+    asic_evt_remove_handler(ASIC_EVT_EXP_8BIT);
 }
 
 #define dspSetClear8(addr, mask, clear)\

--- a/kernel/arch/dreamcast/hardware/modem/mintr.c
+++ b/kernel/arch/dreamcast/hardware/modem/mintr.c
@@ -746,9 +746,11 @@ void modemIntResetControlCode(void) {
    a flag to a non zero value, call a function, or both when a timer interrupt
    is generated until it's stopped. */
 
-static void modemIntrTimeoutCallback(irq_t source, irq_context_t *context) {
+static void modemIntrTimeoutCallback(irq_t source, irq_context_t *context,
+                                     void *data) {
     (void)source;
     (void)context;
+    (void)data;
 
     if(modemTimeoutCallbackFlag != NULL)
         *modemTimeoutCallbackFlag = 1;
@@ -770,7 +772,7 @@ void modemIntSetupTimeoutTimer(int bps, unsigned char *callbackFlag,
         *modemTimeoutCallbackFlag = 0;
 
     /* Modify TMU1 so that it can be used for a timeout */
-    irq_set_handler(EXC_TMU1_TUNI1, modemIntrTimeoutCallback);
+    irq_set_handler(EXC_TMU1_TUNI1, modemIntrTimeoutCallback, NULL);
     timer_prime(TMU1, bps, 1);
     timer_clear(TMU1);
 
@@ -800,7 +802,7 @@ void modemIntShutdownTimeoutTimer(void) {
     modemIntResetTimeoutTimer();
 
     if(modemInternalFlags & MODEM_INTERNAL_FLAG_TIMER_HANDLER_SET) {
-        irq_set_handler(EXC_TMU1_TUNI1, NULL);
+        irq_set_handler(EXC_TMU1_TUNI1, NULL, NULL);
         modemInternalFlags &= ~MODEM_INTERNAL_FLAG_TIMER_HANDLER_SET;
     }
 }

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -229,7 +229,7 @@ static volatile int link_stable;
 static eth_rx_callback_t eth_rx_callback;
 
 /* Forward-declaration for IRQ handler */
-static void bba_irq_hnd(uint32 code);
+static void bba_irq_hnd(uint32 code, void *data);
 
 /* Reads the MAC address of the BBA into the specified array */
 void bba_get_mac(uint8 *arr) {
@@ -363,7 +363,7 @@ static int bba_hw_init(void) {
     g2_write_16(NIC(RT_MULTIINTR), 0);
 
     /* Enable G2 interrupts */
-    asic_evt_set_handler(ASIC_EVT_EXP_PCI, bba_irq_hnd);
+    asic_evt_set_handler(ASIC_EVT_EXP_PCI, bba_irq_hnd, NULL);
     asic_evt_enable(ASIC_EVT_EXP_PCI, BBA_ASIC_IRQ);
 
     /* Enable receive interrupts */
@@ -420,7 +420,7 @@ static void bba_hw_shutdown(void) {
 
     /* Disable G2 interrupts */
     asic_evt_disable(ASIC_EVT_EXP_PCI, BBA_ASIC_IRQ);
-    asic_evt_set_handler(ASIC_EVT_EXP_PCI, NULL);
+    asic_evt_remove_handler(ASIC_EVT_EXP_PCI);
 }
 
 static void g2_read_block_8_fast(uint8 *dst, uint8 *src, int len) {
@@ -808,10 +808,11 @@ static void bba_link_change(void) {
 }
 
 /* Ethernet IRQ handler */
-static void bba_irq_hnd(uint32 code) {
+static void bba_irq_hnd(uint32 code, void *data) {
     int intr, hnd;
 
     (void)code;
+    (void)data;
 
     /* Acknowledge 8193 interrupt, except RX ACK bits. We'll handle
        those in the RX int handler. */

--- a/kernel/arch/dreamcast/hardware/network/lan_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/lan_adapter.c
@@ -220,7 +220,7 @@ static int la_started = LA_NOT_STARTED;
 static uint8 la_mac[6];
 
 /* Forward declaration */
-static void la_irq_hnd(uint32 code);
+static void la_irq_hnd(uint32 code, void *data);
 
 /* Set the current bank */
 static void la_set_bank(int bank) {
@@ -390,7 +390,7 @@ static int la_hw_init(void) {
     la_write(DLCR5, (la_read(DLCR5) & ~DLCR5_AM_MASK) | DLCR5_AM_OTHER);
 
     /* Setup interrupt handler */
-    asic_evt_set_handler(ASIC_EVT_EXP_8BIT, la_irq_hnd);
+    asic_evt_set_handler(ASIC_EVT_EXP_8BIT, la_irq_hnd, NULL);
     asic_evt_enable(ASIC_EVT_EXP_8BIT, ASIC_IRQB);
 
     /* Enable receive interrupt */
@@ -436,7 +436,7 @@ static void la_hw_shutdown(void) {
 
     /* Unhook interrupts */
     asic_evt_disable(ASIC_EVT_EXP_8BIT, ASIC_IRQB);
-    asic_evt_set_handler(ASIC_EVT_EXP_8BIT, NULL);
+    asic_evt_remove_handler(ASIC_EVT_EXP_8BIT);
 }
 
 /* We don't really need these stats right now but we might want 'em later */
@@ -528,10 +528,11 @@ static int la_rx(void) {
     }
 }
 
-static void la_irq_hnd(uint32 code) {
+static void la_irq_hnd(uint32 code, void *data) {
     int intr_rx, intr_tx, hnd = 0;
 
     (void)code;
+    (void)data;
 
     /* Acknowledge Lan Adapter interrupt(s) */
     intr_tx = la_read(DLCR0);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
@@ -38,8 +38,9 @@ static vuint32 * const pvr_dma = (vuint32 *)0xa05f6800;
 #define PVR_LMMODE0 0x84/4
 #define PVR_LMMODE1 0x88/4
 
-static void pvr_dma_irq_hnd(uint32_t code) {
+static void pvr_dma_irq_hnd(uint32_t code, void *data) {
     (void)code;
+    (void)data;
 
     if(DMAC_DMATCR2 != 0)
         dbglog(DBG_INFO, "pvr_dma: The dma did not complete successfully\n");
@@ -178,7 +179,7 @@ void pvr_dma_init(void) {
     pvr_dma[PVR_LMMODE1] = 1;
 
     /* Hook the necessary interrupts */
-    asic_evt_set_handler(ASIC_EVT_PVR_DMA, pvr_dma_irq_hnd);
+    asic_evt_set_handler(ASIC_EVT_PVR_DMA, pvr_dma_irq_hnd, NULL);
     asic_evt_enable(ASIC_EVT_PVR_DMA, ASIC_IRQ_DEFAULT);
 }
 
@@ -190,7 +191,7 @@ void pvr_dma_shutdown(void) {
 
     /* Clean up */
     asic_evt_disable(ASIC_EVT_PVR_DMA, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_DMA, NULL);
+    asic_evt_remove_handler(ASIC_EVT_PVR_DMA);
     sem_destroy(&dma_done);
 }
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -142,30 +142,30 @@ int pvr_init(pvr_init_params_t *params) {
     /* Hook the PVR interrupt events on G2 */
     pvr_state.vbl_handle = vblank_handler_add(pvr_int_handler);
     
-    asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEDONE, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEDONE, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_OPAQUEDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEMODDONE, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEMODDONE, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_OPAQUEMODDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_TRANSDONE, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_TRANSDONE, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_TRANSDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_TRANSMODDONE, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_TRANSMODDONE, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_TRANSMODDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_PTDONE, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_PTDONE, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_PTDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE_TSP, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE_TSP, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_RENDERDONE_TSP, ASIC_IRQ_DEFAULT);
 
 #ifdef PVR_RENDER_DBG
     /* Hook up interrupt handlers for error events */
-    asic_evt_set_handler(ASIC_EVT_PVR_ISP_OUTOFMEM, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_ISP_OUTOFMEM, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_ISP_OUTOFMEM, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_STRIP_HALT, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_STRIP_HALT, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_STRIP_HALT, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_OPB_OUTOFMEM, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_OPB_OUTOFMEM, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_OPB_OUTOFMEM, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_ERR, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_ERR, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_TA_INPUT_ERR, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_OVERFLOW, pvr_int_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_OVERFLOW, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_TA_INPUT_OVERFLOW, ASIC_IRQ_DEFAULT);
 #endif
 
@@ -226,17 +226,17 @@ int pvr_shutdown(void) {
 
     /* Unhook any int handlers */
     vblank_handler_remove(pvr_state.vbl_handle);
-    asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEDONE, NULL);
+    asic_evt_remove_handler(ASIC_EVT_PVR_OPAQUEDONE);
     asic_evt_disable(ASIC_EVT_PVR_OPAQUEDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEMODDONE, NULL);
+    asic_evt_remove_handler(ASIC_EVT_PVR_OPAQUEMODDONE);
     asic_evt_disable(ASIC_EVT_PVR_OPAQUEMODDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_TRANSDONE, NULL);
+    asic_evt_remove_handler(ASIC_EVT_PVR_TRANSDONE);
     asic_evt_disable(ASIC_EVT_PVR_TRANSDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_TRANSMODDONE, NULL);
+    asic_evt_remove_handler(ASIC_EVT_PVR_TRANSMODDONE);
     asic_evt_disable(ASIC_EVT_PVR_TRANSMODDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_PTDONE, NULL);
+    asic_evt_remove_handler(ASIC_EVT_PVR_PTDONE);
     asic_evt_disable(ASIC_EVT_PVR_PTDONE, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE_TSP, NULL);
+    asic_evt_remove_handler(ASIC_EVT_PVR_RENDERDONE_TSP);
     asic_evt_disable(ASIC_EVT_PVR_RENDERDONE_TSP, ASIC_IRQ_DEFAULT);
 
     /* Shut down PVR DMA */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -140,7 +140,7 @@ int pvr_init(pvr_init_params_t *params) {
     }
 
     /* Hook the PVR interrupt events on G2 */
-    pvr_state.vbl_handle = vblank_handler_add(pvr_int_handler);
+    pvr_state.vbl_handle = vblank_handler_add(pvr_int_handler, NULL);
     
     asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEDONE, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_OPAQUEDONE, ASIC_IRQ_DEFAULT);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -292,7 +292,7 @@ void pvr_blank_polyhdr_buf(int type, pvr_poly_hdr_t * buf);
 /**** pvr_irq.c *******************************************************/
 
 /* Interrupt handler for PVR events */
-void pvr_int_handler(uint32 code);
+void pvr_int_handler(uint32 code, void *data);
 
 
 #endif

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -77,8 +77,10 @@ static void dma_next_list(void *data) {
     }
 }
 
-void pvr_int_handler(uint32 code) {
+void pvr_int_handler(uint32 code, void *data) {
     int bufn = pvr_state.view_target;
+
+    (void)data;
 
     // What kind of event did we get?
     switch(code) {

--- a/kernel/arch/dreamcast/hardware/scif.c
+++ b/kernel/arch/dreamcast/hardware/scif.c
@@ -103,9 +103,10 @@ static int rb_space_used(void) {
    must look for available data and error conditions, and clear them all
    out if possible. If our internal ring buffer comes close to overflowing,
    the best we can do is twiddle RTS/CTS for a while. */
-static void scif_err_irq(irq_t src, irq_context_t * cxt) {
+static void scif_err_irq(irq_t src, irq_context_t *cxt, void *data) {
     (void)src;
     (void)cxt;
+    (void)data;
 
     /* Clear status bits */
     SCSCR2 &= ~0x08;
@@ -131,9 +132,10 @@ static void scif_err_irq(irq_t src, irq_context_t * cxt) {
     }
 }
 
-static void scif_data_irq(irq_t src, irq_context_t * cxt) {
+static void scif_data_irq(irq_t src, irq_context_t *cxt, void *data) {
     (void)src;
     (void)cxt;
+    (void)data;
 
     /* Clear status bits */
     SCSCR2 &= ~0x40;
@@ -160,9 +162,9 @@ int scif_set_irq_usage(int on) {
 
     if(scif_irq_usage) {
         /* Hook the SCIF interrupt */
-        irq_set_handler(EXC_SCIF_ERI, scif_err_irq);
-        irq_set_handler(EXC_SCIF_BRI, scif_err_irq);
-        irq_set_handler(EXC_SCIF_RXI, scif_data_irq);
+        irq_set_handler(EXC_SCIF_ERI, scif_err_irq, NULL);
+        irq_set_handler(EXC_SCIF_BRI, scif_err_irq, NULL);
+        irq_set_handler(EXC_SCIF_RXI, scif_data_irq, NULL);
         *((vuint16*)0xffd0000c) |= 0x000e << 4;
 
         /* Enable transmit/receive, recv/recv error ints */
@@ -174,9 +176,9 @@ int scif_set_irq_usage(int on) {
 
         /* Unhook the SCIF interrupt */
         *((vuint16*)0xffd0000c) &= ~(0x000e << 4);
-        irq_set_handler(EXC_SCIF_ERI, NULL);
-        irq_set_handler(EXC_SCIF_BRI, NULL);
-        irq_set_handler(EXC_SCIF_RXI, NULL);
+        irq_set_handler(EXC_SCIF_ERI, NULL, NULL);
+        irq_set_handler(EXC_SCIF_BRI, NULL, NULL);
+        irq_set_handler(EXC_SCIF_RXI, NULL, NULL);
     }
 
     return 0;

--- a/kernel/arch/dreamcast/hardware/ubc.c
+++ b/kernel/arch/dreamcast/hardware/ubc.c
@@ -315,10 +315,11 @@ void ubc_clear_breakpoints(void) {
 }
 
 /* Entry-point for UBC-related interrupt handling. */
-static void handle_exception(irq_t code, irq_context_t *irq_ctx) {
+static void handle_exception(irq_t code, irq_context_t *irq_ctx, void *data) {
     bool serviced = false;
 
     (void)code;
+    (void)data;
 
     /* Check if channel B's condition is active. */
     if(BRCR & CMFB) {
@@ -386,8 +387,8 @@ void ubc_init(void) {
     ubc_wait();
 
     /* Install our exception handler for the UBC exception types. */
-    irq_set_handler(EXC_USER_BREAK_PRE, handle_exception);
-    irq_set_handler(EXC_USER_BREAK_POST, handle_exception);
+    irq_set_handler(EXC_USER_BREAK_PRE, handle_exception, NULL);
+    irq_set_handler(EXC_USER_BREAK_POST, handle_exception, NULL);
 }
 
 /* UBC shutdown routine called when exiting KOS. */
@@ -400,7 +401,7 @@ void ubc_shutdown(void) {
     ubc_wait();
 
     /* Uninstall our exception handler from the UBC exception types. */
-    irq_set_handler(EXC_USER_BREAK_PRE, NULL);
-    irq_set_handler(EXC_USER_BREAK_POST, NULL);
+    irq_set_handler(EXC_USER_BREAK_PRE, NULL, NULL);
+    irq_set_handler(EXC_USER_BREAK_POST, NULL, NULL);
 }
 

--- a/kernel/arch/dreamcast/hardware/ubc.c
+++ b/kernel/arch/dreamcast/hardware/ubc.c
@@ -316,21 +316,21 @@ void ubc_clear_breakpoints(void) {
 
 /* Entry-point for UBC-related interrupt handling. */
 static void handle_exception(irq_t code, irq_context_t *irq_ctx, void *data) {
+    struct ubc_channel_state *state = data;
     bool serviced = false;
 
     (void)code;
-    (void)data;
 
     /* Check if channel B's condition is active. */
     if(BRCR & CMFB) {
         bool disable = false;
 
         /* Invoke the user's callback if there is one. */
-        if(channel_state[ubc_channel_b].cb)
-            disable = channel_state[ubc_channel_b].cb(
-                            channel_state[ubc_channel_b].bp,
+        if(state[ubc_channel_b].cb)
+            disable = state[ubc_channel_b].cb(
+                            state[ubc_channel_b].bp,
                             irq_ctx,
-                            channel_state[ubc_channel_b].ud);
+                            state[ubc_channel_b].ud);
 
         /* Check whether the breakpoint should disable itself. */
         if(disable) {
@@ -387,8 +387,8 @@ void ubc_init(void) {
     ubc_wait();
 
     /* Install our exception handler for the UBC exception types. */
-    irq_set_handler(EXC_USER_BREAK_PRE, handle_exception, NULL);
-    irq_set_handler(EXC_USER_BREAK_POST, handle_exception, NULL);
+    irq_set_handler(EXC_USER_BREAK_PRE, handle_exception, channel_state);
+    irq_set_handler(EXC_USER_BREAK_POST, handle_exception, channel_state);
 }
 
 /* UBC shutdown routine called when exiting KOS. */

--- a/kernel/arch/dreamcast/hardware/vblank.c
+++ b/kernel/arch/dreamcast/hardware/vblank.c
@@ -22,6 +22,7 @@ struct vblhnd {
     TAILQ_ENTRY(vblhnd) listent;
     int         id;
     asic_evt_handler    handler;
+    void *data;
 };
 static TAILQ_HEAD(vhlist, vblhnd) vblhnds;
 static int vblid_high;
@@ -30,12 +31,14 @@ static int vblid_high;
 static void vblank_handler(uint32 src, void *data) {
     struct vblhnd * t;
 
+    (void)data;
+
     TAILQ_FOREACH(t, &vblhnds, listent) {
-        t->handler(src, data);
+        t->handler(src, t->data);
     }
 }
 
-int vblank_handler_add(asic_evt_handler hnd) {
+int vblank_handler_add(asic_evt_handler hnd, void *data) {
     struct vblhnd * vh;
     int old;
 
@@ -55,6 +58,7 @@ int vblank_handler_add(asic_evt_handler hnd) {
 
     /* Finish filling the struct */
     vh->handler = hnd;
+    vh->data = data;
 
     /* Add it to the list */
     TAILQ_INSERT_TAIL(&vblhnds, vh, listent);

--- a/kernel/arch/dreamcast/hardware/vblank.c
+++ b/kernel/arch/dreamcast/hardware/vblank.c
@@ -27,11 +27,11 @@ static TAILQ_HEAD(vhlist, vblhnd) vblhnds;
 static int vblid_high;
 
 /* Our internal IRQ handler */
-static void vblank_handler(uint32 src) {
+static void vblank_handler(uint32 src, void *data) {
     struct vblhnd * t;
 
     TAILQ_FOREACH(t, &vblhnds, listent) {
-        t->handler(src);
+        t->handler(src, data);
     }
 }
 
@@ -95,7 +95,7 @@ int vblank_init(void) {
     vblid_high = 1;
 
     /* Hook and enable the interrupt */
-    asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEGIN, vblank_handler);
+    asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEGIN, vblank_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);
 
     return 0;
@@ -106,7 +106,7 @@ int vblank_shutdown(void) {
 
     /* Disable and unhook the interrupt */
     asic_evt_disable(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEGIN, NULL);
+    asic_evt_remove_handler(ASIC_EVT_PVR_VBLANK_BEGIN);
 
     /* Free any allocated handlers */
     c = TAILQ_FIRST(&vblhnds);

--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -274,7 +274,7 @@ typedef uint32_t irq_t;
     \param  source          The IRQ that caused the handler to be called.
     \param  context         The CPU's context.
 */
-typedef void (*irq_handler)(irq_t source, irq_context_t *context);
+typedef void (*irq_handler)(irq_t source, irq_context_t *context, void *data);
 
 /** \brief   Are we inside an interrupt handler?
     \ingroup irqs
@@ -301,11 +301,12 @@ void irq_force_return(void);
     \param  source          The IRQ type to set the handler for
                             (see \ref irq_exception_codes).
     \param  hnd             A pointer to a procedure to handle the exception.
+    \param  data            A pointer that will be passed along to the callback.
     
     \retval 0               On success.
     \retval -1              If the source is invalid.
 */
-int irq_set_handler(irq_t source, irq_handler hnd);
+int irq_set_handler(irq_t source, irq_handler hnd, void *data);
 
 /** \brief   Get the address of the current handler for the IRQ type.
     \ingroup irqs
@@ -321,11 +322,12 @@ irq_handler irq_get_handler(irq_t source);
     
     \param  code            The value passed to the trapa opcode.
     \param  hnd             A pointer to the procedure to handle the trap.
+    \param  data            A pointer that will be passed along to the callback.
 
     \retval 0               On success.
     \retval -1              If the code is invalid (greater than 0xFF).
 */
-int trapa_set_handler(irq_t code, irq_handler hnd);
+int trapa_set_handler(irq_t code, irq_handler hnd, void *data);
 
 /** \brief   Set a global exception handler.
     \ingroup irqs
@@ -337,10 +339,11 @@ int trapa_set_handler(irq_t code, irq_handler hnd);
                             these will stop the unhandled exception error.
 
     \param  hnd             A pointer to the procedure to handle the exception.
+    \param  data            A pointer that will be passed along to the callback.
 
     \retval 0               On success (no error conditions defined).
 */
-int irq_set_global_handler(irq_handler hnd);
+int irq_set_global_handler(irq_handler hnd, void *data);
 
 /** \brief   Get the global exception handler.
     \ingroup irqs

--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -21,6 +21,7 @@
 #ifndef __ARCH_IRQ_H
 #define __ARCH_IRQ_H
 
+#include <stdint.h>
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
@@ -52,18 +53,18 @@ __BEGIN_DECLS
     \headerfile arch/irq.h
 */
 typedef struct irq_context {
-    uint32  pc;         /**< \brief Program counter */
-    uint32  pr;         /**< \brief Procedure register (aka return address) */
-    uint32  gbr;        /**< \brief Global base register */
-    uint32  vbr;        /**< \brief Vector base register */
-    uint32  mach;       /**< \brief Multiply-and-accumulate register (high) */
-    uint32  macl;       /**< \brief Multiply-and-accumulate register (low) */
-    uint32  sr;         /**< \brief Status register */
-    uint32  fpul;       /**< \brief Floatint-point communication register */
-    uint32  fr[16];     /**< \brief Primary floating point registers */
-    uint32  frbank[16]; /**< \brief Secondary floating point registers */
-    uint32  r[16];      /**< \brief 16 general purpose (integer) registers */
-    uint32  fpscr;      /**< \brief Floating-point status/control register */
+    uint32_t  pc;         /**< \brief Program counter */
+    uint32_t  pr;         /**< \brief Procedure register (aka return address) */
+    uint32_t  gbr;        /**< \brief Global base register */
+    uint32_t  vbr;        /**< \brief Vector base register */
+    uint32_t  mach;       /**< \brief Multiply-and-accumulate register (high) */
+    uint32_t  macl;       /**< \brief Multiply-and-accumulate register (low) */
+    uint32_t  sr;         /**< \brief Status register */
+    uint32_t  fpul;       /**< \brief Floatint-point communication register */
+    uint32_t  fr[16];     /**< \brief Primary floating point registers */
+    uint32_t  frbank[16]; /**< \brief Secondary floating point registers */
+    uint32_t  r[16];      /**< \brief 16 general purpose (integer) registers */
+    uint32_t  fpscr;      /**< \brief Floating-point status/control register */
 } irq_context_t __attribute__((aligned(32)));
 
 /* A couple of architecture independent access macros */
@@ -265,7 +266,7 @@ typedef struct irq_context {
 /** \brief   The type of an interrupt identifier 
     \ingroup irqs
 */
-typedef uint32 irq_t;
+typedef uint32_t irq_t;
 
 /** \brief   The type of an IRQ handler
     \ingroup irqs 
@@ -384,8 +385,8 @@ irq_context_t *irq_get_context(void);
                             to the architecture maximum.
     \param  usermode        1 to run the routine in user mode, 0 for supervisor.
 */
-void irq_create_context(irq_context_t *context, uint32 stack_pointer,
-                        uint32 routine, uint32 *args, int usermode);
+void irq_create_context(irq_context_t *context, uint32_t stack_pointer,
+                        uint32_t routine, uint32_t *args, int usermode);
 
 /* Enable/Disable interrupts */
 /** \brief   Disable interrupts.

--- a/kernel/arch/dreamcast/include/dc/asic.h
+++ b/kernel/arch/dreamcast/include/dc/asic.h
@@ -181,9 +181,11 @@ __BEGIN_DECLS
     interrupt context, so don't try anything funny.
 
     \param  code            The ASIC event code that generated this event.
+    \param  data            The user pointer that was passed to
+                            \ref asic_evt_set_handler.
     \see    asic_events
 */
-typedef void (*asic_evt_handler)(uint32_t code);
+typedef void (*asic_evt_handler)(uint32_t code, void *data);
 
 /** \brief   Set or remove an ASIC handler.
     \ingroup asic
@@ -193,9 +195,10 @@ typedef void (*asic_evt_handler)(uint32_t code);
 
     \param  code            The ASIC event code to hook (see \ref asic_events).
     \param  handler         The function to call when the event happens.
+    \param  data            A user pointer that will be passed to the callback.
 
 */
-void asic_evt_set_handler(uint16_t code, asic_evt_handler handler);
+void asic_evt_set_handler(uint16_t code, asic_evt_handler handler, void *data);
 
 /** \brief   Unregister any handler set to the given ASIC event.
     \ingroup asic

--- a/kernel/arch/dreamcast/include/dc/asic.h
+++ b/kernel/arch/dreamcast/include/dc/asic.h
@@ -197,6 +197,14 @@ typedef void (*asic_evt_handler)(uint32_t code);
 */
 void asic_evt_set_handler(uint16_t code, asic_evt_handler handler);
 
+/** \brief   Unregister any handler set to the given ASIC event.
+    \ingroup asic
+
+    \param  code            The ASIC event code to unhook (see
+                            \ref asic_events).
+*/
+void asic_evt_remove_handler(uint16_t code);
+
 /** \brief   Disable all ASIC events.
     \ingroup asic
 

--- a/kernel/arch/dreamcast/include/dc/asic.h
+++ b/kernel/arch/dreamcast/include/dc/asic.h
@@ -200,6 +200,29 @@ typedef void (*asic_evt_handler)(uint32_t code, void *data);
 */
 void asic_evt_set_handler(uint16_t code, asic_evt_handler handler, void *data);
 
+/** \brief   Register a threaded handler with the given ASIC event.
+    \ingroup asic
+
+    This function will spawn a thread, that will sleep until notified when an
+    event happens. It will then call the handler. As the handler is not called
+    in an interrupt context, it can hold locks, and even sleep.
+
+    \param  code            The ASIC event code to hook (see \ref asic_events).
+    \param  handler         The function to call when the event happens.
+    \param  data            A user pointer that will be passed to the callback.
+    \param  ack_and_mask    An optional function that will be called by the real
+                            interrupt handler, to acknowledge and mask the
+                            interrupt, so that it won't trigger again while the
+                            threaded handler is running.
+    \param  unmask          An optional function that will be called by the
+                            thread after the handler function returned, to
+                            re-enable the interrupt.
+*/
+int asic_evt_request_threaded_handler(uint16_t code, asic_evt_handler handler,
+                                      void *data,
+                                      void (*ack_and_mask)(uint16_t),
+                                      void (*unmask)(uint16_t));
+
 /** \brief   Unregister any handler set to the given ASIC event.
     \ingroup asic
 

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -175,6 +175,8 @@ TAILQ_HEAD(maple_frame_queue, maple_frame);
 
 struct maple_driver;
 LIST_HEAD(maple_driver_list, maple_driver);
+
+struct maple_state_str;
 /* \endcond */
 
 /** \brief   Maple frame to be queued for transport.
@@ -200,7 +202,7 @@ typedef struct maple_frame {
 
     struct maple_device *dev;       /**< \brief Does this belong to a device? */
 
-    void (*callback)(struct maple_frame *);     /**< \brief Response callback */
+    void (*callback)(struct maple_state_str *, struct maple_frame *);     /**< \brief Response callback */
 
 #if MAPLE_DMA_DEBUG
     uint8   recv_buf_arr[1024 + 1024 + 32]; /**< \brief Response receive area */

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -756,15 +756,17 @@ void maple_detach_callback(uint32 functions, maple_detach_callback_t cb);
     \ingroup maple
     
     \param  code            The ASIC event code.
+    \param  data            The user pointer associated with this callback.
 */
-void maple_vbl_irq_hnd(uint32 code);
+void maple_vbl_irq_hnd(uint32 code, void *data);
 
 /** \brief   Called after a Maple DMA send / receive pair completes.
     \ingroup maple 
     
     \param  code            The ASIC event code.
+    \param  data            The user pointer associated with this callback.
 */
-void maple_dma_irq_hnd(uint32 code);
+void maple_dma_irq_hnd(uint32 code, void *data);
 
 /**************************************************************************/
 /* maple_enum.c */

--- a/kernel/arch/dreamcast/include/dc/vblank.h
+++ b/kernel/arch/dreamcast/include/dc/vblank.h
@@ -38,10 +38,11 @@ __BEGIN_DECLS
     were passed to the IRQ handler for vblanks.
 
     \param  hnd             The handler to add.
+    \param  data            A user pointer that will be passed to the callback.
     
     \return                 The handle id on success, or <0 on failure.
 */
-int vblank_handler_add(asic_evt_handler hnd);
+int vblank_handler_add(asic_evt_handler hnd, void *data);
 
 /** \brief  Remove a vblank handler.
 

--- a/kernel/arch/dreamcast/kernel/gdb_stub.c
+++ b/kernel/arch/dreamcast/kernel/gdb_stub.c
@@ -912,18 +912,20 @@ static void flushDebugChannel(void) {
     }
 }
 
-static void handle_exception(irq_t code, irq_context_t *context) {
+static void handle_exception(irq_t code, irq_context_t *context, void *data) {
+    (void)data;
     registers = (uint32 *)context;
     gdb_handle_exception(code);
 }
 
-static void handle_user_trapa(irq_t code, irq_context_t *context) {
+static void handle_user_trapa(irq_t code, irq_context_t *context, void *data) {
     (void)code;
+    (void)data;
     registers = (uint32 *)context;
     gdb_handle_exception(EXC_TRAPA);
 }
 
-static void handle_gdb_trapa(irq_t code, irq_context_t *context) {
+static void handle_gdb_trapa(irq_t code, irq_context_t *context, void *data) {
     /*
     * trapa 0x20 indicates a software trap inserted in
     * place of code ... so back up PC by one
@@ -931,6 +933,7 @@ static void handle_gdb_trapa(irq_t code, irq_context_t *context) {
     * later be replaced by its original one!
     */
     (void)code;
+    (void)data;
     registers = (uint32 *)context;
     registers[PC] -= 2;
     gdb_handle_exception(EXC_TRAPA);
@@ -942,14 +945,14 @@ void gdb_init(void) {
     else
         scif_set_parameters(57600, 1);
 
-    irq_set_handler(EXC_ILLEGAL_INSTR, handle_exception);
-    irq_set_handler(EXC_SLOT_ILLEGAL_INSTR, handle_exception);
-    irq_set_handler(EXC_DATA_ADDRESS_READ, handle_exception);
-    irq_set_handler(EXC_DATA_ADDRESS_WRITE, handle_exception);
-    irq_set_handler(EXC_USER_BREAK_PRE, handle_exception);
+    irq_set_handler(EXC_ILLEGAL_INSTR, handle_exception, NULL);
+    irq_set_handler(EXC_SLOT_ILLEGAL_INSTR, handle_exception, NULL);
+    irq_set_handler(EXC_DATA_ADDRESS_READ, handle_exception, NULL);
+    irq_set_handler(EXC_DATA_ADDRESS_WRITE, handle_exception, NULL);
+    irq_set_handler(EXC_USER_BREAK_PRE, handle_exception, NULL);
 
-    trapa_set_handler(32, handle_gdb_trapa);
-    trapa_set_handler(255, handle_user_trapa);
+    trapa_set_handler(32, handle_gdb_trapa, NULL);
+    trapa_set_handler(255, handle_user_trapa, NULL);
 
     BREAKPOINT();
 }

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -79,7 +79,7 @@ int trapa_set_handler(irq_t code, irq_handler hnd) {
 /* Print a kernel panic reg dump */
 extern irq_context_t *irq_srt_addr;
 void irq_dump_regs(int code, int evt) {
-    uint32 *regs = irq_srt_addr->r;
+    uint32_t *regs = irq_srt_addr->r;
     dbglog(DBG_DEAD, "Unhandled exception: PC %08lx, code %d, evt %04x\n",
            irq_srt_addr->pc, code, (uint16)evt);
     dbglog(DBG_DEAD, " R0-R7: %08lx %08lx %08lx %08lx %08lx %08lx %08lx %08lx\n",
@@ -97,13 +97,13 @@ void irq_dump_regs(int code, int evt) {
 /* The C-level routine that processes context switching and other
    types of interrupts. NOTE: We are running on the stack of the process
    that was interrupted! */
-volatile uint32 jiffies = 0;
+volatile uint32_t jiffies = 0;
 void irq_handle_exception(int code) {
     /* Get the exception code */
-    /* volatile uint32 *tra = (uint32*)0xff000020; */
-    volatile uint32 *expevt = (uint32*)0xff000024;
-    volatile uint32 *intevt = (uint32*)0xff000028;
-    uint32 evt = 0;
+    /* volatile uint32_t *tra = (uint32_t*)0xff000020; */
+    volatile uint32_t *expevt = (uint32_t *)0xff000024;
+    volatile uint32_t *intevt = (uint32_t *)0xff000028;
+    uint32_t evt = 0;
     int handled = 0;
 
     /* If it's a code 0, well, we shouldn't be here. */
@@ -186,9 +186,9 @@ void irq_handle_exception(int code) {
 
 void irq_handle_trapa(irq_t code, irq_context_t *context) {
     /* Get the exception code */
-    volatile uint32 *tra = (uint32*)0xff000020;
+    volatile uint32_t *tra = (uint32_t *)0xff000020;
     irq_handler hnd;
-    uint32 vec;
+    uint32_t vec;
 
     (void)code;
 
@@ -223,8 +223,8 @@ irq_context_t *irq_get_context(void) {
 /* Fill a newly allocated context block for usage with supervisor/kernel
    or user mode. The given parameters will be passed to the called routine (up
    to the architecture maximum). */
-void irq_create_context(irq_context_t *context, uint32 stkpntr,
-                        uint32 routine, uint32 *args, int usermode) {
+void irq_create_context(irq_context_t *context, uint32_t stkpntr,
+                        uint32_t routine, uint32_t *args, int usermode) {
     int i;
 
     /* Clear out user and FP regs */
@@ -244,7 +244,7 @@ void irq_create_context(irq_context_t *context, uint32 stkpntr,
     context->fpul = 0;
 
     /* Setup the program frame */
-    context->pc = (uint32)routine;
+    context->pc = (uint32_t)routine;
     context->pr = 0;
     context->sr = 0x40000000;   /* note: need to handle IMASK */
     context->r[15] = stkpntr;
@@ -276,7 +276,7 @@ static void irq_def_fpu(irq_t src, irq_context_t *context) {
 }
 
 /* Pre-init SR and VBR */
-static uint32 pre_sr, pre_vbr;
+static uint32_t pre_sr, pre_vbr;
 
 /* Have we been initialized? */
 static int initted = 0;

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -17,15 +17,21 @@
 #include <kos/thread.h>
 #include <kos/library.h>
 
+struct irq_cb {
+    irq_handler hdl;
+    void *data;
+};
+
 /* Exception table -- this table matches (EXPEVT>>4) to a function pointer.
    If the pointer is null, then nothing happens. Otherwise, the function will
    handle the exception. */
-static irq_handler irq_handlers[0x100];
-static irq_handler trapa_handlers[0x100];
+static struct irq_cb irq_handlers[0x100];
+static struct irq_cb trapa_handlers[0x100];
 
 /* Global exception handler -- hook this if you want to get each and every
    exception; you might get more than you bargained for, but it can be useful. */
 static irq_handler irq_hnd_global;
+static void *irq_hnd_global_data;
 
 /* Default IRQ context location */
 static irq_context_t irq_context_default;
@@ -37,12 +43,12 @@ int irq_inside_int(void) {
 }
 
 /* Set a handler, or remove a handler */
-int irq_set_handler(irq_t code, irq_handler hnd) {
+int irq_set_handler(irq_t code, irq_handler hnd, void *data) {
     /* Make sure they don't do something crackheaded */
     if(code >= 0x1000 || (code & 0x000f)) return -1;
 
     code = code >> 4;
-    irq_handlers[code] = hnd;
+    irq_handlers[code] = (struct irq_cb){ hnd, data };
 
     return 0;
 }
@@ -53,12 +59,13 @@ irq_handler irq_get_handler(irq_t code) {
     if(code >= 0x1000 || (code & 0x000f)) return NULL;
 
     code = code >> 4;
-    return irq_handlers[code];
+    return irq_handlers[code].hdl;
 }
 
 /* Set a global handler */
-int irq_set_global_handler(irq_handler hnd) {
+int irq_set_global_handler(irq_handler hnd, void *data) {
     irq_hnd_global = hnd;
+    irq_hnd_global_data = data;
     return 0;
 }
 
@@ -68,10 +75,10 @@ irq_handler irq_get_global_handler(void) {
 }
 
 /* Set or remove a trapa handler */
-int trapa_set_handler(irq_t code, irq_handler hnd) {
+int trapa_set_handler(irq_t code, irq_handler hnd, void *data) {
     if(code > 0xff) return -1;
 
-    trapa_handlers[code] = hnd;
+    trapa_handlers[code] = (struct irq_cb){ hnd, data };
 
     return 0;
 }
@@ -103,6 +110,7 @@ void irq_handle_exception(int code) {
     /* volatile uint32_t *tra = (uint32_t*)0xff000020; */
     volatile uint32_t *expevt = (uint32_t *)0xff000024;
     volatile uint32_t *intevt = (uint32_t *)0xff000028;
+    const struct irq_cb *hnd;
     uint32_t evt = 0;
     int handled = 0;
 
@@ -116,11 +124,9 @@ void irq_handle_exception(int code) {
     if(code == 3) evt = *intevt;
 
     if(inside_int) {
-        irq_handler hnd = irq_handlers[EXC_DOUBLE_FAULT >> 4];
-
-        if(hnd != NULL) {
-            hnd(EXC_DOUBLE_FAULT, irq_srt_addr);
-        }
+        hnd = &irq_handlers[EXC_DOUBLE_FAULT >> 4];
+        if(hnd->hdl != NULL)
+            hnd->hdl(EXC_DOUBLE_FAULT, irq_srt_addr, hnd->data);
         else
             irq_dump_regs(code, evt);
 
@@ -135,7 +141,7 @@ void irq_handle_exception(int code) {
 
     /* If there's a global handler, call it */
     if(irq_hnd_global) {
-        irq_hnd_global(evt, irq_srt_addr);
+        irq_hnd_global(evt, irq_srt_addr, irq_hnd_global_data);
         handled = 1;
     }
 
@@ -158,20 +164,17 @@ void irq_handle_exception(int code) {
 
     /* If there's a handler, call it */
     {
-        irq_handler hnd = irq_handlers[evt >> 4];
-
-        if(hnd != NULL) {
-            hnd(evt, irq_srt_addr);
+        hnd = &irq_handlers[evt >> 4];
+        if(hnd->hdl != NULL) {
+            hnd->hdl(evt, irq_srt_addr, hnd->data);
             handled = 1;
         }
     }
 
     if(!handled) {
-        irq_handler hnd = irq_handlers[EXC_UNHANDLED_EXC >> 4];
-
-        if(hnd != NULL) {
-            hnd(evt, irq_srt_addr);
-        }
+        hnd = &irq_handlers[EXC_UNHANDLED_EXC >> 4];
+        if(hnd->hdl != NULL)
+            hnd->hdl(evt, irq_srt_addr, hnd->data);
         else
             irq_dump_regs(code, evt);
 
@@ -184,10 +187,10 @@ void irq_handle_exception(int code) {
     inside_int = 0;
 }
 
-void irq_handle_trapa(irq_t code, irq_context_t *context) {
+void irq_handle_trapa(irq_t code, irq_context_t *context, void *data) {
     /* Get the exception code */
     volatile uint32_t *tra = (uint32_t *)0xff000020;
-    irq_handler hnd;
+    const struct irq_cb *hnd, *handlers = data;
     uint32_t vec;
 
     (void)code;
@@ -196,10 +199,10 @@ void irq_handle_trapa(irq_t code, irq_context_t *context) {
     vec = (*tra) >> 2;
 
     /* Check for handler and call if present */
-    hnd = trapa_handlers[vec];
+    hnd = &handlers[vec];
 
-    if(hnd != NULL)
-        hnd(vec, context);
+    if(hnd->hdl != NULL)
+        hnd->hdl(vec, context, hnd->data);
 }
 
 
@@ -264,14 +267,16 @@ void irq_create_context(irq_context_t *context, uint32_t stkpntr,
 }
 
 /* Default timer handler (until threads can take over) */
-static void irq_def_timer(irq_t src, irq_context_t *context) {
+static void irq_def_timer(irq_t src, irq_context_t *context, void *data) {
     (void)src;
     (void)context;
+    (void)data;
 }
 
 /* Default FPU exception handler (can't seem to turn these off) */
-static void irq_def_fpu(irq_t src, irq_context_t *context) {
+static void irq_def_fpu(irq_t src, irq_context_t *context, void *data) {
     (void)src;
+    (void)data;
     context->pc += 2;
 }
 
@@ -296,18 +301,19 @@ int irq_init(void) {
     memset(irq_handlers, 0, sizeof(irq_handlers));
     memset(trapa_handlers, 0, sizeof(trapa_handlers));
     irq_hnd_global = NULL;
+    irq_hnd_global_data = NULL;
 
     /* Default to not in an interrupt */
     inside_int = 0;
 
     /* Set a default timer handler */
-    irq_set_handler(TIMER_IRQ, irq_def_timer);
+    irq_set_handler(TIMER_IRQ, irq_def_timer, NULL);
 
     /* Set a trapa handler */
-    irq_set_handler(EXC_TRAPA, irq_handle_trapa);
+    irq_set_handler(EXC_TRAPA, irq_handle_trapa, trapa_handlers);
 
     /* Set a default FPU exception handler */
-    irq_set_handler(EXC_FPU, irq_def_fpu);
+    irq_set_handler(EXC_FPU, irq_def_fpu, NULL);
 
     /* Set a default context (will be superseded if threads are
        enabled later) */

--- a/kernel/arch/dreamcast/kernel/mmu.c
+++ b/kernel/arch/dreamcast/kernel/mmu.c
@@ -666,12 +666,14 @@ void mmu_gen_tlb_miss(const char *what, irq_t source, irq_context_t *context) {
 }
 
 /* Instruction TLB miss exception */
-static void itlb_miss(irq_t source, irq_context_t *context) {
+static void itlb_miss(irq_t source, irq_context_t *context, void *data) {
+    (void)data;
     mmu_gen_tlb_miss("itlb_miss", source, context);
 }
 
 /* Instruction TLB protection violation */
-static void itlb_pv(irq_t source, irq_context_t *context) {
+static void itlb_pv(irq_t source, irq_context_t *context, void *data) {
+    (void)data;
     dbgio_printf("itlb_pv\n");
     unhandled_mmu(source, context);
 }
@@ -679,29 +681,34 @@ static void itlb_pv(irq_t source, irq_context_t *context) {
 /* Should eventually handle data address read/write here */
 
 /* Data TLB miss (read) */
-static void dtlb_miss_read(irq_t source, irq_context_t *context) {
+static void dtlb_miss_read(irq_t source, irq_context_t *context, void *data) {
+    (void)data;
     mmu_gen_tlb_miss("dtlb_miss_read", source, context);
 }
 
 /* Data TLB miss (write) */
-static void dtlb_miss_write(irq_t source, irq_context_t *context) {
+static void dtlb_miss_write(irq_t source, irq_context_t *context, void *data) {
+    (void)data;
     mmu_gen_tlb_miss("dtlb_miss_write", source, context);
 }
 
 /* Data TLB protection violation (read) */
-static void dtlb_pv_read(irq_t source, irq_context_t *context) {
+static void dtlb_pv_read(irq_t source, irq_context_t *context, void *data) {
+    (void)data;
     dbgio_printf("dtlb_pv_read\n");
     unhandled_mmu(source, context);
 }
 
 /* Data TLB protection violation (write) */
-static void dtlb_pv_write(irq_t source, irq_context_t *context) {
+static void dtlb_pv_write(irq_t source, irq_context_t *context, void *data) {
+    (void)data;
     dbgio_printf("dtlb_pv_write\n");
     unhandled_mmu(source, context);
 }
 
 /* Initial page write exception */
-static void initial_page_write(irq_t source, irq_context_t *context) {
+static void initial_page_write(irq_t source, irq_context_t *context, void *data) {
+    (void)data;
     dbgio_printf("initial_page_write\n");
     unhandled_mmu(source, context);
 }
@@ -723,13 +730,13 @@ int mmu_init(void) {
     mmu_shortcut_ok = 0;
 
     /* Set up interrupt handlers */
-    irq_set_handler(EXC_ITLB_MISS, itlb_miss);
-    irq_set_handler(EXC_ITLB_PV, itlb_pv);
-    irq_set_handler(EXC_DTLB_MISS_READ, dtlb_miss_read);
-    irq_set_handler(EXC_DTLB_MISS_WRITE, dtlb_miss_write);
-    irq_set_handler(EXC_DTLB_PV_READ, dtlb_pv_read);
-    irq_set_handler(EXC_DTLB_PV_WRITE, dtlb_pv_write);
-    irq_set_handler(EXC_INITIAL_PAGE_WRITE, initial_page_write);
+    irq_set_handler(EXC_ITLB_MISS, itlb_miss, NULL);
+    irq_set_handler(EXC_ITLB_PV, itlb_pv, NULL);
+    irq_set_handler(EXC_DTLB_MISS_READ, dtlb_miss_read, NULL);
+    irq_set_handler(EXC_DTLB_MISS_WRITE, dtlb_miss_write, NULL);
+    irq_set_handler(EXC_DTLB_PV_READ, dtlb_pv_read, NULL);
+    irq_set_handler(EXC_DTLB_PV_WRITE, dtlb_pv_write, NULL);
+    irq_set_handler(EXC_INITIAL_PAGE_WRITE, initial_page_write, NULL);
 
     /* Turn on MMU */
     /* URB=0x3f, URC=0, SQMD=1, SV=0, TI=1, AT=1 */
@@ -751,11 +758,11 @@ void mmu_shutdown(void) {
     mmu_shortcut_ok = 0;
 
     /* Unhook the IRQ handlers */
-    irq_set_handler(EXC_ITLB_MISS, NULL);
-    irq_set_handler(EXC_ITLB_PV, NULL);
-    irq_set_handler(EXC_DTLB_MISS_READ, NULL);
-    irq_set_handler(EXC_DTLB_MISS_WRITE, NULL);
-    irq_set_handler(EXC_DTLB_PV_READ, NULL);
-    irq_set_handler(EXC_DTLB_PV_WRITE, NULL);
-    irq_set_handler(EXC_INITIAL_PAGE_WRITE, NULL);
+    irq_set_handler(EXC_ITLB_MISS, NULL, NULL);
+    irq_set_handler(EXC_ITLB_PV, NULL, NULL);
+    irq_set_handler(EXC_DTLB_MISS_READ, NULL, NULL);
+    irq_set_handler(EXC_DTLB_MISS_WRITE, NULL, NULL);
+    irq_set_handler(EXC_DTLB_PV_READ, NULL, NULL);
+    irq_set_handler(EXC_DTLB_PV_WRITE, NULL, NULL);
+    irq_set_handler(EXC_INITIAL_PAGE_WRITE, NULL, NULL);
 }

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -196,9 +196,10 @@ static          uint32_t timer_ms_countdown;
 
 /* TMU2 interrupt handler, called every second. Simply updates our
    running second counter and clears the underflow flag. */
-static void timer_ms_handler(irq_t source, irq_context_t *context) {
+static void timer_ms_handler(irq_t source, irq_context_t *context, void *data) {
     (void)source;
     (void)context;
+    (void)data;
 
     timer_ms_counter++;
 
@@ -207,7 +208,7 @@ static void timer_ms_handler(irq_t source, irq_context_t *context) {
 }
 
 void timer_ms_enable(void) {
-    irq_set_handler(EXC_TMU2_TUNI2, timer_ms_handler);
+    irq_set_handler(EXC_TMU2_TUNI2, timer_ms_handler, NULL);
     timer_prime(TMU2, 1, 1);
     timer_ms_countdown = timer_count(TMU2);
     timer_clear(TMU2);
@@ -339,8 +340,9 @@ static timer_primary_callback_t tp_callback;
 static uint32_t tp_ms_remaining;
 
 /* IRQ handler for the primary timer interrupt. */
-static void tp_handler(irq_t src, irq_context_t *cxt) {
+static void tp_handler(irq_t src, irq_context_t *cxt, void *data) {
     (void)src;
+    (void)data;
 
     /* Are we at zero? */
     if(tp_ms_remaining == 0) {
@@ -374,14 +376,14 @@ static void timer_primary_init(void) {
     tp_callback = NULL;
 
     /* Clear out TMU0 and get ready for wakeups */
-    irq_set_handler(EXC_TMU0_TUNI0, tp_handler);
+    irq_set_handler(EXC_TMU0_TUNI0, tp_handler, NULL);
     timer_clear(TMU0);
 }
 
 static void timer_primary_shutdown(void) {
     timer_stop(TMU0);
     timer_disable_ints(TMU0);
-    irq_set_handler(EXC_TMU0_TUNI0, NULL);
+    irq_set_handler(EXC_TMU0_TUNI0, NULL, NULL);
 }
 
 timer_primary_callback_t timer_primary_set_callback(timer_primary_callback_t cb) {

--- a/kernel/arch/dreamcast/kernel/wdt.c
+++ b/kernel/arch/dreamcast/kernel/wdt.c
@@ -51,9 +51,10 @@ static uint32_t us_interval = 0;
 static uint32_t us_elapsed = 0;
 
 /* Interval timer mode interrupt handler */
-static void wdt_isr(irq_t src, irq_context_t *cxt) {
+static void wdt_isr(irq_t src, irq_context_t *cxt, void *data) {
     (void)src;
     (void)cxt;
+    (void)data;
 
     /* Update elapsed time */
     us_elapsed += WDT_INT_DEFAULT;
@@ -87,7 +88,7 @@ void wdt_enable_timer(uint8_t initial_count,
     us_interval = micro_seconds;
 
     /* Register our interrupt handler */
-    irq_set_handler(EXC_WDT_ITI, wdt_isr);
+    irq_set_handler(EXC_WDT_ITI, wdt_isr, NULL);
 
     /* Unmask the WDTIT interrupt, giving it a new priority */
     IPR(IPRB) = IPR(IPRB) | ((irq_prio & IPRB_WDT_MASK) << IPRB_WDT);
@@ -142,7 +143,7 @@ void wdt_disable(void) {
     IPR(IPRB) = IPR(IPRB) & ~(IPRB_WDT_MASK << IPRB_WDT);
 
     /* Unregister our interrupt handler */
-    irq_set_handler(EXC_WDT_ITI, NULL);
+    irq_set_handler(EXC_WDT_ITI, NULL, NULL);
 
     /* Reset the WDT counter */
     wdt_pet();


### PR DESCRIPTION
Update `irq_set_handler`, `irq_set_global_handler`, `asic_evt_set_handler`, `vblank_handler_add` to accept an extra argument, that will be passed along to the registered callback.

This is very useful to pass state structures to the IRQ handlers, which can then pass it down the functions.

This will later be used to pass structures between a first-level IRQ handler and second-level threaded IRQ handlers, when those are implemented.