### PR TITLE
Allow for --enable-host-shared GCC option in dc-chain configs

### DIFF
--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -159,6 +159,12 @@ ifdef disable_nls
   endif
 endif
 
+ifdef enable_host_shared
+  ifneq (0,$(enable_host_shared))
+    extra_configure_args += --enable-host-shared
+  endif
+endif
+
 # Function to verify variable is not empty
 # Args:
 # 1 - Variable Name


### PR DESCRIPTION
This option is necessary in order to build `libgccjit` (for the purposes of interfacing `rustc_codegen_gcc` with the GCC backend to build Rust for Dreamcast). Since it isn't really applicable to a normal compiler, I didn't add the setting to the existing individual `config.mk` samples. I'll use it in `config.mk` sample files later on. 

```
--enable-host-shared
Specify that the host code should be built into position-independent
machine code (with -fPIC), allowing it to be used within shared libraries,
but yielding a slightly slower compiler.

This option is required when building the libgccjit.so library.
```