### PR TITLE
Added Toolchain Option to Enable Newlib's Multibyte/Wide Character Support

### DIFF
--- a/utils/dc-chain/config/config.mk.10.5.0.sample
+++ b/utils/dc-chain/config/config.mk.10.5.0.sample
@@ -138,6 +138,13 @@ thread_model=kos
 # ptrdiff_t, intmax_t, and sized integral types.
 newlib_c99_formats=1
 
+# Multibyte Character Set Support (1|0)
+# Define this to build Newlib with additional multibyte support. This enables
+# three special locales: "C-JIS", "C-SJIS", and "C-EUCJP". The multibyte
+# support extends to the mb and wc functions in stdlib as well as format
+# characters for the printf and scanf family of routines.
+#newlib_multibyte=1
+
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will
 # build Newlib with compiler flags which favor smaller code sizes over faster

--- a/utils/dc-chain/config/config.mk.11.4.0.sample
+++ b/utils/dc-chain/config/config.mk.11.4.0.sample
@@ -138,6 +138,13 @@ thread_model=kos
 # ptrdiff_t, intmax_t, and sized integral types.
 newlib_c99_formats=1
 
+# Multibyte Character Set Support (1|0)
+# Define this to build Newlib with additional multibyte support. This enables
+# three special locales: "C-JIS", "C-SJIS", and "C-EUCJP". The multibyte
+# support extends to the mb and wc functions in stdlib as well as format
+# characters for the printf and scanf family of routines.
+#newlib_multibyte=1
+
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will
 # build Newlib with compiler flags which favor smaller code sizes over faster

--- a/utils/dc-chain/config/config.mk.12.3.0.sample
+++ b/utils/dc-chain/config/config.mk.12.3.0.sample
@@ -138,6 +138,13 @@ thread_model=kos
 # ptrdiff_t, intmax_t, and sized integral types.
 newlib_c99_formats=1
 
+# Multibyte Character Set Support (1|0)
+# Define this to build Newlib with additional multibyte support. This enables
+# three special locales: "C-JIS", "C-SJIS", and "C-EUCJP". The multibyte
+# support extends to the mb and wc functions in stdlib as well as format
+# characters for the printf and scanf family of routines.
+#newlib_multibyte=1
+
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will
 # build Newlib with compiler flags which favor smaller code sizes over faster

--- a/utils/dc-chain/config/config.mk.9.3.0.sample
+++ b/utils/dc-chain/config/config.mk.9.3.0.sample
@@ -138,6 +138,13 @@ thread_model=kos
 # ptrdiff_t, intmax_t, and sized integral types.
 newlib_c99_formats=1
 
+# Multibyte Character Set Support (1|0)
+# Define this to build Newlib with additional multibyte support. This enables
+# three special locales: "C-JIS", "C-SJIS", and "C-EUCJP". The multibyte
+# support extends to the mb and wc functions in stdlib as well as format
+# characters for the printf and scanf family of routines.
+#newlib_multibyte=1
+
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will
 # build Newlib with compiler flags which favor smaller code sizes over faster

--- a/utils/dc-chain/config/config.mk.devel.sample
+++ b/utils/dc-chain/config/config.mk.devel.sample
@@ -148,6 +148,13 @@ thread_model=kos
 # ptrdiff_t, intmax_t, and sized integral types.
 newlib_c99_formats=1
 
+# Multibyte Character Set Support (1|0)
+# Define this to build Newlib with additional multibyte support. This enables
+# three special locales: "C-JIS", "C-SJIS", and "C-EUCJP". The multibyte
+# support extends to the mb and wc functions in stdlib as well as format
+# characters for the printf and scanf family of routines.
+#newlib_multibyte=1
+
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will
 # build Newlib with compiler flags which favor smaller code sizes over faster

--- a/utils/dc-chain/config/config.mk.legacy.sample
+++ b/utils/dc-chain/config/config.mk.legacy.sample
@@ -138,6 +138,13 @@ thread_model=kos
 # ptrdiff_t, intmax_t, and sized integral types.
 newlib_c99_formats=1
 
+# Multibyte Character Set Support (1|0)
+# Define this to build Newlib with additional multibyte support. This enables
+# three special locales: "C-JIS", "C-SJIS", and "C-EUCJP". The multibyte
+# support extends to the mb and wc functions in stdlib as well as format
+# characters for the printf and scanf family of routines.
+#newlib_multibyte=1
+
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will
 # build Newlib with compiler flags which favor smaller code sizes over faster

--- a/utils/dc-chain/config/config.mk.stable.sample
+++ b/utils/dc-chain/config/config.mk.stable.sample
@@ -138,6 +138,13 @@ thread_model=kos
 # ptrdiff_t, intmax_t, and sized integral types.
 newlib_c99_formats=1
 
+# Multibyte Character Set Support (1|0)
+# Define this to build Newlib with additional multibyte support. This enables
+# three special locales: "C-JIS", "C-SJIS", and "C-EUCJP". The multibyte
+# support extends to the mb and wc functions in stdlib as well as format
+# characters for the printf and scanf family of routines.
+#newlib_multibyte=1
+
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will
 # build Newlib with compiler flags which favor smaller code sizes over faster

--- a/utils/dc-chain/config/config.mk.winxp-latest.sample
+++ b/utils/dc-chain/config/config.mk.winxp-latest.sample
@@ -138,6 +138,13 @@ thread_model=kos
 # ptrdiff_t, intmax_t, and sized integral types.
 newlib_c99_formats=1
 
+# Multibyte Character Set Support (1|0)
+# Define this to build Newlib with additional multibyte support. This enables
+# three special locales: "C-JIS", "C-SJIS", and "C-EUCJP". The multibyte
+# support extends to the mb and wc functions in stdlib as well as format
+# characters for the printf and scanf family of routines.
+#newlib_multibyte=1
+
 # Optimize Newlib for Space (1|0)
 # Define this to enable optimizing for space when building Newlib. This will
 # build Newlib with compiler flags which favor smaller code sizes over faster

--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -146,6 +146,12 @@ ifdef newlib_opt_space
   endif
 endif
 
+ifdef newlib_multibyte
+  ifneq (0,$(newlib_multibyte))
+    newlib_extra_configure_args += --enable-newlib-mb
+  endif
+endif
+
 # Function to verify variable is not empty
 # Args:
 # 1 - Variable Name


### PR DESCRIPTION
Someone actually asked about this today... maybe they were joking, but it doesn't seem that unreasonable. I've really been considering how I'd be handling localization lately on a game, and this could be a potential avenue. Might as well give them the option, because I tested, and it works fine!

- Added check for variable and application of flag to Newlib in init.mk
- Added a (default disabled) flag for enabling it with a description in config.mk.stable.sample