### PR TITLE
Fix example warnings and docs in SQ

### DIFF
--- a/examples/dreamcast/Makefile
+++ b/examples/dreamcast/Makefile
@@ -5,7 +5,7 @@
 #
 
 DIRS = 2ndmix basic libdream kgl hello sound png network vmu conio pvr video \
-	   lua parallax modem dreameye sd g1ata lightgun keyboard sdl random rumble \
+	   lua parallax modem dreameye sd g1ata lightgun keyboard sdl dev rumble \
 	   micropython
 
 ifdef KOS_CCPLUS

--- a/examples/dreamcast/basic/exec/exec.c
+++ b/examples/dreamcast/basic/exec/exec.c
@@ -7,8 +7,6 @@
 #include <kos.h>
 #include <assert.h>
 
-#define false (1 == 0)
-
 int main(int argc, char **argv) {
     file_t f;
     void *subelf;

--- a/examples/dreamcast/kgl/basic/gl/gltest.c
+++ b/examples/dreamcast/kgl/basic/gl/gltest.c
@@ -235,7 +235,7 @@ int main(int argc, char **argv) {
     }
 
     pvr_get_stats(&stats);
-    printf("VBL Count: %ld, last_time: %d, frame rate: %f fps\n",
+    printf("VBL Count: %d, last_time: %lld, frame rate: %f fps\n",
            stats.vbl_count, stats.frame_last_time, (double)stats.frame_rate);
 
     return 0;

--- a/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
+++ b/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
+++ b/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
+++ b/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/parallax/delay_cube/delay_cube.c
+++ b/examples/dreamcast/parallax/delay_cube/delay_cube.c
@@ -185,7 +185,7 @@ int main(int argc, char **argv) {
     // You have to keep a watch on these, especially the vertex used
     // for really poly intensive effects.
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
            stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;

--- a/examples/dreamcast/parallax/rotocube/rotocube.c
+++ b/examples/dreamcast/parallax/rotocube/rotocube.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv) {
     // You have to keep a watch on these, especially the vertex used
     // for really poly intensive effects.
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
            stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;

--- a/examples/dreamcast/pvr/pvrmark/pvrmark.c
+++ b/examples/dreamcast/pvr/pvrmark/pvrmark.c
@@ -33,7 +33,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
+++ b/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
@@ -33,7 +33,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
+++ b/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
@@ -33,7 +33,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld frames, frame rate ~%f fps\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d frames, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/pvr/texture_render/texture_render.c
+++ b/examples/dreamcast/pvr/texture_render/texture_render.c
@@ -246,7 +246,7 @@ int main(int argc, char **argv) {
            (double)(counter / ((float)end - start) * 1000.0f));
 
     pvr_get_stats(&stats);
-    printf("From pvr_get_stats:\n\tVBlank Count: %lu\n\tFrame Count: %lu\n",
+    printf("From pvr_get_stats:\n\tVBlank Count: %u\n\tFrame Count: %u\n",
            stats.vbl_count, stats.frame_count);
 
     pvr_mem_free(d_texture);

--- a/kernel/arch/dreamcast/include/dc/sq.h
+++ b/kernel/arch/dreamcast/include/dc/sq.h
@@ -166,7 +166,7 @@ void *sq_fast_cpy(void *dest, const void *src, size_t n);
     \param  n               The number of bytes to set (multiple of 32).
     \return                 The original value of dest.
 
-    \sa sq_set16(), sq_set32(), sq_set_pvr()
+    \sa sq_set16(), sq_set32()
 */
 void *sq_set(void *dest, uint32_t c, size_t n);
 
@@ -185,7 +185,7 @@ void *sq_set(void *dest, uint32_t c, size_t n);
     \param  n               The number of bytes to set (multiple of 32).
     \return                 The original value of dest.
 
-    \sa sq_set(), sq_set32(), sq_set_pvr()
+    \sa sq_set(), sq_set32()
 */
 void *sq_set16(void *dest, uint32_t c, size_t n);
 
@@ -203,7 +203,7 @@ void *sq_set16(void *dest, uint32_t c, size_t n);
     \param  n               The number of bytes to set (multiple of 32).
     \return                 The original value of dest.
 
-    \sa sq_set(), sq_set16(), sq_set_pvr()
+    \sa sq_set(), sq_set16()
 */
 void *sq_set32(void *dest, uint32_t c, size_t n);
 


### PR DESCRIPTION
1. random got moved to dev folder
2. example warnings due to Falcos update of status property types
3. sq_set_pvr() no longer exists and has become a part of the pvr API