### PR TITLE
Fixed Release Build Warnings from Defining NDEBUG.

### DIFF
--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -62,11 +62,11 @@ __BEGIN_DECLS
     \headerfile sys/dirent.h
  */
 struct dirent {
-    int       d_ino;              /**< \brief File unique identifier. */
-    off_t     d_off;              /**< \brief File offset */
-    uint16_t  d_reclen;           /**< \brief Record length */
-    uint8_t   d_type;             /**< \brief File type */
-    char      d_name[0];          /**< \brief Filename */
+    int       d_ino;     /**< \brief File unique identifier. */
+    off_t     d_off;     /**< \brief File offset */
+    uint16_t  d_reclen;  /**< \brief Record length */
+    uint8_t   d_type;    /**< \brief File type */
+    char      d_name[0]; /**< \brief Filename */
 };
 
 /** \brief  Type representing a directory stream.

--- a/kernel/arch/dreamcast/hardware/modem/mdata.c
+++ b/kernel/arch/dreamcast/hardware/modem/mdata.c
@@ -399,6 +399,7 @@ void modemDataHandleDialingData(void) {
     if(modemDataLockFlag(&txBufferLockFlag)) {
         /* Get the byte to send to the MDP */
         length = readFromChainBuffer(txBuffer, &data, 1);
+        (void)length;
         assert(length == 1); /* Should have read one byte */
 
         /* If this is going to be the last byte of data sent to the MDP then

--- a/kernel/arch/dreamcast/include/dc/matrix.h
+++ b/kernel/arch/dreamcast/include/dc/matrix.h
@@ -105,11 +105,12 @@ void mat_transform(vector_t *invecs, vector_t *outvecs, int veccnt, int vecskip)
     the transformed coordinates. This is perfect, for instance, for transforming
     pvr_vertex_t vertices.
 
+    \note                   sq_lock() must have been called beforehand
+
     \param  input           The list of input vertices.
-    \param  output          The output pointer.
+    \param  output          The output pointer (SQ address)
     \param  veccnt          The number of vertices to transform.
-    \note                   The \ref QACR0 and \ref QACR1 registers must be set
-                            appropriately BEFORE calling this function.
+
     \author Jim Ursetto
 */
 void mat_transform_sq(void *input, void *output, int veccnt);

--- a/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
+++ b/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
@@ -193,7 +193,7 @@ __BEGIN_DECLS
 #define RT_RX_STATUS_OK     0x0001  /**< \brief Status ok: a good packet was received */
 /** @} */
 
-/** \defgroup bba_config5bits RTL8139C RX Config Register (RT_RXCONFIG) bits
+/** \defgroup bba_configrx RTL8139C RX Config Register (RT_RXCONFIG) bits
 
     From RTL8139C(L) datasheet v1.4.
 

--- a/kernel/arch/dreamcast/include/dc/sq.h
+++ b/kernel/arch/dreamcast/include/dc/sq.h
@@ -86,8 +86,6 @@ void sq_lock(void *dest);
     by KOS; however, they must be called manually when driving the SQs directly from 
     outside this API.
 
-    \param  dest            The address to copy to (32-byte aligned).
-
     \sa sq_lock()
 */
 void sq_unlock(void);

--- a/kernel/arch/dreamcast/include/dc/video.h
+++ b/kernel/arch/dreamcast/include/dc/video.h
@@ -345,7 +345,7 @@ bool vid_get_enabled(void);
     Unlike vid_clear/vid_empty this does not modify any framebuffer.
     Instead it merely sets registers that immediately disable output.
 */
-void vid_set_enabled(bool);
+void vid_set_enabled(bool val);
 
 /** \defgroup video_misc Miscellaneous
     \brief               Miscellaneous video API utilities

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -589,6 +589,7 @@ void snd_stream_start_adpcm(snd_stream_hnd_t hnd, uint32_t freq, int st) {
 
 /* Actually make it go (in queued mode) */
 void snd_stream_queue_go(snd_stream_hnd_t hnd) {
+    (void)hnd;
     CHECK_HND(hnd);
     snd_sh4_to_aica_start();
 }

--- a/kernel/libc/koslib/readdir.c
+++ b/kernel/libc/koslib/readdir.c
@@ -32,7 +32,7 @@ struct dirent *readdir(DIR *dir) {
     else
         dir->d_ent.d_type = DT_REG;
 
-    strncpy(dir->d_ent.d_name, d->name, sizeof(dir->d_name));
+    strncpy(dir->d_name, d->name, sizeof(dir->d_name));
 
     return &dir->d_ent;
 }

--- a/kernel/thread/sem.c
+++ b/kernel/thread/sem.c
@@ -174,6 +174,7 @@ int sem_signal(semaphore_t *sm) {
     /* Is there anyone waiting? If so, pass off to them */
     else if(sm->count < 0) {
         woken = genwait_wake_cnt(sm, 1, 0);
+        (void)woken;
         assert(woken == 1);
         sm->count++;
     }


### PR DESCRIPTION
- All of them were for unused variables. They were being used within `assert()` statements that have now been compiled out.
- Added `(void)` expressions around the variables to get GCC to shut up.
- Also fixed all Doxygen warnings while I was at it.