### PR TITLE
Fixed Build Issue with -Og for inode.c

### DIFF
--- a/addons/libkosext2fs/inode.c
+++ b/addons/libkosext2fs/inode.c
@@ -1042,7 +1042,7 @@ int ext2_inode_by_path(ext2_fs_t *fs, const char *path, ext2_inode_t **rv,
     int blocks, i, block_size;
     uint8_t *buf;
     uint32_t *ib;
-    ext2_dirent_t *dent;
+    ext2_dirent_t *dent = NULL;
     int err = 0;
     size_t tmp_sz;
     char *symbuf;


### PR DESCRIPTION
- When using debug optimization level, inode.c:1270 was issuing a warning about "dent" being used without being initialized. This warning was treated as an error.
- Initialized "dent" to NULL at the beginning of the function.

Why does this only happen with `-Og`? ...I have no idea.

Here's the actual error:
```
make[2]: Entering directory '/opt/toolchains/dc/kos/addons/libkosext2fs'
kos-cc  -c ext2fs.c -o ext2fs.o
kos-cc  -c bitops.c -o bitops.o
kos-cc  -c block.c -o block.o
kos-cc  -c inode.c -o inode.o
inode.c: In function ‘ext2_inode_by_path’:
inode.c:1270:22: error: ‘dent’ may be used uninitialized [-Werror=maybe-uninitialized]
 1270 |     *inode_num = dent->inode;
      |                  ~~~~^~~~~~~
inode.c:1045:20: note: ‘dent’ was declared here
 1045 |     ext2_dirent_t *dent;
      |                    ^~~~
cc1: all warnings being treated as errors
make[2]: *** [/opt/toolchains/dc/kos/Makefile.rules:13: inode.o] Error 1
```