### PR TITLE
Minor Floating-Point Precision Fixes

### DIFF
--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -164,10 +164,20 @@
 #define __no_inline __attribute__((__noinline__))
 #endif
 
-#if __SH4_SINGLE_ONLY__
-#   define __sh4_single_no_inline
-#else
-#   define __sh4_single_no_inline __no_inline
+#ifndef __sh4_single_only_inline
+#   if __SH4_SINGLE_ONLY__
+#       define __sh4_single_only_inline inline static
+#   else
+#       define __sh4_single_only_inline __no_inline
+#   endif
+#endif
+
+#ifndef __sh4_single_only_always_inline
+#   if __SH4_SINGLE_ONLY__
+#       define __sh4_single_only_always_inline __always_inline
+#   else
+#       define __sh4_single_only_always_inline __no_inline
+#   endif
 #endif
 
 /* GCC macros for special cases */

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -164,22 +164,6 @@
 #define __no_inline __attribute__((__noinline__))
 #endif
 
-#ifndef __sh4_single_only_inline
-#   if __SH4_SINGLE_ONLY__
-#       define __sh4_single_only_inline inline static
-#   else
-#       define __sh4_single_only_inline __no_inline
-#   endif
-#endif
-
-#ifndef __sh4_single_only_always_inline
-#   if __SH4_SINGLE_ONLY__
-#       define __sh4_single_only_always_inline __always_inline
-#   else
-#       define __sh4_single_only_always_inline __no_inline
-#   endif
-#endif
-
 /* GCC macros for special cases */
 /* #if __GNUC__ ==  */
 

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -164,6 +164,12 @@
 #define __no_inline __attribute__((__noinline__))
 #endif
 
+#if __SH4_SINGLE_ONLY__
+#   define __sh4_single_no_inline
+#else
+#   define __sh4_single_no_inline __no_inline
+#endif
+
 /* GCC macros for special cases */
 /* #if __GNUC__ ==  */
 

--- a/kernel/arch/dreamcast/include/dc/vec3f.h
+++ b/kernel/arch/dreamcast/include/dc/vec3f.h
@@ -33,8 +33,8 @@ typedef struct vec3f {
 } vec3f_t;
 
 /** \cond */
-#define R_DEG 182.04444443623349541909523793743
-#define R_RAD 10430.37835
+#define R_DEG 182.04444443623349541909523793743f
+#define R_RAD 10430.37835f
 /* \endcond */
 
 /** \brief  Macro to return the scalar dot product of two 3d vectors.


### PR DESCRIPTION
~~1) `cdefs.h`
    - added a new function attribute, `__sh4_single_no_inline`, which
      conditionally only declares a function non-inlined when using
      `-m4-single`.~~
2) `vec3f.h`
    - explicitly truncated two double-precision fp constants to
      single-precision floats