### PR TITLE
Bump binutils to 2.42 for dc-chain dev configurations

### DIFF
--- a/utils/dc-chain/config/config.mk.13.2.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.13.2.1-dev.sample
@@ -8,12 +8,12 @@
 ###############################################################################
 ###############################################################################
 ### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
-## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2024-01-04.
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2024-01-29.
 ###############################################################################
 ###############################################################################
 
 # Toolchain versions for SH
-sh_binutils_ver=2.41
+sh_binutils_ver=2.42
 sh_gcc_ver=13.2.1
 newlib_ver=4.4.0.20231231
 gdb_ver=14.1
@@ -29,7 +29,7 @@ gdb_download_type=xz
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.41
+arm_binutils_ver=2.42
 arm_gcc_ver=8.5.0
 
 # Tarball extensions to download for ARM

--- a/utils/dc-chain/config/config.mk.14.0.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.14.0.1-dev.sample
@@ -8,14 +8,14 @@
 ###############################################################################
 ###############################################################################
 ### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
-## THERE IS ONE KNOWN ISSUE BUILDING THIS VERSION as of 2024-01-04:
+## THERE IS ONE KNOWN ISSUE BUILDING THIS VERSION as of 2024-01-29:
 ## 1. GCC 14.0.1 currently does not build with m4-single-only precision, which
 ##    is the only officially supported KOS mode for floating-point precision.
 ###############################################################################
 ###############################################################################
 
 # Toolchain versions for SH
-sh_binutils_ver=2.41
+sh_binutils_ver=2.42
 sh_gcc_ver=14.0.1
 newlib_ver=4.4.0.20231231
 gdb_ver=14.1
@@ -31,7 +31,7 @@ gdb_download_type=xz
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.41
+arm_binutils_ver=2.42
 arm_gcc_ver=8.5.0
 
 # Tarball extensions to download for ARM


### PR DESCRIPTION
Just a l'il bumpy-bump to the unstable configs. It seems to work fine. 