### PR TITLE
Changed abort() to call arch_abort()

### DIFF
--- a/kernel/libc/koslib/abort.c
+++ b/kernel/libc/koslib/abort.c
@@ -1,15 +1,17 @@
 /* KallistiOS ##version##
 
    abort.c
-   (c)2001 Megan Potter
-
+   Copyright (C) 2001 Megan Potter
+   Copyright (C) 2024 Falco Girgis
 */
 
 #include <stdlib.h>
 #include <arch/arch.h>
 
-/* This is probably the closest mapping we've got for abort() */
+/* abort() causes abnormal/erroneous program termination
+   WITHOUT calling the atexit() handlers. This will eventually
+   return EXIT_FAILURE as the program's return code. */
 __used void abort(void) {
-    arch_exit();
+    arch_abort();
 }
 


### PR DESCRIPTION
In preparation for eventually wanting to proxy return codes from `main()` back to dc-tool for testing automation, I've been checking out our exit/termination paths to ensure they return proper success/failure codes... `abort()` struck my eye as not quite doing the right thing, especially given `arch_abort()` almost perfectly matches what it is supposed to do.

- `abort()` should 1) not return a successful result code 2) should not invoke the `atexit()` finalizers upon being called, both of which were happening
- Changed `abort()` to call arch_abort(), which is a hasty shutdown without calling `atexit()` finalizers that will also return `EXIT_FAILURE`.

Reference: https://en.cppreference.com/w/c/program/abort