### PR TITLE
Update dc-chain configs to build new GDB 14.1

### DIFF
--- a/utils/dc-chain/config/config.mk.10.5.0.sample
+++ b/utils/dc-chain/config/config.mk.10.5.0.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.41
 sh_gcc_ver=10.5.0
 newlib_ver=4.3.0.20230120
-gdb_ver=13.2
+gdb_ver=14.1
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.11.4.0.sample
+++ b/utils/dc-chain/config/config.mk.11.4.0.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.41
 sh_gcc_ver=11.4.0
 newlib_ver=4.3.0.20230120
-gdb_ver=13.2
+gdb_ver=14.1
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.12.3.0.sample
+++ b/utils/dc-chain/config/config.mk.12.3.0.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.41
 sh_gcc_ver=12.3.0
 newlib_ver=4.3.0.20230120
-gdb_ver=13.2
+gdb_ver=14.1
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.devel.sample
+++ b/utils/dc-chain/config/config.mk.devel.sample
@@ -16,7 +16,7 @@
 sh_binutils_ver=2.41
 sh_gcc_ver=devel
 newlib_ver=4.3.0.20230120
-gdb_ver=13.2
+gdb_ver=14.1
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.stable.sample
+++ b/utils/dc-chain/config/config.mk.stable.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.41
 sh_gcc_ver=13.2.0
 newlib_ver=4.3.0.20230120
-gdb_ver=13.2
+gdb_ver=14.1
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.winxp-latest.sample
+++ b/utils/dc-chain/config/config.mk.winxp-latest.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.34
 sh_gcc_ver=9.5.0
 newlib_ver=4.3.0.20230120
-gdb_ver=13.2
+gdb_ver=14.1
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz


### PR DESCRIPTION
Updates GDB to 14.1 for the configs that are using the latest versions (previously 13.2). 

GDB update details:

https://www.phoronix.com/news/GNU-Debugger-GDB-14.1

https://sourceware.org/pipermail/gdb-announce/2023/000137.html