### PR TITLE
fs: Remove duplicated fcntl() function

### DIFF
--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -696,7 +696,7 @@ int fs_rmdir(const char * fn) {
     }
 }
 
-int fs_vfcntl(file_t fd, int cmd, va_list ap) {
+static int fs_vfcntl(file_t fd, int cmd, va_list ap) {
     fs_hnd_t *h = fs_map_hnd(fd);
     int rv;
 

--- a/kernel/libc/newlib/newlib_fcntl.c
+++ b/kernel/libc/newlib/newlib_fcntl.c
@@ -5,25 +5,13 @@
 
 */
 
-#include <sys/reent.h>
 #include <sys/fcntl.h>
-#include <stdarg.h>
 
 #include <kos/fs.h>
+
+struct _reent;
 
 int _fcntl_r(struct _reent *reent, int fd, int cmd, int arg) {
     (void)reent;
     return fs_fcntl(fd, cmd, arg);
-}
-
-extern int fs_vfcntl(file_t fd, int cmd, va_list ap);
-
-int fcntl(int fd, int cmd, ...) {
-    va_list ap;
-    int rv;
-
-    va_start(ap, cmd);
-    rv = fs_vfcntl(fd, cmd, ap);
-    va_end(ap);
-    return rv;
 }


### PR DESCRIPTION
Newlib already provides fcntl(), which will end up calling _fcntl_r() provided by KOS. This previously did not cause problems as the linker would pick the first symbol found (which means the link order mattered).

Rust however will complain that the symbol is duplicated. Address this by removing the KOS' fcntl(), which should not have any side effects.