### PR TITLE
Fix bubbles and serpent examples and remove HBlank settings from 

### DIFF
--- a/examples/dreamcast/parallax/bubbles/bubbles.c
+++ b/examples/dreamcast/parallax/bubbles/bubbles.c
@@ -235,7 +235,19 @@ pvr_init_params_t params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0 },
 
     /* Vertex buffer size 512K */
-    512 * 1024
+    512 * 1024,
+
+    /* No DMA */
+    0,
+
+    /* No FSAA */
+    0,
+
+    /* Translucent Autosort enabled. */
+    0,
+
+    /* Extra OPBs */
+    3
 };
 
 int main(int argc, char **argv) {

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -249,7 +249,16 @@ pvr_init_params_t params = {
     2560 * 1024,
 
     /* Vertex DMA enabled */
-    1
+    1,
+
+    /* No FSAA */
+    0,
+
+    /* Translucent Autosort enabled. */
+    0,
+
+    /* Extra OPBs */
+    3
 };
 
 // DMA buffers. This should ideally be in separate memory banks to take

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -187,8 +187,6 @@ int pvr_init(pvr_init_params_t *params) {
     PVR_SET(PVR_UNK_007C, 0x0027df77);      /* M */
     PVR_SET(PVR_TEXTURE_MODULO, 0x00000000);    /* stride width */
     PVR_SET(PVR_FOG_DENSITY, 0x0000ff07);       /* fog density */
-    PVR_SET(PVR_HPOS_IRQ, PVR_GET(PVR_BORDER_X) << 16);   /* HBLANK settings (fire on line 0 at the start of the line) */
-    //PVR_SET(PVR_VPOS_IRQ, PVR_GET(PVR_BORDER_Y));   /* VBLANK settings (VBLANK begin at start, VBLANK end at end) */
     PVR_SET(PVR_UNK_0118, 0x00008040);      /* M */
 
     /* Initialize PVR DMA */


### PR DESCRIPTION
Remove all `VPOS_IRQ` and `HPOS_IRQ` settings from pvr_init. `VPOS_IRQ` is already set up in `vid_set_mode_ex`, and nothing in KOS relies on HBlank so `HPOS_IRQ` doesn't need to be set.

These changes have been tested on VGA and non-VGA display modes.