### PR TITLE
Implement POSIX scandir() + alphasort() for dirent.h

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -214,6 +214,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Increased resolution of TMU timers + date/time functions [FG && PC]
 - *** Increased resolution of clock() and CLOCKS_PER_SEC to microseconds [FG]
 - DC  Created separate performance counter driver and enhanced API [FG]
+- *** Implemented scandir() and alphasort() POSIX functions from dirent.h [FG]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -13,6 +13,7 @@
     This partially implements the standard POSIX dirent.h functionality.
 
     \author Megan Potter
+    \author Falco Girgis
 */
 
 #ifndef __SYS_DIRENT_H
@@ -23,13 +24,35 @@
 __BEGIN_DECLS
 
 #include <unistd.h>
-#include <arch/types.h>
+#include <stdint.h>
 #include <kos/fs.h>
 #include <kos/limits.h>
 
 /** \addtogroup vfs_posix
     @{
 */
+
+/** \name  Directory File Types
+    \brief POSIX file types for dirent::d_name
+
+    \remark
+    These directory entry types are not part of the POSIX specifican per-se,
+    but are used by BSD and glibc.
+
+    \todo Ensure each VFS driver maps its directory types accordingly
+
+    @{
+*/
+#define DT_UNKNOWN  0   /** \brief Unknown */
+#define DT_FIFO     1   /** \brief Named Pipe or FIFO */
+#define DT_CHR      2   /** \brief Character Device */
+#define DT_DIR      4   /** \brief Directory */
+#define DT_BLK      6   /** \brief Block Device */
+#define DT_REG      8   /** \brief Regular File */
+#define DT_LNK      10  /** \brief Symbolic Link */
+#define DT_SOCK     12  /** \brief Local-Domain Socket */
+#define DT_WHT      14  /** \brief Whiteout (ignored) */
+/** @} */
 
 /** \brief  POSIX directory entry structure.
 
@@ -39,11 +62,11 @@ __BEGIN_DECLS
     \headerfile sys/dirent.h
  */
 struct dirent {
-    int     d_ino;              /**< \brief File unique identifier. */
-    off_t   d_off;              /**< \brief File offset */
-    uint16  d_reclen;           /**< \brief Record length */
-    uint8   d_type;             /**< \brief File type */
-    char    d_name[];           /**< \brief Filename */
+    int       d_ino;              /**< \brief File unique identifier. */
+    off_t     d_off;              /**< \brief File offset */
+    uint16_t  d_reclen;           /**< \brief Record length */
+    uint8_t   d_type;             /**< \brief File type */
+    char      d_name[];           /**< \brief Filename */
 };
 
 /** \brief  Type representing a directory stream.
@@ -59,7 +82,7 @@ struct dirent {
 typedef struct {
     file_t          fd;               /**< \brief File descriptor for the directory */
     struct dirent   d_ent;            /**< \brief Current directory entry */
-    char            d_name[NAME_MAX]; /**< \brief Filenaem */
+    char            d_name[NAME_MAX]; /**< \brief Filename */
 } DIR;
 
 // Standard UNIX dir functions. Not all of these are fully functional
@@ -70,12 +93,14 @@ typedef struct {
     The directory specified is opened if it exists. A directory stream object is
     returned for accessing the entries of the directory.
 
-    \param  name        The name of the directory to open.
-    \return             A directory stream object to be used with readdir() on
-                        success, NULL on failure. Sets errno as appropriate.
     \note               As with other functions for opening files on the VFS,
                         relative paths are permitted for the name parameter of
                         this function.
+
+    \param  name        The name of the directory to open.
+
+    \return             A directory stream object to be used with readdir() on
+                        success, NULL on failure. Sets errno as appropriate.
     \see    closedir
     \see    readdir
 */
@@ -88,6 +113,7 @@ DIR *opendir(const char *name);
     associated with the directory stream.
 
     \param  dir         The directory stream to close.
+
     \return             0 on success. -1 on error, setting errno as appropriate.
 */
 int closedir(DIR *dir);
@@ -98,13 +124,14 @@ int closedir(DIR *dir);
     returning the directory entry associated with the next object in the
     directory.
 
+    \warning            Do not free the returned dirent!
+
     \param  dir         The directory stream to read from.
+
     \return             A pointer to the next directory entry in the directory
                         or NULL if there are no other entries in the directory.
                         If an error is incurred, NULL will be returned and errno
                         set to indicate the error.
-
-    \note               Do not free the returned dirent!
 */
 struct dirent *readdir(DIR *dir);
 
@@ -113,13 +140,14 @@ struct dirent *readdir(DIR *dir);
     This function retrieves the file descriptor of a directory stream that was
     previously opened with opendir().
 
-    \param  dirp        The directory stream to retrieve the descriptor of.
-    \return             The file descriptor from the directory stream on success
-                        or -1 on failure (sets errno as appropriate).
-
-    \note               Do not close() the returned file descriptor. It will be
+    \warning            Do not close() the returned file descriptor. It will be
                         closed when closedir() is called on the directory
                         stream.
+
+    \param  dirp        The directory stream to retrieve the descriptor of.
+
+    \return             The file descriptor from the directory stream on success
+                        or -1 on failure (sets errno as appropriate).
 */
 int dirfd(DIR *dirp);
 
@@ -128,26 +156,70 @@ int dirfd(DIR *dirp);
     This function rewinds the directory stream so that the next call to the
     readdir() function will return the first entry in the directory.
 
-    \param  dir         The directory stream to rewind.
-
-    \note               Some filesystems do not support this call. Notably, none
+    \warning            Some filesystems do not support this call. Notably, none
                         of the dcload filesystems support it. Error values will
                         be returned in errno (so set errno to 0, then check
                         after calling the function to see if there was a problem
                         anywhere).
+
+    \param  dir         The directory stream to rewind.
 */
 void rewinddir(DIR *dir);
 
-/** \brief Not implemented */
+/** \brief Scan, filter, and sort files within a directory.
+
+    This function scans through all files within the directory located at the
+    path given by \p dir, calling \p filter on each entry. Entries for which
+    \p filter returns nonzero are stored within \p namelist and are sorted
+    using qsort() with the comparison function, \p compar. The resulting
+    directory entries are accumulated and stored witin \p namelist.
+
+    \note
+    \p filter and \p compar may be NULL, if you do not wish to filter or sort
+    the files.
+
+    \warning
+    The entries within \p namelist are each independently heap-allocated, then
+    the list itself heap allocated, so each entry must be freed within the list
+    followed by the list itself.
+
+    \param  dir         The path to the directory to scan
+    \param  namelist    A pointer through which the list of entries will be
+                        returned.
+    \param  filter      The callback used to filter each directory entry
+                        (returning 1 for inclusion, 0 for exclusion).
+    \param  compar      The callback passed to qsort() to sort \p namelist by
+
+    \retval >=0         On success, the number of directory entries within \p
+                        namelist is returned
+    \retval -1          On failure, -1 is returned and errno is set
+
+    \sa alphasort
+*/
 int scandir(const char *__RESTRICT dir, struct dirent ***__RESTRICT namelist,
             int(*filter)(const struct dirent *),
             int(*compar)(const struct dirent **, const struct dirent **));
 
-int alphasort(const struct dirent **a, const struct dirent **b);
 
-/*
-int versionsort(const struct dirent **a, const struct dirent **b);
+/** \brief Comparison function for sorting directory entries alphabetically
+
+    Sorts two directory entries, \p a and \p b in alphabetical order.
+
+    \note
+    This function can be used as the comparison callback passed to scandir(),
+    to sort the returned list of entries in alphabetical order.
+
+    \param  a   The first directory entry to sort
+    \param  b   The second directory entry to sort
+
+    \retval     Returns an integer value greater than, equal to, or less than
+                zero, depending on whether the name of the directory entry
+                pointed to by \p a is lexically greater than, equal to, or
+                less than the directory entry pointed to by \p b.
+
+    \sa scandir()
 */
+int alphasort(const struct dirent **a, const struct dirent **b);
 
 /** \brief Not implemented */
 void seekdir(DIR *dir, off_t offset);

--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -43,15 +43,15 @@ __BEGIN_DECLS
 
     @{
 */
-#define DT_UNKNOWN  0   /** \brief Unknown */
-#define DT_FIFO     1   /** \brief Named Pipe or FIFO */
-#define DT_CHR      2   /** \brief Character Device */
-#define DT_DIR      4   /** \brief Directory */
-#define DT_BLK      6   /** \brief Block Device */
-#define DT_REG      8   /** \brief Regular File */
-#define DT_LNK      10  /** \brief Symbolic Link */
-#define DT_SOCK     12  /** \brief Local-Domain Socket */
-#define DT_WHT      14  /** \brief Whiteout (ignored) */
+#define DT_UNKNOWN  0   /**< \brief Unknown */
+#define DT_FIFO     1   /**< \brief Named Pipe or FIFO */
+#define DT_CHR      2   /**< \brief Character Device */
+#define DT_DIR      4   /**< \brief Directory */
+#define DT_BLK      6   /**< \brief Block Device */
+#define DT_REG      8   /**< \brief Regular File */
+#define DT_LNK      10  /**< \brief Symbolic Link */
+#define DT_SOCK     12  /**< \brief Local-Domain Socket */
+#define DT_WHT      14  /**< \brief Whiteout (ignored) */
 /** @} */
 
 /** \brief  POSIX directory entry structure.

--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -2,6 +2,7 @@
 
    dirent.h
    Copyright (C) 2003 Megan Potter
+   Copyright (C) 2024 Falco Girgis
 
 */
 
@@ -24,6 +25,7 @@ __BEGIN_DECLS
 #include <unistd.h>
 #include <arch/types.h>
 #include <kos/fs.h>
+#include <kos/limits.h>
 
 /** \addtogroup vfs_posix
     @{
@@ -41,7 +43,7 @@ struct dirent {
     off_t   d_off;              /**< \brief File offset */
     uint16  d_reclen;           /**< \brief Record length */
     uint8   d_type;             /**< \brief File type */
-    char    d_name[256];        /**< \brief Filename */
+    char    d_name[];           /**< \brief Filename */
 };
 
 /** \brief  Type representing a directory stream.
@@ -55,8 +57,9 @@ struct dirent {
     \headerfile sys/dirent.h
 */
 typedef struct {
-    file_t          fd;         /**< \brief File descriptor for the directory */
-    struct dirent   d_ent;      /**< \brief Current directory entry */
+    file_t          fd;               /**< \brief File descriptor for the directory */
+    struct dirent   d_ent;            /**< \brief Current directory entry */
+    char            d_name[NAME_MAX]; /**< \brief Filenaem */
 } DIR;
 
 // Standard UNIX dir functions. Not all of these are fully functional
@@ -136,9 +139,15 @@ int dirfd(DIR *dirp);
 void rewinddir(DIR *dir);
 
 /** \brief Not implemented */
-int scandir(const char *dir, struct dirent ***namelist,
+int scandir(const char *__RESTRICT dir, struct dirent ***__RESTRICT namelist,
             int(*filter)(const struct dirent *),
             int(*compar)(const struct dirent **, const struct dirent **));
+
+int alphasort(const struct dirent **a, const struct dirent **b);
+
+/*
+int versionsort(const struct dirent **a, const struct dirent **b);
+*/
 
 /** \brief Not implemented */
 void seekdir(DIR *dir, off_t offset);

--- a/kernel/libc/koslib/readdir.c
+++ b/kernel/libc/koslib/readdir.c
@@ -2,16 +2,17 @@
 
    readdir.c
    Copyright (C) 2004 Megan Potter
-
+   Copyright (C) 2024 Falco Girgis
 */
 
 #include <dirent.h>
 #include <errno.h>
 #include <string.h>
 #include <kos/fs.h>
+#include <stdio.h>
 
-struct dirent *readdir(DIR * dir) {
-    dirent_t * d;
+struct dirent *readdir(DIR *dir) {
+    dirent_t *d;
 
     if(!dir) {
         errno = EBADF;
@@ -28,11 +29,11 @@ struct dirent *readdir(DIR * dir) {
     dir->d_ent.d_reclen = 0;
 
     if(d->size < 0)
-        dir->d_ent.d_type = 4;  // DT_DIR
+        dir->d_ent.d_type = DT_DIR;
     else
-        dir->d_ent.d_type = 8;  // DT_REG
+        dir->d_ent.d_type = DT_REG;
 
-    strncpy(dir->d_name, d->name, sizeof(dir->d_name));
+    strncpy(dir->d_ent.d_name, d->name, sizeof(dir->d_name));
 
     return &dir->d_ent;
 }

--- a/kernel/libc/koslib/readdir.c
+++ b/kernel/libc/koslib/readdir.c
@@ -1,7 +1,7 @@
 /* KallistiOS ##version##
 
    readdir.c
-   Copyright (C)2004 Megan Potter
+   Copyright (C) 2004 Megan Potter
 
 */
 
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <kos/fs.h>
 
-struct dirent * readdir(DIR * dir) {
+struct dirent *readdir(DIR * dir) {
     dirent_t * d;
 
     if(!dir) {
@@ -32,7 +32,7 @@ struct dirent * readdir(DIR * dir) {
     else
         dir->d_ent.d_type = 8;  // DT_REG
 
-    strncpy(dir->d_ent.d_name, d->name, sizeof(dir->d_ent.d_name));
+    strncpy(dir->d_name, d->name, sizeof(dir->d_name));
 
     return &dir->d_ent;
 }

--- a/kernel/libc/koslib/readdir.c
+++ b/kernel/libc/koslib/readdir.c
@@ -9,7 +9,6 @@
 #include <errno.h>
 #include <string.h>
 #include <kos/fs.h>
-#include <stdio.h>
 
 struct dirent *readdir(DIR *dir) {
     dirent_t *d;

--- a/kernel/libc/koslib/scandir.c
+++ b/kernel/libc/koslib/scandir.c
@@ -1,24 +1,98 @@
 /* KallistiOS ##version##
 
    scandir.c
-   Copyright (C)2004 Megan Potter
-
+   Copyright (C) 2004 Megan Potter
+   Copyright (C) 2024 Falco Girgis
 */
 
 #include <kos/dbglog.h>
 #include <sys/dirent.h>
+
 #include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <stdio.h>
 
-int scandir(const char *dir, struct dirent ***namelist, 
-    int(*filter)(const struct dirent *), 
-    int(*compar)(const struct dirent ** , const struct dirent **) ) {
+// make sure needed
+int alphasort(const struct dirent **a, const struct dirent **b) {
+   assert(a && b);
+   return strcoll((*a)->d_name, (*b)->d_name);
+}
 
-    (void)dir;
-    (void)namelist;
-    (void)filter;
-    (void)compar;
+static int push_back(struct dirent ***list, int *size, int *capacity,
+                      const struct dirent *dir) {
+    struct dirent *new_dir;
+    int entry_size;
+    struct dirent ***list_tmp = list;
 
-    dbglog(DBG_WARNING, "scandir: call ignored\n");
-    errno = ENOSYS;
-    return -1;
+    dbglog(DBG_CRITICAL, "PB - %s\n", dir->d_name);
+
+    if(*size == *capacity) {
+        if(*capacity)
+            *capacity *= 2;
+        else
+            *capacity = 1;
+
+        list_tmp = list;
+        *list = realloc(list, *capacity * sizeof(struct dirent*));
+
+        if(!list)
+            goto out_of_memory;
+
+    }
+
+    entry_size = sizeof(struct dirent) + strlen(dir->d_name) + 1;
+    new_dir = malloc(entry_size);
+
+    if(!new_dir)
+        goto out_of_memory;
+
+    memcpy(new_dir, dir, entry_size);
+    (*list)[++*size] = new_dir;
+
+    return 1;
+
+out_of_memory:
+    for(int e = 0; e < *size; ++e)
+        free((*list_tmp)[e]);
+
+    free(*list_tmp);
+    *list = NULL;
+    *size = 0;
+    *capacity = 0;
+
+    return 0;
+}
+
+int scandir(const char *dirname, struct dirent ***namelist, 
+            int(*filter)(const struct dirent *), 
+            int(*compar)(const struct dirent ** , const struct dirent **)) {
+
+    int size = 0, capacity = 0;
+    DIR* dir;
+    struct dirent *dirent;
+
+    *namelist = NULL;
+
+    assert(dirname);
+
+    if(!(dir = opendir(dirname)))
+        return ENOENT;
+
+    while((dirent = readdir(dir))) {
+        dbglog(DBG_CRITICAL, "%s\n", dirent->d_name);
+        if(!filter || filter(dirent))
+            if(!push_back(namelist, &size, &capacity, dirent)) {
+                size = ENOMEM;
+                break;
+            }
+    }
+
+    if(size > 0 && compar)
+        qsort(*namelist, size, sizeof(struct dirent*), (void *)compar);
+
+   closedir(dir);
+
+   return size;
 }

--- a/kernel/libc/koslib/scandir.c
+++ b/kernel/libc/koslib/scandir.c
@@ -14,50 +14,77 @@
 #include <assert.h>
 #include <stdio.h>
 
-// make sure needed
+/* Comparator used to sort two directory entries alphabetically. */
 int alphasort(const struct dirent **a, const struct dirent **b) {
    assert(a && b);
+    /* Simply use strcoll() to determine lexical order. */
    return strcoll((*a)->d_name, (*b)->d_name);
 }
 
+/* Static utility function used to add an entry to our current list of entries.
+   The list's capacity doubles every time its size reaches its capacity,
+   similarly to a C++ std::vector's allocation behavior.
+
+   The only real difference here is that we must gracefully handle
+   out-of-memory situations (malloc() returns NULL), in which case we clean up
+   the vector and its entries, returning 0 to denote failure. */
 static int push_back(struct dirent ***list, int *size, int *capacity,
                       const struct dirent *dir) {
     struct dirent *new_dir;
     int entry_size;
     struct dirent ***list_tmp = list;
 
-    dbglog(DBG_CRITICAL, "PB - %s\n", dir->d_name);
-
+    /* Check if the "vector" needs to resize */
     if(*size == *capacity) {
+        /* Capacity should be powers-of-2 */
         if(*capacity)
             *capacity *= 2;
         else
             *capacity = 1;
 
+        /* Save the previous list pointer in case realloc() fails. */
         list_tmp = list;
-        *list = realloc(list, *capacity * sizeof(struct dirent*));
 
+        /* Resize our list */
+        *list = realloc(*list, *capacity * sizeof(struct dirent*));
+
+        /* Handle out-of-memory in case realloc() failed. */
         if(!list)
             goto out_of_memory;
-
+        else
+            list_tmp = list;
     }
 
+    /* Allocate space for the new directory entry on the heap.
+
+       NOTE: We only allocate EXACTLY as much space as is needed
+             for the directory entry, based on the length of its name,
+             using our flexible array member, dirent::d_name */
     entry_size = sizeof(struct dirent) + strlen(dir->d_name) + 1;
     new_dir = malloc(entry_size);
 
+    /* Check for malloc() failure of the singel entry */
     if(!new_dir)
         goto out_of_memory;
 
+    /* Copy the directory entry into its new heap-allocated storage. */
     memcpy(new_dir, dir, entry_size);
-    (*list)[++*size] = new_dir;
+
+    /* Add it to the list, incrementing its size. */
+    (*list)[(*size)++] = new_dir;
 
     return 1;
 
+/* Handle out-of-memory failure: */
 out_of_memory:
+    /* Free each individual directory entry. */
     for(int e = 0; e < *size; ++e)
         free((*list_tmp)[e]);
 
+    /* Free the overall directory entry list */
     free(*list_tmp);
+
+    /* Reset our list variables */
     *list = NULL;
     *size = 0;
     *capacity = 0;
@@ -65,34 +92,72 @@ out_of_memory:
     return 0;
 }
 
+/* Implementation of the POSIX scandir() function within dirent.h. */
 int scandir(const char *dirname, struct dirent ***namelist, 
             int(*filter)(const struct dirent *), 
             int(*compar)(const struct dirent ** , const struct dirent **)) {
 
-    int size = 0, capacity = 0;
     DIR* dir;
     struct dirent *dirent;
+    struct stat stat;
+    int size = 0, capacity = 0;
 
+    /* Initialize namelist to its initial value */
     *namelist = NULL;
 
-    assert(dirname);
+    /* There's no standard way to validate these, so we'll assert(). */
+    assert(dirname && namelist);
 
-    if(!(dir = opendir(dirname)))
-        return ENOENT;
+    /* First we simply attempt to open the directory using the POSIX API. */
+    if(!(dir = opendir(dirname))) {
 
+        /* If we cannot open the directory, we attempt to stat it for more
+           detailed information on why it failed */
+        if(fs_stat(dirname, &stat, 0) < 0) {
+            /* If stat itself failes, there's no directory entry found. */
+            errno = ENOENT;
+            return -1;
+        }
+
+        /* Check whether the file type is even a directory. */
+        if(stat.st_mode != S_IFDIR) {
+            errno = ENOTDIR;
+            return -1;
+        }
+        else
+        {
+            /* If it's a directory according to stat, yet we failed to open it,
+               this could potentially be a KOS issue or some unknown failure.
+               assert() and return a generic error. Not much we can do. */
+            assert(0);
+            errno = ENOENT;
+            return -1;
+        }
+    }
+
+    /* Iterate over each file within the directory. */
     while((dirent = readdir(dir))) {
-        dbglog(DBG_CRITICAL, "%s\n", dirent->d_name);
+        /* If we provided no filter, or the file is within the filter,
+           attempt to add it to the namelist.*/
         if(!filter || filter(dirent))
+            /* If we successfully added dirent to the namelist, continue. */
             if(!push_back(namelist, &size, &capacity, dirent)) {
-                size = ENOMEM;
-                break;
+                /* If push_back() returned 0, we ran out of memory.
+                   Close the directory and return the appropriate error. */
+                closedir(dir);
+                errno = ENOMEM;
+                return -1;
             }
     }
 
+    /* If namelist has any entries and we were passed a comparison callback,
+       use qsort() to sort namelist with the callback. */
     if(size > 0 && compar)
         qsort(*namelist, size, sizeof(struct dirent*), (void *)compar);
 
-   closedir(dir);
+    /* Close the directory and release resources when we're done. */
+    closedir(dir);
 
-   return size;
+    /* Return the number of entries stored within namelist. */
+    return size;
 }

--- a/kernel/libc/koslib/scandir.c
+++ b/kernel/libc/koslib/scandir.c
@@ -12,7 +12,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <stdio.h>
 
 /* Comparator used to sort two directory entries alphabetically. */
 int alphasort(const struct dirent **a, const struct dirent **b) {


### PR DESCRIPTION
I noticed a few missing pieces of functionality within the filesystem, specifically around the POSIX `dirent.h` header. Some of the unimplemented functions look as though they don't quite map to KOS's VFS, but a few, such as `scandir()` look more like they just weren't previously implemented because they're a pain in the ass. :)

- Implemented `scandir()` (confirmed: PITA)
- Implemented `alphasort()` (same POSIX standard revision as `scandir()` and often used with it). 
- Tested proper behavior by scanning VMU directories and MASSIVE PC directories (that literally took like 5 minutes on BBA to populate).
- Tested proper error behavior when attempting to scan a nonexistent directory or a regular file
- Tested that the thing can actually properly recover from running out-of-memory, free what it's using, and gracefully return `ENOMEM` to the user
- Updated the documentation