### PR TITLE
Added Disclaimer to 800x608 Resolution Example

### DIFF
--- a/examples/dreamcast/libdream/800x608/800x608.c
+++ b/examples/dreamcast/libdream/800x608/800x608.c
@@ -22,6 +22,9 @@ int main(int argc, char **argv) {
     cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
                       (cont_btn_callback_t)arch_exit);
 
+    printf("\n\n*** NOTE: This example is still a work in progress\n");
+    printf("          as this resolution is not fully supported! ***\n\n");
+
     /* Set video mode */
     vid_set_mode(DM_800x608, PM_RGB565);
 


### PR DESCRIPTION
- Because users, including our own developers, are continually being confused by the garbled output after not fully reading the example's comment. :)

Related Issue: https://github.com/KallistiOS/KallistiOS/issues/264