### PR TITLE
Improve fipr for single-only too

### DIFF
--- a/kernel/arch/dreamcast/include/dc/fmath_base.h
+++ b/kernel/arch/dreamcast/include/dc/fmath_base.h
@@ -130,23 +130,59 @@ __BEGIN_DECLS
                 : "=f" (__arg) : "0" (__arg)); \
         __arg; })
 
+
+#if __SH4_SINGLE_ONLY__
+
 /* Floating point inner product (dot product) */
-#define __fipr(x, y, z, w, a, b, c, d) ({ \
-        register float __x __asm__("fr5") = (x); \
-        register float __y __asm__("fr4") = (y); \
-        register float __z __asm__("fr7") = (z); \
-        register float __w __asm__("fr6") = (w); \
-        register float __a __asm__("fr9") = (a); \
-        register float __b __asm__("fr8") = (b); \
-        register float __c __asm__("fr11") = (c); \
-        register float __d __asm__("fr10") = (d); \
+#define __fipr(x, y, z, w, a, b, c, d)                                  \
+    ({                                                                  \
+        register float __x __asm__("fr4") = (x);                        \
+        register float __y __asm__("fr5") = (y);                        \
+        register float __z __asm__("fr6") = (z);                        \
+        register float __w __asm__("fr7") = (w);                        \
+        register float __a __asm__("fr8") = (a);                        \
+        register float __b __asm__("fr9") = (b);                        \
+        register float __c __asm__("fr10") = (c);                       \
+        register float __d __asm__("fr11") = (d);                       \
+        __asm__ __volatile__("fipr	fv8,fv4"                             \
+                             : "+f"(__z)                                \
+                             : "f"(__x), "f"(__y), "f"(__z), "f"(__w),  \
+                               "f"(__a), "f"(__b), "f"(__c), "f"(__d)); \
+        __z;                                                            \
+    })
+
+/* Floating point inner product w/self (square of vector magnitude) */
+#define __fipr_magnitude_sqr(x, y, z, w) ({ \
+        register float __x __asm__("fr4") = (x); \
+        register float __y __asm__("fr5") = (y); \
+        register float __z __asm__("fr6") = (z); \
+        register float __w __asm__("fr7") = (w); \
         __asm__ __volatile__( \
-                              "fipr	fv8,fv4" \
+                              "fipr	fv4,fv4" \
                               : "+f" (__z) \
-                              : "f" (__x), "f" (__y), "f" (__z), "f" (__w), \
-                              "f" (__a), "f" (__b), "f" (__c), "f" (__d) \
+                              : "f" (__x), "f" (__y), "f" (__z), "f" (__w) \
                             ); \
         __z; })
+
+#else
+
+/* Floating point inner product (dot product) */
+#define __fipr(x, y, z, w, a, b, c, d)                                  \
+    ({                                                                  \
+        register float __x __asm__("fr5") = (x);                        \
+        register float __y __asm__("fr4") = (y);                        \
+        register float __z __asm__("fr7") = (z);                        \
+        register float __w __asm__("fr6") = (w);                        \
+        register float __a __asm__("fr9") = (a);                        \
+        register float __b __asm__("fr8") = (b);                        \
+        register float __c __asm__("fr11") = (c);                       \
+        register float __d __asm__("fr10") = (d);                       \
+        __asm__ __volatile__("fipr	fv8,fv4"                             \
+                             : "+f"(__z)                                \
+                             : "f"(__x), "f"(__y), "f"(__z), "f"(__w),  \
+                               "f"(__a), "f"(__b), "f"(__c), "f"(__d)); \
+        __z;                                                            \
+    })
 
 /* Floating point inner product w/self (square of vector magnitude) */
 #define __fipr_magnitude_sqr(x, y, z, w) ({ \
@@ -160,6 +196,8 @@ __BEGIN_DECLS
                               : "f" (__x), "f" (__y), "f" (__z), "f" (__w) \
                             ); \
         __z; })
+
+#endif
 
 /** \endcond */
 

--- a/kernel/arch/dreamcast/include/dc/fmath_base.h
+++ b/kernel/arch/dreamcast/include/dc/fmath_base.h
@@ -144,11 +144,11 @@ __BEGIN_DECLS
         register float __b __asm__("fr9") = (b);                        \
         register float __c __asm__("fr10") = (c);                       \
         register float __d __asm__("fr11") = (d);                       \
-        __asm__ __volatile__("fipr	fv8,fv4"                             \
-                             : "+f"(__z)                                \
+        __asm__ __volatile__("fipr	fv8,fv4"                        \
+                             : "+f"(__w)                                \
                              : "f"(__x), "f"(__y), "f"(__z), "f"(__w),  \
                                "f"(__a), "f"(__b), "f"(__c), "f"(__d)); \
-        __z;                                                            \
+        __w;                                                            \
     })
 
 /* Floating point inner product w/self (square of vector magnitude) */
@@ -159,10 +159,10 @@ __BEGIN_DECLS
         register float __w __asm__("fr7") = (w); \
         __asm__ __volatile__( \
                               "fipr	fv4,fv4" \
-                              : "+f" (__z) \
+                              : "+f" (__w) \
                               : "f" (__x), "f" (__y), "f" (__z), "f" (__w) \
                             ); \
-        __z; })
+        __w; })
 
 #else
 
@@ -177,7 +177,7 @@ __BEGIN_DECLS
         register float __b __asm__("fr8") = (b);                        \
         register float __c __asm__("fr11") = (c);                       \
         register float __d __asm__("fr10") = (d);                       \
-        __asm__ __volatile__("fipr	fv8,fv4"                             \
+        __asm__ __volatile__("fipr	fv8,fv4"                        \
                              : "+f"(__z)                                \
                              : "f"(__x), "f"(__y), "f"(__z), "f"(__w),  \
                                "f"(__a), "f"(__b), "f"(__c), "f"(__d)); \


### PR DESCRIPTION
Our current implementations of these functions for -m4-single-only flag are slower than they are for -m4-single.  This PR works around a possible bug in GCC described by zcrc:

for -m4 and -m4-single, float parameter passing order is fr5, fr4, fr7, fr6, fr9, fr8, fr11, fr10 (on little-endian at least)
Apparently GCC considers that for -m4-single-only the passing order is fr4, fr5, fr6, fr7... fr11

https://godbolt.org/z/ME67xrxEM

