### PR TITLE
Implemented Newlib try_lock() Functions

### DIFF
--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -52,13 +52,13 @@ typedef __newlib_recursive_lock_t _LOCK_RECURSIVE_T;
 void __newlib_lock_init(__newlib_lock_t*);
 void __newlib_lock_close(__newlib_lock_t*);
 void __newlib_lock_acquire(__newlib_lock_t*);
-void __newlib_lock_try_acquire(__newlib_lock_t*);
+int __newlib_lock_try_acquire(__newlib_lock_t*);
 void __newlib_lock_release(__newlib_lock_t*);
 
 void __newlib_lock_init_recursive(__newlib_recursive_lock_t*);
 void __newlib_lock_close_recursive(__newlib_recursive_lock_t*);
 void __newlib_lock_acquire_recursive(__newlib_recursive_lock_t*);
-void __newlib_lock_try_acquire_recursive(__newlib_recursive_lock_t*);
+int __newlib_lock_try_acquire_recursive(__newlib_recursive_lock_t*);
 void __newlib_lock_release_recursive(__newlib_recursive_lock_t*);
 
 /** \endcond */

--- a/kernel/libc/newlib/lock_common.c
+++ b/kernel/libc/newlib/lock_common.c
@@ -45,17 +45,7 @@ void __newlib_lock_close_recursive(__newlib_recursive_lock_t *lock) {
 }
 
 void __newlib_lock_acquire_recursive(__newlib_recursive_lock_t *lock) {
-    int old;
-    int iscur;
-
-    // Check to see if we already own it. If so, everything is clear
-    // to incr nest. Otherwise, we can safely go on to do a normal
-    // spinlock wait.
-    old = irq_disable();
-    iscur = lock->owner == thd_current;
-    irq_restore(old);
-
-    if(iscur) {
+    if(lock->owner == thd_get_current()) {
         lock->nest++;
         return;
     }
@@ -64,7 +54,7 @@ void __newlib_lock_acquire_recursive(__newlib_recursive_lock_t *lock) {
     spinlock_lock(&lock->lock);
 
     // We own it now, so it's safe to init the rest of this.
-    lock->owner = thd_current;
+    lock->owner = thd_get_current();
     lock->nest = 1;
 }
 


### PR DESCRIPTION
So this one really isn't going to do a whole lot, considering that the functions I've implemented clearly weren't being used, or they'd be aborting, PLUS I did a search through the Newlib repository and couldn't find anywhere where they were actually used; however, I did want to go ahead and implement these, since they are part of what Newlib expects to be there, and there doesn't seem to be any real reason not to have them now that we have `spinlock_trylock()`. 

Oh, also, our function signatures on those two were incorrect. They should return an `int`. 

- `__newlib_lock_try_acquire()` and `__newlib_lock_try_acquire_recursive()` were stubbed out to assert and abort due to not being implemented
- Implemented both using the new `spinlock_trylock()` API
- Also had to fix their prototypes, since they both should be returning an integer for whether the lock was successfully obtained