### PR TITLE
Fix KGL Nehe26 Example Build Failure

### DIFF
--- a/examples/dreamcast/kgl/nehe/nehe26/nehe26.c
+++ b/examples/dreamcast/kgl/nehe/nehe26/nehe26.c
@@ -2,14 +2,15 @@
    KallistiOS 2.0.0
 
    nehe26.c
-   (c)2014 Josh Pearson
-   (c)2001 Benoit Miller
-   (c)2000 Jeff Molofee
+   Copyright (c) 2014 Josh Pearson
+   Copyright (c) 2001 Benoit Miller
+   Copyright (c) 2000 Jeff Molofee
 */
 
 #include <kos.h>
 
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include <KGL/gl.h>
 #include <KGL/glu.h>
@@ -25,55 +26,50 @@
    rotation.
 */
 
-/* screen width, height, and bit depth */
+/* Screen width, height, and bit depth */
 #define SCREEN_WIDTH  640
 #define SCREEN_HEIGHT 400
 
-/* Set up some booleans */
-#define TRUE  1
-#define FALSE 0
-typedef unsigned int bool;
-
-/* Build Our Vertex Structure */
+/* Build our vertex structure. */
 typedef struct {
-    float x, y, z; /* 3D Coordinates */
+    float x, y, z; /* 3D coordinates */
 } vertex;
 
-/* Build Our Object Structure */
+/* Build our object structure. */
 typedef struct {
-    int verts;      /* Number Of Vertices For The Object */
-    vertex *points; /* One Vertice (Vertex x,y & z)      */
+    int verts;      /* Number of vertices for the object */
+    vertex *points; /* One Vertex (Vertex x,y & z)      */
 } object;
 
 GLfloat xrot, yrot, zrot;        /* Camera rotation variables                */
 GLfloat cx, cy, cz = -15;        /* Camera pos variable                      */
-GLfloat xspeed, yspeed, zspeed;  /* Spin Speed                               */
+GLfloat xspeed, yspeed, zspeed;  /* Spin speed                               */
 
-int key = 1;                     /* Make Sure Same Morph Key Not Pressed     */
-int step = 0, steps = 200;       /* Step Counter And Maximum Number Of Steps */
-bool morph = FALSE;              /* Default morph To False (Not Morphing)    */
+int key = 1;                     /* Make sure same morph key not pressed     */
+int step = 0, steps = 200;       /* Step counter and maximum number of steps */
+bool morph = false;              /* Default morph to false (not morphing)    */
 
-int maxver;                            /* Holds The Max Number Of Vertices   */
-object morph1, morph2, morph3, morph4, /* Our 4 Morphable Objects            */
-       helper, *sour, *dest;          /* Helper, Source, Destination Object */
+int maxver;                            /* Holds the max number of vertices   */
+object morph1, morph2, morph3, morph4, /* Our 4 morphable objects            */
+       helper, *sour, *dest;           /* Helper, source, destination object */
 
 #define MORPHS 4
 
-/* function to allocate memory for an object */
+/* Function to allocate memory for an object */
 void objallocate(object *k, int n) {
 
-    /* Sets points Equal To VERTEX * Number Of Vertices */
+    /* Sets points equal to vertex * number of vertices */
     k->points = (vertex *)malloc(sizeof(vertex) * n);
 }
 
-/* function deallocate memory for an object */
+/* Function deallocate memory for an object */
 void objfree(object *k) {
 
     free(k->points);
 }
 
 
-/* function to release/destroy our resources and restoring the old desktop */
+/* Function to release/destroy our resources and restoring the old desktop */
 void Quit(int returnCode) {
 
     /* deallocate the objects' memory */
@@ -87,46 +83,46 @@ void Quit(int returnCode) {
 /* function Loads Object From File (name) */
 void objload(char *name, object *k) {
 
-    int ver;           /* Will Hold Vertice Count                */
-    float rx, ry, rz;  /* Hold Vertex X, Y & Z Position          */
-    FILE *filein;      /* Filename To Open                       */
+    int ver;           /* Will hold vertex count                */
+    float rx, ry, rz;  /* Hold vertex X, Y & Z position          */
+    FILE *filein;      /* Filename to open                       */
     int i;             /* Simple loop variable                   */
 
     printf("  [objload] file: %s\n", name);
 
-    /* Opens The File For Reading */
+    /* Opens the file for reading. */
     filein = fopen(name, "r");
-    /* Reads the number of verts in the file */
+    /* Reads the number of verts in the file. */
     fread(&ver, sizeof(int), 1, filein);
-    /* Sets Objects verts Variable To Equal The Value Of ver */
+    /* Sets object's verts variable to equal the value of ver. */
     k->verts = ver;
-    /* Jumps To Code That Allocates Ram To Hold The Object */
+    /* Jumps to code that allocates RAM to hold the object. */
     objallocate(k, ver);
 
-    /* Loops Through The Vertices */
+    /* Loops through the vertices */
     for(i = 0; i < ver; i++) {
         /* Reads the next three verts */
         fread(&rx, sizeof(float), 1, filein);
         fread(&ry, sizeof(float), 1, filein);
         fread(&rz, sizeof(float), 1, filein);
-        /* Set our object's x, y, z points */
+        /* Set our object's x, y, z points. */
         k->points[i].x = rx;
         k->points[i].y = ry;
         k->points[i].z = rz;
     }
 
-    /* Close The File */
+    /* Close the file. */
     fclose(filein);
 
-    /* If ver Is Greater Than maxver Set maxver Equal To ver */
+    /* If ver is greater than maxver, set maxver equal to ver. */
     if(ver > maxver)
         maxver = ver;
 }
 
-/* function to calculate Movement Of Points During Morphing */
+/* Function to calculate movement of points during morphing */
 vertex calculate(int i) {
 
-    vertex a; /* Temporary Vertex Called a */
+    vertex a; /* Temporary vertex called 'a' */
 
     /* Calculate x, y, and z movement */
     a.x = (sour->points[i].x - dest->points[i].x) / steps;
@@ -136,7 +132,7 @@ vertex calculate(int i) {
     return a;
 }
 
-/* general OpenGL initialization function */
+/* General OpenGL-initialization function */
 int initGL(GLvoid) {
 
     int i; /* Simple Looping variable */
@@ -146,53 +142,53 @@ int initGL(GLvoid) {
 
     ratio =  SCREEN_WIDTH / SCREEN_HEIGHT;
 
-    /* change to the projection matrix and set our viewing volume. */
+    /* Change to the projection matrix and set our viewing volume. */
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
 
-    /* Set our perspective */
+    /* Set our perspective.*/
     gluPerspective(45.0f, ratio, 0.1f, 100.0f);
 
-    /* Make sure we're changing the model view and not the projection */
+    /* Make sure we're changing the model view and not the projection. */
     glMatrixMode(GL_MODELVIEW);
 
-    /* Reset The View */
+    /* Reset the view. */
     glLoadIdentity();
 
-    /* Set The Blending Function For Translucency */
+    /* Set the blending function for translucency. */
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
-    /* This Will Clear The Background Color To Black */
+    /* This will clear the background color to black. */
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 
-    /* Enables Clearing Of The Depth Buffer */
+    /* Enables clearing of the depth buffer. */
     glClearDepth(1.0);
 
-    /* The Type Of Depth Test To Do */
+    /* The type of depth test to do. */
     glDepthFunc(GL_LESS);
 
-    /* Enables Depth Testing */
+    /* Enables depth testing. */
     glEnable(GL_DEPTH_TEST);
 
-    /* Enables Smooth Color Shading */
+    /* Enables smooth color shading. */
     glShadeModel(GL_SMOOTH);
 
-    /* Sets Max Vertices To 0 By Default */
+    /* Sets max vertices to 0 by default. */
     maxver = 0;
-    /* Load The First Object Into morph1 From File sphere.txt */
+    /* Load the first object into morph1 from file sphere.txt. */
     objload("/rd/sphere.bin", &morph1);
-    /* Load The Second Object Into morph2 From File torus.txt */
+    /* Load the second object into morph2 from file torus.txt. */
     objload("/rd/torus.bin", &morph2);
-    /* Load The Third Object Into morph3 From File tube.txt */
+    /* Load the third pobject into morph3 from file tube.txt. */
     objload("/rd/tube.bin", &morph3);
 
-    /* Manually Reserve Ram For A 4th 486 Vertice Object (morph4) */
+    /* Manually reserve RAM for a 4th 486 vertice object (morph4). */
     objallocate(&morph4, 486);
 
-    /* Loop Through All 468 Vertices */
+    /* Loop through all 468 vertices */
     for(i = 0; i < 486; i++) {
         /* Generate a random point in xyz space for each vertex */
-        /* Values range from -7 to 7                            */
+        /* Values range from -7 to 7.                           */
         morph4.points[i].x = ((float)(rand() % 14000) / 1000) - 7;
         morph4.points[i].y = ((float)(rand() % 14000) / 1000) - 7;
         morph4.points[i].z = ((float)(rand() % 14000) / 1000) - 7;
@@ -203,7 +199,7 @@ int initGL(GLvoid) {
     /* Source & Destination Are Set To Equal First Object (morph1) */
     sour = dest = &morph1;
 
-    return(TRUE);
+    return(true);
 }
 
 void draw_gl(void) {
@@ -225,19 +221,19 @@ void draw_gl(void) {
     /* Rotate On The Z Axis By zrot */
     glRotatef(zrot, 0.0f, 0.0f, 1.0f);
 
-    /* Increase xrot,yrot & zrot by xspeed, yspeed & zspeed */
+    /* Increase xrot, yrot & zrot by xspeed, yspeed & zspeed. */
     xrot += xspeed;
     yrot += yspeed;
     zrot += zspeed;
 
-    /* Begin Drawing Points */
+    /* Begin drawing points. */
     glBegin(GL_POINTS);
 
-    /* Loop Through All The Verts Of morph1 (All Objects Have
-     * * The Same Amount Of Verts For Simplicity, Could Use maxver Also)
+    /* Loop through all the verts of morph1 (all objects have
+     * * the same amount of verts for simplicity, could use maxver also).
      * */
     for(i = 0; i < morph1.verts; i++) {
-        /* If morph Is True Calculate Movement Otherwise Movement=0 */
+        /* If morph is true calculate movement, otherwise movement=0 */
         if(morph)
             q = calculate(i);
         else
@@ -253,44 +249,44 @@ void draw_gl(void) {
         ty = helper.points[i].y;
         tz = helper.points[i].z;
 
-        /* Set Color To A Bright Shade Of Off Blue */
+        /* Set color to a bright shade of off-blue. */
         glColor3f(0.0f, 1.0f, 1.0f);
-        /* Draw A Point At The Current Temp Values (Vertex) */
+        /* Draw a point at the current temp values (vertex). */
         glVertex3f(tx, ty, tz);
         /* Darken Color A Bit */
         glColor3f(0.0f, 0.5f, 1.0f);
-        /* Calculate Two Positions Ahead */
+        /* Calculate two positions ahead. */
         tx -= 2.0f * q.x;
         ty -= 2.0f * q.y;
         tz -= 2.0f * q.z;
 
-        /* Draw A Second Point At The Newly Calculate Position */
+        /* Draw a second point at the newly calculated position. */
         glVertex3f(tx, ty, tz);
-        /* Set Color To A Very Dark Blue */
+        /* Set color to a very dark blue. */
         glColor3f(0.0f, 0.0f, 1.0f);
 
-        /* Calculate Two More Positions Ahead */
+        /* Calculate two more positions ahead. */
         tx -= 2.0f * q.x;
         ty -= 2.0f * q.y;
         tz -= 2.0f * q.z;
 
-        /* Draw A Third Point At The Second New Position */
+        /* Draw a third point at the second new position. */
         glVertex3f(tx, ty, tz);
     }
 
     glEnd();
 
-    /* If We're Morphing And We Haven't Gone Through All 200 Steps
-     * Increase Our Step Counter
-     * Otherwise Set Morphing To False, Make Source=Destination And
-     * Set The Step Counter Back To Zero.
+    /* If we're morphing, and we haven't gone through all 200 steps,
+     * increase our step counter.
+     * Otherwise, set morphing to false, make source=destination, and
+     * set the step counter back to zero.
      */
 
     if(morph && step <= steps) {
         step++;
     }
     else {
-        morph = FALSE;
+        morph = false;
         sour  = dest;
         step  = 0;
     }
@@ -329,25 +325,25 @@ int main(int argc, char **argv) {
             break;
 
         if((state->buttons & CONT_A) && !morph && NOT_LAST) {
-            morph = TRUE;
+            morph = true;
             dest = &morph1;
             last = CONT_A;
         }
 
         if((state->buttons & CONT_X) && !morph && NOT_LAST) {
-            morph = TRUE;
+            morph = true;
             dest = &morph2;
             last = CONT_X;
         }
 
         if((state->buttons & CONT_Y) && !morph && NOT_LAST) {
-            morph = TRUE;
+            morph = true;
             dest = &morph3;
             last = CONT_Y;
         }
 
         if((state->buttons & CONT_B) && !morph && NOT_LAST) {
-            morph = TRUE;
+            morph = true;
             dest = &morph4;
             last = CONT_B;
         }


### PR DESCRIPTION
- Also defining its own "bool" type, which conflicts with KOS including <stdbool.h> in a public header file...
- Swapping to use <stdbool.h> within the example
- While find + replacing "TRUE" and "FALSE," it was pointed out that suddenly comments looked weird, given they're all camel-cased for some reason... It was pointed out that these should really just be translated to real english with this change while I was at it... ;)