### PR TITLE
Fixed INIT_MALLOCSTATS KOS init flag

### DIFF
--- a/kernel/libc/koslib/malloc.c
+++ b/kernel/libc/koslib/malloc.c
@@ -5280,11 +5280,11 @@ void mSTATs(void) {
 #endif
 
 
-    fprintf(stderr, "max system bytes = %10lu\n",
+    dbglog(DBG_CRITICAL, "max system bytes = %10lu\n",
             (CHUNK_SIZE_T)(mi.usmblks));
-    fprintf(stderr, "system bytes     = %10lu\n",
+    dbglog(DBG_CRITICAL, "system bytes     = %10lu\n",
             (CHUNK_SIZE_T)(mi.arena + mi.hblkhd));
-    fprintf(stderr, "in use bytes     = %10lu\n",
+    dbglog(DBG_CRITICAL, "in use bytes     = %10lu\n",
             (CHUNK_SIZE_T)(mi.uordblks + mi.hblkhd));
 
 #ifdef WIN32


### PR DESCRIPTION
- It was not displaying properly previously when used
- Apparently newlib had already shut down standard I/O handling code when this code was called (which used `fprintf(stderr)`)
- Moved to KOS's logging mechanism to bypass newlib