### PR TITLE
Fixed libparallax bubbles and rotocube examples

### DIFF
--- a/examples/dreamcast/parallax/bubbles/bubbles.c
+++ b/examples/dreamcast/parallax/bubbles/bubbles.c
@@ -135,8 +135,6 @@ static void sphere_frame_opaque(void) {
 
     plx_mat3d_pop();
 
-    plx_dr_finish();
-
     vid_border_color(0, 0, 255);
     pvr_scene_finish();
 

--- a/examples/dreamcast/parallax/bubbles/bubbles.c
+++ b/examples/dreamcast/parallax/bubbles/bubbles.c
@@ -27,7 +27,7 @@ the same, but it uses the Parallax functions instead of KGL.
 static float phase = 0.0f;
 static pvr_poly_cxt_t cxt;
 static pvr_poly_hdr_t hdr;
-static pvr_dr_state_t  dr_state;
+static plx_dr_state_t  dr_state;
 static void sphere(float radius, int slices, int stacks) {
     int i, j;
     float   pitch, pitch2;
@@ -36,6 +36,9 @@ static void sphere(float radius, int slices, int stacks) {
 
     /* Put our own polygon header */
     pvr_prim(&hdr, sizeof(hdr));
+
+    /* Setup our Direct Render state: pick a store queue and setup QACR0/1 */
+    plx_dr_init(&dr_state);
 
     /* Initialize xmtrx with the values from KGL */
     plx_mat_identity();
@@ -84,6 +87,8 @@ static void sphere(float radius, int slices, int stacks) {
             }
         }
     }
+
+    plx_dr_finish();
 }
 
 #define SPHERE_CNT 12
@@ -97,9 +102,6 @@ static void sphere_frame_opaque(void) {
 
     pvr_scene_begin();
     pvr_list_begin(PVR_LIST_OP_POLY);
-
-    /* Setup our Direct Render state: pick a store queue and setup QACR0/1 */
-    pvr_dr_init(&dr_state);
 
     plx_mat3d_identity();
     plx_mat3d_translate(0.0f, 0.0f, -12.0f);
@@ -132,6 +134,8 @@ static void sphere_frame_opaque(void) {
     }
 
     plx_mat3d_pop();
+
+    plx_dr_finish();
 
     vid_border_color(0, 0, 255);
     pvr_scene_finish();

--- a/examples/dreamcast/parallax/rotocube/rotocube.c
+++ b/examples/dreamcast/parallax/rotocube/rotocube.c
@@ -78,6 +78,8 @@ void drawcube(void) {
     plx_vert_indm3(&dr, PLX_VERT, -3, 3,  3, color);
     plx_vert_indm3(&dr, PLX_VERT,  3, 3, -3, color);
     plx_vert_indm3(&dr, PLX_VERT_EOS,  3, 3,  3, color);
+
+    plx_dr_finish();
 }
 
 // Draws the wave in the background (2D)


### PR DESCRIPTION
NOTE: This fix requires this PR for libParallax: https://github.com/KallistiOS/libparallax/pull/1

- Both required a libparallax update as well as minor changes
- Neither were calling the new pvr_dr_finish() to relinquish SQ ownership when using direct rendering
- Bubbles was interleaving pvr_prim() with direct rendering, which already took ownership over the SQs