### PR TITLE
Fixed GLdc Nehe26 Example Build Failure

### DIFF
--- a/examples/dreamcast/gldc/nehe/nehe26/nehe26.c
+++ b/examples/dreamcast/gldc/nehe/nehe26/nehe26.c
@@ -47,7 +47,7 @@ GLfloat xspeed, yspeed, zspeed;  /* Spin Speed                               */
 
 int key = 1;                     /* Make Sure Same Morph Key Not Pressed     */
 int step = 0, steps = 200;       /* Step Counter And Maximum Number Of Steps */
-bool morph = false;              /* Default morph To false (Not Morphing)    */
+bool morph = false;              /* Default morph To False (Not Morphing)    */
 
 int maxver;                            /* Holds The Max Number Of Vertices   */
 object morph1, morph2, morph3, morph4, /* Our 4 Morphable Objects            */
@@ -234,7 +234,7 @@ void draw_gl(void) {
      * * The Same Amount Of Verts For Simplicity, Could Use maxver Also)
      * */
     for(i = 0; i < morph1.verts; i++) {
-        /* If morph Is true Calculate Movement Otherwise Movement=0 */
+        /* If morph Is True, Calculate Movement Otherwise Movement=0 */
         if(morph)
             q = calculate(i);
         else
@@ -289,7 +289,7 @@ void draw_gl(void) {
 
     /* If We're Morphing And We Haven't Gone Through All 200 Steps
      * Increase Our Step Counter
-     * Otherwise Set Morphing To false, Make Source=Destination And
+     * Otherwise Set Morphing To False, Make Source=Destination And
      * Set The Step Counter Back To Zero.
      */
 

--- a/examples/dreamcast/gldc/nehe/nehe26/nehe26.c
+++ b/examples/dreamcast/gldc/nehe/nehe26/nehe26.c
@@ -10,6 +10,7 @@
 #include <kos.h>
 
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include <GL/gl.h>
 #include <GL/glu.h>
@@ -29,11 +30,6 @@
 #define SCREEN_WIDTH  640
 #define SCREEN_HEIGHT 400
 
-/* Set up some booleans */
-#define TRUE  1
-#define FALSE 0
-typedef unsigned int bool;
-
 /* Build Our Vertex Structure */
 typedef struct {
     float x, y, z; /* 3D Coordinates */
@@ -51,7 +47,7 @@ GLfloat xspeed, yspeed, zspeed;  /* Spin Speed                               */
 
 int key = 1;                     /* Make Sure Same Morph Key Not Pressed     */
 int step = 0, steps = 200;       /* Step Counter And Maximum Number Of Steps */
-bool morph = FALSE;              /* Default morph To False (Not Morphing)    */
+bool morph = false;              /* Default morph To false (Not Morphing)    */
 
 int maxver;                            /* Holds The Max Number Of Vertices   */
 object morph1, morph2, morph3, morph4, /* Our 4 Morphable Objects            */
@@ -203,7 +199,7 @@ int initGL(GLvoid) {
     /* Source & Destination Are Set To Equal First Object (morph1) */
     sour = dest = &morph1;
 
-    return(TRUE);
+    return(true);
 }
 
 void draw_gl(void) {
@@ -238,7 +234,7 @@ void draw_gl(void) {
      * * The Same Amount Of Verts For Simplicity, Could Use maxver Also)
      * */
     for(i = 0; i < morph1.verts; i++) {
-        /* If morph Is True Calculate Movement Otherwise Movement=0 */
+        /* If morph Is true Calculate Movement Otherwise Movement=0 */
         if(morph)
             q = calculate(i);
         else
@@ -293,7 +289,7 @@ void draw_gl(void) {
 
     /* If We're Morphing And We Haven't Gone Through All 200 Steps
      * Increase Our Step Counter
-     * Otherwise Set Morphing To False, Make Source=Destination And
+     * Otherwise Set Morphing To false, Make Source=Destination And
      * Set The Step Counter Back To Zero.
      */
 
@@ -301,7 +297,7 @@ void draw_gl(void) {
         step++;
     }
     else {
-        morph = FALSE;
+        morph = false;
         sour  = dest;
         step  = 0;
     }
@@ -340,25 +336,25 @@ int main(int argc, char **argv) {
             break;
 
         if((state->buttons & CONT_A) && !morph && NOT_LAST) {
-            morph = TRUE;
+            morph = true;
             dest = &morph1;
             last = CONT_A;
         }
 
         if((state->buttons & CONT_X) && !morph && NOT_LAST) {
-            morph = TRUE;
+            morph = true;
             dest = &morph2;
             last = CONT_X;
         }
 
         if((state->buttons & CONT_Y) && !morph && NOT_LAST) {
-            morph = TRUE;
+            morph = true;
             dest = &morph3;
             last = CONT_Y;
         }
 
         if((state->buttons & CONT_B) && !morph && NOT_LAST) {
-            morph = TRUE;
+            morph = true;
             dest = &morph4;
             last = CONT_B;
         }

--- a/examples/dreamcast/gldc/nehe/nehe26/nehe26.c
+++ b/examples/dreamcast/gldc/nehe/nehe26/nehe26.c
@@ -2,9 +2,9 @@
    KallistiOS 2.0.0
 
    nehe26.c
-   (c)2014 Josh Pearson
-   (c)2001 Benoit Miller
-   (c)2000 Jeff Molofee
+   Copyright (c) 2014 Josh Pearson
+   Copyright (c) 2001 Benoit Miller
+   Copyright (c) 2000 Jeff Molofee
 */
 
 #include <kos.h>
@@ -26,53 +26,53 @@
    rotation.
 */
 
-/* screen width, height, and bit depth */
+/* Screen width, height, and bit depth */
 #define SCREEN_WIDTH  640
 #define SCREEN_HEIGHT 400
 
-/* Build Our Vertex Structure */
+/* Build our vertex structure */
 typedef struct {
-    float x, y, z; /* 3D Coordinates */
+    float x, y, z; /* 3D coordinates */
 } vertex;
 
-/* Build Our Object Structure */
+/* Build our object structure */
 typedef struct {
-    int verts;      /* Number Of Vertices For The Object */
-    vertex *points; /* One Vertice (Vertex x,y & z)      */
+    int verts;      /* Number of vertices for the object */
+    vertex *points; /* One Vertex (Vertex x,y & z)       */
 } object;
 
 GLfloat xrot, yrot, zrot;        /* Camera rotation variables                */
 GLfloat cx, cy, cz = -15;        /* Camera pos variable                      */
-GLfloat xspeed, yspeed, zspeed;  /* Spin Speed                               */
+GLfloat xspeed, yspeed, zspeed;  /* Spin speed                               */
 
-int key = 1;                     /* Make Sure Same Morph Key Not Pressed     */
-int step = 0, steps = 200;       /* Step Counter And Maximum Number Of Steps */
-bool morph = false;              /* Default morph To False (Not Morphing)    */
+int key = 1;                     /* Make sure same morph key not pressed     */
+int step = 0, steps = 200;       /* Step counter and maximum number of steps */
+bool morph = false;              /* Default morph to false (not morphing)    */
 
-int maxver;                            /* Holds The Max Number Of Vertices   */
-object morph1, morph2, morph3, morph4, /* Our 4 Morphable Objects            */
-       helper, *sour, *dest;          /* Helper, Source, Destination Object */
+int maxver;                            /* Holds the max number of vertices   */
+object morph1, morph2, morph3, morph4, /* Our 4 morphable objects            */
+       helper, *sour, *dest;           /* Helper, source, destination object */
 
 #define MORPHS 4
 
-/* function to allocate memory for an object */
+/* Function to allocate memory for an object */
 void objallocate(object *k, int n) {
 
-    /* Sets points Equal To VERTEX * Number Of Vertices */
+    /* Sets points equal to vertex * number of vertices */
     k->points = (vertex *)malloc(sizeof(vertex) * n);
 }
 
-/* function deallocate memory for an object */
+/* Function deallocate memory for an object */
 void objfree(object *k) {
 
     free(k->points);
 }
 
 
-/* function to release/destroy our resources and restoring the old desktop */
+/* Function to release/destroy our resources and restoring the old desktop */
 void Quit(int returnCode) {
 
-    /* deallocate the objects' memory */
+    /* Deallocate the objects' memory */
     objfree(&morph1);
     objfree(&morph2);
     objfree(&morph3);
@@ -83,23 +83,23 @@ void Quit(int returnCode) {
 /* function Loads Object From File (name) */
 void objload(char *name, object *k) {
 
-    int ver;           /* Will Hold Vertice Count                */
-    float rx, ry, rz;  /* Hold Vertex X, Y & Z Position          */
-    FILE *filein;      /* Filename To Open                       */
+    int ver;           /* Will hold vertex count                 */
+    float rx, ry, rz;  /* Hold vertex X, Y & Z position          */
+    FILE *filein;      /* Filename to open                       */
     int i;             /* Simple loop variable                   */
 
     printf("  [objload] file: %s\n", name);
 
-    /* Opens The File For Reading */
+    /* Opens the file for reading */
     filein = fopen(name, "r");
     /* Reads the number of verts in the file */
     fread(&ver, sizeof(int), 1, filein);
-    /* Sets Objects verts Variable To Equal The Value Of ver */
+    /* Sets objects verts variable to equal the value of ver */
     k->verts = ver;
-    /* Jumps To Code That Allocates Ram To Hold The Object */
+    /* Jumps to code that allocates RAM to hold the object */
     objallocate(k, ver);
 
-    /* Loops Through The Vertices */
+    /* Loops through the vertices */
     for(i = 0; i < ver; i++) {
         /* Reads the next three verts */
         fread(&rx, sizeof(float), 1, filein);
@@ -111,18 +111,18 @@ void objload(char *name, object *k) {
         k->points[i].z = rz;
     }
 
-    /* Close The File */
+    /* Close the file */
     fclose(filein);
 
-    /* If ver Is Greater Than maxver Set maxver Equal To ver */
+    /* If ver is greater than maxver set maxver equal to ver */
     if(ver > maxver)
         maxver = ver;
 }
 
-/* function to calculate Movement Of Points During Morphing */
+/* Function to calculate movement of points during morphing */
 vertex calculate(int i) {
 
-    vertex a; /* Temporary Vertex Called a */
+    vertex a; /* Temporary vertex called 'a' */
 
     /* Calculate x, y, and z movement */
     a.x = (sour->points[i].x - dest->points[i].x) / steps;
@@ -132,17 +132,17 @@ vertex calculate(int i) {
     return a;
 }
 
-/* general OpenGL initialization function */
+/* General OpenGL initialization function */
 int initGL(GLvoid) {
 
-    int i; /* Simple Looping variable */
+    int i; /* Simple looping variable */
 
-    /* Height / width ration */
+    /* Height / width ratio */
     GLfloat ratio;
 
     ratio =  SCREEN_WIDTH / SCREEN_HEIGHT;
 
-    /* change to the projection matrix and set our viewing volume. */
+    /* Change to the projection matrix and set our viewing volume */
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
 
@@ -152,40 +152,40 @@ int initGL(GLvoid) {
     /* Make sure we're changing the model view and not the projection */
     glMatrixMode(GL_MODELVIEW);
 
-    /* Reset The View */
+    /* Reset the view */
     glLoadIdentity();
 
-    /* Set The Blending Function For Translucency */
+    /* Set the blending function for translucency */
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
-    /* This Will Clear The Background Color To Black */
+    /* This will clear the background color to black */
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 
-    /* Enables Clearing Of The Depth Buffer */
+    /* Enables clearing of the depth buffer */
     glClearDepth(1.0);
 
-    /* The Type Of Depth Test To Do */
+    /* The type of depth test to do */
     glDepthFunc(GL_LESS);
 
-    /* Enables Depth Testing */
+    /* Enables depth testing */
     glEnable(GL_DEPTH_TEST);
 
-    /* Enables Smooth Color Shading */
+    /* Enables smooth color shading */
     glShadeModel(GL_SMOOTH);
 
-    /* Sets Max Vertices To 0 By Default */
+    /* Sets max vertices to 0 by default */
     maxver = 0;
-    /* Load The First Object Into morph1 From File sphere.txt */
+    /* Load the first object into morph1 From file sphere.txt */
     objload("/rd/sphere.bin", &morph1);
-    /* Load The Second Object Into morph2 From File torus.txt */
+    /* Load the second object into morph2 from file torus.txt */
     objload("/rd/torus.bin", &morph2);
-    /* Load The Third Object Into morph3 From File tube.txt */
+    /* Load the third object into morph3 from file tube.txt */
     objload("/rd/tube.bin", &morph3);
 
-    /* Manually Reserve Ram For A 4th 486 Vertice Object (morph4) */
+    /* Manually reserve RAM for a 4th 486 vertex object (morph4) */
     objallocate(&morph4, 486);
 
-    /* Loop Through All 468 Vertices */
+    /* Loop through all 468 vertices */
     for(i = 0; i < 486; i++) {
         /* Generate a random point in xyz space for each vertex */
         /* Values range from -7 to 7                            */
@@ -194,9 +194,9 @@ int initGL(GLvoid) {
         morph4.points[i].z = ((float)(rand() % 14000) / 1000) - 7;
     }
 
-    /* Load sphere.txt Object Into Helper (Used As Starting Point) */
+    /* Load sphere.txt object into helper (used as starting point) */
     objload("/rd/sphere.bin", &helper);
-    /* Source & Destination Are Set To Equal First Object (morph1) */
+    /* Source & destination are set to equal first object (morph1) */
     sour = dest = &morph1;
 
     return(true);
@@ -204,37 +204,37 @@ int initGL(GLvoid) {
 
 void draw_gl(void) {
 
-    GLfloat tx, ty, tz; /* Temp X, Y & Z Variables                     */
-    vertex q;       /* Holds Returned Calculated Values For One Vertex */
-    int i;          /* Simple Looping Variable                         */
+    GLfloat tx, ty, tz; /* Temp X, Y & Z variables                     */
+    vertex q;       /* Holds returned calculated values for one vertex */
+    int i;          /* Simple looping variable                         */
 
-    /* Clear The Screen And The Depth Buffer */
+    /* Clear the screen and the depth buffer */
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    /* Reset The View */
+    /* Reset the view */
     glLoadIdentity();
-    /* Translate The The Current Position To Start Drawing */
+    /* Translate the current position to start drawing */
     glTranslatef(cx, cy, cz);
-    /* Rotate On The X Axis By xrot */
+    /* Rotate on the X axis by xrot */
     glRotatef(xrot, 1.0f, 0.0f, 0.0f);
-    /* Rotate On The Y Axis By yrot */
+    /* Rotate on the Y axis by yrot */
     glRotatef(yrot, 0.0f, 1.0f, 0.0f);
-    /* Rotate On The Z Axis By zrot */
+    /* Rotate on the Z axis by zrot */
     glRotatef(zrot, 0.0f, 0.0f, 1.0f);
 
-    /* Increase xrot,yrot & zrot by xspeed, yspeed & zspeed */
+    /* Increase xrot, yrot & zrot by xspeed, yspeed & zspeed */
     xrot += xspeed;
     yrot += yspeed;
     zrot += zspeed;
 
-    /* Begin Drawing Points -- GLdc does not implement GL_POINTS,
+    /* Begin drawing points -- GLdc does not implement GL_POINTS,
        so we will make an approximation using GL_TRIANGLES */
     glBegin(GL_TRIANGLES);
 
-    /* Loop Through All The Verts Of morph1 (All Objects Have
-     * * The Same Amount Of Verts For Simplicity, Could Use maxver Also)
+    /* Loop through all the verts of morph1 (all objects have
+     * * The same amount of verts for simplicity, could use maxver also)
      * */
     for(i = 0; i < morph1.verts; i++) {
-        /* If morph Is True, Calculate Movement Otherwise Movement=0 */
+        /* If morph is true, calculate movement otherwise movement=0 */
         if(morph)
             q = calculate(i);
         else
@@ -250,36 +250,36 @@ void draw_gl(void) {
         ty = helper.points[i].y;
         tz = helper.points[i].z;
 
-        /* Set Color To A Bright Shade Of Off Blue */
+        /* Set color to a bright shade of off blue */
         glColor3f(0.0f, 1.0f, 1.0f);
 
-        /* Draw A Point At The Current Temp Values (Vertex) */
+        /* Draw a point at the current temp values (vertex) */
         glVertex3f(tx, ty, tz);
         glVertex3f(tx+0.05f, ty+0.05f, tz);
         glVertex3f(tx, ty+0.05f, tz+0.05f);
 
-        /* Darken Color A Bit */
+        /* Darken color a bit */
         glColor3f(0.0f, 0.5f, 1.0f);
 
-        /* Calculate Two Positions Ahead */
+        /* Calculate two positions ahead */
         tx -= 2.0f * q.x;
         ty -= 2.0f * q.y;
         tz -= 2.0f * q.z;
 
-        /* Draw A Second Point At The Newly Calculate Position */
+        /* Draw a second point at the newly calculate position */
         glVertex3f(tx, ty, tz);
         glVertex3f(tx+0.05f, ty+0.05f, tz);
         glVertex3f(tx, ty+0.05f, tz+0.05f);
 
-        /* Set Color To A Very Dark Blue */
+        /* Set color to a very dark blue */
         glColor3f(0.0f, 0.0f, 1.0f);
 
-        /* Calculate Two More Positions Ahead */
+        /* Calculate two more positions ahead */
         tx -= 2.0f * q.x;
         ty -= 2.0f * q.y;
         tz -= 2.0f * q.z;
 
-        /* Draw A Third Point At The Second New Position */
+        /* Draw a third point at the second new position */
         glVertex3f(tx, ty, tz);
         glVertex3f(tx+0.05f, ty+0.05f, tz);
         glVertex3f(tx, ty+0.05f, tz+0.05f);
@@ -287,10 +287,10 @@ void draw_gl(void) {
 
     glEnd();
 
-    /* If We're Morphing And We Haven't Gone Through All 200 Steps
-     * Increase Our Step Counter
-     * Otherwise Set Morphing To False, Make Source=Destination And
-     * Set The Step Counter Back To Zero.
+    /* If we're morphing and we haven't gone through all 200 steps,
+     * increase our step counter
+     * Otherwise set morphing to false, make source=destination and
+     * Set the step counter back to zero.
      */
 
     if(morph && step <= steps) {


### PR DESCRIPTION
- It was definining its own `bool` type which was conflicting with a header within KOS using `<stdbool.h>`
- Converted the example to use standard C booleans. This is C99/GNU99, after all, shouldn't be doing that in example code that's building with this standard.