### PR TITLE
Avoid flexible array member in struct dirent

### DIFF
--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -66,7 +66,7 @@ struct dirent {
     off_t     d_off;              /**< \brief File offset */
     uint16_t  d_reclen;           /**< \brief Record length */
     uint8_t   d_type;             /**< \brief File type */
-    char      d_name[];           /**< \brief Filename */
+    char      d_name[0];          /**< \brief Filename */
 };
 
 /** \brief  Type representing a directory stream.


### PR DESCRIPTION
GCC doesn't like having the dirent member be in the middle of DIR because struct dirent's `d_name` is a flexible array. This could be fixed by swapping the placement of DIR::d_ent and DIR::d_name, but I think a better solution is to have the size of struct dirent's `d_name` be exactly NAME_MAX bytes so that it matches DIR's `d_name`.

This change allows me to work past an error such as:

```
In file included from /opt/toolchains/dc/sh-elf/sh-elf/include/dirent.h:39,                                                                                                                                                           
                 from dreamcast_main.cpp:9:                                                                                                                                                                                           
/opt/toolchains/dc/kos/include/sys/dirent.h:69:15: error: flexible array member ‘dirent::d_name’ not at end of ‘struct<unnamed>’                                                                                                      
   69 |     char      d_name[];           /**< \brief Filename */                                                                                                                                                                     
      |               ^~~~~~                                                                                                                                                                                                          
/opt/toolchains/dc/kos/include/sys/dirent.h:85:21: note: next member ‘char <unnamed struct>::d_name [256]’ declared here
   85 |     char            d_name[NAME_MAX]; /**< \brief Filename */                                              
      |                     ^~~~~~                       
/opt/toolchains/dc/kos/include/sys/dirent.h:82:16: note: in the definition of ‘struct<unnamed>’
   82 | typedef struct {                                 
      |                ^                                 
```

I've tested with a small program which uses opendir() and readdir() and it shows me reasonable results (file system entries `/vmu`, `/cd`, etc.)