### PR TITLE
Update configs with GDB 14.1 to 14.2

### DIFF
--- a/utils/dc-chain/config/config.mk.10.5.0.sample
+++ b/utils/dc-chain/config/config.mk.10.5.0.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.41
 sh_gcc_ver=10.5.0
 newlib_ver=4.3.0.20230120
-gdb_ver=14.1
+gdb_ver=14.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.11.4.0.sample
+++ b/utils/dc-chain/config/config.mk.11.4.0.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.41
 sh_gcc_ver=11.4.0
 newlib_ver=4.3.0.20230120
-gdb_ver=14.1
+gdb_ver=14.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.12.3.0.sample
+++ b/utils/dc-chain/config/config.mk.12.3.0.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.41
 sh_gcc_ver=12.3.0
 newlib_ver=4.3.0.20230120
-gdb_ver=14.1
+gdb_ver=14.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.13.2.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.13.2.1-dev.sample
@@ -16,7 +16,7 @@
 sh_binutils_ver=2.42
 sh_gcc_ver=13.2.1
 newlib_ver=4.4.0.20231231
-gdb_ver=14.1
+gdb_ver=14.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.14.0.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.14.0.1-dev.sample
@@ -16,7 +16,7 @@
 sh_binutils_ver=2.42
 sh_gcc_ver=14.0.1
 newlib_ver=4.4.0.20231231
-gdb_ver=14.1
+gdb_ver=14.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.9.5.0-winxp.sample
+++ b/utils/dc-chain/config/config.mk.9.5.0-winxp.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.34
 sh_gcc_ver=9.5.0
 newlib_ver=4.3.0.20230120
-gdb_ver=14.1
+gdb_ver=14.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz

--- a/utils/dc-chain/config/config.mk.stable.sample
+++ b/utils/dc-chain/config/config.mk.stable.sample
@@ -9,7 +9,7 @@
 sh_binutils_ver=2.41
 sh_gcc_ver=13.2.0
 newlib_ver=4.3.0.20230120
-gdb_ver=14.1
+gdb_ver=14.2
 
 # Tarball extensions to download for SH
 sh_binutils_download_type=xz


### PR DESCRIPTION
GDB 14.2 was released today:
https://sourceware.org/pipermail/gdb-announce/2024/000138.html

This PR updates all `dc-chain` configs with GDB 14.1 to 14.2.

This is in draft until I can actually confirm things build properly.