### PR TITLE
Added <dc/vmu_fb.h> to <kos.h>

### DIFF
--- a/include/kos.h
+++ b/include/kos.h
@@ -112,6 +112,7 @@ __BEGIN_DECLS
 #   include <dc/vblank.h>
 #   include <dc/vec3f.h>
 #   include <dc/video.h>
+#   include <dc/vmu_fb.h>
 #   include <dc/vmu_pkg.h>
 #   include <dc/vmufs.h>
 #else   /* _arch_dreamcast */


### PR DESCRIPTION
Found this extremely flattering example of someone using BOTH the new VMU framebuffer API AND C23 with the new toolchain... https://maddie.info/homebrew/dreamcast/2023/06/03/interfacing-with-the-dreamcast-controller-in-kos.html

...but notice they have to go out of the way to separately include it when they're already including `<kos.h>`... Oops!

- It looks like we forgot to do this when we added the VMU framebuffer API.