### PR TITLE
Added and Improved BBA Doxygen Documentation

### DIFF
--- a/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
+++ b/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
@@ -23,12 +23,18 @@
 __BEGIN_DECLS
 
 /** \defgroup bba Broadband Adapter
-    \brief        Driver for the Dreamcast's BBA (RTL8139C).
-    \ingroup      networking_drivers
+    \brief    Driver for the Dreamcast's BBA (RTL8139C).
+    \ingroup  networking_drivers
+    @{
 */
 
-/** \defgroup bba_regs  Register Definitions
-    \ingroup  bba
+/** \defgroup bba_regs Registers
+    \brief    Registers and related info for the broadband adapter
+    @{
+*/
+
+/** \defgroup bba_regs_locs Locations
+    \brief    Locations for various broadband adapter registers.
 
     The default assumption is that these are all RW at any aligned size unless 
     otherwise noted. ex (RW 32bit, RO 16/8) indicates read/write at 32bit and 
@@ -94,9 +100,13 @@ __BEGIN_DECLS
 #define RT_CONFIG5          0xD8    /**< \brief Config register 5 */
 /** @} */
 
+/** \defgroup bba_regs_fields Fields
+    \brief    Register fields for the broadband adapter
+    @{
+*/
+
 /** \defgroup bba_miicb MII Control Bits
-    \brief              Control bits for the Media Independent Interface of the BBA
-    \ingroup            bba
+    \brief    BBA media independent interface control register fields
     @{
 */
 #define RT_MII_RESET       0x8000  /**< \brief Reset the MII chip */
@@ -107,12 +117,10 @@ __BEGIN_DECLS
 #define RT_MII_RES0400     0x0400  /**< \brief Reserved */
 #define RT_MII_AN_START    0x0200  /**< \brief Start auto-negotiation */
 #define RT_MII_DUPLEX      0x0100  /**< \brief 1 for full 0 for half. Ignored if AN enabled. */
-
 /** @} */
 
 /** \defgroup bba_miisb MII Status Bits
-    \brief              Status bits for the Media Independent Interface of the BBA
-    \ingroup            bba
+    \brief    BBA media independent interface status register fields
     @{
 */
 #define RT_MII_LINK         0x0004  /**< \brief Link is present */
@@ -125,7 +133,7 @@ __BEGIN_DECLS
 /** @} */
 
 /** \defgroup bba_cbits Command Bits
-    \ingroup            bba
+    \brief    BBA command register fields
 
     OR appropriate bit values together and write into the RT_CHIPCMD register to
     execute the command.
@@ -139,7 +147,7 @@ __BEGIN_DECLS
 /** @} */
 
 /** \defgroup bba_ibits Interrupt Status Bits
-    \ingroup            bba
+    \brief    BBA interrupt status fields
     @{
 */
 #define RT_INT_PCIERR           0x8000  /**< \brief PCI Bus error */
@@ -153,14 +161,12 @@ __BEGIN_DECLS
 #define RT_INT_RX_ERR           0x0002  /**< \brief Rx error */
 #define RT_INT_RX_OK            0x0001  /**< \brief Rx OK */
 
-/** \brief   Composite RX bits we check for while doing an RX interrupt. 
-    \ingroup bba
- */
+/** \brief Composite RX bits we check for while doing an RX interrupt. */
 #define RT_INT_RX_ACK (RT_INT_RXFIFO_OVERFLOW | RT_INT_RXBUF_OVERFLOW | RT_INT_RX_OK)
 /** @} */
 
 /** \defgroup bba_tbits Transmit Status Bits
-    \ingroup            bba
+    \brief    BBA transmit status register fields
     @{
 */
 #define RT_TX_CARRIER_LOST  0x80000000  /**< \brief Carrier sense lost */
@@ -173,7 +179,7 @@ __BEGIN_DECLS
 /** @} */
 
 /** \defgroup bba_rbits Receive Status Bits
-    \ingroup            bba
+    \brief    BBA receive status register fields
     @{
 */
 #define RT_RX_MULTICAST     0x00008000  /**< \brief Multicast packet */
@@ -188,7 +194,7 @@ __BEGIN_DECLS
 /** @} */
 
 /** \defgroup bba_config1bits Config Register 1 Bits
-    \ingroup                  bba
+    \brief    BBA config register 1 fields
 
     From RTL8139C(L) datasheet v1.4
 
@@ -205,7 +211,7 @@ __BEGIN_DECLS
 /** @} */
 
 /** \defgroup bba_config4bits Config Register 4 Bits
-    \ingroup  bba
+    \brief    BBA config register 4 fields
 
     From RTL8139C(L) datasheet v1.4. Only RT_CONFIG4_RxFIFIOAC is used.
 
@@ -222,7 +228,7 @@ __BEGIN_DECLS
 /** @} */
 
 /** \defgroup bba_config5bits Config Register 5 Bits
-    \ingroup                  bba
+    \brief    BBA config register 5 fields
 
     From RTL8139C(L) datasheet v1.4. Only RT_CONFIG5_LDPS is used.
 
@@ -238,8 +244,11 @@ __BEGIN_DECLS
 #define RT_CONFIG5_PME_STS  0x01 /**< \brief Allow PCI reset to set PME_Status bit. */
 /** @} */
 
+/** @} */
+
+/** @} */
+
 /** \brief   Retrieve the MAC Address of the attached BBA.
-    \ingroup bba
 
     This function reads the MAC Address of the BBA and places it in the buffer
     passed in. The resulting data is undefined if no BBA is connected.
@@ -248,8 +257,12 @@ __BEGIN_DECLS
 */
 void bba_get_mac(uint8 *arr);
 
+/** \defgroup bba_rx RX
+    \brief    Receive packet API for the BBA
+    @{
+*/
+
 /** \brief   Receive packet callback function type.
-    \ingroup bba
 
     When a packet is received by the BBA, the callback function will be called
     to handle it.
@@ -260,7 +273,6 @@ void bba_get_mac(uint8 *arr);
 typedef void (*eth_rx_callback_t)(uint8 *pkt, int len);
 
 /** \brief   Set the ethernet packet receive callback.
-    \ingroup bba
 
     This function sets the function called when a packet is received by the BBA.
     Generally, this inputs into the network layer.
@@ -269,8 +281,15 @@ typedef void (*eth_rx_callback_t)(uint8 *pkt, int len);
 */
 void bba_set_rx_callback(eth_rx_callback_t cb);
 
-/** \defgroup bba_txrv  bba_tx() Return Values
-    \ingroup            bba
+/** @} */
+
+/** \defgroup bba_tx TX
+    \brief    Transmit packet API for the BBA
+    @{
+*/
+
+/** \defgroup bba_txrv  Return Values
+    \brief    Return values for bba_tx()
     @{
 */
 #define BBA_TX_OK       0   /**< \brief Transmit success */
@@ -279,13 +298,14 @@ void bba_set_rx_callback(eth_rx_callback_t cb);
 /** @} */
 
 /** \defgroup bba_wait  Wait Modes
-    \ingroup            bba
+    \brief    Wait modes for bba_tx()
+    @{
 */
 #define BBA_TX_NOWAIT   0   /**< \brief Don't block waiting for the transfer. */
 #define BBA_TX_WAIT     1   /**< \brief Wait, if needed on transfer. */
+/** @} */
 
 /** \brief   Transmit a single packet.
-    \ingroup bba
 
     This function transmits a single packet on the bba, waiting for the link to
     become stable, if requested.
@@ -302,6 +322,8 @@ void bba_set_rx_callback(eth_rx_callback_t cb);
 */
 int bba_tx(const uint8 *pkt, int len, int wait);
 
+/** @} */
+
 /* \cond */
 /* Initialize */
 int bba_init(void);
@@ -309,6 +331,8 @@ int bba_init(void);
 /* Shutdown */
 int bba_shutdown(void);
 /* \endcond */
+
+/** @} */
 
 __END_DECLS
 


### PR DESCRIPTION
- I went back through and noticed somehow the BBA was the only set of doxygen topics in the whole codebase still missing `\brief` info, added.
- Reorganized topics for improved discoverablity and grouping

Here she is now:
![Screenshot from 2023-12-20 23-11-58](https://github.com/KallistiOS/KallistiOS/assets/5545520/0c9339f5-a6b6-41a9-bcc9-132f5f658dc7)
