### PR TITLE
`dc-chain`: Updating documentation

### DIFF
--- a/utils/dc-chain/doc/CONTRIBUTORS.md
+++ b/utils/dc-chain/doc/CONTRIBUTORS.md
@@ -13,7 +13,7 @@
 * 2012 [Donald Haase](https://github.com/QuzarDC)
 * 2014 [Christian Groessler](https://github.com/groessler)
 * 2016, 2017, 2018, 2019, 2020 [Luke Benstead](https://simulant.dev/)
-* 2018, 2019, 2020 [SiZiOUS](http://sizious.com/)
+* 2018, 2019, 2020, 2021, 2022, 2023, 2024 [Mickaël Cardoso](http://sizious.com/)
 * 2019 [Ellen Marie Dash](https://gitlab.com/duckinator)
 * 2020 [Ben Baron](https://github.com/einsteinx2)
 * 2020 [Jon Daniel](https://github.com/jopadan)

--- a/utils/dc-chain/doc/README.md
+++ b/utils/dc-chain/doc/README.md
@@ -9,7 +9,7 @@ Tested environments are:
 - **BSD** (`FreeBSD 11.2`)
 - **Cygwin**
 - **GNU/Linux** (`Lubuntu 18.04`, `Alpine Linux 3.11`, `Debian 10.3`)
-- **macOS** (`High Sierra 10.13`, `Mojave 10.14`, `Catalina 10.15`);
+- **macOS** (`High Sierra 10.13`, `Mojave 10.14`, `Catalina 10.15`, `Sonoma 14.2.1`);
 - **MinGW/MSYS**
 - **MinGW-w64/MSYS2**
 - **Windows Subsystem for Linux (WSL)** (with `Alpine Linux`, `Ubuntu`); regular

--- a/utils/dc-chain/doc/bsd/README.md
+++ b/utils/dc-chain/doc/bsd/README.md
@@ -90,10 +90,13 @@ To make the toolchains, do the following:
 	bash
 	```
 2. Navigate to the `dc-chain` directory by entering:
+	```
+	cd /opt/toolchains/dc/kos/utils/dc-chain/
+	```
+3. Provide your own `config.mk`. If you don't know which version
+   to choose, you may probably use `config.mk.stable.sample` as a template.
 
-		cd /opt/toolchains/dc/kos/utils/dc-chain/
-	
-3. Enter the following to start downloading and building toolchain:
+4. Enter the following to start downloading and building toolchain:
 	```
 	gmake
 	```

--- a/utils/dc-chain/doc/changelog.txt
+++ b/utils/dc-chain/doc/changelog.txt
@@ -1,3 +1,4 @@
+2024-01-06: Update documentations (Mickaël Cardoso)
 2023-07-31: Update Binutils to 2.41. Verified no regressions in KOS examples compared to
             current stable GCC 9.3.0, so promoting GCC 13.2.0 configuration to stable.
             New config directory created to store alternative configurations, currently

--- a/utils/dc-chain/doc/cygwin/README.md
+++ b/utils/dc-chain/doc/cygwin/README.md
@@ -109,10 +109,15 @@ To make the toolchains, do the following:
 	```
 	cd /opt/toolchains/dc/kos/utils/dc-chain/
 	```
-3. Enter the following to start downloading and building toolchain:
+
+3. Provide your own `config.mk`. If you don't know which version
+   to choose, you may probably use `config.mk.stable.sample` as a template.
+
+4. Enter the following to start downloading and building toolchain:
 	```
 	make
 	```
+
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 

--- a/utils/dc-chain/doc/linux/alpine.md
+++ b/utils/dc-chain/doc/linux/alpine.md
@@ -79,10 +79,15 @@ To make the toolchains, do the following:
 	```
 	cd /opt/toolchains/dc/kos/utils/dc-chain/
 	```
-2. Enter the following to start downloading and building toolchain:
+
+2. Provide your own `config.mk`. If you don't know which version
+   to choose, you may probably use `config.mk.stable.sample` as a template.
+
+3. Enter the following to start downloading and building toolchain:
 	```
 	make
 	```
+
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 

--- a/utils/dc-chain/doc/linux/debian.md
+++ b/utils/dc-chain/doc/linux/debian.md
@@ -80,10 +80,15 @@ To make the toolchains, do the following:
 	```
 	cd /opt/toolchains/dc/kos/utils/dc-chain/
 	```
-2. Enter the following to start downloading and building toolchain:
+
+2. Provide your own `config.mk`. If you don't know which version
+   to choose, you may probably use `config.mk.stable.sample` as a template.
+
+3. Enter the following to start downloading and building toolchain:
 	```
 	make
 	```
+
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 

--- a/utils/dc-chain/doc/macos/README.md
+++ b/utils/dc-chain/doc/macos/README.md
@@ -3,27 +3,31 @@
 This document contains all the instructions to create a fully working
 toolchains targeting the **Sega Dreamcast** system under **macOS**.
 
-This document was written when using **macOS** (`10.14 Mojave`) but it should be
-applicable on all **macOS** systems. Note that Apple introduced some breaking
-changes in `10.14 Mojave`; so starting from that version, some header files have
-moved. They have been removed in `10.15 Catalina` and later versions.
+This document was initially written while using **macOS** (`10.14 Mojave`) but
+it should be applicable on all **macOS** systems. Note that Apple introduced some
+breaking changes in `10.14 Mojave`; so starting from that version, some header
+files have moved. They have been removed in `10.15 Catalina` and later versions.
 **dc-chain** supports all modern macOS versions, including `pre-Mojave`
 releases.
+
+This document has been refreshed using `14.2.1 Sonoma`.
 
 ## Introduction ##
 
 On **macOS** system, the package manager is the `brew` tool, which is provided
 by the [Homebrew project](https://brew.sh).
  
-If you never used the `brew` tool before, you will need to install it. The
-procedure to do that is given below.
+If you never used the `brew` tool before, you will need to install it, using
+your user session.
 
-All the operations in this document should be executed with the `root` user. To
-do that, from a **Terminal** window, input:
-
+All the operations in this document (excepting the `brew` installation and
+usage) should be executed with the `root` user. To do that, from a
+**Terminal** window, input:
+	```
 	sudo -s
-
-If you don't want to use the `root` user, another option is to use the `sudo`
+	```
+ 
+If you don't want to use the `root` user directly, another option is to use the `sudo`
 command. In that case, you will need to add the `sudo` command before entering
 all the commands specified below.
 
@@ -59,24 +63,21 @@ project. This is normal and doesn't affect the **dc-chain** process.
 
 As already said in the introduction, the **macOS** system doesn't come with a
 package manager, but fortunately, the [Homebrew project](https://brew.sh) is
-here to fill this gap:
+here to fill this gap.
 
-1. Open a **Terminal** window.
+Click [here](https://brew.sh) and follow the instructions. Please note,
+all operations done using **Homebrew** should be done under your user account,
+`root` is not allowed while using `brew`.
 
-2. Execute the following:
-	```
-	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-	```
-**Homebrew** is now installed. You can check if it's working by entering
-`brew --version`.
+You can check later if `brew` is working by entering `brew --version`.
 
 ### Installation of required packages ###
 
 The packages below need to be installed:
 ```
-brew install libjpeg libpng libelf
+brew install libjpeg-turbo libpng libelf texinfo
 ```
-All the other required packages have already been installed, i.e. `git`, `svn`
+All the other required packages have already been installed, e.g., `git`
 or `python`.
 
 ## Preparing the environment installation ##
@@ -107,10 +108,15 @@ To make the toolchains, do the following:
 	```
 	cd /opt/toolchains/dc/kos/utils/dc-chain/
 	```
-2. Enter the following to start downloading and building toolchain:
+
+2. Provide your own `config.mk`. If you don't know which version to choose,
+   you may probably use `config.mk.stable.sample` as a template.
+    
+3. Enter the following to start downloading and building toolchain:
 	```
 	make
 	```
+
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 

--- a/utils/dc-chain/doc/mingw/mingw-w64.md
+++ b/utils/dc-chain/doc/mingw/mingw-w64.md
@@ -114,14 +114,20 @@ the main `README.md` file at the root for more information.
 To make the toolchains, do the following:
 
 1. Start the **MSYS2 Shell** if not already done.
+
 2. Navigate to the `dc-chain` directory by entering:
 	```
 	cd /opt/toolchains/dc/kos/utils/dc-chain/
 	```
-3. Enter the following to start downloading and building toolchain:
+
+3. Provide your own `config.mk`. If you don't know which version
+   to choose, you may probably use `config.mk.stable.sample` as a template.
+
+4. Enter the following to start downloading and building toolchain:
 	```
 	make
 	```
+
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 

--- a/utils/dc-chain/doc/mingw/mingw.md
+++ b/utils/dc-chain/doc/mingw/mingw.md
@@ -179,14 +179,20 @@ the main `README.md` file at the root for more information.
 To make the toolchains, do the following:
 
 1. Start the **MSYS Shell** if not already done.
+
 2. Navigate to the `dc-chain` directory by entering:
    ```
    cd /opt/toolchains/dc/kos/utils/dc-chain/
    ```
-3. Enter the following to start downloading and building toolchain:
+
+3. Provide your own `config.mk`. If you don't know which version
+   to choose, you may probably use `config.mk.stable.sample` as a template.
+
+4. Enter the following to start downloading and building toolchain:
    ```
 	make
    ```
+
 Now it's time to take a coffee as this process is really long: several hours
 will be needed to make the full toolchains!
 


### PR DESCRIPTION
Updating all prerequisite documentation for `dc-chain` (`dc-chain/doc` directory):

- Added a step indicating to provide a `config.mk` file before running `make`
- Updated the **macOS** documentation for macOS Sonoma (`14.2.1`)
