### PR TITLE
dc-chain: Use treeless clone when git repo is used as source

### DIFF
--- a/utils/dc-chain/scripts/download.mk
+++ b/utils/dc-chain/scripts/download.mk
@@ -127,7 +127,7 @@ GIT_TARGETS = $(foreach target,$(FROM_GIT_REPOS), $(stamp_$(target)_download))
 $(GIT_TARGETS):
 	@echo "+++ Cloning $(git_repo)..."
 	rm -rf $(name)
-	git clone $(git_repo) $(additional_git_args) $(if $(dest),$(dest),$(name))
+	git clone --filter=tree:0 $(git_repo) $(additional_git_args) $(if $(dest),$(dest),$(name))
 	touch $@
 
 


### PR DESCRIPTION
This cuts down drastically on the amount of data downloaded when building from git sources. Commit history is still downloaded so developers can `make fetch` GCC sources and then checkout specific commit IDs, but the tree and blob data will be downloaded by the git client on demand in such case.