### PR TITLE
fix fb_console's max height

### DIFF
--- a/kernel/arch/dreamcast/util/fb_console.c
+++ b/kernel/arch/dreamcast/util/fb_console.c
@@ -131,7 +131,7 @@ void dbgio_fb_set_target(uint16 *t, int w, int h, int borderx, int bordery) {
     min_x = borderx;
     min_y = bordery;
     max_x = fb_w - borderx;
-    max_y = fb_w - bordery;
+    max_y = fb_h - bordery;
     cur_x = min_x;
     cur_y = min_y;
 }

--- a/kernel/arch/dreamcast/util/fb_console_naomi.c
+++ b/kernel/arch/dreamcast/util/fb_console_naomi.c
@@ -133,7 +133,7 @@ void dbgio_fb_set_target(uint16 *t, int w, int h, int borderx, int bordery) {
     min_x = borderx;
     min_y = bordery;
     max_x = fb_w - borderx;
-    max_y = fb_w - bordery;
+    max_y = fb_h - bordery;
     cur_x = min_x;
     cur_y = min_y;
 }


### PR DESCRIPTION
fixes fb_console taking the screen width as reference for the maximum height