### PR TITLE
Fix dc-chain host-detect include order

### DIFF
--- a/utils/dc-chain/Makefile
+++ b/utils/dc-chain/Makefile
@@ -20,11 +20,14 @@ else
   $(error The required $(config_file) file is missing)
 endif
 
-# Initialization rules
-include scripts/init.mk
+# Download Functions
+include scripts/utils.mk
 
 # Detect host machine
 include scripts/host-detect.mk
+
+# Initialization rules
+include scripts/init.mk
 
 # Makefile variables
 include scripts/variables.mk

--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -165,32 +165,3 @@ warn_and_fallback = $(if $($(1)),, \
 # Fallback to _tarball_type config options if _download_type was not provided
 packages = gdb
 $(foreach package, $(packages), $(eval $(call warn_and_fallback,$(package)_download_type,$(package)_tarball_type)))
-
-# Web downloaders command-lines
-downloaders = curl wget
-wget_cmd = wget -c $(if $(2),-O $(2)) '$(1)'
-curl_cmd = curl --fail --location  -C - $(if $(2),-o $(2),-O) '$(1)' 
-
-ifneq ($(force_downloader),)
-# Check if specified downloader is in supported list
-  web_downloader = $(if $(filter $(downloaders),$(force_downloader)),$(force_downloader))
-else
-# If no downloader specified, check to see if any are detected
-  web_downloader = $(if $(shell command -v curl),curl,$(if $(shell command -v wget),wget))
-endif
-
-# Make sure valid downloader was found
-ifeq ($(web_downloader),)
-  ifeq ($(force_downloader),)
-    $(error No supported downloader was found ($(downloaders)))
-  else
-    $(error Unsupported downloader ($(force_downloader)), select from ($(downloaders))) 
-  endif
-endif
-
-$(info Using $(web_downloader) as download tool)
-# Function to call downloader
-# Args:
-# 1 - URL
-# 2 - Output File (Optional)
-web_download = $(call $(web_downloader)_cmd,$(1),$(2))

--- a/utils/dc-chain/scripts/utils.mk
+++ b/utils/dc-chain/scripts/utils.mk
@@ -1,0 +1,34 @@
+# Sega Dreamcast Toolchains Maker (dc-chain)
+# This file is part of KallistiOS.
+#
+# Added by Colton Pawielski (2023)
+#
+
+# Web downloaders command-lines
+downloaders = curl wget
+wget_cmd = wget -c $(if $(2),-O $(2)) '$(1)'
+curl_cmd = curl --fail --location  -C - $(if $(2),-o $(2),-O) '$(1)' 
+
+ifneq ($(force_downloader),)
+# Check if specified downloader is in supported list
+  web_downloader = $(if $(filter $(downloaders),$(force_downloader)),$(force_downloader))
+else
+# If no downloader specified, check to see if any are detected
+  web_downloader = $(if $(shell command -v curl),curl,$(if $(shell command -v wget),wget))
+endif
+
+# Make sure valid downloader was found
+ifeq ($(web_downloader),)
+  ifeq ($(force_downloader),)
+    $(error No supported downloader was found ($(downloaders)))
+  else
+    $(error Unsupported downloader ($(force_downloader)), select from ($(downloaders))) 
+  endif
+endif
+
+$(info Using $(web_downloader) as download tool)
+# Function to call downloader
+# Args:
+# 1 - URL
+# 2 - Output File (Optional)
+web_download = $(call $(web_downloader)_cmd,$(1),$(2))


### PR DESCRIPTION
Splits the download function into a separate file to be included prior to `host-detect.mk`. This allows the order of `init.mk` and `host-detect.mk` to be reverted to match their order prior to being changed in [a9ac6f8](https://github.com/KallistiOS/KallistiOS/commit/a9ac6f8a5b1cacf8a1ffb98682795853ba16286b).

Fixes #418