### PR TITLE
RTC Date/TIme Fix for Negative Unix Timestamps

### DIFF
--- a/kernel/arch/dreamcast/include/arch/rtc.h
+++ b/kernel/arch/dreamcast/include/arch/rtc.h
@@ -66,14 +66,7 @@ __BEGIN_DECLS
     (with an epoch of January 1, 1970 00:00). This is assumed to be in the
     timezone of the user (as the RTC does not support timezones).
 
-    \warning
-    This function may fail! Since the Dreamcast's BIOS allows for the clock to
-    be set to January 1, 1950 00:00, not all valid Dreamcast timestamps are
-    valid, positive Unix timestamps! Compare the return value to -1 to check for
-    sanity.
-
-    \return                 The current UNIX-style timestamp (local time) or
-                            -1 for failure.
+    \return                 The current UNIX-style timestamp (local time).
 
     \sa rtc_set_unix_secs(), rtc_boot_time()
 */
@@ -88,8 +81,8 @@ time_t rtc_unix_secs(void);
 
     \warning
     This function may fail! Since `time_t` is typically 64-bit while the RTC
-    uses a 32-bit timestamp, which also has a different epoch, not all `time_t`
-    values can be represented within the RTC!
+    uses a 32-bit timestamp (which also has a different epoch), not all
+    `time_t` values can be represented within the RTC!
 
     \param time             Unix timestamp to set the current time to
 
@@ -105,13 +98,7 @@ int rtc_set_unix_secs(time_t time);
     This function retrieves the cached RTC value from when KallistiOS was started. As
     with rtc_unix_secs(), this is a UNIX-style timestamp in local time.
 
-    \warning
-    Due to differences in epochs between the RTC's and UNIX's timestamps,
-    any DC with a BIOS time set before the UNIX epoch of January 1, 1970 00:00
-    will return -1 for an invalid, negative UNIX timestamp.
-
-    \return                 The boot time if it can be represented as a
-                            UNIX-style timestamp or -1 otherwise.
+    \return                 The boot time as a UNIX-style timestamp.
 
     \sa rtc_unix_secs()
 */

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -7,7 +7,8 @@
    Copyright (C) 2023 Megavolt85
 */
 
-/* Real-Time Clock (RTC) support
+/*
+   Real-Time Clock (RTC) Support
 
    The functions in here return various info about the real-world time and
    date stored in the machine. The general process here is to retrieve
@@ -29,8 +30,55 @@
 #include <dc/g2bus.h>
 #include <stdint.h>
 
-#define RTC_UNIX_EPOCH_DELTA    631152000   /* Twenty years in seconds */
-#define RTC_RETRY_COUNT         3           /* # of times to repeat on bad access */
+/*
+    High 16-bit Timestamp Value
+
+    32-bit register containing the upper 16-bits of
+    the 32-bit timestamp in seconds. Only the lower 16-bits
+    are valid.
+
+    Writing to this register will lock the timestamp registers.
+*/
+#define RTC_TIMESTAMP_HIGH_ADDR   0xa0710000
+
+/*
+    Low 16-bit Timestamp Value
+
+    32-bit register containing the lower 16-bits of
+    the 32-bit timestamp in seconds. Only the lower 16-bits
+    are valid.
+*/
+#define RTC_TIMESTAMP_LOW_ADDR    0xa0710004
+
+/*
+    Timestamp Control Register
+
+    All fields are reserved except for RTC_CTRL_WRITE_EN,
+    which is write-only.
+*/
+#define RTC_CTRL_ADDR             0xa0710008
+
+/*
+    Timestamp Write Enable
+
+    RTC_CTRL_ADDR field to be written in order to unlock
+    writing to the timestamp registers.
+*/
+#define RTC_CTRL_WRITE_EN         (1 << 0)
+
+/*
+   Second Delta between Sega and Unix Epochs
+
+   Twenty years in seconds.
+*/
+#define RTC_UNIX_EPOCH_DELTA    631152000
+
+/*
+    # of Read/Write Retry Attempts
+
+    To ensure a coherent, race-free read/write operation.
+*/
+#define RTC_RETRY_COUNT         3
 
 /* The boot time; we'll save this in rtc_init() */
 static time_t boot_time = 0;
@@ -60,8 +108,11 @@ time_t rtc_unix_secs(void) {
             break;
     }
 
-    /* Subtract out 20 years */
-    rtcnew = rtcnew - RTC_UNIX_EPOCH_DELTA;
+    /* Subtract out 20 years, only if it creates a valid unix timestamp. */
+    if(rtcnew < RTC_UNIX_EPOCH_DELTA)
+        rtcnew = -1;
+    else
+        rtcnew -= RTC_UNIX_EPOCH_DELTA;
 
     return rtcnew;
 }
@@ -69,12 +120,21 @@ time_t rtc_unix_secs(void) {
 /* Sets the date/time value from a UNIX epoch time stamp, 
    returning 0 for success or -1 for failure. */
 int rtc_set_unix_secs(time_t secs) {
+    time_t adjusted_time = secs + RTC_UNIX_EPOCH_DELTA;
     int result = 0;
     uint32_t rtcnew;
     int i;
 
+    /* Early exit if the timestamp isn't even valid. */
+    if(secs == -1)
+        return -1;
+
+    /* Protect against overflowing our 32-bit timestamp. */
+    if(adjusted_time > UINT32_MAX)
+        return -1;
+
     /* Adjust by 20 years to get to the expected RTC time. */
-    const uint32_t adjusted = secs + RTC_UNIX_EPOCH_DELTA;
+    const uint32_t adjusted = adjusted_time;
 
     /* Enable writing by setting LSB of control */
     g2_write_32(RTC_CTRL_ADDR, RTC_CTRL_WRITE_EN);
@@ -93,6 +153,9 @@ int rtc_set_unix_secs(time_t secs) {
         if(rtcnew == adjusted)
             break;
     }
+
+    /* Disable further writing by clearing LSB of control */
+    g2_write_32(RTC_CTRL_ADDR, 0);
 
     /* Signify failure if the fetched time never matched the
        time we attempted to set. */

--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.23)
 
 ### Helper Function for Generating Romdisk ###
-function(generate_romdisk target romdiskName romdiskPath)
+function(kos_generate_romdisk target romdiskName romdiskPath)
     set(obj ${CMAKE_CURRENT_BINARY_DIR}/${romdiskName}.o)
     set(img ${CMAKE_CURRENT_BINARY_DIR}/${romdiskName}.img)
 
@@ -33,7 +33,7 @@ add_custom_command(
 endfunction()
 
 ### Function to Enable SH4 Math Optimizations ###
-function(enable_sh4_math)
+function(kos_enable_sh4_math)
     if(NOT ${PLATFORM_DREAMCAST})
         message(WARN " PLATFORM_DREAMCAST not set, skipping SH4 Math flags")
         return()

--- a/utils/cmake/dreamcast.toolchain.cmake
+++ b/utils/cmake/dreamcast.toolchain.cmake
@@ -82,8 +82,11 @@ else()
     ADD_DEFINITIONS(-D_arch_sub_pristine)
 endif()
 
+separate_arguments(KOS_CFLAGS NATIVE_COMMAND $ENV{KOS_CFLAGS})
+
 ##### Configure Build Flags #####
-add_compile_options(-ml -m4-single-only -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec)
+add_compile_options(${KOS_CFLAGS})
+#add_compile_options(-ml -m4-single-only -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec)
 
 set(ENABLE_DEBUG_FLAGS   $<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>)
 set(ENABLE_RELEASE_FLAGS $<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>)
@@ -97,7 +100,7 @@ set(CMAKE_ASM_FLAGS "")
 set(CMAKE_ASM_FLAGS_RELEASE "")
 
 ##### Configure Include Directories #####
-set(CMAKE_SYSTEM_INCLUDE_PATH "${CMAKE_SYSTEM_INCLUDE_PATH} ${KOS_BASE}/include ${KOS_BASE}/kernel/arch/dreamcast/include ${KOS_BASE}/addons/include ${KOS_PORTS}/include")
+set(CMAKE_SYSTEM_INCLUDE_PATH "${CMAKE_SYSTEM_INCLUDE_PATH} $ENV{KOS_INC_PATHS}")
 
 INCLUDE_DIRECTORIES(
     $ENV{KOS_BASE}/include
@@ -125,3 +128,5 @@ LINK_DIRECTORIES(
 
 add_link_options(-L${KOS_BASE}/lib/dreamcast -L${KOS_BASE}/addons/lib/dreamcast -L${KOS_PORTS}/lib)
 LINK_LIBRARIES(-Wl,--start-group -lstdc++ -lkallisti -lc -lgcc -Wl,--end-group m)
+
+include("${KOS_BASE}/utils/cmake/dreamcast.cmake")


### PR DESCRIPTION
I encountered a pretty strange bug with the RTC with a dead Dreamcast CMOS battery... The reported date/time range was close to overflowing the `uint32_t` AICA RTC counter rather than being closer to the epoch... I was able to reproduce the issue simply by setting the DC's date/time to the 1950s... Which internally winds up using a negative `time_t` value, which completely screws up all subsequent date/time operations...

This PR does the following:

1. Fixes negative time_t values for retrieving the current RTC seconds
2. Fixes negative time_t values for setting the current RTC seconds
3. Performs boundary and overflow checks when setting the current RTC seconds
4. Moves a bunch of the private internals of the RTC driver (registers and bitfields) to the source file
5. Updates (and fixes) documentation.