### PR TITLE
Updated the AUTHORS file to Add 2024 Dates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,7 +27,7 @@ Sam Steele: 2004
 Gil Megidish: 2002
 Florian Schulze: 2002
 Walter van Niftrik: 2005
-Donald Haase: 2008, 2014, 2023
+Donald Haase: 2008, 2014, 2023, 2024
 Andrew Kieschnick: 2000, 2001, 2002, 2003
 Jordan DeLong: 2000, 2001, 2002
 Bero: 2002
@@ -44,10 +44,10 @@ Stefan Galowicz: 2016, 2017
 Luke Benstead: 2020, 2021, 2022, 2023
 Eric Fradella: 2023, 2024
 Falco Girgis: 2023, 2024
-Ruslan Rostovtsev: 2014, 2016, 2023
+Ruslan Rostovtsev: 2014, 2016, 2023, 2024
 Colton Pawielski: 2023
 Andy Barajas: 2023, 2024
-Paul Cercueil: 2023
+Paul Cercueil: 2023, 2024
 
 Files with Specific licenses:
 -----------------------------


### PR DESCRIPTION
Added year 2024 for the following people:

1) Donald Haase (@QuzarDC)
2) Paul Cercueil (@pcercuei)
3) Ruslan Rostovtsev (@DC-SWAT)