### PR TITLE
Increased Resolution of C's clock() to Microseconds

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -212,7 +212,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Added basic example for micropython KOS port [Aaron Glazer == AG]
 - DC  Improved performance of IRQ context save / restore [PC]
 - DC  Increased resolution of TMU timers + date/time functions [FG && PC]
-- DC  Increased resolution of C's clock() and CLOCKS_PERS_SEC to microseconds [FG]
+- *** Increased resolution of clock() and CLOCKS_PER_SEC to microseconds [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -212,6 +212,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Added basic example for micropython KOS port [Aaron Glazer == AG]
 - DC  Improved performance of IRQ context save / restore [PC]
 - DC  Increased resolution of TMU timers + date/time functions [FG && PC]
+- DC  Increased resolution of C's clock() and CLOCKS_PERS_SEC to microseconds [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -34,6 +34,7 @@ __BEGIN_DECLS
 struct timespec;
 
 #define TIME_UTC 1
+#define CLOCKS_PER_SEC 1000000
 
 extern int timespec_get(struct timespec *ts, int base);
 

--- a/kernel/libc/newlib/newlib_times.c
+++ b/kernel/libc/newlib/newlib_times.c
@@ -3,6 +3,7 @@
    newlib_times.c
    Copyright (C) 2004 Megan Potter
    Copyright (C) 2022 Lawrence Sebald
+   Copyright (C) 2023 Falco Girgis
 
 */
 
@@ -11,13 +12,13 @@
 #include <sys/times.h>
 #include <arch/timer.h>
 
-int _times_r(struct _reent * re, struct tms * tmsbuf) {
+int _times_r(struct _reent *re, struct tms *tmsbuf) {
     (void)re;
 
     if(tmsbuf) {
-        /* Conveniently, CLOCKS_PER_SEC is 1000, so we can just use the
-           millisecond timer. */
-        tmsbuf->tms_utime = (clock_t)timer_ms_gettime64();
+        /* Conveniently, CLOCKS_PER_SEC is 1000000, so we can just use the
+           microsecond timer. */
+        tmsbuf->tms_utime = (clock_t)timer_us_gettime64();
         tmsbuf->tms_stime = 0;
         tmsbuf->tms_cutime = 0;
         tmsbuf->tms_cstime = 0;


### PR DESCRIPTION
- Added #define to kos/time.h to provide newlib with an initial value for `CLOCKS_PER_SEC`
- Modified newlib_times.c to use the microsecond timer, which is what backs the `clock()` C stdlib function
- Updated CHANGELOG

EDIT: Just wanted to mention why this change is important. With the newfound `TMU` precision, we can increase to micro and nanosecond to timing; however, as noted here: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/time.h.html

` The value of CLOCKS_PER_SEC shall be 1 million on XSI-conformant systems. `

I figured we might as well be XSI-conformant and bump this bad boy up to microsecond resolution...
