### PR TITLE
Fix 'parameter name omitted' errors on older compilers

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -49,7 +49,9 @@ void cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb) {
 }
 
 /* Response callback for the GETCOND Maple command. */
-static void cont_reply(maple_state_t *, maple_frame_t *frm) {
+static void cont_reply(maple_state_t *st, maple_frame_t *frm) {
+    (void)st;
+
     maple_response_t *resp;
     uint32_t         *respbuf;
     cont_cond_t      *raw;

--- a/kernel/arch/dreamcast/hardware/maple/dreameye.c
+++ b/kernel/arch/dreamcast/hardware/maple/dreameye.c
@@ -19,7 +19,9 @@ static int dreameye_send_get_image(maple_device_t *dev,
 
 static dreameye_state_t *first_state = NULL;
 
-static void dreameye_get_image_count_cb(maple_state_t *, maple_frame_t *frame) {
+static void dreameye_get_image_count_cb(maple_state_t *st, maple_frame_t *frame) {
+    (void)st;
+
     dreameye_state_t *de;
     maple_response_t *resp;
     uint32 *respbuf32;
@@ -59,7 +61,9 @@ static void dreameye_get_image_count_cb(maple_state_t *, maple_frame_t *frame) {
     genwait_wake_all(frame);
 }
 
-static void dreameye_get_transfer_count_cb(maple_state_t *, maple_frame_t *frame) {
+static void dreameye_get_transfer_count_cb(maple_state_t *st, maple_frame_t *frame) {
+    (void)st;
+
     dreameye_state_t *de;
     maple_response_t *resp;
     uint32 *respbuf32;
@@ -139,7 +143,9 @@ int dreameye_get_image_count(maple_device_t *dev, int block) {
     return MAPLE_EOK;
 }
 
-static void dreameye_get_image_cb(maple_state_t *, maple_frame_t *frame) {
+static void dreameye_get_image_cb(maple_state_t *st, maple_frame_t *frame) {
+    (void)st;
+
     maple_device_t *dev;
     maple_response_t *resp;
     uint32 *respbuf32;
@@ -327,7 +333,9 @@ fail:
     return MAPLE_EFAIL;
 }
 
-static void dreameye_erase_cb(maple_state_t *, maple_frame_t *frame) {
+static void dreameye_erase_cb(maple_state_t *st, maple_frame_t *frame) {
+    (void)st;
+
     maple_response_t *resp;
     uint8 *respbuf;
 

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -580,7 +580,9 @@ static void kbd_check_poll(maple_frame_t *frm) {
     }
 }
 
-static void kbd_reply(maple_state_t *, maple_frame_t *frm) {
+static void kbd_reply(maple_state_t *st, maple_frame_t *frm) {
+    (void)st;
+
     maple_response_t *resp;
     uint32 *respbuf;
     kbd_state_t *state;

--- a/kernel/arch/dreamcast/hardware/maple/mouse.c
+++ b/kernel/arch/dreamcast/hardware/maple/mouse.c
@@ -9,7 +9,9 @@
 #include <string.h>
 #include <assert.h>
 
-static void mouse_reply(maple_state_t *, maple_frame_t *frm) {
+static void mouse_reply(maple_state_t *st, maple_frame_t *frm) {
+    (void)st;
+
     maple_response_t    *resp;
     uint32          *respbuf;
     mouse_cond_t        *raw;

--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -14,7 +14,9 @@
 /* Be warned, not all purus are created equal, in fact, most of
    them act different for just about everything you feed to them. */
 
-static void purupuru_rumble_cb(maple_state_t *, maple_frame_t *frame) {
+static void purupuru_rumble_cb(maple_state_t *st, maple_frame_t *frame) {
+    (void)st;
+
     /* Unlock the frame */
     maple_frame_unlock(frame);
 

--- a/kernel/arch/dreamcast/hardware/maple/sip.c
+++ b/kernel/arch/dreamcast/hardware/maple/sip.c
@@ -15,7 +15,9 @@
 
 #define SIP_START_SAMPLING 0x80
 
-static void sip_start_sampling_cb(maple_state_t *, maple_frame_t *frame) {
+static void sip_start_sampling_cb(maple_state_t *st, maple_frame_t *frame) {
+    (void)st;
+
     sip_state_t *sip;
     maple_response_t *resp;
 
@@ -36,7 +38,9 @@ static void sip_start_sampling_cb(maple_state_t *, maple_frame_t *frame) {
     genwait_wake_all(frame);
 }
 
-static void sip_stop_sampling_cb(maple_state_t *, maple_frame_t *frame) {
+static void sip_stop_sampling_cb(maple_state_t *st, maple_frame_t *frame) {
+    (void)st;
+
     sip_state_t *sip;
     maple_response_t *resp;
 
@@ -207,7 +211,9 @@ int sip_stop_sampling(maple_device_t *dev, int block) {
     return MAPLE_EOK;
 }
 
-static void sip_reply(maple_state_t *, maple_frame_t *frm) {
+static void sip_reply(maple_state_t *st, maple_frame_t *frm) {
+    (void)st;
+
     maple_response_t *resp;
     uint32 *respbuf;
     sip_state_t *sip;

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -63,7 +63,9 @@ static int vmu_attach(maple_driver_t *drv, maple_device_t *dev) {
     return 0;
 }
 
-static void vmu_poll_reply(maple_state_t *, maple_frame_t *frm) {
+static void vmu_poll_reply(maple_state_t *st, maple_frame_t *frm) {
+    (void)st;
+
     maple_response_t   *resp;
     uint32_t           *respbuf;
     vmu_cond_t         *raw;
@@ -264,7 +266,9 @@ int vmu_set_icon_shape(maple_device_t *dev, uint8_t icon_shape) {
    can stay the same */
 
 /* Callback that unlocks the frame, general use */
-static void vmu_gen_callback(maple_state_t *, maple_frame_t *frame) {
+static void vmu_gen_callback(maple_state_t *st, maple_frame_t *frame) {
+    (void)st;
+
     /* Unlock the frame for the next usage */
     maple_frame_unlock(frame);
 
@@ -412,7 +416,9 @@ void vmu_set_icon(const char *vmu_icon) {
 /* Read the data in block blocknum into buffer, return a -1
    if an error occurs, for now we ignore MAPLE_RESPONSE_FILEERR,
    which will be changed shortly */
-static void vmu_block_read_callback(maple_state_t *, maple_frame_t *frm) {
+static void vmu_block_read_callback(maple_state_t *st, maple_frame_t *frm) {
+    (void)st;
+
     /* Wakey, wakey! */
     genwait_wake_all(frm);
 }
@@ -486,7 +492,9 @@ int vmu_block_read(maple_device_t *dev, uint16_t blocknum, uint8_t *buffer) {
 
 /* writes buffer into block blocknum.  ret a -1 on error.  We don't do anything about the
    maple bus returning file errors, etc, right now, but that will change soon. */
-static void vmu_block_write_callback(maple_state_t *, maple_frame_t *frm) {
+static void vmu_block_write_callback(maple_state_t *st, maple_frame_t *frm) {
+    (void)st;
+
     /* Reset the frame status (but still keep it for us to use) */
     frm->state = MAPLE_FRAME_UNSENT;
 
@@ -661,7 +669,9 @@ int vmu_set_datetime(maple_device_t *dev, time_t unix) {
     return MAPLE_EOK;
 }
 
-static void vmu_get_datetime_callback(maple_state_t *, maple_frame_t *frm) {
+static void vmu_get_datetime_callback(maple_state_t *st, maple_frame_t *frm) {
+    (void)st;
+
     /* Wakey, wakey! */
     genwait_wake_all(frm);
 }


### PR DESCRIPTION
4.7.4 and 9.3.0 toolchains complain about code introduced in #393 

```
controller.c: In function ‘cont_reply’:
controller.c:52:24: error: parameter name omitted
   52 | static void cont_reply(maple_state_t *, maple_frame_t *frm) {
      |                        ^~~~~~~~~~~~~~~
```

This PR adds parameter names to fix these compilation errors.