### PR TITLE
Update memory.h with MMU and UBC registers

### DIFF
--- a/kernel/arch/dreamcast/include/arch/memory.h
+++ b/kernel/arch/dreamcast/include/arch/memory.h
@@ -201,6 +201,155 @@ __BEGIN_DECLS
 */
 #define MEM_AREA_CTRL_REG_BASE                0xff000000
 
+/** \brief MMU Control Registers
+    \defgroup sh4_mmu_regs
+    \ingroup sh4_cr_regs
+
+    \see arch\mmu.h
+
+    These are registers for controlling the MMU as defined in table 3.1
+    of Hitatchi SH7750 Series Hardware Manual rev 6.0, titled "MMU Registers".
+    All are accessed as 32-bit values.
+
+*/
+
+/** \brief MMU Page table entry high.
+    \ingroup sh4_mmu_regs
+
+    When an MMU exception or address error exception occurs, the virtual page number (VPN)
+    (the upper 22-bits of the virtual address causing the exception) is written
+    to the register. The bottom 8 bits of the register are software-fillable as
+    an 8 bit ID (ASID) of the process causing the exception.
+*/
+#define SH4_REG_MMU_PTEH                      0xff000000
+
+/** \brief MMU Page table entry low.
+    \ingroup sh4_mmu_regs
+
+    Holds the physical page number (PPN) in bits 10-28 and page management flags in 0-8.
+*/
+#define SH4_REG_MMU_PTEL                      0xff000004
+
+/** \brief MMU Translation table base.
+    \ingroup sh4_mmu_regs
+
+    Holds the base address of the currently used page table.
+*/
+#define SH4_REG_MMU_TTB                       0xff000008
+
+/** \brief MMU TLB Exception address.
+    \ingroup sh4_mmu_regs
+
+    After an MMU exception or address error exception occurs, the virtual address where the
+    exception occurred is stored here.
+*/
+#define SH4_REG_MMU_TEA                       0xff00000c
+
+/** \brief MMU Control Register.
+    \ingroup sh4_mmu_regs
+
+    Holds configuration values including enable/disable of MMU Address Translation (at bit 0)
+*/
+#define SH4_REG_MMU_CR                        0xff000010
+
+/** \brief MMU Page table entry assistance.
+    \ingroup sh4_mmu_regs
+
+    Stores assistance bits for PCMCIA access to the UTLB via LDTLB. This is currently unused by KOS.
+*/
+#define SH4_REG_MMU_PTEA                      0xff000034
+
+/** \brief UBC Control Registers
+    \defgroup sh4_ubc_regs
+    \ingroup sh4_cr_regs
+
+    \see dc\ubc.h
+
+    These are registers for controlling the UBC as defined in table 20.1
+    of Hitatchi SH7750 Series Hardware Manual rev 6.0, titled "UBC Registers"
+
+*/
+
+/** \brief UBC Break ASID register A
+    \ingroup sh4_ubc_regs
+
+    Specifies the ASID used in the channel A break condition. 8-bit RW.
+*/
+#define SH4_REG_UBC_BASRA                     0xff000014
+
+/** \brief UBC Break ASID register B
+    \ingroup sh4_ubc_regs
+
+    Specifies the ASID used in the channel B break condition. 8-bit RW.
+*/
+#define SH4_REG_UBC_BASRB                     0xff000018
+
+/** \brief UBC Break address register A
+    \ingroup sh4_ubc_regs
+
+    Specifies the virtual address used in the channel A break conditions. 32-bit RW.
+*/
+#define SH4_REG_UBC_BARA                      0xff200000
+
+/** \brief UBC Break address mask register A
+    \ingroup sh4_ubc_regs
+
+    Specifies the settings for masking the ASID in channel A. 8-bit RW.
+*/
+#define SH4_REG_UBC_BAMRA                     0xff200004
+
+/** \brief UBC Break bus cycle register A
+    \ingroup sh4_ubc_regs
+
+    Sets three conditions: 1) instruction/operand access 2) RW 3) Operand size. 16-bit RW.
+*/
+#define SH4_REG_UBC_BBRA                      0xff200008
+
+/** \brief UBC Break address register B
+    \ingroup sh4_ubc_regs
+
+    Specifies the virtual address used in the channel B break conditions. 32-bit RW.
+*/
+#define SH4_REG_UBC_BARB                      0xff20000c
+
+/** \brief UBC Break address mask register B
+    \ingroup sh4_ubc_regs
+
+    Specifies the settings for masking the ASID in channel B. 8-bit RW.
+*/
+#define SH4_REG_UBC_BAMRB                     0xff200010
+
+/** \brief UBC Break bus cycle register B
+    \ingroup sh4_ubc_regs
+
+    Sets three conditions: 1) instruction/operand access 2) RW 3) Operand size. 16-bit RW.
+*/
+#define SH4_REG_UBC_BBRB                      0xff200014
+
+
+/** \brief UBC Break data register B
+    \ingroup sh4_ubc_regs
+
+    Specifies the data to be used in the channel B break conditions. 32-bit RW.
+    Currently unused by KOS
+*/
+#define SH4_REG_UBC_BDRB                      0xff200018
+
+/** \brief UBC Break mask register B
+    \ingroup sh4_ubc_regs
+
+    Specifies which bits of the break data set in SH4_REG_UBC_BDRB are to be masked. 32-bit RW.
+    Currently unused by KOS
+*/
+#define SH4_REG_UBC_BDMRB                     0xff20001c
+
+/** \brief UBC Break control register
+    \ingroup sh4_ubc_regs
+
+    Specifies various settings for UBC as well as condition match flags. 16-bit RW.
+*/
+#define SH4_REG_UBC_BRCR                      0xff200020
+
 __END_DECLS
 
 #endif /* __ARCH_MEMORY_H */

--- a/kernel/arch/dreamcast/include/dc/ubc.h
+++ b/kernel/arch/dreamcast/include/dc/ubc.h
@@ -20,6 +20,7 @@
 __BEGIN_DECLS
 
 #include <arch/types.h>
+#include <arch/memory.h>
 
 /* From the SH-4 PDF */
 /** \defgroup   ubc_regs    UBC Registers

--- a/kernel/arch/dreamcast/include/dc/ubc.h
+++ b/kernel/arch/dreamcast/include/dc/ubc.h
@@ -29,15 +29,15 @@ __BEGIN_DECLS
 
     @{
 */
-#define BARA (*((vuint32*)0xFF200000))  /**< \brief BARA register. */
-#define BASRA (*((vuint8*)0xFF000014))  /**< \brief BASRA register. */
-#define BAMRA (*((vuint8*)0xFF200004))  /**< \brief BAMRA register. */
-#define BBRA (*((vuint16*)0xFF200008))  /**< \brief BBRA register. */
-#define BARB (*((vuint32*)0xFF20000C))  /**< \brief BARB register. */
-#define BASRB (*((vuint8*)0xFF000018))  /**< \brief BASRB register. */
-#define BAMRB (*((vuint8*)0xFF200010))  /**< \brief BAMRB register. */
-#define BBRB (*((vuint16*)0xFF200014))  /**< \brief BBRB register. */
-#define BRCR (*((vuint16*)0xFF200020))  /**< \brief BRCR register. */
+#define BARA (*((vuint32*)SH4_REG_UBC_BARA))   /**< \brief BARA register. */
+#define BASRA (*((vuint8*)SH4_REG_UBC_BASRA))  /**< \brief BASRA register. */
+#define BAMRA (*((vuint8*)SH4_REG_UBC_BAMRA))  /**< \brief BAMRA register. */
+#define BBRA (*((vuint16*)SH4_REG_UBC_BBRA))   /**< \brief BBRA register. */
+#define BARB (*((vuint32*)SH4_REG_UBC_BARB))   /**< \brief BARB register. */
+#define BASRB (*((vuint8*)SH4_REG_UBC_BDRB))   /**< \brief BASRB register. */
+#define BAMRB (*((vuint8*)SH4_REG_UBC_BAMRB))  /**< \brief BAMRB register. */
+#define BBRB (*((vuint16*)SH4_REG_UBC_BBRB))   /**< \brief BBRB register. */
+#define BRCR (*((vuint16*)SH4_REG_UBC_BRCR))   /**< \brief BRCR register. */
 /** @} */
 
 /* These are inlined to avoid complications with using them */

--- a/kernel/arch/dreamcast/kernel/mmu.c
+++ b/kernel/arch/dreamcast/kernel/mmu.c
@@ -13,6 +13,7 @@
 #include <arch/arch.h>
 #include <arch/types.h>
 #include <arch/irq.h>
+#include <arch/memory.h>
 #include <arch/mmu.h>
 #include <kos/dbgio.h>
 #include <arch/cache.h>
@@ -20,12 +21,12 @@
 /********************************************************************************/
 /* Register definitions */
 
-static volatile uint32 * const pteh = (uint32 *)(0xff000000);
-static volatile uint32 * const ptel = (uint32 *)(0xff000004);
-//static volatile uint32 * const ptea = (uint32 *)(0xff000034);
-static volatile uint32 * const ttb = (uint32 *)(0xff000008);
-static volatile uint32 * const tea = (uint32 *)(0xff00000c);
-static volatile uint32 * const mmucr = (uint32 *)(0xff000010);
+static volatile uint32 * const pteh = (uint32 *)(SH4_REG_MMU_PTEH);
+static volatile uint32 * const ptel = (uint32 *)(SH4_REG_MMU_PTEL);
+//static volatile uint32 * const ptea = (uint32 *)(SH4_REG_MMU_PTEA);
+static volatile uint32 * const ttb = (uint32 *)(SH4_REG_MMU_TTB);
+static volatile uint32 * const tea = (uint32 *)(SH4_REG_MMU_TEA);
+static volatile uint32 * const mmucr = (uint32 *)(SH4_REG_MMU_CR);
 
 #define SET_PTEH(VA, ASID) \
     do { *pteh = ((VA) & 0xfffffc00) | ((ASID) & 0xff); } while(0)


### PR DESCRIPTION
As the ongoing project for documenting and giving access to SH4 hardware, have updated memory.h to have the next two devices in the registers range. Along with this will be updating places that were previously using magic numbers to use these defines.