### PR TITLE
Disabling Watchdog Timer on KOS exit and init

### DIFF
--- a/examples/dreamcast/basic/watchdog/watchdog.c
+++ b/examples/dreamcast/basic/watchdog/watchdog.c
@@ -30,7 +30,7 @@
 #define SEC             (1000 * MSEC)
 
 /* Test configuration constants */
-#define WDT_PET_COUNT   2000
+#define WDT_PET_COUNT   4000
 #define WDT_INTERVAL    (500 * MSEC)
 #define WDT_SECONDS     10 
 #define WDT_COUNT_MAX   ((WDT_SECONDS * SEC) / WDT_INTERVAL)
@@ -56,14 +56,6 @@ int main(int argc, char *argv[]) {
     cont_btn_callback(0, CONT_START | CONT_A | CONT_B | CONT_X | CONT_Y,
                       (cont_btn_callback_t)exit);
 
-    /* Note that is EXTREMELY important that the WDT gets disabled 
-       when it is done being used, otherwise it can continue running
-       after the application exits and can interfere with DC-Load 
-       operation. Since we have multiple exit points (one from returning
-       from main and one from the button callback), the safest thing to do
-       is to register wdt_disable() to be called automatically upon exit. */
-    atexit(wdt_disable);
-
     printf("\nEnabling WDT in watchdog mode!\n");
 
     /* Enable watchdog mode with a period of 5.25ms, causing a manual 
@@ -81,7 +73,8 @@ int main(int argc, char *argv[]) {
         if(current_count > max_count)  
             max_count = current_count;
 
-        wdt_pet();
+        if(current_count) 
+            wdt_pet();
     }
 
     /* Immediately disable the WDT once we're done with it. */

--- a/examples/dreamcast/cpp/concurrency/concurrency.cpp
+++ b/examples/dreamcast/cpp/concurrency/concurrency.cpp
@@ -706,9 +706,6 @@ int main(int argc, char* argv[]) {
                         exit(EXIT_FAILURE);
                     }, nullptr);
 
-    // Ensure that we disable the watchdog timer no matter how we exit 
-    atexit(wdt_disable);
-
     /* Spawn N automatically joined threads which will each spawn threads 
        for each test case and asynchronously wait upon their results... Basically 
        making each thread execute its own instances of every test case concurrently 

--- a/kernel/arch/dreamcast/include/arch/wdt.h
+++ b/kernel/arch/dreamcast/include/arch/wdt.h
@@ -47,13 +47,6 @@ __BEGIN_DECLS
 
     The timer can be stopped in either mode by calling wdt_disable().
 
-    \warning
-    Once the WDT has been enabled, special care must be taken to disable it
-    when exiting from the application. If left enabled, the WDT will continue
-    running beyond the lifetime of the application, causing either a reset or
-    an unhandled exception (depending on which mode was used), preventing you
-    from gracefully returning to a DC-Load session when testing.
-
     \sa rtc
 */
 

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -17,6 +17,7 @@
 #include <arch/memory.h>
 #include <arch/rtc.h>
 #include <arch/timer.h>
+#include <arch/wdt.h>
 #include <dc/ubc.h>
 #include <dc/pvr.h>
 #include <dc/vmufs.h>
@@ -250,6 +251,9 @@ void arch_main(void) {
     *DMAOR = 0x8201;
 #endif /* _arch_sub_naomi */
 
+    /* Ensure the WDT is not enabled from a previous session */
+    wdt_disable();
+
     /* Ensure that UBC is not enabled from a previous session */
     ubc_disable_all();
 
@@ -288,6 +292,9 @@ void arch_shutdown(void) {
     _fini();
 
     dbglog(DBG_CRITICAL, "arch: shutting down kernel\n");
+
+    /* Disable the WDT, if active */
+    wdt_disable();
 
     /* Turn off UBC breakpoints, if any */
     ubc_disable_all();
@@ -366,6 +373,9 @@ void arch_menu(void) {
 /* Called to shut down non-gracefully; assume the system is in peril
    and don't try to call the dtors */
 void arch_abort(void) {
+    /* Disable the WDT, if active */
+    wdt_disable();
+
     /* Turn off UBC breakpoints, if any */
     ubc_disable_all();
 


### PR DESCRIPTION
So long story short, I had tried to make the WDT driver completely standalone and noninvasive, which meant REQUIRING the user disable it when they were done with it, or bad things would happen... I had explained that `atexit(wdt_disable)` was the preferred mechanism... But it turns out that when we aren't exiting gracefully from something like an unhandled exception or an abort, that finalizer entry never even gets called...

...and trust me, you want it to be called. Otherwise either your DC will reboot itself after the program exits (when used as a WDT) OR you will get an unhandled exception error the minute KOS initializes, as the IRQ is still enabled but has no handler (when used as an interval timer). The only graceful way to handle this is to make KOS itself handle deinitializing the WDT... But perhaps this is better than forcing it upon the user anyway? The same exact scenario holds true for the UBC, and this is how it is handled within KOS as well (disabling UBC breakpoints on startup and shutdown). 

- Kept running into issues where nongraceful exit would not call `atexit(wdt_disable)`
- The only foolproof way to ensure graceful WDT behavior is to disable it within KOS itself for deinit/init paths
- Updated examples to reflect this change

EDIT: Oh, I noticed that 1 in 10 test runs for the WDT test would fail, due to not giving it enough time to increment the counter before petting it... Made the testing more robust while I was at it, so shouldn't have any false failures now. Should also fail gracefully on an emulator. :)