### PR TITLE
init: Add KOS_NO_SHUTDOWN flag to disable shutdown

### DIFF
--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -61,6 +61,7 @@ __BEGIN_DECLS
     KOS_INIT_FLAG(flags, INIT_FS_ROMDISK, fs_romdisk_init); \
     KOS_INIT_FLAG(flags, INIT_FS_ROMDISK, fs_romdisk_shutdown); \
     KOS_INIT_FLAG(flags, INIT_EXPORT, export_init); \
+    KOS_INIT_FLAG_NONE(flags, INIT_NO_SHUTDOWN, kos_shutdown); \
     KOS_INIT_FLAGS_ARCH(flags)
 
 #define __KOS_INIT_FLAGS_1(flags) \
@@ -138,6 +139,7 @@ extern void * __kos_romdisk;
 #define INIT_QUIET       0x00000010  /**< \brief Disable dbgio */
 #define INIT_EXPORT      0x00000020  /**< \brief Export kernel symbols */
 #define INIT_FS_ROMDISK  0x00000040  /**< \brief Enable support for romdisks */
+#define INIT_NO_SHUTDOWN 0x00000080  /**< \brief Disable hardware shutdown */
 /** @} */
 
 __END_DECLS

--- a/kernel/libc/newlib/newlib_exit.c
+++ b/kernel/libc/newlib/newlib_exit.c
@@ -6,9 +6,23 @@
 */
 
 #include <arch/arch.h>
+#include <stdbool.h>
 
 extern void arch_exit_handler(int ret_code) __noreturn;
 
+static int ret_code;
+
+void kos_shutdown(void)
+{
+    arch_exit_handler(ret_code);
+
+    __builtin_unreachable();
+}
+
+KOS_INIT_FLAG_WEAK(kos_shutdown, true);
+
 void _exit(int code) {
-    arch_exit_handler(code);
+    ret_code = code;
+
+    KOS_INIT_FLAG_CALL(kos_shutdown);
 }


### PR DESCRIPTION
Serious homebrew games and apps generally don't have any way to return to the calling application; exiting them means rebooting the console.

Those applications can now shave off a few kilobytes of RAM by using the KOS_NO_SHUTDOWN init flag.