### PR TITLE
Set minimum Cmake version based on actual minimum requirements

### DIFF
--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.23)
+### This minimum is based on the minimum requirement in dreamcast.toolchain.cmake
+cmake_minimum_required(VERSION 3.13)
 
 ### Helper Function for Bin2Object ###
 function(kos_bin2o inFile symbol)

--- a/utils/cmake/dreamcast.toolchain.cmake
+++ b/utils/cmake/dreamcast.toolchain.cmake
@@ -16,7 +16,8 @@
 # The original toolchain file was created by Kazade for the Simulant 
 # engine who has graciously allowed the rest of the scene to warez it. 
 
-cmake_minimum_required(VERSION 3.23)
+#### This minimum is due to the use of add_link_options
+cmake_minimum_required(VERSION 3.13)
 
 #### Set Configuration Variables From Environment ####
 if(NOT DEFINED KOS_BASE)


### PR DESCRIPTION
Based on the minimum requirements of the kos_ports, tested with cmake 3.12, but the toolchain file also uses the option [add_link_options](https://cmake.org/cmake/help/latest/command/add_link_options.html) which was only added in 3.13.

Having tested with cmake 3.13, I was able to successfully build the three kos-ports cmake-based ports, so it should be sufficient. If possible future changes to these should be tested to validate that they can still use 3.13 and we can bump it up as needed.

This helps the issue of the arbitrary minimum currently in place (3.23) being higher than what's provided in ubuntu and debian LTS versions, and should reduce false incompatibility.