### PR TITLE
Handle double promotion

### DIFF
--- a/examples/dreamcast/2ndmix/2ndmix.c
+++ b/examples/dreamcast/2ndmix/2ndmix.c
@@ -237,7 +237,7 @@ void draw_cube(int which) {
        then try setting *32 on ytrans to something higher =) */
     xtrans = mcos(ra) * 220;
     ytrans = msin((ra * 3) % 256) * 32;
-    ztrans = msin(ra) * 256 + 256.0;
+    ztrans = msin(ra) * 256 + 256.0f;
 
     for(cp = 0; cp < (NUM_FACES * 4 * 3); cp += 3) {
         x = cube_points[cp + 0] * mult * cubesizes[which];
@@ -274,7 +274,7 @@ void draw_cube(int which) {
 
         vert.x = xt + 320.0f;
         vert.y = yt + 240.0f;
-        vert.z = 128.0 - (z / 64.0);
+        vert.z = 128.0f - (z / 64.0f);
         a = 0.8f;
 
         if(ztrans == 0) ztrans++;

--- a/examples/dreamcast/kgl/basic/gl/gltest.c
+++ b/examples/dreamcast/kgl/basic/gl/gltest.c
@@ -236,7 +236,7 @@ int main(int argc, char **argv) {
 
     pvr_get_stats(&stats);
     printf("VBL Count: %ld, last_time: %d, frame rate: %f fps\n",
-           stats.vbl_count, stats.frame_last_time, stats.frame_rate);
+           stats.vbl_count, stats.frame_last_time, (double)stats.frame_rate);
 
     return 0;
 }

--- a/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
+++ b/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
@@ -40,7 +40,7 @@ void stats(void) {
 
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
-           stats.vbl_count, stats.frame_rate);
+           stats.vbl_count, (double)stats.frame_rate);
 }
 
 
@@ -113,7 +113,7 @@ void check_switch(void) {
 
     if(now >= (begin + 5)) {
         begin = time(NULL);
-        printf("  Average Frame Rate: ~%f fps (%d pps)\n", avgfps, (int)(polycnt * avgfps * 2));
+        printf("  Average Frame Rate: ~%f fps (%d pps)\n", (double)avgfps, (int)(polycnt * avgfps * 2));
 
         switch(phase) {
             case PHASE_HALVE:

--- a/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
+++ b/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
@@ -40,7 +40,7 @@ void stats(void) {
 
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
-           stats.vbl_count, stats.frame_rate);
+           stats.vbl_count, (double)stats.frame_rate);
 }
 
 
@@ -112,7 +112,7 @@ void check_switch(void) {
 
     if(now >= (begin + 5)) {
         begin = time(NULL);
-        printf("  Average Frame Rate: ~%f fps (%d pps)\n", avgfps, (int)(polycnt * avgfps * 2));
+        printf("  Average Frame Rate: ~%f fps (%d pps)\n", (double)avgfps, (int)(polycnt * avgfps * 2));
 
         switch(phase) {
             case PHASE_HALVE:

--- a/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
+++ b/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
@@ -40,7 +40,7 @@ void stats(void) {
 
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
-           stats.vbl_count, stats.frame_rate);
+           stats.vbl_count, (double)stats.frame_rate);
 }
 
 
@@ -115,7 +115,7 @@ void check_switch(void) {
 
     if(now >= (begin + 5)) {
         begin = time(NULL);
-        printf("  Average Frame Rate: ~%f fps (%d pps)\n", avgfps, (int)(polycnt * avgfps * 2));
+        printf("  Average Frame Rate: ~%f fps (%d pps)\n", (double)avgfps, (int)(polycnt * avgfps * 2));
 
         switch(phase) {
             case PHASE_HALVE:

--- a/examples/dreamcast/kgl/demos/mipmap/gl-mipmap.c
+++ b/examples/dreamcast/kgl/demos/mipmap/gl-mipmap.c
@@ -69,9 +69,9 @@ void RenderInit(void) {
 
 /* Render a Textured Quad of given texture ID, width, and height */
 void RenderTexturedQuadCentered(GLuint texID, GLfloat width, GLfloat height) {
-    GLfloat x1 = (vid_mode->width - width) / 2.0;
+    GLfloat x1 = (vid_mode->width - width) / 2.0f;
     GLfloat x2 = x1 + width;
-    GLfloat y1 = (vid_mode->height - height) / 2.0;
+    GLfloat y1 = (vid_mode->height - height) / 2.0f;
     GLfloat y2 = y1 + height;
 
     glBindTexture(GL_TEXTURE_2D, texID);

--- a/examples/dreamcast/kgl/demos/specular/input.c
+++ b/examples/dreamcast/kgl/demos/specular/input.c
@@ -16,7 +16,7 @@
 #define SHIFT_X  0.01f
 #define SHIFT_Z  0.01f
 #define SHIFT_Y  0.2f
-#define ROT_XZ  ROTATION/5.0
+#define ROT_XZ  ROTATION/5.0f
 
 
 void InputCallback(vector3f campos, vector3f camdst) {

--- a/examples/dreamcast/kgl/demos/specular/specular.c
+++ b/examples/dreamcast/kgl/demos/specular/specular.c
@@ -40,8 +40,8 @@ static GLfloat z = -5.0f;   /* Depth Into The Screen */
 static GLuint texture[2];   /* Storage For Two Textures */
 
 static vector3f      up = { 0,  1,  0 },
-                     camFrom = { -74, 10, 0.0 },
-                     camTo = { -74, 10, 10.0 };
+                     camFrom = { -74, 10, 0.0f },
+                     camTo = { -74, 10, 10.0f };
 
 typedef struct {
     float min,
@@ -946,7 +946,7 @@ void GPU_Stats(void) {
 
         if(fps.frame % 60 == 0) {
             printf("PVR FPS MIN: %.2f | MAX: %.2f | LAST: %.2f | AVG: %.2f\n",
-                   (double)fps.min, (double)fps.max, (double)fps.last, (double)fps.avg / fps.frame);
+                   fps.min, fps.max, fps.last, fps.avg / fps.frame);
         }
     }
     else
@@ -1021,11 +1021,11 @@ int main() {
     glEnable(GL_LIGHT0);
 
     /* Set Light and Material Parameters */
-    float lp[4] = { 0.0, 10.0, 0.0, 0.0 };
-    float lp2[4] = { 0.0, 10.0, 0.0, 0.0 };
-    float lc[4] = { -50.0, 10.0, 0.0, 0.0 };
-    float lcolor[3] = { 0.8f, 0.0f, 0.0f };
-    float lcolor2[3] = { 0.0f, 0.0f, 0.8f };
+    float lp[4] = { 0, 10, 0, 0 };
+    float lp2[4] = { 0, 10, 0, 0 };
+    float lc[4] = { -50, 10, 0, 0 };
+    float lcolor[3] = { 0.8f, 0, 0 };
+    float lcolor2[3] = { 0, 0, 0.8f };
     float lcolors[3] = { 0.6f, 0.6f, 0.6f };
     glLightfv(GL_LIGHT0, GL_POSITION, lp);
     glLightfv(GL_LIGHT0, GL_DIFFUSE, lcolor);
@@ -1034,14 +1034,14 @@ int main() {
     glLightfv(GL_LIGHT1, GL_DIFFUSE, lcolor2);
     glLightfv(GL_LIGHT1, GL_SPECULAR, lcolors);
 
-    float l3c[3] = { 0.5, 0.5, 0.0 };
+    float l3c[3] = { 0.5f, 0.5f, 0 };
     float l3p[4] = { 0, -10, 0, 0 };
     float l3d[3] = { 0, 1, 0 };
     glLightfv(GL_LIGHT2, GL_POSITION, l3p);
     glLightfv(GL_LIGHT2, GL_DIFFUSE, l3c);
     glLightfv(GL_LIGHT2, GL_SPOT_DIRECTION, l3d);
 
-    float l4c[3] = { 0.0, 0.5, 0.5 };
+    float l4c[3] = { 0, 0.5f, 0.5f };
     float l4p[4] = { -50, -10, 0, 0 };
     float l4d[3] = { 0, 1, 0 };
     glLightfv(GL_LIGHT3, GL_POSITION, l4p);
@@ -1049,7 +1049,7 @@ int main() {
     glLightfv(GL_LIGHT3, GL_SPOT_DIRECTION, l4d);
 
 
-    float l5c[3] = { 0.0, 0.8, 0.0 };
+    float l5c[3] = { 0, 0.8f, 0 };
     float l5p[4] = { -50, -10, 50, 0 };
     float l5d[3] = { 0, 1, 0 };
     glLightfv(GL_LIGHT4, GL_POSITION, l5p);
@@ -1057,10 +1057,10 @@ int main() {
     glLightfv(GL_LIGHT4, GL_SPOT_DIRECTION, l5d);
 
     /* Set Material Parameters */
-    float Mat_Specular[3] = { 0.6, 0.6, 0.6 };
+    float Mat_Specular[3] = { 0.6f, 0.6f, 0.6f };
     glLightfv(GL_LIGHT0, GL_SPECULAR, Mat_Specular);
     glMaterialfv(GL_FRONT, GL_SPECULAR, Mat_Specular);
-    glMaterialf(GL_FRONT, GL_SHININESS, 10.0f);
+    glMaterialf(GL_FRONT, GL_SHININESS, 10);
 
     /* Set up the textures */
     texture[0] = glTextureLoadPVR("/rd/brick_w1.pvr", 0, 0);

--- a/examples/dreamcast/kgl/demos/specular/specular.c
+++ b/examples/dreamcast/kgl/demos/specular/specular.c
@@ -946,7 +946,7 @@ void GPU_Stats(void) {
 
         if(fps.frame % 60 == 0) {
             printf("PVR FPS MIN: %.2f | MAX: %.2f | LAST: %.2f | AVG: %.2f\n",
-                   fps.min, fps.max, fps.last, fps.avg / fps.frame);
+                   (double)fps.min, (double)fps.max, (double)fps.last, (double)(fps.avg / fps.frame));
         }
     }
     else

--- a/examples/dreamcast/kgl/demos/specular/specular.c
+++ b/examples/dreamcast/kgl/demos/specular/specular.c
@@ -1060,7 +1060,7 @@ int main() {
     float Mat_Specular[3] = { 0.6f, 0.6f, 0.6f };
     glLightfv(GL_LIGHT0, GL_SPECULAR, Mat_Specular);
     glMaterialfv(GL_FRONT, GL_SPECULAR, Mat_Specular);
-    glMaterialf(GL_FRONT, GL_SHININESS, 10);
+    glMaterialf(GL_FRONT, GL_SHININESS, 10.0f);
 
     /* Set up the textures */
     texture[0] = glTextureLoadPVR("/rd/brick_w1.pvr", 0, 0);

--- a/examples/dreamcast/kgl/demos/specular/specular.c
+++ b/examples/dreamcast/kgl/demos/specular/specular.c
@@ -39,9 +39,9 @@
 static GLfloat z = -5.0f;   /* Depth Into The Screen */
 static GLuint texture[2];   /* Storage For Two Textures */
 
-static vector3f      up = { 0,  1,  0 },
-                     camFrom = { -74, 10, 0.0f },
-                     camTo = { -74, 10, 10.0f };
+static vector3f      up = { 0.0f,  1.0f,  0.0f },
+                     camFrom = { -74.0f, 10.0f, 0.0f },
+                     camTo = { -74.0f, 10.0f, 10.0f };
 
 typedef struct {
     float min,
@@ -1021,11 +1021,11 @@ int main() {
     glEnable(GL_LIGHT0);
 
     /* Set Light and Material Parameters */
-    float lp[4] = { 0, 10, 0, 0 };
-    float lp2[4] = { 0, 10, 0, 0 };
-    float lc[4] = { -50, 10, 0, 0 };
-    float lcolor[3] = { 0.8f, 0, 0 };
-    float lcolor2[3] = { 0, 0, 0.8f };
+    float lp[4] = { 0.0f, 10.0f, 0.0f, 0.0f };
+    float lp2[4] = { 0.0f, 10.0f, 0.0f, 0.0f };
+    float lc[4] = { -50, 10.0f, 0.0f, 0.0f };
+    float lcolor[3] = { 0.8f, 0.0f, 0.0f };
+    float lcolor2[3] = { 0.0f, 0.0f, 0.8f };
     float lcolors[3] = { 0.6f, 0.6f, 0.6f };
     glLightfv(GL_LIGHT0, GL_POSITION, lp);
     glLightfv(GL_LIGHT0, GL_DIFFUSE, lcolor);
@@ -1034,24 +1034,24 @@ int main() {
     glLightfv(GL_LIGHT1, GL_DIFFUSE, lcolor2);
     glLightfv(GL_LIGHT1, GL_SPECULAR, lcolors);
 
-    float l3c[3] = { 0.5f, 0.5f, 0 };
-    float l3p[4] = { 0, -10, 0, 0 };
-    float l3d[3] = { 0, 1, 0 };
+    float l3c[3] = { 0.5f, 0.5f, 0.0f };
+    float l3p[4] = { 0.0f, -10.0f, 0.0f, 0.0f };
+    float l3d[3] = { 0.0f, 1.0f, 0.0f };
     glLightfv(GL_LIGHT2, GL_POSITION, l3p);
     glLightfv(GL_LIGHT2, GL_DIFFUSE, l3c);
     glLightfv(GL_LIGHT2, GL_SPOT_DIRECTION, l3d);
 
-    float l4c[3] = { 0, 0.5f, 0.5f };
-    float l4p[4] = { -50, -10, 0, 0 };
-    float l4d[3] = { 0, 1, 0 };
+    float l4c[3] = { 0.0f, 0.5f, 0.5f };
+    float l4p[4] = { -50, -10.0f, 0.0f, 0.0f };
+    float l4d[3] = { 0.0f, 1.0f, 0.0f };
     glLightfv(GL_LIGHT3, GL_POSITION, l4p);
     glLightfv(GL_LIGHT3, GL_DIFFUSE, l4c);
     glLightfv(GL_LIGHT3, GL_SPOT_DIRECTION, l4d);
 
 
-    float l5c[3] = { 0, 0.8f, 0 };
-    float l5p[4] = { -50, -10, 50, 0 };
-    float l5d[3] = { 0, 1, 0 };
+    float l5c[3] = { 0.0f, 0.8f, 0.0f };
+    float l5p[4] = { -50.0f, -10.0f, 50.0f, 0.0f};
+    float l5d[3] = { 0.0f, 1.0f, 0.0f };
     glLightfv(GL_LIGHT4, GL_POSITION, l5p);
     glLightfv(GL_LIGHT4, GL_DIFFUSE, l5c);
     glLightfv(GL_LIGHT4, GL_SPOT_DIRECTION, l5d);

--- a/examples/dreamcast/kgl/demos/specular/vector.h
+++ b/examples/dreamcast/kgl/demos/specular/vector.h
@@ -15,8 +15,8 @@ typedef float vector4f[4];
 
 #define DEG2RAD (F_PI / 180.0f)
 #define RAD2DEG (180.0f / F_PI)
-#define RADIAN 0.0174532925   // Convert Degrees to Radians
-#define CIRCLE 6.2831853      // RADIAN * 360.0f
+#define RADIAN 0.0174532925f   // Convert Degrees to Radians
+#define CIRCLE 6.2831853f      // RADIAN * 360.0f
 
 void  VectorShift(vector3f p, vector3f c, float mag);
 

--- a/examples/dreamcast/parallax/bubbles/Makefile
+++ b/examples/dreamcast/parallax/bubbles/Makefile
@@ -17,7 +17,7 @@ rm-elf:
 	-rm -f $(TARGET)
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -lparallax -lGL
+	kos-cc -o $(TARGET) $(OBJS) -lparallax
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/parallax/bubbles/bubbles.c
+++ b/examples/dreamcast/parallax/bubbles/bubbles.c
@@ -45,13 +45,13 @@ static void sphere(float radius, int slices, int stacks) {
 
     /* Iterate over stacks */
     for(i = 0; i < stacks; i++) {
-        pitch = 2 * M_PI * ((float)i / (float)stacks);
-        pitch2 = 2 * M_PI * ((float)(i + 1) / (float)stacks);
+        pitch = 2 * F_PI * ((float)i / (float)stacks);
+        pitch2 = 2 * F_PI * ((float)(i + 1) / (float)stacks);
 
         /* Iterate over slices: each entire stack will be one
            long triangle strip. */
         for(j = 0; j <= slices / 2; j++) {
-            yaw = 2 * M_PI * ((float)j / (float)slices);
+            yaw = 2 * F_PI * ((float)j / (float)slices);
 
             /* x, y+1 */
             x = radius * fcos(yaw) * fcos(pitch2);
@@ -107,7 +107,7 @@ static void sphere_frame_opaque(void) {
     plx_mat3d_push();
 
     for(i = 0; i < SPHERE_CNT; i++) {
-        plx_mat3d_translate(6.0f * fcos(i * 2 * M_PI / SPHERE_CNT), 0.0f, 6.0f * fsin(i * 2 * M_PI / SPHERE_CNT));
+        plx_mat3d_translate(6.0f * fcos(i * 2 * F_PI / SPHERE_CNT), 0.0f, 6.0f * fsin(i * 2 * F_PI / SPHERE_CNT));
         plx_mat3d_rotate(r, 1.0f, 1.0f, 1.0f);
         sphere(1.2f, 20, 20);
 
@@ -123,7 +123,7 @@ static void sphere_frame_opaque(void) {
     plx_mat3d_push();
 
     for(i = 0; i < SPHERE_CNT; i++) {
-        plx_mat3d_translate(3.0f * fcos(i * 2 * M_PI / SPHERE_CNT), 0.0f, 3.0f * fsin(i * 2 * M_PI / SPHERE_CNT));
+        plx_mat3d_translate(3.0f * fcos(i * 2 * F_PI / SPHERE_CNT), 0.0f, 3.0f * fsin(i * 2 * F_PI / SPHERE_CNT));
         plx_mat3d_rotate(r, 1.0f, 1.0f, 1.0f);
         sphere(0.8f, 20, 20);
 
@@ -137,7 +137,7 @@ static void sphere_frame_opaque(void) {
     pvr_scene_finish();
 
     r++;
-    phase += 2 * M_PI / 240.0f;
+    phase += 2 * F_PI / 240.0f;
 }
 
 static void sphere_frame_trans(void) {
@@ -156,7 +156,7 @@ static void sphere_frame_trans(void) {
     plx_mat3d_push();
 
     for(i = 0; i < SPHERE_CNT; i++) {
-        plx_mat3d_translate(4.0f * fcos(i * 2 * M_PI / SPHERE_CNT), 0.0f, 4.0f * fsin(i * 2 * M_PI / SPHERE_CNT));
+        plx_mat3d_translate(4.0f * fcos(i * 2 * F_PI / SPHERE_CNT), 0.0f, 4.0f * fsin(i * 2 * F_PI / SPHERE_CNT));
         plx_mat3d_rotate(r, 1.0f, 1.0f, 1.0f);
         sphere(1.0f, 20, 20);
 
@@ -170,7 +170,7 @@ static void sphere_frame_trans(void) {
     pvr_scene_finish();
 
     r++;
-    phase += 2 * M_PI / 240.0f;
+    phase += 2 * F_PI / 240.0f;
 }
 
 void do_sphere_test(void) {

--- a/examples/dreamcast/parallax/delay_cube/delay_cube.c
+++ b/examples/dreamcast/parallax/delay_cube/delay_cube.c
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
     // for really poly intensive effects.
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
-           stats.vbl_count, stats.frame_rate, stats.vtx_buffer_used_max);
+           stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;
 }

--- a/examples/dreamcast/parallax/delay_cube/delay_cube.c
+++ b/examples/dreamcast/parallax/delay_cube/delay_cube.c
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
     // for really poly intensive effects.
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
-           stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
+           stats.vbl_count, stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;
 }

--- a/examples/dreamcast/parallax/rotocube/rotocube.c
+++ b/examples/dreamcast/parallax/rotocube/rotocube.c
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
     // for really poly intensive effects.
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
-           stats.vbl_count, stats.frame_rate, stats.vtx_buffer_used_max);
+           stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;
 }

--- a/examples/dreamcast/parallax/rotocube/rotocube.c
+++ b/examples/dreamcast/parallax/rotocube/rotocube.c
@@ -105,16 +105,16 @@ void drawwave(int theta) {
     plx_dr_init(&dr);
 
     // Convert to radians for sin/cos
-    t = theta * 2 * M_PI / 360.0f;
+    t = theta * 2 * F_PI / 360.0f;
 
     for(i = 0; i <= divs; i++) {
         x = i * 640.0f / divs;
 
         // These are more or less magic numbers I played with until
         // it looked neat.
-        y = 240.0f + fsin(t + i * M_PI / 64.0f) * 30.0f * fsin(t * 4);
-        y += fcos(t + i * M_PI / 36.0f) * 40.0f * fcos(t * 6);
-        y += fcos(t + i * M_PI / 30.0f) * 24.0f * fcos(t * 8);
+        y = 240.0f + fsin(t + i * F_PI / 64.0f) * 30.0f * fsin(t * 4);
+        y += fcos(t + i * F_PI / 36.0f) * 40.0f * fcos(t * 6);
+        y += fcos(t + i * F_PI / 30.0f) * 24.0f * fcos(t * 8);
 
         plx_vert_ind(&dr, PLX_VERT, x, y, 0.0001f, color);
         plx_vert_ind(&dr, i == divs ? PLX_VERT_EOS : PLX_VERT, x, 480.0f, 0.0001f, color);
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
     // for really poly intensive effects.
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
-           stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
+           stats.vbl_count, stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;
 }

--- a/examples/dreamcast/parallax/serpent_dma/Makefile
+++ b/examples/dreamcast/parallax/serpent_dma/Makefile
@@ -17,7 +17,7 @@ rm-elf:
 	-rm -f $(TARGET)
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -lparallax -lkosutils -lpng -ljpeg -lkmg -lz -lm
+	kos-cc -o $(TARGET) $(OBJS) -lparallax -lkosutils -lm
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/parallax/serpent_dma/perfmeter.c
+++ b/examples/dreamcast/parallax/serpent_dma/perfmeter.c
@@ -48,7 +48,7 @@ void pm_draw(void) {
 
     // Make a nice stat display
     sprintf(str, "fps %.2f  buf %d  reg %d  rnd %d",
-            (double)stats.frame_rate,
+            (float)stats.frame_rate,
             (int)stats.buf_last_time,
             (int)stats.reg_last_time,
             (int)stats.rnd_last_time);
@@ -60,7 +60,7 @@ void pm_draw(void) {
     plx_fcxt_end(fcxt);
 
     sprintf(str, "avg fps %.2f",
-            (double)(60.0 * stats.frame_count / stats.vbl_count));
+            (float)(60.0f * stats.frame_count / stats.vbl_count));
     plx_fcxt_setpos(fcxt, posx, posy + 16.0f, posz);
     plx_fcxt_begin(fcxt);
     plx_fcxt_draw(fcxt, str);

--- a/examples/dreamcast/parallax/serpent_dma/perfmeter.c
+++ b/examples/dreamcast/parallax/serpent_dma/perfmeter.c
@@ -48,7 +48,7 @@ void pm_draw(void) {
 
     // Make a nice stat display
     sprintf(str, "fps %.2f  buf %d  reg %d  rnd %d",
-            stats.frame_rate,
+            (double)stats.frame_rate,
             stats.buf_last_time,
             stats.reg_last_time,
             stats.rnd_last_time);
@@ -60,7 +60,7 @@ void pm_draw(void) {
     plx_fcxt_end(fcxt);
 
     sprintf(str, "avg fps %.2f",
-            60.0f * stats.frame_count / stats.vbl_count);
+            (double)(60.0 * stats.frame_count / stats.vbl_count));
     plx_fcxt_setpos(fcxt, posx, posy + 16.0f, posz);
     plx_fcxt_begin(fcxt);
     plx_fcxt_draw(fcxt, str);

--- a/examples/dreamcast/parallax/serpent_dma/perfmeter.c
+++ b/examples/dreamcast/parallax/serpent_dma/perfmeter.c
@@ -48,10 +48,10 @@ void pm_draw(void) {
 
     // Make a nice stat display
     sprintf(str, "fps %.2f  buf %d  reg %d  rnd %d",
-            (float)stats.frame_rate,
-            (int)stats.buf_last_time,
-            (int)stats.reg_last_time,
-            (int)stats.rnd_last_time);
+            stats.frame_rate,
+            stats.buf_last_time,
+            stats.reg_last_time,
+            stats.rnd_last_time);
     plx_fcxt_setcolor4f(fcxt, 1, 1, 1, 1);
     plx_fcxt_setsize(fcxt, 16.0f);
     plx_fcxt_setpos(fcxt, posx, posy, posz);
@@ -60,7 +60,7 @@ void pm_draw(void) {
     plx_fcxt_end(fcxt);
 
     sprintf(str, "avg fps %.2f",
-            (float)(60.0f * stats.frame_count / stats.vbl_count));
+            60.0f * stats.frame_count / stats.vbl_count);
     plx_fcxt_setpos(fcxt, posx, posy + 16.0f, posz);
     plx_fcxt_begin(fcxt);
     plx_fcxt_draw(fcxt, str);

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -60,13 +60,13 @@ static void sphere(sphere_t *s) { /* {{{ */
 
     /* Iterate over stacks */
     for(i = 0; i < s->stacks; i++) {
-        pitch = 2 * M_PI * ((float)i / (float)s->stacks);
-        pitch2 = 2 * M_PI * ((float)(i + 1) / (float)s->stacks);
+        pitch = 2 * F_PI * ((float)i / (float)s->stacks);
+        pitch2 = 2 * F_PI * ((float)(i + 1) / (float)s->stacks);
 
         /* Iterate over slices: each entire stack will be one
            long triangle strip. */
         for(j = 0; j <= s->slices / 2; j++) {
-            yaw = 2 * M_PI * ((float)j / (float)s->slices);
+            yaw = 2 * F_PI * ((float)j / (float)s->slices);
 
             /* x, y+1 */
             v->x = s->radius * fcos(yaw) * fcos(pitch2);
@@ -172,7 +172,7 @@ static void sphere_frame(void) {
     plx_mat3d_push();
 
     for(i = 0; i < SPHERE_CNT; i++) {
-        plx_mat3d_translate(6.0f * fcos(i * 2 * M_PI / SPHERE_CNT), 0.0f, 6.0f * fsin(i * 2 * M_PI / SPHERE_CNT));
+        plx_mat3d_translate(6.0f * fcos(i * 2 * F_PI / SPHERE_CNT), 0.0f, 6.0f * fsin(i * 2 * F_PI / SPHERE_CNT));
         plx_mat3d_rotate(r, 1.0f, 1.0f, 1.0f);
 
         if(!(i % 2))
@@ -192,7 +192,7 @@ static void sphere_frame(void) {
     plx_mat3d_push();
 
     for(i = 0; i < SPHERE_CNT; i++) {
-        plx_mat3d_translate(3.0f * fcos(i * 2 * M_PI / SPHERE_CNT), 0.0f, 3.0f * fsin(i * 2 * M_PI / SPHERE_CNT));
+        plx_mat3d_translate(3.0f * fcos(i * 2 * F_PI / SPHERE_CNT), 0.0f, 3.0f * fsin(i * 2 * F_PI / SPHERE_CNT));
         plx_mat3d_rotate(r, 1.0f, 1.0f, 1.0f);
 
         if(!(i % 2))
@@ -212,7 +212,7 @@ static void sphere_frame(void) {
     //printf("%d\n", (uint32)(timer_ms_gettime64() - start));
 
     r++;
-    phase += 2 * M_PI / 240.0f;
+    phase += 2 * F_PI / 240.0f;
 
     pm_draw();
 
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
 
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
-           stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
+           stats.vbl_count, stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;
 }

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
 
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
-           stats.vbl_count, stats.frame_rate, stats.vtx_buffer_used_max);
+           stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;
 }

--- a/examples/dreamcast/parallax/sinus/sinus.c
+++ b/examples/dreamcast/parallax/sinus/sinus.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
     plx_cxt_culling(PLX_CULL_NONE);
 
     // Until the user hits start...
-    dt = 2 * M_PI / 160.0f;
+    dt = 2 * F_PI / 160.0f;
 
     for(done = 0, theta = 0.0f; !done;) {
         // Check for start
@@ -95,8 +95,8 @@ int main(int argc, char **argv) {
         // Move our counters
         theta += dt;
 
-        while(theta >= 2 * M_PI)
-            theta -= 2 * M_PI;
+        while(theta >= 2 * F_PI)
+            theta -= 2 * F_PI;
     }
 
     return 0;

--- a/examples/dreamcast/png/example.c
+++ b/examples/dreamcast/png/example.c
@@ -87,29 +87,29 @@ void draw_back(void) {
     vert.x = 1;
     vert.y = 1;
     vert.z = 1;
-    vert.u = 0.0;
-    vert.v = 0.0;
+    vert.u = 0;
+    vert.v = 0;
     pvr_prim(&vert, sizeof(vert));
 
     vert.x = 640;
     vert.y = 1;
     vert.z = 1;
-    vert.u = 1.0;
-    vert.v = 0.0;
+    vert.u = 1;
+    vert.v = 0;
     pvr_prim(&vert, sizeof(vert));
 
     vert.x = 1;
     vert.y = 480;
     vert.z = 1;
-    vert.u = 0.0;
-    vert.v = 1.0;
+    vert.u = 0;
+    vert.v = 1;
     pvr_prim(&vert, sizeof(vert));
 
     vert.x = 640;
     vert.y = 480;
     vert.z = 1;
-    vert.u = 1.0;
-    vert.v = 1.0;
+    vert.u = 1;
+    vert.v = 1;
     vert.flags = PVR_CMD_VERTEX_EOL;
     pvr_prim(&vert, sizeof(vert));
 }

--- a/examples/dreamcast/png/example.c
+++ b/examples/dreamcast/png/example.c
@@ -84,32 +84,32 @@ void draw_back(void) {
     vert.oargb = 0;
     vert.flags = PVR_CMD_VERTEX;
 
-    vert.x = 1;
-    vert.y = 1;
-    vert.z = 1;
-    vert.u = 0;
-    vert.v = 0;
+    vert.x = 0.0f;
+    vert.y = 0.0f;
+    vert.z = 1.0f;
+    vert.u = 0.0f;
+    vert.v = 0.0f;
     pvr_prim(&vert, sizeof(vert));
 
-    vert.x = 640;
-    vert.y = 1;
-    vert.z = 1;
-    vert.u = 1;
-    vert.v = 0;
+    vert.x = 640.0f;
+    vert.y = 0.0f;
+    vert.z = 1.0f;
+    vert.u = 1.0f;
+    vert.v = 0.0f;
     pvr_prim(&vert, sizeof(vert));
 
-    vert.x = 1;
-    vert.y = 480;
-    vert.z = 1;
-    vert.u = 0;
-    vert.v = 1;
+    vert.x = 1.0f;
+    vert.y = 480.0f;
+    vert.z = 1.0f;
+    vert.u = 0.0f;
+    vert.v = 1.0f;
     pvr_prim(&vert, sizeof(vert));
 
-    vert.x = 640;
-    vert.y = 480;
-    vert.z = 1;
-    vert.u = 1;
-    vert.v = 1;
+    vert.x = 640.0f;
+    vert.y = 480.0f;
+    vert.z = 1.0f;
+    vert.u = 1.0f;
+    vert.v = 1.0f;
     vert.flags = PVR_CMD_VERTEX_EOL;
     pvr_prim(&vert, sizeof(vert));
 }

--- a/examples/dreamcast/pvr/plasma/plasma.c
+++ b/examples/dreamcast/pvr/plasma/plasma.c
@@ -66,8 +66,8 @@ void plasma_init(void) {
     hsv = 0.0f;
 
     for(i = 0; i < 512; i++) {
-        pcos[i] = (short)(fcos(i * 2 * (2 * M_PI / 512.0f)) * 256.0f);
-        psin[i] = (short)(fsin(i * 2 * (2 * M_PI / 512.0f)) * 256.0f);
+        pcos[i] = (short)(fcos(i * 2 * (2 * F_PI / 512.0f)) * 256.0f);
+        psin[i] = (short)(fsin(i * 2 * (2 * F_PI / 512.0f)) * 256.0f);
     }
 }
 

--- a/examples/dreamcast/pvr/pvrmark/pvrmark.c
+++ b/examples/dreamcast/pvr/pvrmark/pvrmark.c
@@ -34,7 +34,7 @@ void stats(void) {
 
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
-           stats.vbl_count, stats.frame_rate);
+           stats.vbl_count, (double)stats.frame_rate);
 }
 
 
@@ -127,7 +127,7 @@ void check_switch(void) {
 
     if(now >= (begin + 5)) {
         begin = time(NULL);
-        printf("  Average Frame Rate: ~%f fps (%d pps)\n", avgfps, (int)(polycnt * avgfps));
+        printf("  Average Frame Rate: ~%f fps (%d pps)\n", (double)avgfps, (int)(polycnt * avgfps));
 
         switch(phase) {
             case PHASE_HALVE:

--- a/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
+++ b/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
@@ -34,7 +34,7 @@ void stats(void) {
 
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
-           stats.vbl_count, stats.frame_rate);
+           stats.vbl_count, (double)stats.frame_rate);
 }
 
 
@@ -129,7 +129,7 @@ void check_switch(void) {
 
     if(now >= (begin + 5)) {
         begin = time(NULL);
-        printf("  Average Frame Rate: ~%f fps (%d pps)\n", avgfps, (int)(polycnt * avgfps));
+        printf("  Average Frame Rate: ~%f fps (%d pps)\n", (double)avgfps, (int)(polycnt * avgfps));
 
         switch(phase) {
             case PHASE_HALVE:

--- a/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
+++ b/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
@@ -34,7 +34,7 @@ void stats(void) {
 
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %ld frames, frame rate ~%f fps\n",
-           stats.vbl_count, stats.frame_rate);
+           stats.vbl_count, (double)stats.frame_rate);
 }
 
 
@@ -151,7 +151,7 @@ void check_switch(void) {
 
     if(now >= (begin + 5)) {
         begin = time(NULL);
-        printf("  Average Frame Rate: ~%f fps (%d pps)\n", avgfps, (int)(polycnt * avgfps));
+        printf("  Average Frame Rate: ~%f fps (%d pps)\n", (double)avgfps, (int)(polycnt * avgfps));
 
         switch(phase) {
             case PHASE_HALVE:

--- a/examples/dreamcast/pvr/texture_render/texture_render.c
+++ b/examples/dreamcast/pvr/texture_render/texture_render.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
     end = timer_ms_gettime64();
 
     printf("%lu frames in %llu ms = %f FPS\n", counter, end - start,
-           counter / ((float)end - start) * 1000.0);
+           (double)(counter / ((float)end - start) * 1000.0f));
 
     pvr_get_stats(&stats);
     printf("From pvr_get_stats:\n\tVBlank Count: %lu\n\tFrame Count: %lu\n",

--- a/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
@@ -158,17 +158,17 @@ static int setup_pvr(void) {
 
     vert[0].x = 0;
     vert[0].y = 0;
-    vert[0].u = 0.0;
-    vert[0].v = 0.0;
+    vert[0].u = 0;
+    vert[0].v = 0;
 
     vert[1].x = 640;
     vert[1].y = 0;
     vert[1].u = width_ratio;
-    vert[1].v = 0.0;
+    vert[1].v = 0;
 
     vert[2].x = 0;
     vert[2].y = 480;
-    vert[2].u = 0.0;
+    vert[2].u = 0;
     vert[2].v = height_ratio;
 
     vert[3].x = 640;

--- a/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
@@ -156,23 +156,23 @@ static int setup_pvr(void) {
     float width_ratio = (float)FRAME_TEXTURE_WIDTH / PVR_TEXTURE_WIDTH;
     float height_ratio = (float)FRAME_TEXTURE_HEIGHT / PVR_TEXTURE_HEIGHT;
 
-    vert[0].x = 0;
-    vert[0].y = 0;
-    vert[0].u = 0;
-    vert[0].v = 0;
+    vert[0].x = 0.0f;
+    vert[0].y = 0.0f;
+    vert[0].u = 0.0f;
+    vert[0].v = 0.0f;
 
-    vert[1].x = 640;
-    vert[1].y = 0;
+    vert[1].x = 640.0f;
+    vert[1].y = 0.0f;
     vert[1].u = width_ratio;
-    vert[1].v = 0;
+    vert[1].v = 0.0f;
 
-    vert[2].x = 0;
-    vert[2].y = 480;
-    vert[2].u = 0;
+    vert[2].x = 0.0f;
+    vert[2].y = 480.0f;
+    vert[2].u = 0.0f;
     vert[2].v = height_ratio;
 
-    vert[3].x = 640;
-    vert[3].y = 480;
+    vert[3].x = 640.0f;
+    vert[3].y = 480.0f;
     vert[3].u = width_ratio;
     vert[3].v = height_ratio;
 

--- a/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
@@ -158,17 +158,17 @@ static int setup_pvr(void) {
 
     vert[0].x = 0;
     vert[0].y = 0;
-    vert[0].u = 0.0;
-    vert[0].v = 0.0;
+    vert[0].u = 0;
+    vert[0].v = 0;
 
     vert[1].x = 640;
     vert[1].y = 0;
     vert[1].u = width_ratio;
-    vert[1].v = 0.0;
+    vert[1].v = 0;
 
     vert[2].x = 0;
     vert[2].y = 480;
-    vert[2].u = 0.0;
+    vert[2].u = 0;
     vert[2].v = height_ratio;
 
     vert[3].x = 640;

--- a/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
@@ -156,23 +156,23 @@ static int setup_pvr(void) {
     float width_ratio = (float)FRAME_TEXTURE_WIDTH / PVR_TEXTURE_WIDTH;
     float height_ratio = (float)FRAME_TEXTURE_HEIGHT / PVR_TEXTURE_HEIGHT;
 
-    vert[0].x = 0;
-    vert[0].y = 0;
-    vert[0].u = 0;
-    vert[0].v = 0;
+    vert[0].x = 0.0f;
+    vert[0].y = 0.0f;
+    vert[0].u = 0.0f;
+    vert[0].v = 0.0f;
 
-    vert[1].x = 640;
-    vert[1].y = 0;
+    vert[1].x = 640.0f;
+    vert[1].y = 0.0f;
     vert[1].u = width_ratio;
-    vert[1].v = 0;
+    vert[1].v = 0.0f;
 
-    vert[2].x = 0;
-    vert[2].y = 480;
-    vert[2].u = 0;
+    vert[2].x = 0.0f;
+    vert[2].y = 480.0f;
+    vert[2].u = 0.0f;
     vert[2].v = height_ratio;
 
-    vert[3].x = 640;
-    vert[3].y = 480;
+    vert[3].x = 640.0f;
+    vert[3].y = 480.0f;
     vert[3].u = width_ratio;
     vert[3].v = height_ratio;
 

--- a/examples/dreamcast/sound/ghettoplay-vorbis/gp.h
+++ b/examples/dreamcast/sound/ghettoplay-vorbis/gp.h
@@ -5,8 +5,8 @@
 #include <math.h>
 
 /* Floating-point Sin/Cos; 256 angles, -1.0 to 1.0 */
-#define msin(angle) fsin((angle) * 2 * M_PI / 256)
-#define mcos(angle) fcos((angle) * 2 * M_PI / 256)
+#define msin(angle) fsin((angle) * 2 * F_PI / 256)
+#define mcos(angle) fcos((angle) * 2 * F_PI / 256)
 
 /* bkg.c */
 void bkg_setup(void);

--- a/examples/dreamcast/tsunami/banner/banner.cpp
+++ b/examples/dreamcast/tsunami/banner/banner.cpp
@@ -60,8 +60,8 @@ public:
         Vector v;
 
         // Proscribe a circular path around the center point
-        v.x = m_cx + m_mag * m_size * fsin(m_frame * 2 * M_PI / m_spd);
-        v.y = m_cy + m_mag * m_size * fcos(m_frame * 2 * M_PI / m_spd);
+        v.x = m_cx + m_mag * m_size * fsin(m_frame * 2 * F_PI / m_spd);
+        v.y = m_cy + m_mag * m_size * fcos(m_frame * 2 * F_PI / m_spd);
         v.z = m_cz;
         t->setTranslate(v);
 

--- a/examples/dreamcast/vmu/vmu_lcd/lcd.c
+++ b/examples/dreamcast/vmu/vmu_lcd/lcd.c
@@ -26,6 +26,7 @@
 #include <dc/maple/controller.h>
 #include <dc/maple/vmu.h>
 #include <dc/vmu_fb.h>
+#include <dc/fmath.h>
 
 #include <arch/arch.h>
 
@@ -172,7 +173,7 @@ int main(int argc, char **argv) {
     for(i = 0; ; i++) {
         vmufb_clear(&vmufb);
 
-        val = (float)i * M_PI / 360.0f;
+        val = (float)i * F_PI / 360.0f;
         x = 20 + (int)(20.0f * cosf(val));
         y = 12 + (int)(12.0f * sinf(val));
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_fog.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_fog.c
@@ -151,8 +151,8 @@ union ieee32_t {
 
 /* helper functions */
 #define FOG_EXP_TABLE_SIZE 256
-#define FOG_MAX (10.0)
-#define EXP_FOG_MAX .0006595
+#define FOG_MAX (10.0f)
+#define EXP_FOG_MAX .0006595f
 #define FOG_INCR (FOG_MAX/FOG_EXP_TABLE_SIZE)
 
 /* A fast negative argument only exp function - That is it treats any
@@ -163,7 +163,7 @@ float neg_exp(float arg) {
     float result, f;
     int k;
 
-    f = (float)(ABS(arg) * (1.0 / FOG_INCR));
+    f = (float)(ABS(arg) * (1.0f / FOG_INCR));
     k = (int) f;
 
     if(k > FOG_EXP_TABLE_SIZE - 2)

--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -30,7 +30,7 @@ void sq_unlock(void) {
 }
 
 /* Copies n bytes from src to dest, dest must be 32-byte aligned */
-void * sq_cpy(void *dest, const void *src, size_t n) {
+__attribute__((noinline)) void *sq_cpy(void *dest, const void *src, size_t n) {
     uint32_t *d = SQ_MASK_DEST(dest);
     const uint32_t *s = src;
 

--- a/kernel/arch/dreamcast/include/dc/fmath_base.h
+++ b/kernel/arch/dreamcast/include/dc/fmath_base.h
@@ -24,7 +24,7 @@ __BEGIN_DECLS
 
 /** \cond */
 #define __fsin(x) \
-    ({ float __value, __arg = (x), __scale = 10430.37835; \
+    ({ float __value, __arg = (x), __scale = 10430.37835f; \
         __asm__("fmul   %2,%1\n\t" \
                 "ftrc   %1,fpul\n\t" \
                 "fsca   fpul,dr0\n\t" \
@@ -35,7 +35,7 @@ __BEGIN_DECLS
         __value; })
 
 #define __fcos(x) \
-    ({ float __value, __arg = (x), __scale = 10430.37835; \
+    ({ float __value, __arg = (x), __scale = 10430.37835f; \
         __asm__("fmul   %2,%1\n\t" \
                 "ftrc   %1,fpul\n\t" \
                 "fsca   fpul,dr0\n\t" \
@@ -46,7 +46,7 @@ __BEGIN_DECLS
         __value; })
 
 #define __ftan(x) \
-    ({ float __value, __arg = (x), __scale = 10430.37835; \
+    ({ float __value, __arg = (x), __scale = 10430.37835f; \
         __asm__("fmul   %2,%1\n\t" \
                 "ftrc   %1,fpul\n\t" \
                 "fsca   fpul,dr0\n\t" \
@@ -91,7 +91,7 @@ __BEGIN_DECLS
 
 #define __fsincos(r, s, c) \
     ({  register float __r __asm__("fr10") = r; \
-        register float __a __asm__("fr11") = 182.04444443; \
+        register float __a __asm__("fr11") = 182.04444443f; \
         __asm__("fmul fr11, fr10\n\t" \
                 "ftrc fr10, fpul\n\t" \
                 "fsca fpul, dr10\n\t" \
@@ -102,7 +102,7 @@ __BEGIN_DECLS
 
 #define __fsincosr(r, s, c) \
     ({  register float __r __asm__("fr10") = r; \
-        register float __a __asm__("fr11") = 10430.37835; \
+        register float __a __asm__("fr11") = 10430.37835f; \
         __asm__("fmul fr11, fr10\n\t" \
                 "ftrc fr10, fpul\n\t" \
                 "fsca fpul, dr10\n\t" \


### PR DESCRIPTION
While testing against m4-single flag we found some regressions in some examples that were using doubles.  Using -Wdouble-promotion, we found the cause of the regressions. This branch handles those regressions by replacing instances of M_PI with F_PI and handling double promotion by being more explicit with our values (10.0 vs 10.0f).  This PR also handles a double promotion in pvr_fog.

All-in-all this PR should not change any behavior when compiled using m4-single-only.  It just closes up the issues that will pop up when compiled with m4-single.

Updated sq_cpy().  Reason: "It might be necessary to add a [[gnu::noinline]] attribute to the [sq_cpy] function to avoid it being inlined (into potentially another FPU context) e.g. by using LTO." [olegendo](https://github.com/olegendo)