### PR TITLE
Fix directory reading

### DIFF
--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -66,7 +66,7 @@ struct dirent {
     off_t     d_off;     /**< \brief File offset */
     uint16_t  d_reclen;  /**< \brief Record length */
     uint8_t   d_type;    /**< \brief File type */
-    char      d_name[0]; /**< \brief Filename */
+    char      d_name[NAME_MAX]; /**< \brief Filename */
 };
 
 /** \brief  Type representing a directory stream.
@@ -82,7 +82,6 @@ struct dirent {
 typedef struct {
     file_t          fd;               /**< \brief File descriptor for the directory */
     struct dirent   d_ent;            /**< \brief Current directory entry */
-    char            d_name[NAME_MAX]; /**< \brief Filename */
 } DIR;
 
 // Standard UNIX dir functions. Not all of these are fully functional

--- a/kernel/libc/koslib/readdir.c
+++ b/kernel/libc/koslib/readdir.c
@@ -32,7 +32,7 @@ struct dirent *readdir(DIR *dir) {
     else
         dir->d_ent.d_type = DT_REG;
 
-    strncpy(dir->d_name, d->name, sizeof(dir->d_name));
+    strncpy(dir->d_ent.d_name, d->name, sizeof(dir->d_ent.d_name));
 
     return &dir->d_ent;
 }

--- a/kernel/libc/koslib/readdir.c
+++ b/kernel/libc/koslib/readdir.c
@@ -32,7 +32,7 @@ struct dirent *readdir(DIR *dir) {
     else
         dir->d_ent.d_type = DT_REG;
 
-    strncpy(dir->d_ent.d_name, d->name, sizeof(dir->d_ent.d_name));
+    strncpy(dir->d_ent.d_name, d->name, NAME_MAX);
 
     return &dir->d_ent;
 }


### PR DESCRIPTION
Directory reading in most situations have been broken since #453 .

In order to correct it, the destination of the copy of the strncpy needed to be pointed back to the dirent:d_name which is the correct place for the name to be copied out to from the underlying fs_readdir.

To avoid this confusion in the future I'm also removing the DIR:d_name member. DIR is not guaranteed to have anything other than a dirent struct in it (see https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/dirent.h.html ). It seems that DIR:d_name was some sort of oversight in the original implementation, it was never used intentionally and we explicitly don't guarantee it to be present (following the POSIX spec). It was, in fact, only used in the misleading way to get the size in the same readdir that is problematic.

In addition I'm rolling back the implementation of the zero-length-array member for dirent, which itself was a patch on top of variable-length-array/flexible array member not working correctly in cpp in #499 . From what I can understand from the gcc description of it ( https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html ) it wouldn't have been valid with the previous version of DIR because the d_name char[NAME_MAX] sat after it (I understand the intent is to overflow into it, but the description doesn't seem to say it's guaranteed to work like that). Now with that removed, it may make more sense, but it should be subject to demonstrated testing as it's already led to multiple breaking changes.

In any case, by removing the DIR:d_name member, this gives a strictly larger memory gain than changing the dirent:d_name type did.

