### PR TITLE
dc-chain: Allow fp precision adjustments; update configurations

### DIFF
--- a/utils/dc-chain/config/README.md
+++ b/utils/dc-chain/config/README.md
@@ -2,16 +2,16 @@ The available templates include the following configurations:
 
 | filename | sh4 gcc | newlib | sh4 binutils | arm gcc | arm binutils | notes |
 |---------:|:-------:|:----------:|:------------:|:-------:|:----------------:|:------|
-| config.mk.legacy.sample | 4.7.4 | 2.0.0 | 2.34 | 4.7.4 | 2.34 | older toolchain based on GCC 4<br />former "stable" / "legacy" configuration<br /> [some issues may happen in C++](https://dcemulation.org/phpBB/viewtopic.php?f=29&t=104724) |
-| config.mk.9.3.0.sample | 9.3.0 | 3.3.0 | 2.34 | 8.4.0 | 2.34 | older toolchain based on GCC 9<br />former "stable" configuration |
-| config.mk.winxp-latest.sample | 9.5.0 | 4.3.0 | 2.34 | 8.5.0 | 2.34 | latest WinXP-compatible toolchain with GCC 9 |
+| config.mk.4.7.4-legacy.sample | 4.7.4 | 2.0.0 | 2.34 | 4.7.4 | 2.34 | older toolchain based on GCC 4<br />former "stable" / "legacy" configuration<br /> [some issues may happen in C++](https://dcemulation.org/phpBB/viewtopic.php?f=29&t=104724) |
+| config.mk.9.3.0-legacy.sample | 9.3.0 | 3.3.0 | 2.34 | 8.4.0 | 2.34 | older toolchain based on GCC 9<br />former "stable" configuration |
+| config.mk.9.5.0-winxp.sample | 9.5.0 | 4.3.0 | 2.34 | 8.5.0 | 2.34 | latest WinXP-compatible toolchain with GCC 9 |
 | config.mk.10.5.0.sample | 10.5.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 10 |
 | config.mk.11.4.0.sample | 11.4.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 11 |
 | config.mk.12.3.0.sample | 12.3.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 12 |
-| **config.mk.stable.sample** | **13.2.0** | **4.3.0** | **2.41** | **8.5.0** | **2.41** | **modern toolchain with GCC 13**<br />**current "stable" configuration** |
-| config.mk.testing.sample | X | X | X | X | X | most recent GCC release<br />currently none in testing |
-| config.mk.devel.sample | git | 4.3.0 | 2.41 | 8.5.0 | 2.41 | latest dev version from git<br />builds as of 2023-07-30 |
+| **config.mk.stable.sample** | **13.2.0** | **4.3.0** | **2.41** | **8.5.0** | **2.41** | **modern toolchain with GCC 13.2.0 release**<br />**current "stable" configuration** |
+| config.mk.13.2.1-dev.sample | 13.2.1 (git) | 4.4.0 | 2.41 | 8.5.0 | 2.41 | latest GCC 13 development version from git<br />known to build without issues |
+| config.mk.14.0.1-dev.sample | 14.0.1 (git) | 4.4.0 | 2.41 | 8.5.0 | 2.41 | latest GCC 14 development version from git<br />builds with caveats, see sample file for more info |
 
-The **stable** configuration is the primary, widely tested target for KallistiOS, and is the most recent toolchain configuration known to work with all example programs. The **testing** configuration contains the most recent release of GCC that builds KallistiOS and the 2ndmix example, and is without any known major issues. The **legacy** configuration contains an older version of the toolchain that may be useful in compiling older software. The alternative configurations are maintained at a low priority and are not guaranteed to build, but feel free to open a bug report if issues are encountered building one of these configurations.
+The **stable** configuration is the primary, widely tested target for KallistiOS, and is the most recent toolchain configuration known to work with all example programs. The **legacy** configurations contain an older versions of the toolchain that may be useful in compiling older software. The non-"stable" alternative configurations are maintained at a lower priority and are not guaranteed to build, but feel free to open a bug report if issues are encountered building one of these configurations.
 
 Please note that if you choose to install an older version of the GCC compiler, you may be required to use older versions of some of the prerequisites in certain configurations. For instance, building GCC `4.7.4` may require an older version of the `flex` tool be installed. If you receive errors about tools you have installed, check your system's package manager for an older version of that tool. Depending on availability, it may not be possible to build older versions of the toolchain on your platform. 

--- a/utils/dc-chain/config/config.mk.10.5.0.sample
+++ b/utils/dc-chain/config/config.mk.10.5.0.sample
@@ -112,17 +112,30 @@ makejobs=-j2
 # hard drive space.
 pass2_languages=c,c++,objc,obj-c++
 
+# Floating point precision support (m4|m4-single|m4-single-only)
+# Build support for various SH4 floating-point operation ABIs. KallistiOS only
+# officially supports single-precision-only mode. Add m4 (double precision) or
+# m4-single (single precision) to build experimental support for those ABIs.
+precision_modes=m4-single-only
+#precision_modes=m4,m4-single,m4-single-only
+
+# Default floating point mode (m4|m4-single|m4-single-only)
+# Choose the default floating point precision ABI used when GCC is invoked. This
+# can be overridden by using passing -m4, -m4-single, or -m4-single-only to GCC.
+# KallistiOS currently only supports m4-single-only, so that is the default.
+default_precision=m4-single-only
+
 # GCC threading model (single|kos|posix*)
-# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
-# should use it. If you really don't want threading support for C++ (or 
-# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you
+# should use it. If you really don't want threading support for C++ (or
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you
 # probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
 # is not anymore supported.
 thread_model=kos
 
 # Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
+# Uncomment this if you want to disable applying KOS patches to the toolchain
+# source files before building. This will disable usage of the 'kos' thread model.
 #use_kos_patches=0
 
 # Automatic fixup SH-4 Newlib (1|0)

--- a/utils/dc-chain/config/config.mk.11.4.0.sample
+++ b/utils/dc-chain/config/config.mk.11.4.0.sample
@@ -112,17 +112,30 @@ makejobs=-j2
 # hard drive space.
 pass2_languages=c,c++,objc,obj-c++
 
+# Floating point precision support (m4|m4-single|m4-single-only)
+# Build support for various SH4 floating-point operation ABIs. KallistiOS only
+# officially supports single-precision-only mode. Add m4 (double precision) or
+# m4-single (single precision) to build experimental support for those ABIs.
+precision_modes=m4-single-only
+#precision_modes=m4,m4-single,m4-single-only
+
+# Default floating point mode (m4|m4-single|m4-single-only)
+# Choose the default floating point precision ABI used when GCC is invoked. This
+# can be overridden by using passing -m4, -m4-single, or -m4-single-only to GCC.
+# KallistiOS currently only supports m4-single-only, so that is the default.
+default_precision=m4-single-only
+
 # GCC threading model (single|kos|posix*)
-# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
-# should use it. If you really don't want threading support for C++ (or 
-# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you
+# should use it. If you really don't want threading support for C++ (or
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you
 # probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
 # is not anymore supported.
 thread_model=kos
 
 # Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
+# Uncomment this if you want to disable applying KOS patches to the toolchain
+# source files before building. This will disable usage of the 'kos' thread model.
 #use_kos_patches=0
 
 # Automatic fixup SH-4 Newlib (1|0)

--- a/utils/dc-chain/config/config.mk.13.2.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.13.2.1-dev.sample
@@ -8,21 +8,21 @@
 ###############################################################################
 ###############################################################################
 ### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
-## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2023-07-30.
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2024-01-04.
 ###############################################################################
 ###############################################################################
 
 # Toolchain versions for SH
 sh_binutils_ver=2.41
-sh_gcc_ver=devel
-newlib_ver=4.3.0.20230120
+sh_gcc_ver=13.2.1
+newlib_ver=4.4.0.20231231
 gdb_ver=14.1
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz
 sh_gcc_download_type=git
 sh_gcc_git_repo=git://gcc.gnu.org/git/gcc.git
-sh_gcc_git_branch=master
+sh_gcc_git_branch=releases/gcc-13
 newlib_download_type=gz
 gdb_download_type=xz
 
@@ -114,25 +114,37 @@ install_mode=install-strip
 # detected on some OS.
 makejobs=-j2
 
-# Languages (c|c++|objc|obj-c++|rust)
+# Languages (c|c++|objc|obj-c++)
 # Set the languages to build for pass 2 of building gcc for sh-elf. The default
-# here is to build C, C++, Objective-C, Objective-C++, and Rust. You may want
-# to take out some languages if you're not worried about them and/or you're
-# short on hard drive space. Only C is required to build KallistiOS, but some
-# included examples use other languages.
-pass2_languages=c,c++,objc,obj-c++,rust
+# here is to build C, C++, Objective C, and Objective C++. You may want to take
+# out the latter two if you're not worried about them and/or you're short on
+# hard drive space.
+pass2_languages=c,c++,objc,obj-c++
+
+# Floating point precision support (m4|m4-single|m4-single-only)
+# Build support for various SH4 floating-point operation ABIs. KallistiOS only
+# officially supports single-precision-only mode. Add m4 (double precision) or
+# m4-single (single precision) to build experimental support for those ABIs.
+precision_modes=m4-single-only
+#precision_modes=m4,m4-single,m4-single-only
+
+# Default floating point mode (m4|m4-single|m4-single-only)
+# Choose the default floating point precision ABI used when GCC is invoked. This
+# can be overridden by using passing -m4, -m4-single, or -m4-single-only to GCC.
+# KallistiOS currently only supports m4-single-only, so that is the default.
+default_precision=m4-single-only
 
 # GCC threading model (single|kos|posix*)
-# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
-# should use it. If you really don't want threading support for C++ (or 
-# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you
+# should use it. If you really don't want threading support for C++ (or
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you
 # probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
 # is not anymore supported.
 thread_model=kos
 
 # Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
+# Uncomment this if you want to disable applying KOS patches to the toolchain
+# source files before building. This will disable usage of the 'kos' thread model.
 #use_kos_patches=0
 
 # Automatic fixup SH-4 Newlib (1|0)

--- a/utils/dc-chain/config/config.mk.14.0.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.14.0.1-dev.sample
@@ -5,22 +5,33 @@
 # Initially adapted from Stalin's build script version 0.3.
 #
 
+###############################################################################
+###############################################################################
+### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
+## THERE IS ONE KNOWN ISSUE BUILDING THIS VERSION as of 2024-01-04:
+## 1. GCC 14.0.1 currently does not build with m4-single-only precision, which
+##    is the only officially supported KOS mode for floating-point precision.
+###############################################################################
+###############################################################################
+
 # Toolchain versions for SH
-sh_binutils_ver=2.34
-sh_gcc_ver=9.5.0
-newlib_ver=4.3.0.20230120
+sh_binutils_ver=2.41
+sh_gcc_ver=14.0.1
+newlib_ver=4.4.0.20231231
 gdb_ver=14.1
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz
-sh_gcc_download_type=xz
+sh_gcc_download_type=git
+sh_gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+sh_gcc_git_branch=master
 newlib_download_type=gz
 gdb_download_type=xz
 
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.34
+arm_binutils_ver=2.41
 arm_gcc_ver=8.5.0
 
 # Tarball extensions to download for ARM
@@ -37,10 +48,10 @@ arm_gcc_download_type=xz
 #use_custom_dependencies=1
 
 # GCC dependencies for SH
-sh_gmp_ver=6.1.0
-sh_mpfr_ver=3.1.4
-sh_mpc_ver=1.0.3
-sh_isl_ver=0.18
+sh_gmp_ver=6.2.1
+sh_mpfr_ver=4.1.0
+sh_mpc_ver=1.2.1
+sh_isl_ver=0.24
 
 # Tarball extensions to download for GCC dependencies for SH
 sh_gmp_download_type=bz2
@@ -105,24 +116,38 @@ install_mode=install-strip
 # detected on some OS.
 makejobs=-j2
 
-# Languages (c|c++|objc|obj-c++)
+# Languages (c|c++|objc|obj-c++|rust)
 # Set the languages to build for pass 2 of building gcc for sh-elf. The default
-# here is to build C, C++, Objective C, and Objective C++. You may want to take
-# out the latter two if you're not worried about them and/or you're short on
-# hard drive space.
-pass2_languages=c,c++,objc,obj-c++
+# here is to build C, C++, Objective-C, Objective-C++, and Rust. You may want
+# to take out some languages if you're not worried about them and/or you're
+# short on hard drive space. Only C is required to build KallistiOS, but some
+# included examples use other languages.
+pass2_languages=c,c++,objc,obj-c++,rust
+
+# Floating point precision support (m4|m4-single|m4-single-only)
+# Build support for various SH4 floating-point operation ABIs. KallistiOS only
+# officially supports single-precision-only mode. Add m4 (double precision) or
+# m4-single (single precision) to build experimental support for those ABIs.
+precision_modes=m4-single-only
+#precision_modes=m4,m4-single,m4-single-only
+
+# Default floating point mode (m4|m4-single|m4-single-only)
+# Choose the default floating point precision ABI used when GCC is invoked. This
+# can be overridden by using passing -m4, -m4-single, or -m4-single-only to GCC.
+# KallistiOS currently only supports m4-single-only, so that is the default.
+default_precision=m4-single-only
 
 # GCC threading model (single|kos|posix*)
-# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
-# should use it. If you really don't want threading support for C++ (or 
-# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you
+# should use it. If you really don't want threading support for C++ (or
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you
 # probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
 # is not anymore supported.
 thread_model=kos
 
 # Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
+# Uncomment this if you want to disable applying KOS patches to the toolchain
+# source files before building. This will disable usage of the 'kos' thread model.
 #use_kos_patches=0
 
 # Automatic fixup SH-4 Newlib (1|0)

--- a/utils/dc-chain/config/config.mk.4.7.4-legacy.sample
+++ b/utils/dc-chain/config/config.mk.4.7.4-legacy.sample
@@ -6,26 +6,26 @@
 #
 
 # Toolchain versions for SH
-sh_binutils_ver=2.41
-sh_gcc_ver=12.3.0
-newlib_ver=4.3.0.20230120
-gdb_ver=14.1
+sh_binutils_ver=2.34
+sh_gcc_ver=4.7.4
+newlib_ver=2.0.0
+gdb_ver=9.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz
-sh_gcc_download_type=xz
+sh_gcc_download_type=bz2
 newlib_download_type=gz
 gdb_download_type=xz
 
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.41
-arm_gcc_ver=8.5.0
+arm_binutils_ver=2.34
+arm_gcc_ver=4.7.4
 
 # Tarball extensions to download for ARM
 arm_binutils_download_type=xz
-arm_gcc_download_type=xz
+arm_gcc_download_type=bz2
 
 # GCC custom dependencies
 # Specify here if you want to use custom GMP, MPFR and MPC libraries when
@@ -37,10 +37,10 @@ arm_gcc_download_type=xz
 #use_custom_dependencies=1
 
 # GCC dependencies for SH
-sh_gmp_ver=6.2.1
-sh_mpfr_ver=4.1.0
-sh_mpc_ver=1.2.1
-sh_isl_ver=0.24
+sh_gmp_ver=4.3.2
+sh_mpfr_ver=2.4.2
+sh_mpc_ver=0.8.1
+#sh_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for SH
 sh_gmp_download_type=bz2
@@ -49,10 +49,10 @@ sh_mpc_download_type=gz
 sh_isl_download_type=bz2
 
 # GCC dependencies for ARM
-arm_gmp_ver=6.1.0
-arm_mpfr_ver=3.1.4
-arm_mpc_ver=1.0.3
-arm_isl_ver=0.18
+arm_gmp_ver=4.3.2
+arm_mpfr_ver=2.4.2
+arm_mpc_ver=0.8.1
+#arm_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for ARM
 arm_gmp_download_type=bz2

--- a/utils/dc-chain/config/config.mk.9.3.0-legacy.sample
+++ b/utils/dc-chain/config/config.mk.9.3.0-legacy.sample
@@ -112,17 +112,30 @@ makejobs=-j2
 # hard drive space.
 pass2_languages=c,c++,objc,obj-c++
 
+# Floating point precision support (m4|m4-single|m4-single-only)
+# Build support for various SH4 floating-point operation ABIs. KallistiOS only
+# officially supports single-precision-only mode. Add m4 (double precision) or
+# m4-single (single precision) to build experimental support for those ABIs.
+precision_modes=m4-single-only
+#precision_modes=m4,m4-single,m4-single-only
+
+# Default floating point mode (m4|m4-single|m4-single-only)
+# Choose the default floating point precision ABI used when GCC is invoked. This
+# can be overridden by using passing -m4, -m4-single, or -m4-single-only to GCC.
+# KallistiOS currently only supports m4-single-only, so that is the default.
+default_precision=m4-single-only
+
 # GCC threading model (single|kos|posix*)
-# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
-# should use it. If you really don't want threading support for C++ (or 
-# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you
+# should use it. If you really don't want threading support for C++ (or
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you
 # probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
 # is not anymore supported.
 thread_model=kos
 
 # Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
+# Uncomment this if you want to disable applying KOS patches to the toolchain
+# source files before building. This will disable usage of the 'kos' thread model.
 #use_kos_patches=0
 
 # Automatic fixup SH-4 Newlib (1|0)

--- a/utils/dc-chain/config/config.mk.9.5.0-winxp.sample
+++ b/utils/dc-chain/config/config.mk.9.5.0-winxp.sample
@@ -7,13 +7,13 @@
 
 # Toolchain versions for SH
 sh_binutils_ver=2.34
-sh_gcc_ver=4.7.4
-newlib_ver=2.0.0
-gdb_ver=9.2
+sh_gcc_ver=9.5.0
+newlib_ver=4.3.0.20230120
+gdb_ver=14.1
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz
-sh_gcc_download_type=bz2
+sh_gcc_download_type=xz
 newlib_download_type=gz
 gdb_download_type=xz
 
@@ -21,11 +21,11 @@ gdb_download_type=xz
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
 arm_binutils_ver=2.34
-arm_gcc_ver=4.7.4
+arm_gcc_ver=8.5.0
 
 # Tarball extensions to download for ARM
 arm_binutils_download_type=xz
-arm_gcc_download_type=bz2
+arm_gcc_download_type=xz
 
 # GCC custom dependencies
 # Specify here if you want to use custom GMP, MPFR and MPC libraries when
@@ -37,10 +37,10 @@ arm_gcc_download_type=bz2
 #use_custom_dependencies=1
 
 # GCC dependencies for SH
-sh_gmp_ver=4.3.2
-sh_mpfr_ver=2.4.2
-sh_mpc_ver=0.8.1
-#sh_isl_ver=0.18
+sh_gmp_ver=6.1.0
+sh_mpfr_ver=3.1.4
+sh_mpc_ver=1.0.3
+sh_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for SH
 sh_gmp_download_type=bz2
@@ -49,10 +49,10 @@ sh_mpc_download_type=gz
 sh_isl_download_type=bz2
 
 # GCC dependencies for ARM
-arm_gmp_ver=4.3.2
-arm_mpfr_ver=2.4.2
-arm_mpc_ver=0.8.1
-#arm_isl_ver=0.18
+arm_gmp_ver=6.1.0
+arm_mpfr_ver=3.1.4
+arm_mpc_ver=1.0.3
+arm_isl_ver=0.18
 
 # Tarball extensions to download for GCC dependencies for ARM
 arm_gmp_download_type=bz2
@@ -112,17 +112,30 @@ makejobs=-j2
 # hard drive space.
 pass2_languages=c,c++,objc,obj-c++
 
+# Floating point precision support (m4|m4-single|m4-single-only)
+# Build support for various SH4 floating-point operation ABIs. KallistiOS only
+# officially supports single-precision-only mode. Add m4 (double precision) or
+# m4-single (single precision) to build experimental support for those ABIs.
+precision_modes=m4-single-only
+#precision_modes=m4,m4-single,m4-single-only
+
+# Default floating point mode (m4|m4-single|m4-single-only)
+# Choose the default floating point precision ABI used when GCC is invoked. This
+# can be overridden by using passing -m4, -m4-single, or -m4-single-only to GCC.
+# KallistiOS currently only supports m4-single-only, so that is the default.
+default_precision=m4-single-only
+
 # GCC threading model (single|kos|posix*)
-# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
-# should use it. If you really don't want threading support for C++ (or 
-# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you
+# should use it. If you really don't want threading support for C++ (or
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you
 # probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
 # is not anymore supported.
 thread_model=kos
 
 # Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
+# Uncomment this if you want to disable applying KOS patches to the toolchain
+# source files before building. This will disable usage of the 'kos' thread model.
 #use_kos_patches=0
 
 # Automatic fixup SH-4 Newlib (1|0)

--- a/utils/dc-chain/config/config.mk.stable.sample
+++ b/utils/dc-chain/config/config.mk.stable.sample
@@ -112,17 +112,30 @@ makejobs=-j2
 # hard drive space.
 pass2_languages=c,c++,objc,obj-c++
 
+# Floating point precision support (m4|m4-single|m4-single-only)
+# Build support for various SH4 floating-point operation ABIs. KallistiOS only
+# officially supports single-precision-only mode. Add m4 (double precision) or
+# m4-single (single precision) to build experimental support for those ABIs.
+precision_modes=m4-single-only
+#precision_modes=m4,m4-single,m4-single-only
+
+# Default floating point mode (m4|m4-single|m4-single-only)
+# Choose the default floating point precision ABI used when GCC is invoked. This
+# can be overridden by using passing -m4, -m4-single, or -m4-single-only to GCC.
+# KallistiOS currently only supports m4-single-only, so that is the default.
+default_precision=m4-single-only
+
 # GCC threading model (single|kos|posix*)
-# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you 
-# should use it. If you really don't want threading support for C++ (or 
-# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you 
+# With GCC 4.x versions and up, the patches provide a 'kos' thread model, so you
+# should use it. If you really don't want threading support for C++ (or
+# Objective C/Objective C++), you can set this to 'single'. With GCC 3.x, you
 # probably want 'posix' here; but this mode is deprecated as the GCC 3.x branch
 # is not anymore supported.
 thread_model=kos
 
 # Automatic patching for KOS (1|0)
-# Uncomment this if you want to disable applying KOS patches to the toolchain 
-# source files before building. This will disable usage of the 'kos' thread model. 
+# Uncomment this if you want to disable applying KOS patches to the toolchain
+# source files before building. This will disable usage of the 'kos' thread model.
 #use_kos_patches=0
 
 # Automatic fixup SH-4 Newlib (1|0)

--- a/utils/dc-chain/docker/Dockerfile
+++ b/utils/dc-chain/docker/Dockerfile
@@ -5,7 +5,7 @@
 #   - build one of the images:
 #       docker build -t dcchain:latest . 
 #       docker build -t dcchain:stable --build-arg dc_chain=stable .
-#       docker build -t dcchain:legacy --build-arg dc_chain=legacy . 
+#       docker build -t dcchain:9.3.0-legacy --build-arg dc_chain=9.3.0-legacy .
 #   - create and run a container, eg for latest:
 #       docker run -it --name containername dcchain:latest /bin/bash
 

--- a/utils/dc-chain/patches/gcc-13.2.1-kos.diff
+++ b/utils/dc-chain/patches/gcc-13.2.1-kos.diff
@@ -1,6 +1,6 @@
-diff -ruN gcc-devel/gcc/config/sh/sh-c.cc gcc-devel-kos/gcc/config/sh/sh-c.cc
---- gcc-devel/gcc/config/sh/sh-c.cc	2023-06-05 16:50:21.431844529 -0500
-+++ gcc-devel-kos/gcc/config/sh/sh-c.cc	2023-06-05 16:50:25.324856064 -0500
+diff --color -ruN gcc-13.2.1/gcc/config/sh/sh-c.cc gcc-13.2.1-kos/gcc/config/sh/sh-c.cc
+--- gcc-13.2.1/gcc/config/sh/sh-c.cc	2023-06-04 20:48:46.612552162 -0500
++++ gcc-13.2.1-kos/gcc/config/sh/sh-c.cc	2023-06-04 20:49:03.486606055 -0500
 @@ -141,4 +141,11 @@
  
    cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
@@ -13,10 +13,10 @@ diff -ruN gcc-devel/gcc/config/sh/sh-c.cc gcc-devel-kos/gcc/config/sh/sh-c.cc
 +  /* Toolchain supports setting up stack for 32MB */
 +  builtin_define ("__KOS_GCC_32MB__");
  }
-diff -ruN gcc-devel/gcc/configure gcc-devel-kos/gcc/configure
---- gcc-devel/gcc/configure	2023-06-05 16:50:21.441844558 -0500
-+++ gcc-devel-kos/gcc/configure	2023-06-05 16:50:25.326856070 -0500
-@@ -13015,7 +13015,7 @@
+diff --color -ruN gcc-13.2.1/gcc/configure gcc-13.2.1-kos/gcc/configure
+--- gcc-13.2.1/gcc/configure	2023-06-04 20:48:49.679561957 -0500
++++ gcc-13.2.1-kos/gcc/configure	2023-06-04 20:49:03.488606061 -0500
+@@ -13012,7 +13012,7 @@
      target_thread_file='single'
      ;;
    aix | dce | lynx | mipssde | posix | rtems | \
@@ -25,9 +25,9 @@ diff -ruN gcc-devel/gcc/configure gcc-devel-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff -ruN gcc-devel/libgcc/config/sh/t-sh gcc-devel-kos/libgcc/config/sh/t-sh
---- gcc-devel/libgcc/config/sh/t-sh	2023-06-05 16:50:24.448853468 -0500
-+++ gcc-devel-kos/libgcc/config/sh/t-sh	2023-06-05 16:50:25.327856073 -0500
+diff --color -ruN gcc-13.2.1/libgcc/config/sh/t-sh gcc-13.2.1-kos/libgcc/config/sh/t-sh
+--- gcc-13.2.1/libgcc/config/sh/t-sh	2023-06-04 20:48:45.741549380 -0500
++++ gcc-13.2.1-kos/libgcc/config/sh/t-sh	2023-06-04 20:49:03.488606061 -0500
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -37,9 +37,9 @@ diff -ruN gcc-devel/libgcc/config/sh/t-sh gcc-devel-kos/libgcc/config/sh/t-sh
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff -ruN gcc-devel/libgcc/configure gcc-devel-kos/libgcc/configure
---- gcc-devel/libgcc/configure	2023-06-05 16:50:24.452853480 -0500
-+++ gcc-devel-kos/libgcc/configure	2023-06-05 16:50:25.327856073 -0500
+diff --color -ruN gcc-13.2.1/libgcc/configure gcc-13.2.1-kos/libgcc/configure
+--- gcc-13.2.1/libgcc/configure	2023-06-04 20:48:45.787549527 -0500
++++ gcc-13.2.1-kos/libgcc/configure	2023-06-04 20:49:03.489606065 -0500
 @@ -5699,6 +5699,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -48,9 +48,9 @@ diff -ruN gcc-devel/libgcc/configure gcc-devel-kos/libgcc/configure
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
-diff -ruN gcc-devel/libobjc/configure gcc-devel-kos/libobjc/configure
---- gcc-devel/libobjc/configure	2023-06-05 16:50:24.778854446 -0500
-+++ gcc-devel-kos/libobjc/configure	2023-06-05 16:50:25.328856076 -0500
+diff --color -ruN gcc-13.2.1/libobjc/configure gcc-13.2.1-kos/libobjc/configure
+--- gcc-13.2.1/libobjc/configure	2023-06-04 20:48:49.902562670 -0500
++++ gcc-13.2.1-kos/libobjc/configure	2023-06-04 20:49:03.489606065 -0500
 @@ -2918,11 +2918,9 @@
  
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -63,9 +63,9 @@ diff -ruN gcc-devel/libobjc/configure gcc-devel-kos/libobjc/configure
    ;
    return 0;
  }
-diff -ruN gcc-devel/libobjc/Makefile.in gcc-devel-kos/libobjc/Makefile.in
---- gcc-devel/libobjc/Makefile.in	2023-06-05 16:50:24.778854446 -0500
-+++ gcc-devel-kos/libobjc/Makefile.in	2023-06-05 16:50:25.328856076 -0500
+diff --color -ruN gcc-13.2.1/libobjc/Makefile.in gcc-13.2.1-kos/libobjc/Makefile.in
+--- gcc-13.2.1/libobjc/Makefile.in	2023-06-04 20:48:49.901562666 -0500
++++ gcc-13.2.1-kos/libobjc/Makefile.in	2023-06-04 20:49:03.490606068 -0500
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -96,9 +96,9 @@ diff -ruN gcc-devel/libobjc/Makefile.in gcc-devel-kos/libobjc/Makefile.in
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff -ruN gcc-devel/libstdc++-v3/config/cpu/sh/atomicity.h gcc-devel-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-devel/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:50:24.866854707 -0500
-+++ gcc-devel-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:50:25.328856076 -0500
+diff --color -ruN gcc-13.2.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-13.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-13.2.1/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:48:46.047550357 -0500
++++ gcc-13.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:49:03.490606068 -0500
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -149,9 +149,9 @@ diff -ruN gcc-devel/libstdc++-v3/config/cpu/sh/atomicity.h gcc-devel-kos/libstdc
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-devel/libstdc++-v3/configure gcc-devel-kos/libstdc++-v3/configure
---- gcc-devel/libstdc++-v3/configure	2023-06-05 16:50:24.872854725 -0500
-+++ gcc-devel-kos/libstdc++-v3/configure	2023-06-05 16:50:25.332856088 -0500
+diff --color -ruN gcc-13.2.1/libstdc++-v3/configure gcc-13.2.1-kos/libstdc++-v3/configure
+--- gcc-13.2.1/libstdc++-v3/configure	2023-06-04 20:48:46.398551478 -0500
++++ gcc-13.2.1-kos/libstdc++-v3/configure	2023-06-04 20:49:03.493606077 -0500
 @@ -15809,6 +15809,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/patches/gcc-14.0.1-kos.diff
+++ b/utils/dc-chain/patches/gcc-14.0.1-kos.diff
@@ -1,0 +1,162 @@
+diff -ruN gcc-14.0.1/gcc/config/sh/sh-c.cc gcc-14.0.1-kos/gcc/config/sh/sh-c.cc
+--- gcc-14.0.1/gcc/config/sh/sh-c.cc	2024-01-04 16:01:33.790051712 -0600
++++ gcc-14.0.1-kos/gcc/config/sh/sh-c.cc	2024-01-04 16:01:42.910094466 -0600
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff -ruN gcc-14.0.1/gcc/configure gcc-14.0.1-kos/gcc/configure
+--- gcc-14.0.1/gcc/configure	2024-01-04 16:01:33.801051764 -0600
++++ gcc-14.0.1-kos/gcc/configure	2024-01-04 16:01:42.913094480 -0600
+@@ -13214,7 +13214,7 @@
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32 | mcf)
++  single | tpf | vxworks | win32 | kos | mcf)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff -ruN gcc-14.0.1/libgcc/config/sh/t-sh gcc-14.0.1-kos/libgcc/config/sh/t-sh
+--- gcc-14.0.1/libgcc/config/sh/t-sh	2024-01-04 16:01:37.134067388 -0600
++++ gcc-14.0.1-kos/libgcc/config/sh/t-sh	2024-01-04 16:01:42.914094485 -0600
+@@ -23,6 +23,8 @@
+   $(LIB1ASMFUNCS_CACHE)
+ LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
+ 
++LIB2ADD = $(srcdir)/config/sh/fake-kos.S
++
+ crt1.o: $(srcdir)/config/sh/crt1.S
+ 	$(gcc_compile) -c $<
+ 
+diff -ruN gcc-14.0.1/libgcc/configure gcc-14.0.1-kos/libgcc/configure
+--- gcc-14.0.1/libgcc/configure	2024-01-04 16:01:37.139067412 -0600
++++ gcc-14.0.1-kos/libgcc/configure	2024-01-04 16:01:42.914094485 -0600
+@@ -5763,6 +5763,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 
+diff -ruN gcc-14.0.1/libobjc/configure gcc-14.0.1-kos/libobjc/configure
+--- gcc-14.0.1/libobjc/configure	2024-01-04 16:01:37.499069099 -0600
++++ gcc-14.0.1-kos/libobjc/configure	2024-01-04 16:01:42.915094489 -0600
+@@ -2924,11 +2924,9 @@
+ 
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#include <stdio.h>
+ int
+ main ()
+ {
+-printf ("hello world\n");
+   ;
+   return 0;
+ }
+diff -ruN gcc-14.0.1/libobjc/Makefile.in gcc-14.0.1-kos/libobjc/Makefile.in
+--- gcc-14.0.1/libobjc/Makefile.in	2024-01-04 16:01:37.499069099 -0600
++++ gcc-14.0.1-kos/libobjc/Makefile.in	2024-01-04 16:01:42.915094489 -0600
+@@ -308,14 +308,16 @@
+ $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
+ 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+ 
+-install: install-libs install-headers
++install-strip: INSTALL_STRIP_FLAG = -s
++install install-strip: install-libs install-headers
+ 
+ install-libs: installdirs
+ 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
+-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
++	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+ 	if [ "$(OBJC_BOEHM_GC)" ]; then \
+-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
+-				$(DESTDIR)$(toolexeclibdir);\
++	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
+ 	fi
+ 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
+ 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
+@@ -328,7 +330,7 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
+diff -ruN gcc-14.0.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-14.0.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-14.0.1/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:37.608069611 -0600
++++ gcc-14.0.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:42.916094494 -0600
+@@ -22,14 +22,40 @@
+ // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ // <http://www.gnu.org/licenses/>.
+ 
+-// Use the default atomicity stuff, which will use __atomic* builtins
+-// if threads are available, or the *_single functions on single-thread
+-// configurations.
+-// Actually we wouldn't need this header at all, but because of PR 53579
+-// libstdc++'s configury will not pickup the -matomic-model= option when
+-// set in the environment.  This makes it impossible to enable the proper
+-// atomic model on SH without modifying GCC itself, because libstdc++ always
+-// thinks the target doesn't do any atomics and uses the default mutex based
+-// implementation from cpu/generic/atomicity_mutex.
++/* This is generic/atomicity.h */
+ 
+ #include <ext/atomicity.h>
++#include <ext/concurrence.h>
++
++namespace 
++{
++  __gnu_cxx::__mutex&
++  get_atomic_mutex()
++  {
++    static __gnu_cxx::__mutex atomic_mutex;
++    return atomic_mutex;
++  }
++} // anonymous namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val) throw ()
++  {
++    __gnu_cxx::__scoped_lock sentry(get_atomic_mutex());
++    _Atomic_word __result;
++    __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word* __mem, int __val) throw ()
++  { __exchange_and_add(__mem, __val); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff -ruN gcc-14.0.1/libstdc++-v3/configure gcc-14.0.1-kos/libstdc++-v3/configure
+--- gcc-14.0.1/libstdc++-v3/configure	2024-01-04 16:01:37.616069648 -0600
++++ gcc-14.0.1-kos/libstdc++-v3/configure	2024-01-04 16:01:42.919094508 -0600
+@@ -15959,6 +15959,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 

--- a/utils/dc-chain/scripts/build.mk
+++ b/utils/dc-chain/scripts/build.mk
@@ -35,7 +35,7 @@ build_arm_targets = build-arm-binutils build-arm-gcc build-arm-gcc-pass1
 # Available targets for SH
 $(build_sh4_targets): prefix = $(sh_prefix)
 $(build_sh4_targets): target = $(sh_target)
-$(build_sh4_targets): extra_configure_args = --with-multilib-list=m4-single-only --with-endian=little --with-cpu=m4-single-only
+$(build_sh4_targets): extra_configure_args = --with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 $(build_sh4_targets): gcc_ver = $(sh_gcc_ver)
 $(build_sh4_targets): binutils_ver = $(sh_binutils_ver)
 


### PR DESCRIPTION
(Merge #449 before this PR since 2 new dev configs need Newlib 4.4.0)

This PR makes changes to `utils/dc-chain`:
- `legacy` configuration is renamed to `4.7.4-legacy`
- `9.3.0` configuration is renamed to `9.3.0-legacy`
- `winxp-latest` configuration is renamed to `9.5.0-winxp`
- `devel` configuration is renamed to `14.0.1-dev`, upgraded Newlib to `4.4.0` (now required for `14.0.1` to build properly)
- Add new `13.2.1-dev` configuration, using `13.2.1` dev version from git with Newlib `4.4.0`
- Update KOS patch for GCC `14.0.1` and add KOS patch for GCC `13.2.1`
- Added `precision_modes` option to dc-chain configs to configure building m4/m4-single/m4-single-only multilib support
- Add `default_precision` option to dc-chain configs to configure the default fp precision mode
- Update README/Dockerfile for above changes