### PR TITLE
Allow the patched toolchain to support -m4-nofpu

### DIFF
--- a/kernel/arch/dreamcast/kernel/startup.S
+++ b/kernel/arch/dreamcast/kernel/startup.S
@@ -109,6 +109,7 @@ memchk_done:
 	stc	vbr,r1
 	mov.l	r1,@r0
 
+#ifndef __SH4_NOFPU__
 	! Save FPSCR
 	mov.l	old_fpscr_addr,r0
 	sts	fpscr,r1
@@ -119,6 +120,7 @@ memchk_done:
 	mov.l	fpscr_addr,r0
 	jsr	@r0
 	shll16	r4
+#endif
 
 	! Setup a sentinel value for frame pointer in case we're using
 	! FRAME_POINTERS for stack tracing.

--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -128,7 +128,7 @@ enable_objcpp=1
 ### GCC OPTIONS ###
 ###################
 
-### Floating-point precision support (m4-single|m4-single-only|m4)
+### Floating-point precision support (m4-single|m4-single-only|m4|m4-nofpu)
 # Build support for various SH4 floating-point operation ABIs. KallistiOS
 # supports both the single-precision-default ABI (m4-single) and the
 # single-precision-only ABI (m4-single-only). When using m4-single, the SH4 will
@@ -137,12 +137,14 @@ enable_objcpp=1
 # will always be in single-precision mode and 64-bit doubles will be truncated to
 # 32-bit floats. In double-precision mode (m4), which is unsupported by
 # KallistiOS, the SH4 will be in double precision mode upon function entry.
+# Finally in no fpu mode (m4-nofpu), which is also unsupported by KallistiOS and
+# objc/++, there is no support for floating-point operations at all.
 # Historically, m4-single-only was used in both official and homebrew Dreamcast
 # software, but m4-single is the default as of KOS 2.2.0 to increase
 # compatibility with newer libraries which require 64-bit doubles.
 precision_modes=m4-single,m4-single-only
 
-### Default floating-point mode (m4-single|m4-single-only|m4)
+### Default floating-point mode (m4-single|m4-single-only|m4|m4-nofpu)
 # Choose the default floating-point precision ABI used when GCC is invoked. This
 # may be overridden by passing -m4-single, -m4-single-only, or -m4 to GCC.
 default_precision=m4-single

--- a/utils/dc-chain/scripts/patch.mk
+++ b/utils/dc-chain/scripts/patch.mk
@@ -56,7 +56,7 @@ patch-arm-gcc: fetch-arm-gcc
 patch-sh4-gcc: sh-gcc-fixup
 sh-gcc-fixup: fetch-sh-gcc
 	@echo "+++ Copying required KOS files into GCC directory..."
-	cp $(kos_base)/kernel/arch/dreamcast/kernel/startup.s $(src_dir)/libgcc/config/sh/crt1.S
+	cp $(kos_base)/kernel/arch/dreamcast/kernel/startup.S $(src_dir)/libgcc/config/sh/crt1.S
 	cp $(patches)/gcc/gthr-kos.h $(src_dir)/libgcc/config/sh/gthr-kos.h
 	cp $(patches)/gcc/fake-kos.S $(src_dir)/libgcc/config/sh/fake-kos.S
 


### PR DESCRIPTION
As on tin. The startup.S becomes crt1.S in the toolchain. While it's likely pointless to have KOS support that mode, with a few minor changes, it can be used to build dcload-serial.

Needs extra things for obj-c to work, so keeping in draft briefly to see if I can get that sorted out.

Edit: Have rebased this and updated the notes with it to indicate the limitations (can't build KOS with it, no support for objc/cpp).