### PR TITLE
dc-chain: Disable GCC documentation

### DIFF
--- a/utils/dc-chain/scripts/gcc-pass1.mk
+++ b/utils/dc-chain/scripts/gcc-pass1.mk
@@ -26,6 +26,7 @@ $(build_gcc_pass1): logdir
 	      --enable-checking=release \
 	      $(extra_configure_args) \
 	      $(macos_gcc_configure_args) \
+	      MAKEINFO=missing \
 	      CC="$(CC)" \
 	      CXX="$(CXX)" \
 	      $(static_flag) \

--- a/utils/dc-chain/scripts/gcc-pass2.mk
+++ b/utils/dc-chain/scripts/gcc-pass2.mk
@@ -23,6 +23,7 @@ $(build_gcc_pass2): logdir
           --enable-checking=release \
           $(extra_configure_args) \
           $(macos_gcc_configure_args) \
+          MAKEINFO=missing \
           CC="$(CC)" \
           CXX="$(CXX)" \
           $(static_flag) \


### PR DESCRIPTION
We do not need to build GCC's documentation; and it was a common failure point as old versions of GCC don't play well with the recent makeinfo/texinfo programs.