### PR TITLE
Patch Newlib to fix -m4-single-only on GCC 14 based toolchains

### DIFF
--- a/utils/dc-chain/config/README.md
+++ b/utils/dc-chain/config/README.md
@@ -10,7 +10,7 @@ The available templates include the following configurations:
 | config.mk.12.3.0.sample | 12.3.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | modern toolchain with GCC 12 |
 | **config.mk.stable.sample** | **13.2.0** | **4.3.0** | **2.41** | **8.5.0** | **2.41** | **modern toolchain with GCC 13.2.0 release**<br />**current "stable" configuration** |
 | config.mk.13.2.1-dev.sample | 13.2.1 (git) | 4.4.0 | 2.41 | 8.5.0 | 2.41 | latest GCC 13 development version from git<br />known to build without issues |
-| config.mk.14.0.1-dev.sample | 14.0.1 (git) | 4.4.0 | 2.41 | 8.5.0 | 2.41 | latest GCC 14 development version from git<br />builds with caveats, see sample file for more info |
+| config.mk.14.0.1-dev.sample | 14.0.1 (git) | 4.4.0 | 2.41 | 8.5.0 | 2.41 | latest GCC 14 development version from git<br />known to build without issues |
 
 The **stable** configuration is the primary, widely tested target for KallistiOS, and is the most recent toolchain configuration known to work with all example programs. The **legacy** configurations contain an older versions of the toolchain that may be useful in compiling older software. The non-"stable" alternative configurations are maintained at a lower priority and are not guaranteed to build, but feel free to open a bug report if issues are encountered building one of these configurations.
 

--- a/utils/dc-chain/config/config.mk.14.0.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.14.0.1-dev.sample
@@ -8,9 +8,7 @@
 ###############################################################################
 ###############################################################################
 ### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
-## THERE IS ONE KNOWN ISSUE BUILDING THIS VERSION as of 2024-01-29:
-## 1. GCC 14.0.1 currently does not build with m4-single-only precision, which
-##    is the only officially supported KOS mode for floating-point precision.
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2024-02-10.
 ###############################################################################
 ###############################################################################
 

--- a/utils/dc-chain/patches/newlib-4.4.0.20231231-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.4.0.20231231-kos.diff
@@ -1,6 +1,6 @@
 diff --color -ruN newlib-4.4.0.20231231/newlib/configure.host newlib-4.4.0.20231231-kos/newlib/configure.host
---- newlib-4.4.0.20231231/newlib/configure.host	2023-02-02 15:26:13.620093007 -0600
-+++ newlib-4.4.0.20231231-kos/newlib/configure.host	2023-02-02 15:26:28.805127895 -0600
+--- newlib-4.4.0.20231231/newlib/configure.host	2024-02-10 09:30:58.772247624 -0600
++++ newlib-4.4.0.20231231-kos/newlib/configure.host	2024-02-10 09:31:16.329331366 -0600
 @@ -322,6 +322,7 @@
  	;;
    sh | sh64)
@@ -10,8 +10,8 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/configure.host newlib-4.4.0.20231
    sparc*)
  	libm_machine_dir=sparc
 diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/assert.h newlib-4.4.0.20231231-kos/newlib/libc/include/assert.h
---- newlib-4.4.0.20231231/newlib/libc/include/assert.h	2023-02-02 15:26:13.629093028 -0600
-+++ newlib-4.4.0.20231231-kos/newlib/libc/include/assert.h	2023-02-02 15:26:28.805127895 -0600
+--- newlib-4.4.0.20231231/newlib/libc/include/assert.h	2024-02-10 09:30:58.781247667 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libc/include/assert.h	2024-02-10 09:31:16.329331366 -0600
 @@ -13,8 +13,8 @@
  #ifdef NDEBUG           /* required by ANSI standard */
  # define assert(__e) ((void)0)
@@ -39,8 +39,8 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/assert.h newlib-4.4.
  #if __STDC_VERSION__ >= 201112L && !defined __cplusplus
  # define static_assert _Static_assert
 diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/sys/_pthreadtypes.h newlib-4.4.0.20231231-kos/newlib/libc/include/sys/_pthreadtypes.h
---- newlib-4.4.0.20231231/newlib/libc/include/sys/_pthreadtypes.h	2023-02-02 15:26:13.632093035 -0600
-+++ newlib-4.4.0.20231231-kos/newlib/libc/include/sys/_pthreadtypes.h	2023-02-02 15:26:28.805127895 -0600
+--- newlib-4.4.0.20231231/newlib/libc/include/sys/_pthreadtypes.h	2024-02-10 09:30:58.783247676 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libc/include/sys/_pthreadtypes.h	2024-02-10 09:31:16.329331366 -0600
 @@ -22,16 +22,6 @@
  
  #include <sys/sched.h>
@@ -188,8 +188,8 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/sys/_pthreadtypes.h 
 -
  #endif /* ! _SYS__PTHREADTYPES_H_ */
 diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/sys/signal.h newlib-4.4.0.20231231-kos/newlib/libc/include/sys/signal.h
---- newlib-4.4.0.20231231/newlib/libc/include/sys/signal.h	2023-02-02 15:26:13.633093038 -0600
-+++ newlib-4.4.0.20231231-kos/newlib/libc/include/sys/signal.h	2023-02-02 15:26:28.805127895 -0600
+--- newlib-4.4.0.20231231/newlib/libc/include/sys/signal.h	2024-02-10 09:30:58.783247676 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libc/include/sys/signal.h	2024-02-10 09:31:16.329331366 -0600
 @@ -223,9 +223,11 @@
  int sigaltstack (const stack_t *__restrict, stack_t *__restrict);
  #endif
@@ -203,8 +203,8 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/sys/signal.h newlib-
  #if __POSIX_VISIBLE >= 199309
  
 diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/sys/_types.h newlib-4.4.0.20231231-kos/newlib/libc/include/sys/_types.h
---- newlib-4.4.0.20231231/newlib/libc/include/sys/_types.h	2023-02-02 15:26:13.632093035 -0600
-+++ newlib-4.4.0.20231231-kos/newlib/libc/include/sys/_types.h	2023-02-02 15:26:28.806127897 -0600
+--- newlib-4.4.0.20231231/newlib/libc/include/sys/_types.h	2024-02-10 09:30:58.783247676 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libc/include/sys/_types.h	2024-02-10 09:31:16.329331366 -0600
 @@ -69,7 +69,7 @@
  
  #ifndef __machine_ino_t_defined
@@ -215,8 +215,8 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/sys/_types.h newlib-
  #else
  typedef unsigned short __ino_t;
 diff --color -ruN newlib-4.4.0.20231231/newlib/libc/ssp/stack_protector.c newlib-4.4.0.20231231-kos/newlib/libc/ssp/stack_protector.c
---- newlib-4.4.0.20231231/newlib/libc/ssp/stack_protector.c	2023-02-02 15:26:13.656093090 -0600
-+++ newlib-4.4.0.20231231-kos/newlib/libc/ssp/stack_protector.c	2023-02-02 15:26:28.806127897 -0600
+--- newlib-4.4.0.20231231/newlib/libc/ssp/stack_protector.c	2024-02-10 09:30:58.832247910 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libc/ssp/stack_protector.c	2024-02-10 09:31:16.329331366 -0600
 @@ -32,12 +32,11 @@
  #endif
  
@@ -232,8 +232,8 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/libc/ssp/stack_protector.c newlib
  }
  
 diff --color -ruN newlib-4.4.0.20231231/newlib/libc/stdlib/assert.c newlib-4.4.0.20231231-kos/newlib/libc/stdlib/assert.c
---- newlib-4.4.0.20231231/newlib/libc/stdlib/assert.c	2023-02-02 15:26:13.661093102 -0600
-+++ newlib-4.4.0.20231231-kos/newlib/libc/stdlib/assert.c	2023-02-02 15:26:28.806127897 -0600
+--- newlib-4.4.0.20231231/newlib/libc/stdlib/assert.c	2024-02-10 09:30:58.811247810 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libc/stdlib/assert.c	2024-02-10 09:31:16.329331366 -0600
 @@ -47,6 +47,8 @@
  #include <stdlib.h>
  #include <stdio.h>
@@ -251,3 +251,262 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/libc/stdlib/assert.c newlib-4.4.0
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
 +
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/cargl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/cargl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/cargl.c	2024-02-10 09:30:58.838247939 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/cargl.c	2024-02-10 09:25:08.854578630 -0600
+@@ -7,12 +7,11 @@
+ #include <complex.h>
+ #include <math.h>
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double
+ cargl(long double complex z)
+ {     
+-       #ifdef _LDBL_EQ_DBL
+          return carg (z);
+-       #else
+-         return atan2l (cimagl (z), creall (z));
+-       #endif
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/catanl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/catanl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/catanl.c	2024-02-10 09:30:58.838247939 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/catanl.c	2024-02-10 09:25:03.094551157 -0600
+@@ -33,6 +33,8 @@
+ #include <math.h>
+ #include "cephes_subrl.h"
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ #ifdef __weak_alias
+ __weak_alias(catanl, _catanl)
+ #endif
+@@ -72,4 +74,4 @@
+ 	w = HUGE_VALL + HUGE_VALL * I;
+ 	return w;
+ }
+-
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/ccoshl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/ccoshl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/ccoshl.c	2024-02-10 09:30:58.838247939 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/ccoshl.c	2024-02-10 09:25:21.637639601 -0600
+@@ -32,6 +32,8 @@
+ #include <complex.h>
+ #include <math.h>
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ ccoshl(long double complex z)
+ {
+@@ -43,3 +45,4 @@
+ 	w = coshl(x) * cosl(y) + (sinhl(x) * sinl(y)) * I;
+ 	return w;
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/ccosl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/ccosl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/ccosl.c	2024-02-10 09:30:58.838247939 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/ccosl.c	2024-02-10 09:26:34.295986157 -0600
+@@ -33,6 +33,8 @@
+ #include <math.h>
+ #include "cephes_subrl.h"
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ ccosl(long double complex z)
+ {
+@@ -43,3 +45,4 @@
+ 	w = cosl(creall(z)) * ch - (sinl(creall(z)) * sh) * I;
+ 	return w;
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/cephes_subrl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/cephes_subrl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/cephes_subrl.c	2024-02-10 09:30:58.839247944 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/cephes_subrl.c	2024-02-10 09:26:48.976056176 -0600
+@@ -35,6 +35,8 @@
+ 
+ /* calculate cosh and sinh */
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ void
+ _cchshl(long double x, long double *c, long double *s)
+ {
+@@ -51,6 +53,7 @@
+ 		*c = e + ei;
+ 	}
+ }
++#endif
+ 
+ /* Program to subtract nearest integer multiple of PI */
+ 
+@@ -85,6 +88,8 @@
+ 
+ /* Taylor series expansion for cosh(2y) - cos(2x) */
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double
+ _ctansl(long double complex z)
+ {
+@@ -126,3 +131,4 @@
+ 	} while (fabsl(t/d) > MACHEPL);
+ 	return d;
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/cexpl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/cexpl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/cexpl.c	2024-02-10 09:30:58.839247944 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/cexpl.c	2024-02-10 09:26:53.999080135 -0600
+@@ -32,6 +32,8 @@
+ #include <complex.h>
+ #include <math.h>
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ cexpl(long double complex z)
+ {
+@@ -44,3 +46,4 @@
+ 	w = r * cosl(y) + r * sinl(y) * I;
+ 	return w;
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/clogl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/clogl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/clogl.c	2024-02-10 09:30:58.839247944 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/clogl.c	2024-02-10 09:27:03.088123487 -0600
+@@ -32,6 +32,8 @@
+ #include <complex.h>
+ #include <math.h>
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ clogl(long double complex z)
+ {
+@@ -44,3 +46,4 @@
+ 	w = p + rr * I;
+ 	return w;
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/cpowl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/cpowl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/cpowl.c	2024-02-10 09:30:58.839247944 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/cpowl.c	2024-02-10 09:27:11.728164697 -0600
+@@ -32,6 +32,8 @@
+ #include <complex.h>
+ #include <math.h>
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ cpowl(long double complex a, long double complex z)
+ {
+@@ -54,3 +56,4 @@
+ 	w = r * cosl(theta) + (r * sinl(theta)) * I;
+ 	return w;
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/cprojl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/cprojl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/cprojl.c	2024-02-10 09:30:58.838247939 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/cprojl.c	2024-02-10 09:27:19.272200680 -0600
+@@ -45,6 +45,9 @@
+  *
+  * INFINITY + I * copysign(0.0, cimag(z))
+  */
++
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ cprojl(long double complex z)
+ {
+@@ -62,3 +65,4 @@
+ 
+ 	return (w.z);
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/csinhl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/csinhl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/csinhl.c	2024-02-10 09:30:58.838247939 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/csinhl.c	2024-02-10 09:27:27.167238336 -0600
+@@ -32,6 +32,8 @@
+ #include <complex.h>
+ #include <math.h>
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ csinhl(long double complex z)
+ {
+@@ -43,3 +45,4 @@
+ 	w = sinhl(x) * cosl(y) + (coshl(x) * sinl(y)) * I;
+ 	return w;
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/csinl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/csinl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/csinl.c	2024-02-10 09:30:58.838247939 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/csinl.c	2024-02-10 09:27:34.343272564 -0600
+@@ -33,6 +33,8 @@
+ #include <math.h>
+ #include "cephes_subrl.h"
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ csinl(long double complex z)
+ {
+@@ -43,3 +45,4 @@
+ 	w = sinl(creall(z)) * ch + (cosl(creall(z)) * sh) * I;
+ 	return w;
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/csqrtl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/csqrtl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/csqrtl.c	2024-02-10 09:30:58.838247939 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/csqrtl.c	2024-02-10 09:27:56.954380412 -0600
+@@ -49,6 +49,8 @@
+ 
+ #define cpackl(r, i) ((r) + (i) * I)
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ csqrtl(long double complex z)
+ {
+@@ -110,3 +112,4 @@
+ 	else
+ 		return (result);
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/ctanhl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/ctanhl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/ctanhl.c	2024-02-10 09:30:58.839247944 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/ctanhl.c	2024-02-10 09:28:01.056399977 -0600
+@@ -32,6 +32,8 @@
+ #include <complex.h>
+ #include <math.h>
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ ctanhl(long double complex z)
+ {
+@@ -45,3 +47,4 @@
+ 
+ 	return w;
+ }
++#endif
+diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/ctanl.c newlib-4.4.0.20231231-kos/newlib/libm/complex/ctanl.c
+--- newlib-4.4.0.20231231/newlib/libm/complex/ctanl.c	2024-02-10 09:30:58.839247944 -0600
++++ newlib-4.4.0.20231231-kos/newlib/libm/complex/ctanl.c	2024-02-10 09:28:05.960423368 -0600
+@@ -34,6 +34,8 @@
+ #include <math.h>
+ #include "cephes_subrl.h"
+ 
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
+ long double complex
+ ctanl(long double complex z)
+ {
+@@ -54,3 +56,4 @@
+ 	w = sinl(2.0L * creall(z)) / d + (sinhl(2.0L * cimagl(z)) / d) * I;
+ 	return w;
+ }
++#endif


### PR DESCRIPTION
This PR fixes broken toolchain compilation when using `-m4-single-only` on GCC 14-based toolchains.

The error occurs because `-Wimplicit-function-declaration` was made into an error on GCC 14:
https://github.com/gcc-mirror/gcc/commit/55e94561e97ed0bce4774aa1c6b5d5d82209a379

Currently, on our GCC 13.2.0-based stable toolchain, while compiling Newlib, we see warnings compiling various `libm/complex` objects:
```
../../../newlib-4.3.0.20230120/newlib/libm/complex/ccoshl.c: In function ‘ccoshl’:
../../../newlib-4.3.0.20230120/newlib/libm/complex/ccoshl.c:43:13: warning: implicit declaration of function ‘coshl’; did you mean ‘coshf’? [-Wimplicit-function-declaration]
   43 |         w = coshl(x) * cosl(y) + (sinhl(x) * sinl(y)) * I;
      |             ^~~~~
      |             coshf
```

To see why these functions aren't being declared and defined, we see that Newlib only supports `long double` math functions on platforms in which `long double` = `double`. In Newlib's `math.h` we see:
```
/* Newlib doesn't fully support long double math functions so far.
   On platforms where long double equals double the long double functions
   simply call the double functions.  On Cygwin the long double functions
   are implemented independently from newlib to be able to use optimized
   assembler functions despite using the Microsoft x86_64 ABI. */
#if defined (_LDBL_EQ_DBL) || defined (__CYGWIN__)
/* Reentrant ANSI C functions.  */
#ifndef __math_68881
extern long double atanl (long double);
extern long double cosl (long double);
extern long double sinl (long double);
extern long double tanl (long double);
[...]
```

And indeed in each `libm/common` source, we see this being enforced via `#ifdef`:
```
/* On platforms where long double is as wide as double.  */
#ifdef _LDBL_EQ_DBL
long double
atanl (long double x)
{
  return atan(x);
}
#endif
```

Since on `-m4-single-only` a `double` = 32-bit (just like `float`), instead of 64-bit like a `long double` these functions aren't included, which is the correct behavior.

However, in `libm/complex`, as opposed to `libm/common`, many functions do not include this `#ifdef`, so we see the above `-Wimplicit-function-declaration` warnings. Using the stable toolchain, if one tries to use any of these functions in KallistiOS applications, an error will occur while linking as the symbols are missing. 

On GCC 14, it prevents Newlib from compiling altogether.

This PR updates the Newlib 4.4.0 patch by going through the `libm/complex` functions and wrapping the functions that give errors in `#ifdef _LDBL_EQ_DBL` to match the `libm/common` functions.

This could also be done for Newlib 4.3.0 too, but since Newlib 4.3.0 isn't compatible with GCC 14 for other reasons anyway, I figured if it ain't broke don't fix it.