### PR TITLE
Add parens to macros for usage safety

### DIFF
--- a/examples/dreamcast/gldc/basic/gl/pvr-texture.c
+++ b/examples/dreamcast/gldc/basic/gl/pvr-texture.c
@@ -16,7 +16,7 @@
 #include <GL/glext.h>
 
 #define PVR_HDR_SIZE 0x20
-#define MAX(x, y) ((x > y) ? x : y)
+#define MAX(x, y)       ((x) > (y) ? (x) : (y))
 
 static GLuint PVR_TextureHeight(unsigned char *HDR);
 static GLuint PVR_TextureWidth(unsigned char *HDR);

--- a/examples/dreamcast/gldc/nehe/nehe06/pvr-texture.c
+++ b/examples/dreamcast/gldc/nehe/nehe06/pvr-texture.c
@@ -16,7 +16,7 @@
 #include <GL/glext.h>
 
 #define PVR_HDR_SIZE 0x20
-#define MAX(x, y) ((x > y) ? x : y)
+#define MAX(x, y)       ((x) > (y) ? (x) : (y))
 
 static GLuint PVR_TextureHeight(unsigned char *HDR);
 static GLuint PVR_TextureWidth(unsigned char *HDR);

--- a/examples/dreamcast/gldc/nehe/nehe08/pvr-texture.c
+++ b/examples/dreamcast/gldc/nehe/nehe08/pvr-texture.c
@@ -16,7 +16,7 @@
 #include <GL/glext.h>
 
 #define PVR_HDR_SIZE 0x20
-#define MAX(x, y) ((x > y) ? x : y)
+#define MAX(x, y)       ((x) > (y) ? (x) : (y))
 
 static GLuint PVR_TextureHeight(unsigned char *HDR);
 static GLuint PVR_TextureWidth(unsigned char *HDR);

--- a/examples/dreamcast/gldc/nehe/nehe09/pvr-texture.c
+++ b/examples/dreamcast/gldc/nehe/nehe09/pvr-texture.c
@@ -16,7 +16,7 @@
 #include <GL/glext.h>
 
 #define PVR_HDR_SIZE 0x20
-#define MAX(x, y) ((x > y) ? x : y)
+#define MAX(x, y)       ((x) > (y) ? (x) : (y))
 
 static GLuint PVR_TextureHeight(unsigned char *HDR);
 static GLuint PVR_TextureWidth(unsigned char *HDR);

--- a/examples/dreamcast/gldc/nehe/nehe16/pvr-texture.c
+++ b/examples/dreamcast/gldc/nehe/nehe16/pvr-texture.c
@@ -16,7 +16,7 @@
 #include <GL/glext.h>
 
 #define PVR_HDR_SIZE 0x20
-#define MAX(x, y) ((x > y) ? x : y)
+#define MAX(x, y)       ((x) > (y) ? (x) : (y))
 
 static GLuint PVR_TextureHeight(unsigned char *HDR);
 static GLuint PVR_TextureWidth(unsigned char *HDR);

--- a/examples/dreamcast/mruby/dreampresent/dckos.c
+++ b/examples/dreamcast/mruby/dreampresent/dckos.c
@@ -42,7 +42,7 @@
 #define CONV1555TO565(colour) ( (((colour) & 0x7C00) << 1) | (((colour) & 0x03E0) << 1) | ((colour) & 0x001F) )
 
 // CONVERT R, G, B to RGB565
-#define PACK_PIXEL(r, g, b) ( ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3)  )
+#define PACK_PIXEL(r, g, b) ( (((r) & 0xF8) << 8) | (((g) & 0xFC) << 3) | ((b) >> 3)  )
 
 int PX_PER_LINE = 640;
 

--- a/examples/dreamcast/mruby/mrbtris/dckos.c
+++ b/examples/dreamcast/mruby/mrbtris/dckos.c
@@ -36,7 +36,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 
-#define PACK_PIXEL(r, g, b) ( ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3)  )
+#define PACK_PIXEL(r, g, b) ( (((r) & 0xF8) << 8) | (((g) & 0xFC) << 3) | ((b) >> 3)  )
 
 #define BUFSIZE 100
 

--- a/examples/dreamcast/pvr/bumpmap/bump.c
+++ b/examples/dreamcast/pvr/bumpmap/bump.c
@@ -30,7 +30,7 @@ static int textured = 1;
 
 #define SIZE 256
 
-#define CLAMP(low, high, value) (value < low ? low : (value > high ? high : value))
+#define CLAMP(low, high, value) ((value) < (low) ? (low) : ((value) > (high) ? (high) : (value)))
 
 static pvr_ptr_t load_texture(const char fn[]) {
     FILE *fp;

--- a/examples/dreamcast/pvr/cheap_shadow/shadow.c
+++ b/examples/dreamcast/pvr/cheap_shadow/shadow.c
@@ -25,7 +25,7 @@ static float mx = 320.0f, my = 240.0f;
 static pvr_list_t list = PVR_LIST_OP_POLY;
 static float shadow = 0.5f;
 
-#define CLAMP(low, high, value) (value < low ? low : (value > high ? high : value))
+#define CLAMP(low, high, value) ((value) < (low) ? (low) : ((value) > (high) ? (high) : (value)))
 
 void setup(void) {
     pvr_poly_cxt_t cxt;

--- a/kernel/arch/dreamcast/hardware/asic.c
+++ b/kernel/arch/dreamcast/hardware/asic.c
@@ -105,7 +105,7 @@
 #define OUT32(addr, data)  IN32(addr) = (data)
 
 /* The set of asic regs are spaced by 0x10 with 0x4 between each sub reg */
-#define ASIC_EVT_REG_ADDR(irq, sub) (ASIC_IRQD_A + (irq * 0x10) + (sub * 0x4))
+#define ASIC_EVT_REG_ADDR(irq, sub) (ASIC_IRQD_A + ((irq) * 0x10) + ((sub) * 0x4))
 
 #define ASIC_EVT_REGS 3
 #define ASIC_EVT_REG_HNDS 32

--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -155,12 +155,12 @@ typedef struct ata_devdata {
 #define G1_DMA_TO_MEMORY            1
 
 /* Macros to access the ATA registers */
-#define OUT32(addr, data) *((volatile uint32_t *)addr) = data
-#define OUT16(addr, data) *((volatile uint16_t *)addr) = data
-#define OUT8(addr, data)  *((volatile uint8_t  *)addr) = data
-#define IN32(addr)        *((volatile uint32_t *)addr)
-#define IN16(addr)        *((volatile uint16_t *)addr)
-#define IN8(addr)         *((volatile uint8_t  *)addr)
+#define OUT32(addr, data) *((volatile uint32_t *)(addr)) = data
+#define OUT16(addr, data) *((volatile uint16_t *)(addr)) = data
+#define OUT8(addr, data)  *((volatile uint8_t  *)(addr)) = data
+#define IN32(addr)        *((volatile uint32_t *)(addr))
+#define IN16(addr)        *((volatile uint16_t *)(addr))
+#define IN8(addr)         *((volatile uint8_t  *)(addr))
 
 static int initted = 0;
 static int devices = 0;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
@@ -28,7 +28,7 @@
 
 #define IS_ALIGNED(x, m) ((x) % (m) == 0)
 
-#define LIST_ENABLED(i) (pvr_state.lists_enabled & (1 << i))
+#define LIST_ENABLED(i) (pvr_state.lists_enabled & (1 << (i)))
 
 
 /* Fill Tile Matrix buffers. This function takes a base address and sets up

--- a/kernel/arch/dreamcast/hardware/sd.c
+++ b/kernel/arch/dreamcast/hardware/sd.c
@@ -24,7 +24,7 @@
 #define READ_RETRIES    50000
 #define WRITE_RETRIES   150000
 
-#define CMD(n) (n | 0x40)
+#define CMD(n) ((n) | 0x40)
 
 static int byte_mode = 0;
 static int is_mmc = 0;

--- a/kernel/arch/dreamcast/hardware/ubc.c
+++ b/kernel/arch/dreamcast/hardware/ubc.c
@@ -16,10 +16,10 @@
 #include <assert.h>
 
 /* Macros for accessing SFRs common to both channels by index */
-#define BAR(o)  (*((vuint32 *)(uintptr_t)(SH4_REG_UBC_BARA  + (unsigned)o * 0xc))) /* Address */
-#define BASR(o) (*((vuint8  *)(uintptr_t)(SH4_REG_UBC_BASRA + (unsigned)o * 0x4))) /* ASID */
-#define BAMR(o) (*((vuint8  *)(uintptr_t)(SH4_REG_UBC_BAMRA + (unsigned)o * 0xc))) /* Address Mask */
-#define BBR(o)  (*((vuint16 *)(uintptr_t)(SH4_REG_UBC_BBRA  + (unsigned)o * 0xc))) /* Bus Cycle */
+#define BAR(o)  (*((vuint32 *)(uintptr_t)(SH4_REG_UBC_BARA  + (unsigned)(o) * 0xc))) /* Address */
+#define BASR(o) (*((vuint8  *)(uintptr_t)(SH4_REG_UBC_BASRA + (unsigned)(o) * 0x4))) /* ASID */
+#define BAMR(o) (*((vuint8  *)(uintptr_t)(SH4_REG_UBC_BAMRA + (unsigned)(o) * 0xc))) /* Address Mask */
+#define BBR(o)  (*((vuint16 *)(uintptr_t)(SH4_REG_UBC_BBRA  + (unsigned)(o) * 0xc))) /* Bus Cycle */
 
 /* Macros for accessing individual, channel-specific SFRs */
 #define BARA  (BAR(ubc_channel_a))              /**< Break Address A */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -370,7 +370,7 @@ const char *kos_get_authors(void);
     \param  fptr            The frame pointer to look at.
     \return                 The return address of the pointer.
 */
-#define arch_fptr_ret_addr(fptr) (*((uint32*)fptr))
+#define arch_fptr_ret_addr(fptr) (*((uint32*)(fptr)))
 
 /** \brief   Pass in a frame pointer value to get the previous frame pointer for
              the given frame.
@@ -379,7 +379,7 @@ const char *kos_get_authors(void);
     \param  fptr            The frame pointer to look at.
     \return                 The previous frame pointer.
 */
-#define arch_fptr_next(fptr) (*((uint32*)(fptr+4)))
+#define arch_fptr_next(fptr) (*((uint32*)((fptr)+4)))
 
 /** \brief   Returns true if the passed address is likely to be valid. Doesn't
              have to be exact, just a sort of general idea.

--- a/kernel/arch/dreamcast/kernel/wdt.c
+++ b/kernel/arch/dreamcast/kernel/wdt.c
@@ -10,7 +10,7 @@
 #include <arch/irq.h>
 
 /* Macros for accessing WDT registers */
-#define WDT(o, t)       (*((volatile t *)(WDT_BASE + o)))
+#define WDT(o, t)       (*((volatile t *)(WDT_BASE + (o))))
 #define WDT_READ(o)     (WDT(o, uint8_t))
 #define WDT_WRITE(o, v) (WDT(o, uint16_t) = ((o##_HIGH << 8) | ((v) & 0xff)))
 

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -240,7 +240,7 @@ static int thd_cb_id = 0;
 #define SEQ_GT(x, y)    (((int32_t)((x) - (y))) > 0)
 #define SEQ_GE(x, y)    (((int32_t)((x) - (y))) >= 0)
 
-#define MAX(x, y)       (x > y ? x : y)
+#define MAX(x, y)       ((x) > (y) ? (x) : (y))
 
 /* Forward declarations */
 static fs_socket_proto_t proto;


### PR DESCRIPTION
Prompted by #191 in which a refactor/update that reused existing macros broke due to improper grouping of arguments. Many of them are in places where it doesn't make a difference as-written but, especially for the examples, it's nice to ensure that they aren't so fragile. The vast majority already have such protections.