### PR TITLE
Added declarations for clock_xxx() POSIX API

### DIFF
--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -15,6 +15,10 @@
     This will probably go away at some point in the future, if/when Newlib gets
     an implementation of this function. But for now, it's here.
 
+    \todo
+    - Implement _POSIX_TIMERS, which requires POSIX signals back-end.
+    - Implement thread-specific CPU time
+
     \author Lawrence Sebald
     \author Falco Girgis
 */
@@ -37,8 +41,11 @@ __BEGIN_DECLS
 struct timespec;
 
 #define TIME_UTC 1
+
+/* Microsecond resolution for clock(), per POSIX standard */
 #define CLOCKS_PER_SEC 1000000
 
+/* C11 nanosecond-resolution timing. */
 extern int timespec_get(struct timespec *ts, int base);
 
 #endif /* !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201703L) */
@@ -63,6 +70,13 @@ extern int timespec_get(struct timespec *ts, int base);
 #define _POSIX_THREAD_CPUTIME 1
 #endif
 */
+
+/* Explicitly provided function declarations for POSIX clock API, since
+   getting them from Newlib requires supporting the rest of the _POSIX_TIMERS
+   API, which is not implemented yet. */
+extern int clock_settime(__clockid_t clock_id, const struct timespec *ts);
+extern int clock_gettime(__clockid_t clock_id, struct timespec *ts);
+extern int clock_getres(__clockid_t clock_id, struct timespec *res);
 
 #endif /* !defined(__STRICT_ANSI__) || (_POSIX_C_SOURCE >= 199309L) */
 

--- a/include/sys/_pthread.h
+++ b/include/sys/_pthread.h
@@ -14,7 +14,4 @@
 /** \brief  POSIX timeouts supported (sorta) */
 #define _POSIX_TIMEOUTS
 
-/** \brief  POSIX timers supported (not really) */
-#define _POSIX_TIMERS
-
 #endif  /* __SYS__PTHREAD_H */


### PR DESCRIPTION
Since we were never defining `_POSIX_TIMERS` support within KOS (we don't support all of its functionality), Newlib was never providing us with the declarations for the POSIX `clock_xxx()` date/time API which we do implement. GCC would let us get away with using these functions without declaring them first, resolving them at link-time, but now this behavior has been deprecated in GCC14, so we need to ensure that we have valid declarations visible during the compilation stage.

- Added explicit prototypes for POSIX clock_gettime(), clock_settime(), and clock_getres().

NOTE: Had to remove the `#define` for `_POSIX_TIMERS` from `pthread.h` in order to not get duplicate declarations from KOS and Newlib... Not sure why this was ever defined to begin with, though, considering we don't actually support the full timer API and support for the `clock_xxx()` functions was just barely added recently.  I don't see why this would've ever been needed, and it's technically not true. 