### PR TITLE
Quick cleanup for 2D_tex_quad example in GLdc

### DIFF
--- a/examples/dreamcast/gldc/2D_tex_quad/Makefile
+++ b/examples/dreamcast/gldc/2D_tex_quad/Makefile
@@ -38,4 +38,4 @@ rm-elf:
 	-rm -f $(TARGET)
 
 run: $(TARGET)
-	$(KOS_LOADER) -x $(TARGET)
+	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/gldc/2D_tex_quad/main.cpp
+++ b/examples/dreamcast/gldc/2D_tex_quad/main.cpp
@@ -162,9 +162,6 @@ int main(int argc, char **argv) {
         if(state->start)
             break;
 
-        int16_t x_axis = state->joyx;
-        int16_t y_axis = state->joyy;
-
         //..:: Rotation on Triggers
         // Rotate CCW
         if(state->ltrig >= 255) {


### PR DESCRIPTION
When recompiling KOS I noticed that dc-tool in environ.sh already has a -x making the one in my makefile redundant.  Also cleaned up an unused variable warning in main.cpp.