### PR TITLE
Fanalyzer ffixes

### DIFF
--- a/addons/libppp/ppp.c
+++ b/addons/libppp/ppp.c
@@ -460,6 +460,8 @@ int ppp_set_login(const char *username, const char *password) {
 
     if(password) {
         if(!(pw = (char *)malloc(strlen(password) + 1))) {
+            if(username)
+                free(un);
             mutex_unlock(&mutex);
             return -1;
         }

--- a/kernel/arch/dreamcast/fs/vmufs.c
+++ b/kernel/arch/dreamcast/fs/vmufs.c
@@ -527,6 +527,9 @@ static int vmufs_setup(maple_device_t * dev, vmu_root_t * root, vmu_dir_t ** dir
             goto dead;
         }
 
+        /* Ensure that the dir is 0'd to avoid possible uninitialized reads */
+        memset(*dir, 0, sizeof(*dirsize));
+
         /* Read it */
         if(vmufs_dir_read(dev, root, *dir) < 0) {
             free(*dir);

--- a/kernel/arch/dreamcast/sound/snd_mem.c
+++ b/kernel/arch/dreamcast/sound/snd_mem.c
@@ -89,6 +89,13 @@ int snd_mem_init(uint32 reserve) {
     TAILQ_INIT(&pool);
 
     blk = (snd_block_t *)malloc(sizeof(snd_block_t));
+
+    if(!blk) {
+        spinlock_unlock(&snd_mem_mutex);
+        errno = ENOMEM;
+        return -1;
+    }
+
     memset(blk, 0, sizeof(snd_block_t));
     blk->addr = reserve;
     blk->size = 2 * 1024 * 1024 - reserve;
@@ -190,6 +197,13 @@ uint32 snd_mem_malloc(size_t size) {
 
     /* Nope: break it up into two chunks */
     e = (snd_block_t*)malloc(sizeof(snd_block_t));
+
+    if(e == NULL) {
+        dbglog(DBG_ERROR, "snd_mem_malloc: not enough main memory to alloc(%d)\n", size);
+        spinlock_unlock(&snd_mem_mutex);
+        return 0;
+    }
+
     memset(e, 0, sizeof(snd_block_t));
     e->addr = best->addr + size;
     e->size = best->size - size;

--- a/kernel/fs/fs_null.c
+++ b/kernel/fs/fs_null.c
@@ -38,6 +38,10 @@ static null_fh_t *null_open_file(vfs_handler_t *vfs, const char *fn, int mode) {
 
     /* Malloc a new fh struct */
     fd = malloc(sizeof(null_fh_t));
+    if(!fd) {
+        errno = ENOMEM;
+        return NULL;
+    }
 
     /* Fill in the filehandle struct */
     fd->mode = mode;

--- a/kernel/fs/fs_random.c
+++ b/kernel/fs/fs_random.c
@@ -51,21 +51,21 @@ static rnd_fh_t *rnd_open_file(vfs_handler_t *vfs, const char *fn, int mode) {
     (void) fn;
 
     rnd_fh_t    * fd;       /* file descriptor */
-    int     realmode;
+
+    /* We only allow reading, not writing */
+    if((mode & O_MODE_MASK) != O_RDONLY) {
+        errno = EPERM;
+        return NULL;
 
     /* Malloc a new fh struct */
     fd = malloc(sizeof(rnd_fh_t));
+    if(!fd) {
+        errno = ENOMEM;
+        return NULL;
+    }
 
     /* Fill in the filehandle struct */
     fd->mode = mode;
-
-    realmode = mode & O_MODE_MASK;
-
-    /* We only allow reading, not writing */
-    if(realmode != O_RDONLY) {
-        free(fd);
-        return NULL;
-    }
 
     return fd;
 }


### PR DESCRIPTION
Some small fixes based on -fanalyzer feedback.

The vmufs one is a bit tricky, but vmu_dir_find checks the member filename for 0 to test if it's in use. Without 0-initializing the dir mem, it'll randomly go into the string comparison portion. I'm not 100% sure that it can make a difference since it must first be overwritten by vmu_block_read, but I don't think that's guaranteed to match the full size of the dir buffer.