### PR TITLE
Patch newlib headers to expose lstat

### DIFF
--- a/utils/dc-chain/patches/newlib-2.0.0-kos.diff
+++ b/utils/dc-chain/patches/newlib-2.0.0-kos.diff
@@ -48,6 +48,19 @@ diff -ruN newlib-2.0.0/newlib/libc/include/machine/_default_types.h newlib-2.0.0
  /*
   * Guess on types by examining *_MIN / *_MAX defines.
   */
+diff --color -ruN newlib-2.0.0/newlib/libc/include/sys/stat.h newlib-2.0.0-kos/newlib/libc/include/sys/stat.h
+--- newlib-2.0.0/newlib/libc/include/sys/stat.h	2012-08-08 05:04:16.000000000 -0600
++++ newlib-2.0.0-kos/newlib/libc/include/sys/stat.h	2024-04-28 15:52:33.080212222 -0600
+@@ -150,8 +150,8 @@
+ int	_EXFUN(stat,( const char *__path, struct stat *__sbuf ));
+ mode_t	_EXFUN(umask,( mode_t __mask ));
+ 
+-#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
+ int	_EXFUN(lstat,( const char *__path, struct stat *__buf ));
++#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
+ int	_EXFUN(mknod,( const char *__path, mode_t __mode, dev_t __dev ));
+ #endif
+ 
 diff -ruN newlib-2.0.0/newlib/libc/include/sys/types.h newlib-2.0.0-kos/newlib/libc/include/sys/types.h
 --- newlib-2.0.0/newlib/libc/include/sys/types.h	2012-07-06 06:41:21.000000000 -0400
 +++ newlib-2.0.0-kos/newlib/libc/include/sys/types.h	2013-05-18 00:23:09.000000000 -0400

--- a/utils/dc-chain/patches/newlib-3.3.0-kos.diff
+++ b/utils/dc-chain/patches/newlib-3.3.0-kos.diff
@@ -202,6 +202,19 @@ diff -ruN newlib-3.3.0/newlib/libc/include/sys/signal.h newlib-3.3.0-kos/newlib/
  
  #if __POSIX_VISIBLE >= 199309
  
+diff --color -ruN newlib-3.3.0/newlib/libc/include/sys/stat.h newlib-3.3.0-kos/newlib/libc/include/sys/stat.h
+--- newlib-3.3.0/newlib/libc/include/sys/stat.h	2020-01-22 03:05:51.000000000 -0700
++++ newlib-3.3.0-kos/newlib/libc/include/sys/stat.h	2024-04-28 16:02:15.494325711 -0600
+@@ -142,8 +142,8 @@
+ int	stat (const char *__restrict __path, struct stat *__restrict __sbuf );
+ mode_t	umask (mode_t __mask );
+ 
+-#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
+ int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
++#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
+ int	mknod (const char *__path, mode_t __mode, dev_t __dev );
+ #endif
+ 
 diff -ruN newlib-3.3.0/newlib/libc/include/sys/_types.h newlib-3.3.0-kos/newlib/libc/include/sys/_types.h
 --- newlib-3.3.0/newlib/libc/include/sys/_types.h	2020-01-22 05:05:51.000000000 -0500
 +++ newlib-3.3.0-kos/newlib/libc/include/sys/_types.h	2021-02-24 21:52:37.951297700 -0500

--- a/utils/dc-chain/patches/newlib-4.3.0.20230120-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.3.0.20230120-kos.diff
@@ -38,6 +38,19 @@ diff --color -ruN newlib-4.3.0.20230120/newlib/libc/include/assert.h newlib-4.3.
  
  #if __STDC_VERSION__ >= 201112L && !defined __cplusplus
  # define static_assert _Static_assert
+diff --color -ruN newlib-4.3.0.20230120/newlib/libc/include/sys/stat.h newlib-4.3.0.20230120-kos/newlib/libc/include/sys/stat.h
+--- newlib-4.3.0.20230120/newlib/libc/include/sys/stat.h	2024-04-28 15:07:54.520453819 -0400
++++ newlib-4.3.0.20230120-kos/newlib/libc/include/sys/stat.h	2023-12-31 12:00:18.000000000 -0500
+@@ -142,8 +142,8 @@
+ int	stat (const char *__restrict __path, struct stat *__restrict __sbuf );
+ mode_t	umask (mode_t __mask );
+ 
++int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
+ #if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__)
+-int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
+ int	mknod (const char *__path, mode_t __mode, dev_t __dev );
+ #endif
+ 
 diff --color -ruN newlib-4.3.0.20230120/newlib/libc/include/sys/_pthreadtypes.h newlib-4.3.0.20230120-kos/newlib/libc/include/sys/_pthreadtypes.h
 --- newlib-4.3.0.20230120/newlib/libc/include/sys/_pthreadtypes.h	2023-02-02 15:26:13.632093035 -0600
 +++ newlib-4.3.0.20230120-kos/newlib/libc/include/sys/_pthreadtypes.h	2023-02-02 15:26:28.805127895 -0600

--- a/utils/dc-chain/patches/newlib-4.4.0.20231231-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.4.0.20231231-kos.diff
@@ -524,3 +524,4 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/ctanl.c newlib-4.4.0
  }
 +#endif
  
+

--- a/utils/dc-chain/patches/newlib-4.4.0.20231231-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.4.0.20231231-kos.diff
@@ -38,6 +38,19 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/assert.h newlib-4.4.
  
  #if __STDC_VERSION__ >= 201112L && !defined __cplusplus
  # define static_assert _Static_assert
+diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/sys/stat.h newlib-4.4.0.20231231-kos/newlib/libc/include/sys/stat.h
+--- newlib-4.4.0.20231231/newlib/libc/include/sys/stat.h	2024-04-28 15:07:54.520453819 -0400
++++ newlib-4.4.0.20231231-kos/newlib/libc/include/sys/stat.h	2023-12-31 12:00:18.000000000 -0500
+@@ -142,8 +142,8 @@
+ int	stat (const char *__restrict __path, struct stat *__restrict __sbuf );
+ mode_t	umask (mode_t __mask );
+ 
++int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
+ #if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__)
+-int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
+ int	mknod (const char *__path, mode_t __mode, dev_t __dev );
+ #endif
+ 
 diff --color -ruN newlib-4.4.0.20231231/newlib/libc/include/sys/_pthreadtypes.h newlib-4.4.0.20231231-kos/newlib/libc/include/sys/_pthreadtypes.h
 --- newlib-4.4.0.20231231/newlib/libc/include/sys/_pthreadtypes.h	2024-02-10 09:30:58.783247676 -0600
 +++ newlib-4.4.0.20231231-kos/newlib/libc/include/sys/_pthreadtypes.h	2024-02-10 09:31:16.329331366 -0600
@@ -510,3 +523,4 @@ diff --color -ruN newlib-4.4.0.20231231/newlib/libm/complex/ctanl.c newlib-4.4.0
  	return w;
  }
 +#endif
+ 


### PR DESCRIPTION
Should resolve https://github.com/KallistiOS/kos-ports/issues/54 issue with libjimtcl and the missing lstat.

For whatever reason, I was getting warnings if I didn't add the extra newline at the end of the first patch file. It takes me quite a while to rebuild my toolchain, so I only actually tested the 4.4.0 and figured that perhaps others could test further back (@darcagn ?) The nature of the patch should mean that it'd be valid all the way back.