### PR TITLE
add 2 missing examples temp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ examples/dreamcast/kgl/basic/vq/fruit.vq
 examples/dreamcast/conio/adventure/data.c
 examples/dreamcast/conio/adventure/datagen
 examples/dreamcast/png/romdisk_boot.img
+examples/dreamcast/pvr/bumpmap/romdisk/bricks.kmg
+examples/dreamcast/pvr/bumpmap/romdisk/bumpmap.raw
 examples/dreamcast/pvr/modifier_volume_tex/romdisk/fruit.kmg
 examples/dreamcast/pvr/texture_render/texture_render.bin
 utils/dc-chain/logs


### PR DESCRIPTION
After building kos & all its examples, 
only 2 temp files are considered by git as "untracked", 
while they should be ignored