### PR TITLE
Makefile.rules: Add rule to create binary executables

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -51,6 +51,9 @@ endif
 %.o: %.S
 	kos-cc -c $< -o $@
 
+%.bin: %.elf
+	kos-objcopy -O binary $< $@
+
 subdirs: $(patsubst %, _dir_%, $(SUBDIRS))
 
 $(patsubst %, _dir_%, $(SUBDIRS)):


### PR DESCRIPTION
Add a rule to create (unscrambled) .bin files from .elf files.