### PR TITLE
Fix atomics with LTO

### DIFF
--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -388,6 +388,7 @@ void arch_menu(void) {
 
 /* Called to shut down non-gracefully; assume the system is in peril
    and don't try to call the dtors */
+__used __noreturn
 void arch_abort(void) {
     /* Disable the WDT, if active */
     wdt_disable();

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -828,6 +828,7 @@ void thd_sleep(unsigned int ms) {
 }
 
 /* Manually cause a re-schedule */
+__used
 void thd_pass(void) {
     /* Makes no sense inside int */
     if(irq_inside_int()) return;


### PR DESCRIPTION
- Use irq_disable() / irq_restore() to emulate atomicity instead of spinlocks;
- Compile atomics.c without LTO to fix link issues.

Fix #367.