### PR TITLE
Add environ variable for SH4 floating point precision configuration

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -2,22 +2,22 @@
 #
 # This is a sample script for configuring and customizing your
 # KOS build environment. Modify it to suit your setup. Several
-# settings may be enabled optionally or are provided with 
+# settings may be enabled optionally or are provided with
 # alternative values.
 #
-# This script is typically sourced in your current shell environment 
+# This script is typically sourced in your current shell environment
 # (probably by .bashrc, .bash_profile, or something similar), so that
 # the KOS environment is set up automatically for each shell session.
 #
 
-# Build Architecture 
+# Build Architecture
 #
 # Set the major architecture you'll be building for.
 # The only option here is "dreamcast" as of KOS 2.0.0.
 #
 export KOS_ARCH="dreamcast"
 
-# Build Sub-Architecture 
+# Build Sub-Architecture
 #
 # Defines the sub architecture your configuration
 # is targeting or uses an existing value that
@@ -47,15 +47,15 @@ export KOS_PORTS="${KOS_BASE}/../kos-ports"
 
 # SH Compiler Prefixes
 #
-# Specifies the path to and prefix for the main SH 
+# Specifies the path to and prefix for the main SH
 # GCC toolchain used to target the Dreamcast's SH4 CPU.
 #
-export KOS_CC_BASE="/opt/toolchains/dc/sh-elf"  
+export KOS_CC_BASE="/opt/toolchains/dc/sh-elf"
 export KOS_CC_PREFIX="sh-elf"
 
 # ARM Compiler Prefixes
 #
-# Specifies the path to and prefix for the additional ARM 
+# Specifies the path to and prefix for the additional ARM
 # GCC toolchain used to target the Dreamcast's AICA SPU.
 #
 export DC_ARM_BASE="/opt/toolchains/dc/arm-eabi"
@@ -78,8 +78,8 @@ export KOS_GENROMFS="${KOS_BASE}/utils/genromfs/genromfs"
 # Make Utility
 #
 # Configures the tool to be used as the main "make" utility
-# for building GNU Makefiles. On a platform such as BSD, 
-# the default can be changed to "gmake," for the GNU 
+# for building GNU Makefiles. On a platform such as BSD,
+# the default can be changed to "gmake," for the GNU
 # implementation.
 #
 export KOS_MAKE="make"
@@ -93,9 +93,9 @@ export KOS_MAKE="make"
 # or dc-tool-serial configuration, remembering to change the values
 # for the Dreamcast's IP address or the serial port interface.
 #
-export KOS_LOADER="dc-tool -x"				       
+export KOS_LOADER="dc-tool -x"
 #export KOS_LOADER="dc-tool-ip -t 192.168.1.100 -x"
-#export KOS_LOADER="dc-tool-ser -t /dev/ttyS0 -x" 
+#export KOS_LOADER="dc-tool-ser -t /dev/ttyS0 -x"
 
 # Default Compiler Flags
 #
@@ -109,19 +109,19 @@ export KOS_LDFLAGS=""
 export KOS_AFLAGS=""
 export DC_ARM_LDFLAGS=""
 
-# Optimization Level 
+# Optimization Level
 #
-# Controls the baseline optimization level to use when building. 
+# Controls the baseline optimization level to use when building.
 # Typically this is -Og (debugging), -O0, -01, -02, or -03.
-# NOTE: For our target, -O4 is a valid optimization level that has 
+# NOTE: For our target, -O4 is a valid optimization level that has
 # been seen to have some performance impact as well.
 #
 export KOS_CFLAGS="${KOS_CFLAGS} -O2"
 
 # Additional Optimizations
 #
-# Uncomment this to enable what has been found empirically to be 
-# the optimal set of additional flags for release build performance 
+# Uncomment this to enable what has been found empirically to be
+# the optimal set of additional flags for release build performance
 # on the current stable toolchain. NOTE: Certain KOS-ports and examples
 # do not work properly with "-flto=auto"!
 #
@@ -130,18 +130,18 @@ export KOS_CFLAGS="${KOS_CFLAGS} -O2"
 # Frame Pointers
 #
 # Controls whether frame pointers are emitted or not. Disabled by
-# default. Enable them if you plan to use GDB for debugging. 
+# default. Enable them if you plan to use GDB for debugging.
 #
 export KOS_CFLAGS="${KOS_CFLAGS} -fomit-frame-pointer"
 #export KOS_CFLAGS="${KOS_CFLAGS} -fno-omit-frame-pointer -DFRAME_POINTERS"
 
 # GCC Builtin Functions
 #
-# Comment out this line to enable GCC to use its own builtin implementations of 
+# Comment out this line to enable GCC to use its own builtin implementations of
 # certain standard library functions. Under certain conditions, this can allow
 # compiler-optimized implementations to replace standard function invocations.
 # The downside of this is that it COULD interfere with Newlib or KOS implementations
-# of these functions, and it has not been tested thoroughly to ensure compatibility. 
+# of these functions, and it has not been tested thoroughly to ensure compatibility.
 #
 export KOS_CFLAGS="${KOS_CFLAGS} -fno-builtin"
 
@@ -176,8 +176,9 @@ fi
 
 # Shared Compiler Configuration
 #
-# Include sub architecture-independent configuration file for shared 
-# environment settings. If you want to configure additional compiler 
+# Include sub architecture-independent configuration file for shared
+# environment settings. If you want to configure additional compiler
 # options or see where other build flags are set, look at this file.
 #
 . ${KOS_BASE}/environ_base.sh
+

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -158,9 +158,14 @@ export KOS_CFLAGS="${KOS_CFLAGS} -fno-builtin"
 # SH4 Floating Point Arithmetic Precision
 #
 # KallistiOS only officially supports the single-precision-only floating-point
-# arithmetic mode (-m4-single-only), but experimental support for the double
-# precision default (-m4) or double precision, single default (-m4-single) modes
-# can be enabled here by adjusting KOS_SH4_PRECISION.
+# arithmetic mode (-m4-single-only), but double precision default (-m4) or
+# double precision, single default (-m4-single) modes can be enabled here by
+# adjusting KOS_SH4_PRECISION.
+# WARNING: Adjusting this setting has a high likelihood of breaking KallistiOS,
+#          kos-ports, and existing codebases which assume -m4-single-only.
+#          Do not touch this setting unless you know what you are doing!
+# NOTE: Altering this setting also requires your toolchain to have been built
+#       with support for these modes, which is not the case by default!
 #
 export KOS_SH4_PRECISION="-m4-single-only"
 

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -155,6 +155,15 @@ export KOS_CFLAGS="${KOS_CFLAGS} -fno-builtin"
 #
 # export KOS_CFLAGS="${KOS_CFLAGS} -ffast-math -ffp-contract=fast -mfsrra -mfsca"
 
+# SH4 Floating Point Arithmetic Precision
+#
+# KallistiOS only officially supports the single-precision-only floating-point
+# arithmetic mode (-m4-single-only), but experimental support for the double
+# precision default (-m4) or double precision, single default (-m4-single) modes
+# can be enabled here by adjusting KOS_SH4_PRECISION.
+#
+export KOS_SH4_PRECISION="-m4-single-only"
+
 # Additional Tools Path
 #
 # If not already set, add "bin" directory to PATH variable, which is where

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -1,14 +1,19 @@
 # KallistiOS environment variable settings. These are the shared pieces
 # for the Dreamcast(tm) platform.
 
-export KOS_CFLAGS="${KOS_CFLAGS} -ml -m4-single-only -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec"
+# Default the SH4 floating point precision if it isn't already set.
+if [ -z "${KOS_SH4_PRECISION}" ] ; then
+    export KOS_SH4_PRECISION="-m4-single-only"
+fi
+
+export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_SH4_PRECISION} -ml -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec"
 export KOS_AFLAGS="${KOS_AFLAGS} -little"
 
 if [ x${KOS_SUBARCH} = xnaomi ]; then
-	export KOS_LDFLAGS="${KOS_LDFLAGS} -ml -m4-single-only -Wl,-Ttext=0x8c020000 -Wl,--gc-sections"
+	export KOS_LDFLAGS="${KOS_LDFLAGS} ${KOS_SH4_PRECISION} -ml -Wl,-Ttext=0x8c020000 -Wl,--gc-sections"
 	export KOS_LD_SCRIPT="-T${KOS_BASE}/utils/ldscripts/shlelf-naomi.xc"
 else
-	export KOS_LDFLAGS="${KOS_LDFLAGS} -ml -m4-single-only -Wl,-Ttext=0x8c010000 -Wl,--gc-sections"
+	export KOS_LDFLAGS="${KOS_LDFLAGS} ${KOS_SH4_PRECISION} -ml -Wl,-Ttext=0x8c010000 -Wl,--gc-sections"
 	export KOS_LD_SCRIPT="-T${KOS_BASE}/utils/ldscripts/shlelf.xc"
 fi
 
@@ -25,5 +30,5 @@ if [ x${KOS_ARCH} = xdreamcast ]; then
 	export DC_ARM_START="${KOS_ARCH_DIR}/sound/arm/crt0.s"
 	export DC_ARM_LDFLAGS="${DC_ARM_LDFLAGS} -Wl,-Ttext=0x00000000,-N -nostartfiles -nostdlib -e reset"
 	export DC_ARM_LIB_PATHS=""
-	export DC_ARM_LIBS="-Wl,--start-group -lgcc -Wl,--end-group"	
+	export DC_ARM_LIBS="-Wl,--start-group -lgcc -Wl,--end-group"
 fi


### PR DESCRIPTION
This PR adjusts `environ_dreamcast.sh` so that the SH4 FP precision mode can be overridden based on the environment variable `KOS_SH4_PRECISION`. If the setting is omitted from the user's `environ.sh`, the setting defaults to `-m4-single-only`. The setting is added towards the bottom of the `environ.sh.sample`, but it is noted that only `-m4-single-only` is supported and `-m4`/`-m4-single` are experimental. 