### PR TITLE
Updated dc-chain for DLang +  BETA m4-single support

### DIFF
--- a/utils/dc-chain/config/config.mk.13.2.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.13.2.1-dev.sample
@@ -114,24 +114,27 @@ install_mode=install-strip
 # detected on some OS.
 makejobs=-j2
 
-# Languages (c|c++|objc|obj-c++)
-# Set the languages to build for pass 2 of building gcc for sh-elf. The default
-# here is to build C, C++, Objective C, and Objective C++. You may want to take
-# out the latter two if you're not worried about them and/or you're short on
-# hard drive space.
+# Languages (c|c++|objc|obj-c++|d)
+# Set the languages to build for sh-elf gcc compilation pass 2. The default is
+# to build everything used by all KOS examples; however, only C is actually
+# required for KOS itself. D may also be enabled optionally on POSIX platforms
+# which have its external dependencies installed.
 pass2_languages=c,c++,objc,obj-c++
 
-# Floating point precision support (m4|m4-single|m4-single-only)
+# Floating point precision support (m4-single-only|m4-single|m4)
 # Build support for various SH4 floating-point operation ABIs. KallistiOS only
-# officially supports single-precision-only mode. Add m4 (double precision) or
-# m4-single (single precision) to build experimental support for those ABIs.
-precision_modes=m4-single-only
-#precision_modes=m4,m4-single,m4-single-only
+# officially supports single-precision-only mode (m4-single-only); however,
+# experimental support for single-precision-default mode (m4-single) has just
+# been added to allow for the use of full 64-bit doubles. You may also add m4
+# (double-precision-default) which hasn't been tested, or you can simply stick
+# with m4-single-only to save disc space.
+precision_modes=m4-single-only,m4-single
+#precision_modes=m4-single-only,m4-single,m4
 
-# Default floating point mode (m4|m4-single|m4-single-only)
+# Default floating point mode (m4-single-only|m4-single|m4)
 # Choose the default floating point precision ABI used when GCC is invoked. This
 # can be overridden by using passing -m4, -m4-single, or -m4-single-only to GCC.
-# KallistiOS currently only supports m4-single-only, so that is the default.
+# KOS currently only officially supports m4-single-only, so it is the default.
 default_precision=m4-single-only
 
 # GCC threading model (single|kos|posix*)

--- a/utils/dc-chain/config/config.mk.13.2.1-dev.sample
+++ b/utils/dc-chain/config/config.mk.13.2.1-dev.sample
@@ -127,7 +127,7 @@ pass2_languages=c,c++,objc,obj-c++
 # experimental support for single-precision-default mode (m4-single) has just
 # been added to allow for the use of full 64-bit doubles. You may also add m4
 # (double-precision-default) which hasn't been tested, or you can simply stick
-# with m4-single-only to save disc space.
+# with m4-single-only to save disk space.
 precision_modes=m4-single-only,m4-single
 #precision_modes=m4-single-only,m4-single,m4
 

--- a/utils/dc-chain/doc/changelog.txt
+++ b/utils/dc-chain/doc/changelog.txt
@@ -1,3 +1,6 @@
+2024-04-21: Added D to list of supported languages, added m4-single as a
+            default precision mode, added --disable-libphobos to gcc-pass2
+            (Falco Girgis)
 2024-01-14: Added config option for disabling native language support (NLS) in GCC.
             (Falco Girgis)
 2024-01-06: Update documentations (Mickaël Cardoso)

--- a/utils/dc-chain/scripts/gcc-pass2.mk
+++ b/utils/dc-chain/scripts/gcc-pass2.mk
@@ -18,6 +18,7 @@ $(build_gcc_pass2): logdir
           --with-gnu-ld \
           --with-newlib \
           --disable-libssp \
+          --disable-libphobos \
           --enable-threads=$(thread_model) \
           --enable-languages=$(pass2_languages) \
           --enable-checking=release \


### PR DESCRIPTION
- Added an option for D to the pass2 langauges list, with a note that dependencies must already have been installed.
- Added `--disable-libphobos` flag to the pass2 script to prevent it from being built with D (which doesn't support it), but it's also gracefully ignored without D.
- Added `-m4-single` to the default list of FP configurations to build WHILE STILL KEEPING a strict warning about early beta support for it.

@darcagn If you've reviewed this, can you help me port these changes to your other configs? Or at very least the new GCC14 config, I guess.