### PR TITLE
Add check for host libpng version to warn of possible error

### DIFF
--- a/utils/vqenc/readpng.h
+++ b/utils/vqenc/readpng.h
@@ -24,6 +24,12 @@ typedef unsigned char uint8; */
 #  define Trace(x)  ;
 #endif
 
+#if     ((PNG_LIBPNG_VER_MAJOR == 1) && \
+         (PNG_LIBPNG_VER_MINOR == 6) && \
+         (PNG_LIBPNG_VER_RELEASE == 41) )
+#   warning libpng v1.6.41 has a known bug that may result in failed reading. Please update.
+#endif
+
 void readpng_version_info(void);
 
 uint32 readpng_init(FILE *infile);


### PR DESCRIPTION
The idea is to give a warning about a known incompatibility as reported here: https://discord.com/channels/488332893324836864/614912396460556298/1203065790589444096 . When using libpng 1.6.41 to build vqenc on the host, the building of the bumpmap example fails to read the input png. Without this there's no good way to tell what's happening since it's caused by a bug in libpng.