### PR TITLE
init: Add init flags to enable/disable DCLOAD, CDROM

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -529,15 +529,15 @@ void fs_dcload_init_console(void) {
 }
 
 /* Call fs_dcload_init_console() before calling fs_dcload_init() */
-int fs_dcload_init(void) {
+void fs_dcload_init(void) {
     // This was already done in init_console.
     if(dcload_type == DCLOAD_TYPE_NONE)
-        return -1;
+        return;
 
     /* Check for combination of KOS networking and dcload-ip */
     if((dcload_type == DCLOAD_TYPE_IP) && (__kos_init_flags & INIT_NET)) {
         dbglog(DBG_INFO, "dc-load console+kosnet, will switch to internal ethernet\n");
-        return -1;
+        return;
         /* if(old_printk) {
             dbgio_set_printk(old_printk);
             old_printk = 0;
@@ -546,13 +546,13 @@ int fs_dcload_init(void) {
     }
 
     /* Register with VFS */
-    return nmmgr_handler_add(&vh.nmmgr);
+    nmmgr_handler_add(&vh.nmmgr);
 }
 
-int fs_dcload_shutdown(void) {
+void fs_dcload_shutdown(void) {
     /* Check for dcload */
     if(*DCLOADMAGICADDR != DCLOADMAGICVALUE)
-        return -1;
+        return;
 
     /* Free dcload wrkram */
     if(dcload_wrkmem) {
@@ -566,7 +566,7 @@ int fs_dcload_shutdown(void) {
         dbgio_dev_select("scif");
     }
 
-    return nmmgr_handler_remove(&vh.nmmgr);
+    nmmgr_handler_remove(&vh.nmmgr);
 }
 
 /* used for dcload-ip + lwIP

--- a/kernel/arch/dreamcast/fs/fs_dclsocket.c
+++ b/kernel/arch/dreamcast/fs/fs_dclsocket.c
@@ -837,12 +837,12 @@ error:
     return -1;
 }
 
-int fs_dclsocket_shutdown(void) {
+void fs_dclsocket_shutdown(void) {
     int old;
     command_t cmd;
 
     if(initted != 2)
-        return -1;
+        return;
 
     dbglog(DBG_INFO, "fs_dclsocket: About to disable console\n");
 
@@ -869,5 +869,5 @@ int fs_dclsocket_shutdown(void) {
     /* Finally, clean up the socket */
     close(dcls_socket);
 
-    return nmmgr_handler_remove(&vh.nmmgr);
+    nmmgr_handler_remove(&vh.nmmgr);
 }

--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -1053,7 +1053,7 @@ static vfs_handler_t vh = {
 };
 
 /* Initialize the file system */
-int fs_iso9660_init(void) {
+void fs_iso9660_init(void) {
     int i;
 
     /* Reset fd's */
@@ -1081,11 +1081,11 @@ int fs_iso9660_init(void) {
     iso_vblank_hnd = vblank_handler_add(iso_vblank, NULL);
 
     /* Register with VFS */
-    return nmmgr_handler_add(&vh.nmmgr);
+    nmmgr_handler_add(&vh.nmmgr);
 }
 
 /* De-init the file system */
-int fs_iso9660_shutdown(void) {
+void fs_iso9660_shutdown(void) {
     int i;
 
     /* De-register with vblank */
@@ -1101,5 +1101,5 @@ int fs_iso9660_shutdown(void) {
     mutex_destroy(&cache_mutex);
     mutex_destroy(&fh_mutex);
 
-    return nmmgr_handler_remove(&vh.nmmgr);
+    nmmgr_handler_remove(&vh.nmmgr);
 }

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -470,7 +470,7 @@ int cdrom_spin_down(void) {
 }
 
 /* Initialize: assume no threading issues */
-int cdrom_init(void) {
+void cdrom_init(void) {
     uint32_t p;
     volatile uint32_t *react = (uint32_t *)(0x005f74e4 | MEM_AREA_P2_BASE);
     volatile uint32_t *bios = (uint32_t *)MEM_AREA_P2_BASE;
@@ -500,7 +500,7 @@ int cdrom_init(void) {
     gdc_init_system();
     mutex_unlock(&_g1_ata_mutex);
 
-    return cdrom_reinit();
+    cdrom_reinit();
 }
 
 void cdrom_shutdown(void) {

--- a/kernel/arch/dreamcast/hardware/hardware.c
+++ b/kernel/arch/dreamcast/hardware/hardware.c
@@ -58,6 +58,11 @@ KOS_INIT_FLAG_WEAK(bba_la_init, false);
 KOS_INIT_FLAG_WEAK(bba_la_shutdown, false);
 KOS_INIT_FLAG_WEAK(maple_init, true);
 
+#ifndef _arch_sub_naomi
+KOS_INIT_FLAG_WEAK(cdrom_init, true);
+KOS_INIT_FLAG_WEAK(cdrom_shutdown, true);
+#endif
+
 int hardware_periph_init(void) {
     /* Init sound */
     spu_init();
@@ -65,7 +70,7 @@ int hardware_periph_init(void) {
 
 #ifndef _arch_sub_naomi
     /* Init CD-ROM.. NOTE: NO GD-ROM SUPPORT. ONLY CDs/CDRs. */
-    cdrom_init();
+    KOS_INIT_FLAG_CALL(cdrom_init);
 #endif
 
     /* Setup maple bus */
@@ -92,9 +97,7 @@ void hardware_shutdown(void) {
             KOS_INIT_FLAG_CALL(bba_la_shutdown);
 #endif
             KOS_INIT_FLAG_CALL(maple_shutdown);
-#if 0
-            cdrom_shutdown();
-#endif
+            KOS_INIT_FLAG_CALL(cdrom_shutdown);
             g2_dma_shutdown();
             spu_shutdown();
             vid_shutdown();

--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -44,6 +44,11 @@ __BEGIN_DECLS
     \sa KOS_INIT_FLAGS()
 */
 #define KOS_INIT_FLAGS_ARCH(flags) \
+    KOS_INIT_FLAG_NONE(flags, INIT_NO_DCLOAD, dcload_init); \
+    KOS_INIT_FLAG_NONE(flags, INIT_NO_DCLOAD, fs_dcload_init_console); \
+    KOS_INIT_FLAG_NONE(flags, INIT_NO_DCLOAD, fs_dcload_shutdown); \
+    KOS_INIT_FLAG_NONE(flags, INIT_NO_DCLOAD, arch_init_net_dcload_ip); \
+    KOS_INIT_FLAG(flags, INIT_NO_DCLOAD, arch_init_net_no_dcload); \
     KOS_INIT_FLAG(flags, INIT_CDROM, cdrom_init); \
     KOS_INIT_FLAG(flags, INIT_CDROM, cdrom_shutdown); \
     KOS_INIT_FLAG(flags, INIT_CDROM, fs_iso9660_init); \

--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -44,6 +44,10 @@ __BEGIN_DECLS
     \sa KOS_INIT_FLAGS()
 */
 #define KOS_INIT_FLAGS_ARCH(flags) \
+    KOS_INIT_FLAG(flags, INIT_CDROM, cdrom_init); \
+    KOS_INIT_FLAG(flags, INIT_CDROM, cdrom_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_CDROM, fs_iso9660_init); \
+    KOS_INIT_FLAG(flags, INIT_CDROM, fs_iso9660_shutdown); \
     KOS_INIT_FLAG(flags, INIT_CONTROLLER, cont_init); \
     KOS_INIT_FLAG(flags, INIT_CONTROLLER, cont_shutdown); \
     KOS_INIT_FLAG(flags, INIT_KEYBOARD, kbd_init); \
@@ -79,7 +83,7 @@ __BEGIN_DECLS
 */
 
 /** \brief Default init flags for the Dreamcast. */
-#define INIT_DEFAULT_ARCH   (INIT_MAPLE_ALL)
+#define INIT_DEFAULT_ARCH   (INIT_MAPLE_ALL | INIT_CDROM)
 
 #define INIT_CONTROLLER     0x00001000  /**< \brief Enable Controller maple driver */
 #define INIT_KEYBOARD       0x00002000  /**< \brief Enable Keyboard maple driver */
@@ -90,6 +94,8 @@ __BEGIN_DECLS
 #define INIT_SIP            0x00040000  /**< \brief Enable Sound input maple driver */
 #define INIT_DREAMEYE       0x00080000  /**< \brief Enable DreamEye maple driver */
 #define INIT_MAPLE_ALL      0x000ff000  /**< \brief Enable all Maple drivers */
+
+#define INIT_CDROM          0x00100000  /**< \brief Enable CD-ROM support */
 
 #define INIT_OCRAM          0x10000000  /**< \brief Use half of the dcache as RAM */
 #define INIT_NO_DCLOAD      0x20000000  /**< \brief Disable dcload */

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -493,11 +493,8 @@ int cdrom_spin_down(void);
 
     This initializes the CD-ROM reading system, reactivating the drive and
     handling initial setup of the disc.
-
-    \retval 0               On success.
-    \retval -1              Already initted, shutdown before initting again.
 */
-int cdrom_init(void);
+void cdrom_init(void);
 
 /** \brief    Shutdown the CD reading system.
     \ingroup  gdrom

--- a/kernel/arch/dreamcast/include/dc/fs_dcload.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dcload.h
@@ -140,8 +140,8 @@ int     dcload_unlink(vfs_handler_t * vfs, const char *fn);
 
 /* Init func */
 void fs_dcload_init_console(void);
-int fs_dcload_init(void);
-int fs_dcload_shutdown(void);
+void fs_dcload_init(void);
+void fs_dcload_shutdown(void);
 
 /* Init func for dcload-ip + lwIP */
 int fs_dcload_init_lwip(void *p);

--- a/kernel/arch/dreamcast/include/dc/fs_dclsocket.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dclsocket.h
@@ -36,7 +36,7 @@ extern dbgio_handler_t dbgio_dcls;
 void fs_dclsocket_init_console(void);
 int fs_dclsocket_init(void);
 
-int fs_dclsocket_shutdown(void);
+void fs_dclsocket_shutdown(void);
 /* \endcond */
 
 /** @} */

--- a/kernel/arch/dreamcast/include/dc/fs_iso9660.h
+++ b/kernel/arch/dreamcast/include/dc/fs_iso9660.h
@@ -48,8 +48,8 @@ __BEGIN_DECLS
 int iso_reset(void);
 
 /* \cond */
-int fs_iso9660_init(void);
-int fs_iso9660_shutdown(void);
+void fs_iso9660_init(void);
+void fs_iso9660_shutdown(void);
 /* \endcond */
 
 /** @} */

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -114,6 +114,11 @@ KOS_INIT_FLAG_WEAK(fs_romdisk_mount_builtin_legacy, false);
 KOS_INIT_FLAG_WEAK(vmu_fs_init, true);
 KOS_INIT_FLAG_WEAK(vmu_fs_shutdown, true);
 
+#ifndef _arch_sub_naomi
+KOS_INIT_FLAG_WEAK(fs_iso9660_init, true);
+KOS_INIT_FLAG_WEAK(fs_iso9660_shutdown, true);
+#endif
+
 /* Auto-init stuff: override with a non-weak symbol if you don't want all of
    this to be linked into your code (and do the same with the
    arch_auto_shutdown function too). */
@@ -182,7 +187,7 @@ int  __weak arch_auto_init(void) {
     }
 
 #ifndef _arch_sub_naomi
-    fs_iso9660_init();
+    KOS_INIT_FLAG_CALL(fs_iso9660_init);
 #endif
 
     KOS_INIT_FLAG_CALL(vmu_fs_init);
@@ -218,7 +223,7 @@ void  __weak arch_auto_shutdown(void) {
     fs_dcload_shutdown();
     KOS_INIT_FLAG_CALL(vmu_fs_shutdown);
 #ifndef _arch_sub_naomi
-    fs_iso9660_shutdown();
+    KOS_INIT_FLAG_CALL(fs_iso9660_shutdown);
 #endif
 #if defined(__NEWLIB__) && !(__NEWLIB__ < 2 && __NEWLIB_MINOR__ < 4)
     fs_dev_shutdown();


### PR DESCRIPTION
Add a `INIT_CDROM` init flag, enabled by default, which can control whether the CD-ROM will be initialized and shut down automatically by KallistiOS.

Use the existing `INIT_NO_DCLOAD` flag to garbage-collect dcload code in case that flag is present.