### PR TITLE
gcc: configure GCC to let it know we use GNU tools

### DIFF
--- a/utils/dc-chain/scripts/gcc-pass1.mk
+++ b/utils/dc-chain/scripts/gcc-pass1.mk
@@ -17,6 +17,8 @@ $(build_gcc_pass1): logdir
 	    ../$(src_dir)/configure \
 	      --target=$(target) \
 	      --prefix=$(prefix) \
+	      --with-gnu-as \
+	      --with-gnu-ld \
 	      --without-headers \
 	      --with-newlib \
 	      --enable-languages=c \

--- a/utils/dc-chain/scripts/gcc-pass2.mk
+++ b/utils/dc-chain/scripts/gcc-pass2.mk
@@ -14,6 +14,8 @@ $(build_gcc_pass2): logdir
         ../$(src_dir)/configure \
           --target=$(target) \
           --prefix=$(prefix) \
+          --with-gnu-as \
+          --with-gnu-ld \
           --with-newlib \
           --disable-libssp \
           --enable-threads=$(thread_model) \


### PR DESCRIPTION
In particular, the gcc driver will correctly pass -I from the command
line to the assembler.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>