### PR TITLE
Properly clean dc-chain builds from SH4 Pass1 & GDB

### DIFF
--- a/utils/dc-chain/scripts/build.mk
+++ b/utils/dc-chain/scripts/build.mk
@@ -10,7 +10,6 @@ build-sh4: build-sh4-gcc
 build-arm: build-arm-gcc
 build-sh4-gcc: build-sh4-gcc-pass2
 build-arm-gcc: build-arm-gcc-pass1
-	$(clean_arm_hack)
 build-sh4-newlib: build-sh4-newlib-only fixup-sh4-newlib
 
 fixup_sh4_newlib_stamp = fixup-sh4-newlib.stamp

--- a/utils/dc-chain/scripts/gcc-pass1.mk
+++ b/utils/dc-chain/scripts/gcc-pass1.mk
@@ -30,3 +30,4 @@ $(build_gcc_pass1): logdir
 	      $(to_log)
 	$(MAKE) $(makejobs) -C $(build) DESTDIR=$(DESTDIR) $(to_log)
 	$(MAKE) -C $(build) $(install_mode) DESTDIR=$(DESTDIR) $(to_log)
+	$(clean_up)

--- a/utils/dc-chain/scripts/options.mk
+++ b/utils/dc-chain/scripts/options.mk
@@ -11,11 +11,6 @@ ifeq (1,$(erase))
     @echo "+++ Cleaning up $(build)..."
     -rm -rf $(build)
   endef
-  # Hack to clean up ARM gcc pass 1
-  define clean_arm_hack
-    @echo "+++ Cleaning up build-gcc-$(arm_target)-$(gcc_ver)..."
-    -rm -rf build-gcc-$(arm_target)-$(gcc_ver)
-  endef
 endif
 
 # If verbose=1, display output to screen as well as log files


### PR DESCRIPTION
Due to the split of Pass1 & Pass2 build folders the clean_up helper needed to be added to Pass1 as `build-gcc-sh4-*-pass1` wasn't being cleaned up when `erase=1` was specified in the config. This change also allowed the removal of an "hack" for removing the ARM Pass1 build folder. 

Also added the clean_up helper to the gdb install step to similarly delete the build folder when `erase=1`.