### PR TITLE
Small Fixes from DCPlaya's KOS branch

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -26,6 +26,12 @@ void maple_detach_callback(uint32 functions, maple_detach_callback_t cb) {
 
 /* Register a maple device driver; do this before maple_init() */
 int maple_driver_reg(maple_driver_t *driver) {
+    /* Don't add two drivers for the same function */
+    maple_driver_t *i;
+    LIST_FOREACH(i, &maple_state.driver_list, drv_list)
+        if(i->functions & driver->functions)
+            return -1;
+
     /* Insert it into the device list */
     LIST_INSERT_HEAD(&maple_state.driver_list, driver, drv_list);
     return 0;

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -891,7 +891,7 @@ int fs_ramdisk_shutdown(void) {
     rd_file_t *f1, *f2;
 
     /* Test if initted */
-    if(rootdir === NULL)
+    if(rootdir == NULL)
         return -1;
 
     /* For now assume there's only the root dir, since mkdir and

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -846,6 +846,10 @@ int fs_ramdisk_detach(const char * fn, void ** obj, size_t * size) {
 
 /* Initialize the file system */
 int fs_ramdisk_init(void) {
+    /* Test if initted */
+    if(rootdir != NULL)
+        return -1;
+
     /* Create an empty root dir */
     if(!(rootdir = (rd_dir_t *)malloc(sizeof(rd_dir_t))))
         return -1;
@@ -885,6 +889,11 @@ int fs_ramdisk_init(void) {
 /* De-init the file system */
 int fs_ramdisk_shutdown(void) {
     rd_file_t *f1, *f2;
+
+    /* Test if initted */
+    if(rootdir === NULL)
+        return -1;
+
     /* For now assume there's only the root dir, since mkdir and
        rmdir aren't even implemented... */
     f1 = LIST_FIRST(rootdir);

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -708,6 +708,10 @@ void thd_schedule_next(kthread_t *thd) {
     if(!irq_inside_int())
         return;
 
+    /* We're already running now! */
+    if(thd == thd_current)
+        return;
+
     /* Can't boost a blocked thread */
     if(thd->state != STATE_READY)
         return;


### PR DESCRIPTION
These are three small fixes that are derived from DCPlaya's branch of KOS as found here: https://github.com/zig/kos-dcplaya/commit/c7b02b372e8da65e3cd83016f15840841d76754a

- Prevent the loading of multiple maple drivers for the same function. This would help prevent possible issues when loading them individually/manually or if someone brews up alternative drivers.
- Prevent doublt init or unitted shutdown of fs_ramdisk. Should be helpful if loading manually, and has it match other FSes which have similar protections.
- Shortcut boosting the currently running thread. If thd_schedule_next is called on thd_current, it can just return, it's work done.