### PR TITLE
Adding KOS_PORTS dir as sysroot for cmake to find libraries

### DIFF
--- a/utils/cmake/dreamcast.toolchain.cmake
+++ b/utils/cmake/dreamcast.toolchain.cmake
@@ -71,6 +71,10 @@ set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 # Never use the CMAKE_FIND_ROOT_PATH to find programs with find_program()
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 
+# Set sysroot to kos-ports folder
+set(CMAKE_SYSROOT ${KOS_PORTS})
+set(ENV{PKG_CONFIG_SYSROOT_DIR} ${KOS_PORTS})
+
 ##### Add Platform-Specific #defines #####
 add_compile_definitions(__DREAMCAST__ _arch_dreamcast)
 


### PR DESCRIPTION
This was suggested by @pcercuei as a way to allow cmake to find our available libraries. I successfully tested it in https://github.com/KallistiOS/kos-ports/pull/55 with the libchipmunk port which looks for OGL to be present. I am not sure if this should only be something set when building kos-ports or if it makes sense for building anything.

If anyone has a regular DC project building using cmake, it would be helpful if you could test with this change.