### PR TITLE
Fix erroneous timeout math and change implementation to CLOCK_MONOTONIC

### DIFF
--- a/addons/libpthread/pthread_cond_timedwait.c
+++ b/addons/libpthread/pthread_cond_timedwait.c
@@ -2,6 +2,7 @@
 
    pthread_cond_timedwait.c
    Copyright (C) 2023 Lawrence Sebald
+   Copyright (C) 2024 Eric Fradella
 
 */
 
@@ -16,7 +17,7 @@ int pthread_cond_timedwait(pthread_cond_t *__RESTRICT cond,
                            const struct timespec *__RESTRICT abstime) {
     int old, rv = 0;
     int tmo;
-    struct timeval ctv;
+    struct timespec ctv;
 
     if(!mutex || !abstime)
         return EFAULT;
@@ -26,11 +27,11 @@ int pthread_cond_timedwait(pthread_cond_t *__RESTRICT cond,
 
     old = errno;
 
-    /* Figure out the timeout we need to provide. */
-    gettimeofday(&ctv, NULL);
+    /* Figure out the timeout we need to provide in milliseconds. */
+    clock_gettime(CLOCK_MONOTONIC, &ctv);
 
-    tmo = abstime->tv_sec - ctv.tv_sec;
-    tmo += abstime->tv_nsec / (1000 * 1000) - ctv.tv_usec / 1000;
+    tmo = (abstime->tv_sec - ctv.tv_sec) * 1000;
+    tmo += (abstime->tv_nsec - ctv.tv_nsec) / (1000 * 1000);
 
     if(tmo <= 0)
         return ETIMEDOUT;

--- a/addons/libpthread/pthread_condattr_getclock.c
+++ b/addons/libpthread/pthread_condattr_getclock.c
@@ -15,6 +15,6 @@ int pthread_condattr_getclock(const pthread_condattr_t *__RESTRICT attr,
     if(!attr)
         return EINVAL;
 
-    *clock_id = CLOCK_REALTIME;
+    *clock_id = CLOCK_MONOTONIC;
     return 0;
 }

--- a/addons/libpthread/pthread_condattr_setclock.c
+++ b/addons/libpthread/pthread_condattr_setclock.c
@@ -14,7 +14,7 @@ int pthread_condattr_setclock(pthread_condattr_t *attr, clockid_t clock_id) {
     if(!attr)
         return EINVAL;
 
-    if(clock_id != CLOCK_REALTIME)
+    if(clock_id != CLOCK_MONOTONIC)
         return EINVAL;
 
     return 0;

--- a/addons/libpthread/pthread_mutex_timedlock.c
+++ b/addons/libpthread/pthread_mutex_timedlock.c
@@ -2,6 +2,7 @@
 
    pthread_mutex_timedlock.c
    Copyright (C) 2023 Lawrence Sebald
+   Copyright (C) 2024 Eric Fradella
 
 */
 
@@ -15,7 +16,7 @@ int pthread_mutex_timedlock(pthread_mutex_t *__RESTRICT mutex,
                             const struct timespec *__RESTRICT abstime) {
     int old, rv = 0;
     int tmo;
-    struct timeval ctv;
+    struct timespec ctv;
 
     if(!mutex || !abstime)
         return EFAULT;
@@ -32,11 +33,11 @@ int pthread_mutex_timedlock(pthread_mutex_t *__RESTRICT mutex,
     if(!mutex_trylock(&mutex->mutex))
         return 0;
 
-    /* Figure out the timeout we need to provide. */
-    gettimeofday(&ctv, NULL);
+    /* Figure out the timeout we need to provide in milliseconds. */
+    clock_gettime(CLOCK_MONOTONIC, &ctv);
 
-    tmo = abstime->tv_sec - ctv.tv_sec;
-    tmo += abstime->tv_nsec / (1000 * 1000) - ctv.tv_usec / 1000;
+    tmo = (abstime->tv_sec - ctv.tv_sec) * 1000;
+    tmo += (abstime->tv_nsec - ctv.tv_nsec) / (1000 * 1000);
 
     if(tmo <= 0)
         return ETIMEDOUT;

--- a/addons/libpthread/pthread_rwlock_timedrdlock.c
+++ b/addons/libpthread/pthread_rwlock_timedrdlock.c
@@ -2,6 +2,7 @@
 
    pthread_rwlock_timedrdlock.c
    Copyright (C) 2023 Lawrence Sebald
+   Copyright (C) 2024 Eric Fradella
 
 */
 
@@ -15,7 +16,7 @@ int pthread_rwlock_timedrdlock(pthread_rwlock_t *__RESTRICT rwlock,
                                const struct timespec *__RESTRICT abstime) {
     int old, rv = 0;
     int tmo;
-    struct timeval ctv;
+    struct timespec ctv;
 
     if(!rwlock || !abstime)
         return EFAULT;
@@ -32,11 +33,11 @@ int pthread_rwlock_timedrdlock(pthread_rwlock_t *__RESTRICT rwlock,
     if(!rwsem_read_trylock(&rwlock->rwsem))
         return 0;
 
-    /* Figure out the timeout we need to provide. */
-    gettimeofday(&ctv, NULL);
+    /* Figure out the timeout we need to provide in milliseconds. */
+    clock_gettime(CLOCK_MONOTONIC, &ctv);
 
-    tmo = abstime->tv_sec - ctv.tv_sec;
-    tmo += abstime->tv_nsec / (1000 * 1000) - ctv.tv_usec / 1000;
+    tmo = (abstime->tv_sec - ctv.tv_sec) * 1000;
+    tmo += (abstime->tv_nsec - ctv.tv_nsec) / (1000 * 1000);
 
     if(tmo <= 0)
         return ETIMEDOUT;

--- a/addons/libpthread/pthread_rwlock_timedwrlock.c
+++ b/addons/libpthread/pthread_rwlock_timedwrlock.c
@@ -2,6 +2,7 @@
 
    pthread_rwlock_timedwrlock.c
    Copyright (C) 2023 Lawrence Sebald
+   Copyright (C) 2024 Eric Fradella
 
 */
 
@@ -15,7 +16,7 @@ int pthread_rwlock_timedwrlock(pthread_rwlock_t *__RESTRICT rwlock,
                                const struct timespec *__RESTRICT abstime) {
     int old, rv = 0;
     int tmo;
-    struct timeval ctv;
+    struct timespec ctv;
 
     if(!rwlock || !abstime)
         return EFAULT;
@@ -32,11 +33,11 @@ int pthread_rwlock_timedwrlock(pthread_rwlock_t *__RESTRICT rwlock,
     if(!rwsem_write_trylock(&rwlock->rwsem))
         return 0;
 
-    /* Figure out the timeout we need to provide. */
-    gettimeofday(&ctv, NULL);
+    /* Figure out the timeout we need to provide in milliseconds. */
+    clock_gettime(CLOCK_MONOTONIC, &ctv);
 
-    tmo = abstime->tv_sec - ctv.tv_sec;
-    tmo += abstime->tv_nsec / (1000 * 1000) - ctv.tv_usec / 1000;
+    tmo = (abstime->tv_sec - ctv.tv_sec) * 1000;
+    tmo += (abstime->tv_nsec - ctv.tv_nsec) / (1000 * 1000);
 
     if(tmo <= 0)
         return ETIMEDOUT;


### PR DESCRIPTION
* Switches our pthreads implementation in `libpthread` branch to use `CLOCK_MONOTONIC` instead of `CLOCK_REALTIME`.
* Currently the pthread implementation erroneously calculates timeout `tmo` by calculating the difference in seconds and the difference in milliseconds, and then adding seconds and milliseconds together. This PR fixes the issue by converting seconds to milliseconds before adding to the difference in milliseconds.