### PR TITLE
Fix cmake function kos_add_romdisk not getting KOS_BASE from ENV

### DIFF
--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -60,7 +60,7 @@ function(kos_add_romdisk target romdiskPath)
     add_custom_command(
         OUTPUT  ${obj}
         DEPENDS ${obj_tmp}
-        COMMAND ${CMAKE_C_COMPILER} -o ${obj} -r ${obj_tmp} -L${KOS_BASE}/lib/dreamcast -Wl,--whole-archive -lromdiskbase
+        COMMAND ${CMAKE_C_COMPILER} -o ${obj} -r ${obj_tmp} -L$ENV{KOS_BASE}/lib/dreamcast -Wl,--whole-archive -lromdiskbase
         COMMAND rm ${obj_tmp}
     )
 


### PR DESCRIPTION
This PR is about fixing the path given in the cmake function kos_add_romdisk.
Indeed, we use ${KOS_BASE}  whereas we should take it from $ENV{KOS_BASE} (as it is done  line 54 in the same file for exmaple). The result of this bug was a failure when generating romdisk, as it didn't find the library romdiskbase