### PR TITLE
Added Toolchain Config Variable for Disabling NLS.

### DIFF
--- a/utils/dc-chain/config/config.mk.10.5.0.sample
+++ b/utils/dc-chain/config/config.mk.10.5.0.sample
@@ -164,6 +164,11 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
+# Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Set this variable to disable NLS, forcing GCC to output in American English.
+#disable_nls=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config/config.mk.11.4.0.sample
+++ b/utils/dc-chain/config/config.mk.11.4.0.sample
@@ -164,6 +164,11 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
+# Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Set this variable to disable NLS, forcing GCC to output in American English.
+#disable_nls=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config/config.mk.12.3.0.sample
+++ b/utils/dc-chain/config/config.mk.12.3.0.sample
@@ -164,6 +164,11 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
+# Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Set this variable to disable NLS, forcing GCC to output in American English.
+#disable_nls=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config/config.mk.13.2.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.13.2.1-dev.sample
@@ -173,6 +173,11 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
+# Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Set this variable to disable NLS, forcing GCC to output in American English.
+#disable_nls=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config/config.mk.14.0.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.14.0.1-dev.sample
@@ -176,6 +176,11 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
+# Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Set this variable to disable NLS, forcing GCC to output in American English.
+#disable_nls=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config/config.mk.4.7.4-legacy.sample
+++ b/utils/dc-chain/config/config.mk.4.7.4-legacy.sample
@@ -164,6 +164,11 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
+# Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Set this variable to disable NLS, forcing GCC to output in American English.
+#disable_nls=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config/config.mk.9.3.0-legacy.sample
+++ b/utils/dc-chain/config/config.mk.9.3.0-legacy.sample
@@ -164,6 +164,11 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
+# Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Set this variable to disable NLS, forcing GCC to output in American English.
+#disable_nls=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config/config.mk.9.5.0-winxp.sample
+++ b/utils/dc-chain/config/config.mk.9.5.0-winxp.sample
@@ -164,6 +164,11 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
+# Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Set this variable to disable NLS, forcing GCC to output in American English.
+#disable_nls=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/config/config.mk.stable.sample
+++ b/utils/dc-chain/config/config.mk.stable.sample
@@ -164,9 +164,9 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
-# Disable GCC Native Language Support
+# Disable GCC Native Language Support (1|0)
 # By default, NLS allows GCC to output diagnostics in non-English languages.
-# Uncommenting this line NLS, forcing GCC to output in American English.
+# Set this variable to disable NLS, forcing GCC to output in American English.
 #disable_nls=1
 
 # MinGW/MSYS

--- a/utils/dc-chain/config/config.mk.stable.sample
+++ b/utils/dc-chain/config/config.mk.stable.sample
@@ -164,6 +164,11 @@ newlib_c99_formats=1
 # performance.
 #newlib_opt_space=1
 
+# Disable GCC Native Language Support
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Uncommenting this line NLS, forcing GCC to output in American English.
+#disable_nls=1
+
 # MinGW/MSYS
 # Standalone binaries (1|0)
 # Define this if you want a standalone, no dependency binaries (i.e. static)

--- a/utils/dc-chain/doc/CONTRIBUTORS.md
+++ b/utils/dc-chain/doc/CONTRIBUTORS.md
@@ -18,5 +18,5 @@
 * 2020 [Ben Baron](https://github.com/einsteinx2)
 * 2020 [Jon Daniel](https://github.com/jopadan)
 * 2023 [Colton Pawielski](https://github.com/cepawiel)
-* 2023 [Eric Fradella](https://github.com/darcagn)
+* 2023, 2024 [Eric Fradella](https://github.com/darcagn)
 * 2023, 2024 [Falco Girgis](https://github.com/gyrovorbis)

--- a/utils/dc-chain/doc/CONTRIBUTORS.md
+++ b/utils/dc-chain/doc/CONTRIBUTORS.md
@@ -19,3 +19,4 @@
 * 2020 [Jon Daniel](https://github.com/jopadan)
 * 2023 [Colton Pawielski](https://github.com/cepawiel)
 * 2023 [Eric Fradella](https://github.com/darcagn)
+* 2023, 2024 [Falco Girgis](https://github.com/gyrovorbis)

--- a/utils/dc-chain/doc/changelog.txt
+++ b/utils/dc-chain/doc/changelog.txt
@@ -1,3 +1,5 @@
+2024-01-14: Added config option for disabling native language support (NLS) in GCC.
+            (Falco Girgis)
 2024-01-06: Update documentations (Mickaël Cardoso)
 2023-07-31: Update Binutils to 2.41. Verified no regressions in KOS examples compared to
             current stable GCC 9.3.0, so promoting GCC 13.2.0 configuration to stable.

--- a/utils/dc-chain/scripts/build.mk
+++ b/utils/dc-chain/scripts/build.mk
@@ -35,7 +35,7 @@ build_arm_targets = build-arm-binutils build-arm-gcc build-arm-gcc-pass1
 # Available targets for SH
 $(build_sh4_targets): prefix = $(sh_prefix)
 $(build_sh4_targets): target = $(sh_target)
-$(build_sh4_targets): extra_configure_args = --with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
+$(build_sh4_targets): extra_configure_args += --with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 $(build_sh4_targets): gcc_ver = $(sh_gcc_ver)
 $(build_sh4_targets): binutils_ver = $(sh_binutils_ver)
 

--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -152,6 +152,12 @@ ifdef newlib_multibyte
   endif
 endif
 
+ifdef disable_nls
+  ifneq (0,$(disable_nls))
+    extra_configure_args += --disable-nls
+  endif
+endif
+
 # Function to verify variable is not empty
 # Args:
 # 1 - Variable Name


### PR DESCRIPTION
At least two of our users happen to be English speakers in Japan, and their toolchains build with errors and diagnostics in Japanese, so nobody has any idea what's happening when they try to share their build failures... I've asked them both, and they would both prefer to disable NLS.

- Added "disable_nls" optional variable within the stable toolchain config file (defaulting to off) to disable GCC's native language support.

I did NOT add it to all of the config files, just stable!!! @darcagn, any way you could help get the rest of them? Not sure what you do, but I'm assuming you can do it faster than I can. lol.