### PR TITLE
Correct clean/dist for new multibuffer example

### DIFF
--- a/examples/dreamcast/video/Makefile
+++ b/examples/dreamcast/video/Makefile
@@ -14,10 +14,10 @@ clean:
 	$(KOS_MAKE) -C bfont clean
 	$(KOS_MAKE) -C palmenu clean
 	$(KOS_MAKE) -C minifont clean
-	$(KOS_MAKE) -C multibuffer
+	$(KOS_MAKE) -C multibuffer clean
 
 dist:
 	$(KOS_MAKE) -C bfont dist
 	$(KOS_MAKE) -C palmenu dist
 	$(KOS_MAKE) -C minifont dist
-	$(KOS_MAKE) -C multibuffer
+	$(KOS_MAKE) -C multibuffer dist


### PR DESCRIPTION
Perhaps these should follow the scripting set up in the [libdream examples](https://github.com/KallistiOS/KallistiOS/blob/master/examples/dreamcast/libdream/Makefile) that also has run and doesn't require the manual listing of examples?