### PR TITLE
Added Newlines Around main() Console Output

### DIFF
--- a/examples/dreamcast/hello/hello.c
+++ b/examples/dreamcast/hello/hello.c
@@ -35,7 +35,7 @@
 /* Your program's main entry point */
 int main(int argc, char *argv[]) {
     /* The requisite line */
-    printf("\nHello world!\n\n");
+    printf("Hello world!\n");
 
     return 0;
 }

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -270,6 +270,8 @@ void arch_main(void) {
 
     __verify_newlib_patch();
 
+    dbglog(DBG_INFO, "\n");
+
     /* Run ctors */
     _init();
 
@@ -333,7 +335,7 @@ void arch_exit(void) {
 
 /* Return point from newlib's _exit() (configurable) */
 void arch_exit_handler(int ret_code) {
-    dbglog(DBG_INFO, "arch: exit return code %d\n", ret_code);
+    dbglog(DBG_INFO, "\narch: exit return code %d\n", ret_code);
 
     /* Shut down */
     arch_shutdown();


### PR DESCRIPTION
This is another opinionated change, that you guys can feel free to reject, but like... I'm constantly finding myself having to add newlines around my user code just to set it apart against KOS's init/deinit code, I see GLdc adding newlines to its initialization, and I see even our hello example having to do the same... Seems like we should just make KOS itself do this, as it looks much better and is easier for the user.

Old:
```
KallistiOS Git revision c3be4a13-dirty:
  Thu Jan 18 08:36:07 PM CST 2024
  falco@slutserv:/opt/toolchains/dc/kos
  sh-elf-gcc (GCC) 13.2.1 20240111
thd: pre-emption enabled, HZ=100
maple: active drivers:
    Dreameye (Camera): Camera
    Sound Input Peripheral: Microphone
    PuruPuru (Vibration) Pack: JumpPack
    VMU Driver: Clock, LCD, MemoryCard
    Mouse Driver: Mouse
    Keyboard Driver: Keyboard
    Controller Driver: Controller
    Lightgun: LightGun
  DMA Buffer at ac070080
vid_set_mode: 640x480 VGA
dc-load console support enabled
maple: attached devices:
  A0: Dreamcast Controller          (01000000: Controller)
  A1: Visual Memory                 (0e000000: Clock, LCD, MemoryCard)
  A2: Puru Puru Pack                (00010000: JumpPack)
Hello world!
arch: exit return code 0
arch: shutting down kernel
maple: final stats -- device count = 3, vbl_cntr = 4, dma_cntr = 4
vid_set_mode: 640x480 VGA
```
New:
```
KallistiOS Git revision c3be4a13-dirty:
  Thu Jan 18 08:36:07 PM CST 2024
  falco@slutserv:/opt/toolchains/dc/kos
  sh-elf-gcc (GCC) 13.2.1 20240111
thd: pre-emption enabled, HZ=100
maple: active drivers:
    Dreameye (Camera): Camera
    Sound Input Peripheral: Microphone
    PuruPuru (Vibration) Pack: JumpPack
    VMU Driver: Clock, LCD, MemoryCard
    Mouse Driver: Mouse
    Keyboard Driver: Keyboard
    Controller Driver: Controller
    Lightgun: LightGun
  DMA Buffer at ac070080
vid_set_mode: 640x480 VGA
dc-load console support enabled
maple: attached devices:
  A0: Dreamcast Controller          (01000000: Controller)
  A1: Visual Memory                 (0e000000: Clock, LCD, MemoryCard)
  A2: Puru Puru Pack                (00010000: JumpPack)

Hello world!

arch: exit return code 0
arch: shutting down kernel
maple: final stats -- device count = 3, vbl_cntr = 4, dma_cntr = 4
vid_set_mode: 640x480 VGA
```

- It was difficult to distinguish what was coming from main() and what was coming from KOS from stdout.
- Added newline characters 1) right before app-level code gets called and 2) right after app-level code exits.
- Adjusted the "hello" example which no longer needs padding.