### PR TITLE
Pull out sq fast path assembly to its own file

### DIFF
--- a/kernel/arch/dreamcast/hardware/Makefile
+++ b/kernel/arch/dreamcast/hardware/Makefile
@@ -25,7 +25,7 @@ OBJS += asic.o g2bus.o
 OBJS += video.o vblank.o
 
 # CPU-related
-OBJS += sq.o scif.o
+OBJS += sq.o sq_fast_cpy.o scif.o
 
 # SPI device support
 OBJS += scif-spi.o sd.o

--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -60,11 +60,6 @@ __attribute__((noinline)) void *sq_cpy(void *dest, const void *src, size_t n) {
     uint32_t *d = SQ_MASK_DEST(dest);
     const uint32_t *s = src;
 
-    _Complex float ds;
-    _Complex float ds2;
-    _Complex float ds3;
-    _Complex float ds4;
-
     sq_lock(dest);
 
     /* Fill/write queues as many times necessary */
@@ -86,35 +81,7 @@ __attribute__((noinline)) void *sq_cpy(void *dest, const void *src, size_t n) {
             d += 8;
         }
     } else { /* If src is 8-byte aligned, fast path */
-        /* Moop algorithm; Using the fpu we can fill the queue faster before
-           firing it out off */
-        __asm__ __volatile__ (
-            "fschg\n\t"
-            "clrs\n" 
-            ".align 2\n"
-            "1:\n\t"
-            /* *d++ = *s++ */
-            "fmov.d @%[in]+, %[scratch]\n\t"
-            "fmov.d @%[in]+, %[scratch2]\n\t"
-            "fmov.d @%[in]+, %[scratch3]\n\t"
-            "fmov.d @%[in]+, %[scratch4]\n\t"
-            "add #32, %[out]\n\t"
-            "pref @%[in]\n\t"  /* Prefetch 32 bytes for next loop */
-            "dt %[size]\n\t"   /* while(n--) */
-            "fmov.d %[scratch4], @-%[out]\n\t"
-            "fmov.d %[scratch3], @-%[out]\n\t"
-            "fmov.d %[scratch2], @-%[out]\n\t"
-            "fmov.d %[scratch], @-%[out]\n\t"
-            "pref @%[out]\n\t" /* Fire off store queue */
-            "bf.s 1b\n\t"
-            "add #32, %[out]\n\t"
-            "fschg\n"
-            : [in] "+&r" ((uint32_t)s), [out] "+&r" ((uint32_t)d), 
-              [size] "+&r" (n), [scratch] "=&d" (ds), [scratch2] "=&d" (ds2), 
-              [scratch3] "=&d" (ds3), [scratch4] "=&d" (ds4) /* outputs */
-            : /* inputs */
-            : "t", "memory" /* clobbers */
-        );
+        sq_fast_cpy(d, s, n);
     }
 
     sq_unlock();

--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -60,10 +60,14 @@ __attribute__((noinline)) void *sq_cpy(void *dest, const void *src, size_t n) {
     uint32_t *d = SQ_MASK_DEST(dest);
     const uint32_t *s = src;
 
-    sq_lock(dest);
-
     /* Fill/write queues as many times necessary */
     n >>= 5;
+
+    /* Exit early if we dont have enough data to copy */
+    if(n == 0)
+        return dest;
+
+    sq_lock(dest);
 
     /* If src is not 8-byte aligned, slow path */
     if ((uintptr_t)src & 7) {

--- a/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
+++ b/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
@@ -44,3 +44,4 @@ _sq_fast_cpy:
 .exit:
     rts     
     nop
+    

--- a/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
+++ b/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
@@ -23,8 +23,7 @@ _sq_fast_cpy:
     tst    r6, r6
     bt/s   .exit       ! Exit if size is 0
     mov    r4, r0
-    mov    r4, r1
-    add    #32, r1
+    add    #32, r4
 1:
     fmov.d @r5+, dr0
     fmov.d @r5+, dr2
@@ -32,13 +31,13 @@ _sq_fast_cpy:
     fmov.d @r5+, dr6
     pref   @r5         ! Prefetch 32 bytes for next loop
     dt     r6          ! while(n--)
-    fmov.d dr6, @-r1
-    fmov.d dr4, @-r1
-    fmov.d dr2, @-r1
-    fmov.d dr0, @-r1
-    pref   @r1         ! Fire off store queue
+    fmov.d dr6, @-r4
+    fmov.d dr4, @-r4
+    fmov.d dr2, @-r4
+    fmov.d dr0, @-r4
+    pref   @r4         ! Fire off store queue
     bf.s   1b
-    add    #64, r1
+    add    #64, r4
 
 .exit:
     rts     

--- a/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
+++ b/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
@@ -1,0 +1,46 @@
+! KallistiOS ##version##
+!
+! arch/dreamcast/hardware/sq_fast_path.s
+! Copyright (C) 2024 Andy Barajas
+!
+! Optimized SH4 assembler function for copying 32 bytes of data 
+! (8 bytes at a time) using pair single-precision data transfer
+! (specifically for store queues).
+!
+
+.globl _sq_fast_cpy
+
+!
+! void *sq_fast_cpy(uint32_t *dest, uint32_t *src, size_t n);
+!
+! r4: dest (should be 32-byte aligned store queue address)
+! r5: src (should be 8-byte aligned address)
+! r6: n (how many 32-byte blocks of data you want to copy)
+!
+    .align 2
+_sq_fast_cpy:
+    tst    r6, r6
+    bt/s   .exit       ! Test if size is 0
+    mov    r4, r0
+    mov    r4, r1
+    fschg              ! Change to pair single-precision data
+    1:
+    fmov.d @r5+, dr0
+    fmov.d @r5+, dr2
+    fmov.d @r5+, dr4
+    fmov.d @r5+, dr6
+    add    #32, r1
+    pref   @r5         ! Prefetch 32 bytes for next loop
+    dt     r6          ! while(n--)
+    fmov.d dr6, @-r1
+    fmov.d dr4, @-r1
+    fmov.d dr2, @-r1
+    fmov.d dr0, @-r1
+    pref   @r1         ! Fire off store queue
+    bf.s   1b
+    add    #32, r1
+    fschg
+
+.exit:
+    rts     
+    nop

--- a/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
+++ b/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
@@ -24,12 +24,12 @@ _sq_fast_cpy:
     bt/s   .exit       ! Exit if size is 0
     mov    r4, r0
     mov    r4, r1
+    add    #32, r1
 1:
     fmov.d @r5+, dr0
     fmov.d @r5+, dr2
     fmov.d @r5+, dr4
     fmov.d @r5+, dr6
-    add    #32, r1
     pref   @r5         ! Prefetch 32 bytes for next loop
     dt     r6          ! while(n--)
     fmov.d dr6, @-r1
@@ -38,7 +38,7 @@ _sq_fast_cpy:
     fmov.d dr0, @-r1
     pref   @r1         ! Fire off store queue
     bf.s   1b
-    add    #32, r1
+    add    #64, r1
 
 .exit:
     rts     

--- a/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
+++ b/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
@@ -23,22 +23,24 @@ _sq_fast_cpy:
     tst    r6, r6
     bt/s   .exit       ! Exit if size is 0
     mov    r4, r0
-    add    #32, r4
 1:
     fmov.d @r5+, dr0
+    mov    r4, r1 
     fmov.d @r5+, dr2
+    add    #32, r1 
     fmov.d @r5+, dr4
     fmov.d @r5+, dr6
     pref   @r5         ! Prefetch 32 bytes for next loop
     dt     r6          ! while(n--)
-    fmov.d dr6, @-r4
-    fmov.d dr4, @-r4
-    fmov.d dr2, @-r4
-    fmov.d dr0, @-r4
-    pref   @r4         ! Fire off store queue
+    fmov.d dr6, @-r1
+    fmov.d dr4, @-r1
+    fmov.d dr2, @-r1
+    fmov.d dr0, @-r1
+    add    #32, r4
     bf.s   1b
-    add    #64, r4
+    pref   @r1         ! Fire off store queue
 
 .exit:
     rts     
     fschg
+

--- a/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
+++ b/kernel/arch/dreamcast/hardware/sq_fast_cpy.s
@@ -5,7 +5,7 @@
 !
 ! Optimized SH4 assembler function for copying 32 bytes of data 
 ! (8 bytes at a time) using pair single-precision data transfer
-! (specifically for store queues).
+! specifically for store queues.
 !
 
 .globl _sq_fast_cpy
@@ -19,12 +19,12 @@
 !
     .align 2
 _sq_fast_cpy:
+    fschg              ! Change to pair single-precision data
     tst    r6, r6
-    bt/s   .exit       ! Test if size is 0
+    bt/s   .exit       ! Exit if size is 0
     mov    r4, r0
     mov    r4, r1
-    fschg              ! Change to pair single-precision data
-    1:
+1:
     fmov.d @r5+, dr0
     fmov.d @r5+, dr2
     fmov.d @r5+, dr4
@@ -39,9 +39,7 @@ _sq_fast_cpy:
     pref   @r1         ! Fire off store queue
     bf.s   1b
     add    #32, r1
-    fschg
 
 .exit:
     rts     
-    nop
-    
+    fschg

--- a/kernel/arch/dreamcast/include/dc/sq.h
+++ b/kernel/arch/dreamcast/include/dc/sq.h
@@ -3,8 +3,8 @@
    kernel/arch/dreamcast/include/dc/sq.h
    Copyright (C) 2000-2001 Andrew Kieschnick
    Copyright (C) 2023 Falco Girgis
-   Copyright (C) 2023 Andy Barajas
    Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2023-2024 Andy Barajas
 */
 
 /** \file    dc/sq.h
@@ -128,9 +128,30 @@ void sq_wait(void);
     \param  n               The number of bytes to copy (multiple of 32).
     \return                 The original value of dest.
 
-    \sa sq_cpy_pvr()
+    \sa sq_fast_cpy()
 */
-void * sq_cpy(void *dest, const void *src, size_t n);
+void *sq_cpy(void *dest, const void *src, size_t n);
+
+/** \brief   Copy a block of memory.
+    \ingroup store_queues
+
+    This function is similar to sq_cpy() but expects the user to lock/unlock
+    the store queues before and after as well as having different requirements
+    for the params.
+
+    \warning
+    The dest pointer must be at least 32-byte aligned that already has been 
+    masked by SQ_MASK_DEST(), the src pointer must be at least 8-byte aligned, 
+    and n must be the number of 32-byte blocks you want to copy.
+
+    \param  dest            The store queue address to copy to (32-byte aligned).
+    \param  src             The address to copy from (8-byte aligned).
+    \param  n               The number of 32-byte blocks to copy.
+    \return                 The original value of dest.
+
+    \sa sq_cpy()
+ */
+void *sq_fast_cpy(void *dest, const void *src, size_t n);
 
 /** \brief   Set a block of memory to an 8-bit value.
     \ingroup store_queues
@@ -149,7 +170,7 @@ void * sq_cpy(void *dest, const void *src, size_t n);
 
     \sa sq_set16(), sq_set32(), sq_set_pvr()
 */
-void * sq_set(void *dest, uint32_t c, size_t n);
+void *sq_set(void *dest, uint32_t c, size_t n);
 
 /** \brief   Set a block of memory to a 16-bit value.
     \ingroup store_queues
@@ -168,7 +189,7 @@ void * sq_set(void *dest, uint32_t c, size_t n);
 
     \sa sq_set(), sq_set32(), sq_set_pvr()
 */
-void * sq_set16(void *dest, uint32_t c, size_t n);
+void *sq_set16(void *dest, uint32_t c, size_t n);
 
 /** \brief   Set a block of memory to a 32-bit value.
     \ingroup store_queues
@@ -186,7 +207,7 @@ void * sq_set16(void *dest, uint32_t c, size_t n);
 
     \sa sq_set(), sq_set16(), sq_set_pvr()
 */
-void * sq_set32(void *dest, uint32_t c, size_t n);
+void *sq_set32(void *dest, uint32_t c, size_t n);
 
 /** \brief   Clear a block of memory.
     \ingroup store_queues


### PR DESCRIPTION
There seems to be some issues with the fast path of the sq_cpy().  I read on discord that we should probably pull the assembly into its own file so I did that. 