### PR TITLE
CMake work

### DIFF
--- a/utils/cmake/Platform/Dreamcast.cmake
+++ b/utils/cmake/Platform/Dreamcast.cmake
@@ -1,0 +1,9 @@
+# CMake platform file for the Dreamcast.
+#  Copyright (C) 2024 Paul Cercueil
+
+include(Platform/Generic)
+set(CMAKE_EXECUTABLE_SUFFIX .elf)
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "" CACHE PATH "Install prefix" FORCE)
+endif()

--- a/utils/cmake/dreamcast.toolchain.cmake
+++ b/utils/cmake/dreamcast.toolchain.cmake
@@ -71,6 +71,9 @@ set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 # Never use the CMAKE_FIND_ROOT_PATH to find programs with find_program()
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 
+# Set sysroot to kos-ports folder
+set(CMAKE_SYSROOT ${KOS_PORTS})
+
 ##### Add Platform-Specific #defines #####
 add_compile_definitions(__DREAMCAST__ _arch_dreamcast)
 

--- a/utils/cmake/dreamcast.toolchain.cmake
+++ b/utils/cmake/dreamcast.toolchain.cmake
@@ -51,8 +51,10 @@ if(NOT DEFINED KOS_PORTS)
     message(VERBOSE "KOS_PORTS: ${KOS_PORTS}")
 endif()
 
+list(APPEND CMAKE_MODULE_PATH $ENV{KOS_BASE}/utils/cmake)
+
 ##### Configure CMake System #####
-set(CMAKE_SYSTEM_NAME Generic-ELF)
+set(CMAKE_SYSTEM_NAME Dreamcast)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR SH4)
 set(PLATFORM_DREAMCAST TRUE)

--- a/utils/gnu_wrappers/kos-ccmake
+++ b/utils/gnu_wrappers/kos-ccmake
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+## Make sure KOS_BASE is set
+if [ -z "${KOS_BASE}" ]; then
+    echo "The KOS_BASE environment variable has not been set!"
+    echo "\tDid you source your environ.sh file?"
+    exit 1
+fi
+
+if [ -z "$(which ccmake)" ]; then
+    echo "ccmake program is not present. Please install ccmake or cmake-curses-gui."
+    exit 1
+fi
+
+ccmake \
+  -DCMAKE_TOOLCHAIN_FILE="${KOS_BASE}/utils/cmake/dreamcast.toolchain.cmake" \
+  "$@"
+


### PR DESCRIPTION
Add a kos-ccmake wrapper similar to kos-cmake, which will use the "ccmake" program (provided by the cmake-curses-gui on Debian/Ubuntu) instead.

Set the sysroot, so that CMake will be able to find the libraries installed in kos-ports.
Use a platform file for the Dreamcast which allows the default prefix to be set to an empty string.