### PR TITLE
Fixed kbd build issues due to <stdatomic> in C++

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -652,11 +652,7 @@ static int kbd_attach(maple_driver_t *drv, maple_device_t *dev) {
         state->region = KBD_REGION_US;
 
     /* Make sure all the queue variables are set up properly... */
-    state->queue_tail = state->queue_head = 0;
-
-    const int irqs = irq_disable();
-    state->queue_len = 0;
-    irq_restore(irqs);
+    state->queue_tail = state->queue_head = state->queue_len = 0;
 
     /* Make sure all the key repeat variables are set up properly too */
     state->kbd_repeat_key = KBD_KEY_NONE;

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -379,7 +379,10 @@ void kbd_set_queue(int active) {
 }
 
 /* Take a key scancode, encode it appropriately, and place it on the
-   keyboard queue. At the moment we assume no key overflows. */
+   keyboard queue. At the moment we assume no key overflows.
+
+    NOTE: We are only calling this within an IRQ context, so operations on
+          kbd_state::queue_size are essentially atomic. */
 static int kbd_enqueue(kbd_state_t *state, uint8 keycode, int mods) {
     static char keymap_noshift[] = {
         /*0*/   0, 0, 0, 0, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
@@ -410,10 +413,10 @@ static int kbd_enqueue(kbd_state_t *state, uint8 keycode, int mods) {
         return 0;
 
     /* Queue the key up on the device-specific queue. */
-    if(atomic_load(&state->queue_len) < KBD_QUEUE_SIZE) {
+    if(state->queue_len < KBD_QUEUE_SIZE) {
         state->key_queue[state->queue_head] = keycode | (mods << 8);
         state->queue_head = (state->queue_head + 1) & (KBD_QUEUE_SIZE - 1);
-        atomic_fetch_add(&state->queue_len, 1);
+        ++state->queue_len;
     }
 
     /* If queueing is turned off, don't bother with the global queue. */
@@ -463,12 +466,18 @@ int kbd_queue_pop(maple_device_t *dev, int xlat) {
     uint32 rv, mods;
     uint8 ascii;
 
-    if(!atomic_load(&state->queue_len))
+    const int irqs = irq_disable();
+
+    if(!state->queue_len) {
+        irq_restore(irqs);
         return -1;
+    }
 
     rv = state->key_queue[state->queue_tail];
     state->queue_tail = (state->queue_tail + 1) & (KBD_QUEUE_SIZE - 1);
-    atomic_fetch_sub(&state->queue_len, 1);
+    --state->queue_len;
+
+    irq_restore(irqs);
 
     if(!xlat)
         return (int)rv;
@@ -643,7 +652,11 @@ static int kbd_attach(maple_driver_t *drv, maple_device_t *dev) {
         state->region = KBD_REGION_US;
 
     /* Make sure all the queue variables are set up properly... */
-    state->queue_tail = state->queue_head = state->queue_len = 0;
+    state->queue_tail = state->queue_head = 0;
+
+    const int irqs = irq_disable();
+    state->queue_len = 0;
+    irq_restore(irqs);
 
     /* Make sure all the key repeat variables are set up properly too */
     state->kbd_repeat_key = KBD_KEY_NONE;

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -28,8 +28,6 @@ __BEGIN_DECLS
 #include <arch/types.h>
 #include <dc/maple.h>
 
-#include <stdatomic.h>
-
 /** \defgroup kbd   Keyboard
     \brief          Driver for the Dreamcast's Keyboard Input Device
     \ingroup        peripherals
@@ -299,7 +297,7 @@ typedef struct kbd_state {
     uint32 key_queue[KBD_QUEUE_SIZE];
     int queue_tail;                     /**< \brief Key queue tail. */
     int queue_head;                     /**< \brief Key queue head. */
-    atomic_int queue_len;               /**< \brief Current length of queue. */
+    volatile int queue_len;             /**< \brief Current length of queue. */
 
     uint8 kbd_repeat_key;           /**< \brief Key that is repeating. */
     uint64 kbd_repeat_timer;        /**< \brief Time that the next repeat will trigger. */


### PR DESCRIPTION
- `keyboard.h`'s reliance on `<stdatomic.h>` was breaking C++ builds, since stupid C++ didn't implement compatibilty with this C11 header until C++23.
- Made the atomic `kbd_state_t::queue_len` just a `volatile` integer
- Modified all code touching `queue_len` to do so with interrupts disabled, to essentially emulate atomic behavior.