### PR TITLE
change g2_ctx_t->irq_state type from `uint32_t` to `int`

### DIFF
--- a/kernel/arch/dreamcast/include/dc/g2bus.h
+++ b/kernel/arch/dreamcast/include/dc/g2bus.h
@@ -140,7 +140,7 @@ void g2_dma_shutdown(void);
     is used in with g2_lock() and g2_unlock().
 */
 typedef struct { 
-    uint32_t irq_state;    /** \brief IRQ state when entering a G2 critical block */
+    int irq_state;    /** \brief IRQ state when entering a G2 critical block */
 } g2_ctx_t;
 
 /* Internal constants to access suspend registers for G2 DMA. They are not meant for


### PR DESCRIPTION
Suppress warnings generated by **-Wsign-conversion**, both `irq_disable()` and `irq_restore()` uses `int` type.
