### PR TITLE
maple: Fix race between IRQ and threads

### DIFF
--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -28,6 +28,8 @@ __BEGIN_DECLS
 #include <arch/types.h>
 #include <dc/maple.h>
 
+#include <stdatomic.h>
+
 /** \defgroup kbd   Keyboard
     \brief          Driver for the Dreamcast's Keyboard Input Device
     \ingroup        peripherals
@@ -297,7 +299,7 @@ typedef struct kbd_state {
     uint32 key_queue[KBD_QUEUE_SIZE];
     int queue_tail;                     /**< \brief Key queue tail. */
     int queue_head;                     /**< \brief Key queue head. */
-    int queue_len;                      /**< \brief Current length of queue. */
+    atomic_int queue_len;               /**< \brief Current length of queue. */
 
     uint8 kbd_repeat_key;           /**< \brief Key that is repeating. */
     uint64 kbd_repeat_timer;        /**< \brief Time that the next repeat will trigger. */


### PR DESCRIPTION
The IRQ handler and threads would read-modify-write the state->queue_len field as if races didn't exist.

Address this issue by using atomics instead.

Note that the code in the IRQ handler is using atomic routines as well just to be future-proof, as it may very well be called from a threaded interrupt handler in the future.

This has the added benefit that it also tells GCC that the 'queue_len' may be updated outside the visible scope, and therefore its value may change at any moment. This fixes the code not working properly when building with LTO.