### PR TITLE
maple: Rework device detection, allocation and status buffers

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -221,6 +221,7 @@ static maple_driver_t controller_drv = {
     .functions = MAPLE_FUNC_CONTROLLER,
     .name = "Controller Driver",
     .periodic = cont_periodic,
+    .status_size = sizeof(cont_state_t),
     .attach = NULL,
     .detach = NULL
 };

--- a/kernel/arch/dreamcast/hardware/maple/dreameye.c
+++ b/kernel/arch/dreamcast/hardware/maple/dreameye.c
@@ -433,6 +433,7 @@ static maple_driver_t dreameye_drv = {
     .functions = MAPLE_FUNC_CAMERA,
     .name = "Dreameye (Camera)",
     .periodic = dreameye_periodic,
+    .status_size = sizeof(dreameye_state_t),
     .attach = dreameye_attach,
     .detach = NULL
 };

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -672,6 +672,7 @@ static maple_driver_t kbd_drv = {
     .functions =  MAPLE_FUNC_KEYBOARD,
     .name = "Keyboard Driver",
     .periodic = kbd_periodic,
+    .status_size = sizeof(kbd_state_t),
     .attach = kbd_attach,
     .detach = NULL
 };

--- a/kernel/arch/dreamcast/hardware/maple/maple_enum.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_enum.c
@@ -14,7 +14,7 @@ int maple_enum_count(void) {
 
     for(cnt = 0, p = 0; p < MAPLE_PORT_COUNT; p++)
         for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-            if(maple_state.ports[p].units[u].valid)
+            if(maple_state.ports[p].units[u])
                 cnt++;
         }
 
@@ -23,10 +23,7 @@ int maple_enum_count(void) {
 
 /* Return a raw device info struct for the given device */
 maple_device_t * maple_enum_dev(int p, int u) {
-    if(maple_dev_valid(p, u))
-        return &maple_state.ports[p].units[u];
-    else
-        return NULL;
+    return maple_state.ports[p].units[u];
 }
 
 /* Return the Nth device of the requested type (where N is zero-indexed) */
@@ -103,7 +100,7 @@ maple_device_t * maple_enum_type_ex(int n, uint32 func, uint32 cap) {
    valid before returning. Cast to the appropriate type you're expecting. */
 void * maple_dev_status(maple_device_t *dev) {
     /* The device must be valid, and must get periodic updates. */
-    if(!dev || !dev->valid || !dev->drv || !dev->drv->periodic)
+    if(!dev || !dev->drv || !dev->drv->periodic)
         return NULL;
 
     /* Waits until the first DMA happens: crude but effective (replace me later) */

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -83,8 +83,7 @@ static void maple_hw_init(void) {
     /* Initialize other misc stuff */
     maple_state.vbl_cntr = maple_state.dma_cntr = 0;
     maple_state.detect_port_next = 0;
-    maple_state.detect_unit_next = 0;
-    maple_state.detect_wrapped = 0;
+    maple_state.scan_ready_mask = 0;
     maple_state.gun_port = -1;
     maple_state.gun_x = maple_state.gun_y = -1;
 
@@ -150,7 +149,7 @@ void maple_wait_scan(void) {
     maple_device_t  *dev;
 
     /* Wait for it to finish */
-    while(maple_state.detect_wrapped < 1)
+    while(maple_state.scan_ready_mask != 0xf)
         thd_pass();
 
     /* Enumerate everything */

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -37,23 +37,8 @@
 /* Initialize Hardware (call after driver inits) */
 static void maple_hw_init(void) {
     maple_driver_t *drv;
-    int p, u;
 
     dbglog(DBG_INFO, "maple: active drivers:\n");
-
-    /* Reset structures */
-    for(p = 0; p < MAPLE_PORT_COUNT; p++) {
-        maple_state.ports[p].port = p;
-
-        for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-            maple_state.ports[p].units[u].port = p;
-            maple_state.ports[p].units[u].unit = u;
-            maple_state.ports[p].units[u].valid = 0;
-            maple_state.ports[p].units[u].dev_mask = 0;
-            maple_state.ports[p].units[u].frame.queued = 0;
-            maple_state.ports[p].units[u].frame.state = MAPLE_FRAME_VACANT;
-        }
-    }
 
     TAILQ_INIT(&maple_state.frame_queue);
 
@@ -154,9 +139,9 @@ void maple_wait_scan(void) {
 
     for(p = 0; p < MAPLE_PORT_COUNT; p++) {
         for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-            dev = &maple_state.ports[p].units[u];
+            dev = maple_enum_dev(p, u);
 
-            if(dev->valid) {
+            if(dev) {
                 dbglog(DBG_INFO, "  %c%c: %.30s (%08lx: %s)\n",
                        'A' + p, '0' + u,
                        dev->info.product_name,

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -132,10 +132,7 @@ void maple_hw_shutdown(void) {
     /* Free any attached devices */
     for(cnt = 0, p = 0; p < MAPLE_PORT_COUNT; p++) {
         for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-            if(maple_state.ports[p].units[u].valid) {
-                maple_state.ports[p].units[u].valid = 0;
-                cnt++;
-            }
+            cnt += !!maple_driver_detach(p, u);
         }
     }
 

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -111,6 +111,13 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     maple_device_t      *dev;
     int         p, u;
 
+    if (irq_inside_int() && !malloc_irq_safe()) {
+        /* We can't create or remove a device now. Fail silently as the device
+         * will be re-probed in the next loop of the periodic IRQ. */
+        maple_frame_unlock(frm);
+        return;
+    }
+
     /* So.. did we get a response? */
     resp = (maple_response_t *)frm->recv_buf;
     p = frm->dst_port;

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -8,6 +8,7 @@
 
 #include <malloc.h>
 #include <string.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <assert.h>
 #include <dc/maple.h>
@@ -18,26 +19,27 @@
 /*********************************************************************/
 /* VBlank IRQ handler */
 
+/* Maple frame used for attach/detach detection. */
+static maple_frame_t detect_frame;
+
 /* Fwd declare */
 static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm);
 
 /* Send a DEVINFO command for the given port/unit */
-static void vbl_send_devinfo(maple_state_t *state, int p, int u) {
-    maple_device_t * dev;
-
-    dev = &state->ports[p].units[u];
-
+static bool vbl_send_devinfo(maple_frame_t *frame, int p, int u) {
     /* Reserve access; if we don't get it, forget about it */
-    if(maple_frame_lock(&dev->frame) < 0)
-        return;
+    if(maple_frame_lock(frame) < 0)
+        return false;
 
     /* Setup our autodetect frame to probe at a new device */
-    maple_frame_init(&dev->frame);
-    dev->frame.cmd = MAPLE_COMMAND_DEVINFO;
-    dev->frame.dst_port = p;
-    dev->frame.dst_unit = u;
-    dev->frame.callback = vbl_autodet_callback;
-    maple_queue_frame(&dev->frame);
+    maple_frame_init(frame);
+    frame->cmd = MAPLE_COMMAND_DEVINFO;
+    frame->dst_port = p;
+    frame->dst_unit = u;
+    frame->callback = vbl_autodet_callback;
+    maple_queue_frame(frame);
+
+    return true;
 }
 
 /* Do a potential disconnect on the named device (check to make sure it
@@ -55,35 +57,43 @@ static void vbl_chk_disconnect(maple_state_t *state, int p, int u) {
     }
 }
 
+static void vbl_chk_next_subdev(maple_state_t *state, maple_frame_t *frm, int p) {
+    maple_device_t *dev = maple_enum_dev(p, 0);
+    int u;
+
+    if (dev->probe_mask) {
+        u = __builtin_ffs(dev->probe_mask);
+        dev->probe_mask &= ~(1 << (u - 1));
+
+        vbl_send_devinfo(frm, p, u);
+    } else {
+        /* Nothing else to probe on this port */
+        state->scan_ready_mask |= 1 << p;
+    }
+}
+
+static void vbl_dev_probed(maple_state_t *state, int p, int u) {
+    maple_device_t *dev = maple_enum_dev(p, 0);
+
+    dev->dev_mask |= 1 << (u - 1);
+}
+
 /* Check the sub-devices for a top-level port */
 static void vbl_chk_subdevs(maple_state_t *state, int p, uint8 newmask) {
-    int oldmask, chkmask, u;
+    maple_device_t *dev = maple_enum_dev(p, 0);
+    unsigned int u;
 
-    /* Get the old mask */
-    oldmask = state->ports[p].units[0].dev_mask;
+    newmask &= (1 << (MAPLE_UNIT_COUNT - 1)) - 1;
 
-    /* Is it different from the new mask? */
-    if(oldmask != newmask) {
-        /* Yep -- go through and check the status of each sub-dev */
-        for(u = 1; u < MAPLE_UNIT_COUNT; u++) {
-            chkmask = 1 << (u - 1);
-
-            /* Wasn't set but is set now == newly attached device. Send it a
-               sub-query. Was set but isn't set now == newly detached
-               device. Do a driver detach on it. */
-            if(!(oldmask & chkmask) && (newmask & chkmask)) {
-                /* Send a further query */
-                vbl_send_devinfo(state, p, u);
-            }
-            else if((oldmask & chkmask) && !(newmask & chkmask)) {
-                /* Do a disconnect */
-                vbl_chk_disconnect(state, p, u);
-            }
+    /* Disconnect any device that disappeared */
+    for(u = 1; u < MAPLE_UNIT_COUNT; u++) {
+        if (dev->dev_mask & ~newmask & (1 << (u - 1))) {
+            vbl_chk_disconnect(state, p, u);
         }
-
-        /* Update with the new sub-dev mask */
-        state->ports[p].units[0].dev_mask = newmask;
     }
+
+    dev->dev_mask &= newmask;
+    dev->probe_mask = newmask & ~dev->dev_mask;
 }
 
 /* Handles autodetection of hotswapping; basically every periodic
@@ -98,12 +108,14 @@ static void vbl_chk_subdevs(maple_state_t *state, int p, uint8 newmask) {
    special case instead. */
 static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     maple_response_t    *resp;
+    maple_device_t      *dev;
     int         p, u;
 
     /* So.. did we get a response? */
     resp = (maple_response_t *)frm->recv_buf;
     p = frm->dst_port;
     u = frm->dst_unit;
+    dev = maple_enum_dev(p, u);
 
     if(resp->response == MAPLE_RESPONSE_NONE) {
         /* No device, or not functioning properly; check for removal */
@@ -113,31 +125,32 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
                 vbl_chk_disconnect(state, p, u);
             }
 
-            state->ports[p].units[0].dev_mask = 0;
+            dev->dev_mask = 0;
+            state->scan_ready_mask |= 1 << p;
         }
         else {
             /* Not a top-level device -- only detach this device */
             vbl_chk_disconnect(state, p, u);
         }
+
+        maple_frame_unlock(frm);
     }
     else if(resp->response == MAPLE_RESPONSE_DEVINFO) {
         /* Device is present, check for connections */
-        if(!state->ports[p].units[u].valid) {
+        if(!maple_dev_valid(p, u)) {
 #if MAPLE_IRQ_DEBUG
             dbglog(DBG_KDEBUG, "maple: attach on device %c%c\n",
                    'A' + p, '0' + u);
 #endif
 
             if(maple_driver_attach(frm) >= 0) {
-                assert(state->ports[p].units[u].valid);
+                assert(maple_dev_valid(p, u));
             }
         }
         else {
             maple_devinfo_t     *devinfo;
-            maple_device_t      *dev;
             /* Device already connected, update function data (caps) */
             devinfo = (maple_devinfo_t *)resp->data;
-            dev = &state->ports[p].units[u];
             dev->info.function_data[0] = devinfo->function_data[0];
             dev->info.function_data[1] = devinfo->function_data[1];
             dev->info.function_data[2] = devinfo->function_data[2];
@@ -147,35 +160,35 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
            sub-devices that claim to be attached */
         if(u == 0)
             vbl_chk_subdevs(state, p, resp->src_addr);
+        else
+            vbl_dev_probed(state, p, u);
+
+        maple_frame_unlock(frm);
+
+        /* Probe the next sub-device */
+        vbl_chk_next_subdev(state, frm, p);
     }
     else {
         /* dbglog(DBG_KDEBUG, "maple: unknown response %d on device %c%c\n",
             resp->response, 'A'+p, '0'+u); */
-    }
-
-    maple_frame_unlock(frm);
-}
-
-/* Move on to the next device for next time */
-static void vbl_ad_advance(maple_state_t *state) {
-    state->detect_port_next++;
-
-    if(state->detect_port_next >= MAPLE_PORT_COUNT) {
-        state->detect_port_next = 0;
-        state->detect_wrapped++;
+        maple_frame_unlock(frm);
     }
 }
 
 static void vbl_autodetect(maple_state_t *state) {
-    int p, u;
+    bool queued;
 
     /* Queue a detection on the next device */
-    p = state->detect_port_next;
-    u = state->detect_unit_next;
-    vbl_send_devinfo(state, p, u);
+    queued = vbl_send_devinfo(&detect_frame,
+                              state->detect_port_next, 0);
 
     /* Move to the next device */
-    vbl_ad_advance(state);
+    if (queued) {
+        state->detect_port_next++;
+
+        if(state->detect_port_next >= MAPLE_PORT_COUNT)
+            state->detect_port_next = 0;
+    }
 }
 
 /* Called on every VBL (~60fps) */

--- a/kernel/arch/dreamcast/hardware/maple/maple_queue.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_queue.c
@@ -99,7 +99,7 @@ int maple_queue_frame(maple_frame_t *frame) {
         save = irq_disable();
 
     /* Assign it a device, if applicable */
-    frame->dev = &maple_state.ports[frame->dst_port].units[frame->dst_unit];
+    frame->dev = maple_enum_dev(frame->dst_port, frame->dst_unit);
 
     /* Put it on the queue */
     TAILQ_INSERT_TAIL(&maple_state.frame_queue, frame, frameq);

--- a/kernel/arch/dreamcast/hardware/maple/maple_utils.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_utils.c
@@ -147,7 +147,7 @@ const char * maple_perror(int response) {
 
 /* Determine if a given device is valid */
 int maple_dev_valid(int p, int u) {
-    return maple_state.ports[p].units[u].valid;
+    return !!maple_enum_dev(p, u);
 }
 
 int maple_gun_enable(int port) {

--- a/kernel/arch/dreamcast/hardware/maple/mouse.c
+++ b/kernel/arch/dreamcast/hardware/maple/mouse.c
@@ -76,6 +76,7 @@ static maple_driver_t mouse_drv = {
     .functions = MAPLE_FUNC_MOUSE,
     .name = "Mouse Driver",
     .periodic = mouse_periodic,
+    .status_size = sizeof(mouse_state_t),
     .attach = NULL,
     .detach = NULL
 };

--- a/kernel/arch/dreamcast/hardware/maple/sip.c
+++ b/kernel/arch/dreamcast/hardware/maple/sip.c
@@ -299,6 +299,7 @@ static maple_driver_t sip_drv = {
     .functions = MAPLE_FUNC_MICROPHONE,
     .name = "Sound Input Peripheral",
     .periodic = sip_periodic,
+    .status_size = sizeof(sip_state_t),
     .attach = sip_attach,
     .detach = NULL
 };

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -148,6 +148,7 @@ static maple_driver_t vmu_drv = {
     .functions = MAPLE_FUNC_MEMCARD | MAPLE_FUNC_LCD | MAPLE_FUNC_CLOCK,
     .name = "VMU Driver",
     .periodic = NULL,
+    .status_size = sizeof(vmu_state_t),
     .attach = vmu_attach,
     .detach = NULL
 };

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -269,7 +269,6 @@ typedef struct maple_response {
 */
 typedef struct maple_device {
     /* Public */
-    int             valid;  /**< \brief Is this a valid device? */
     int             port;   /**< \brief Maple bus port connected to */
     int             unit;   /**< \brief Unit number, off of the port */
     maple_devinfo_t info;   /**< \brief Device info struct */
@@ -298,7 +297,7 @@ typedef struct maple_device {
 */
 typedef struct maple_port {
     int             port;                       /**< \brief Port ID */
-    maple_device_t  units[MAPLE_UNIT_COUNT];    /**< \brief Pointers to active units */
+    maple_device_t *units[MAPLE_UNIT_COUNT];    /**< \brief Pointers to active units */
 } maple_port_t;
 
 /** \brief   A maple device driver.

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -280,7 +280,7 @@ typedef struct maple_device {
     struct maple_driver     *drv;           /**< \brief Driver which handles this device */
 
     volatile int            status_valid;   /**< \brief Have we got our first status update? */
-    uint8                   status[1024];   /**< \brief Status buffer (for pollable devices) */
+    uint8                   *status;        /**< \brief Status buffer (for pollable devices) */
 } maple_device_t;
 
 #define MAPLE_PORT_COUNT    4   /**< \brief Number of ports on the bus */
@@ -316,6 +316,8 @@ typedef struct maple_driver {
 
     uint32      functions;  /**< \brief One or more MAPLE_FUNCs ORed together */
     const char  *name;      /**< \brief The driver name */
+
+    size_t      status_size;/**< \brief The size of the status buffer */
 
     /* Callbacks, to be filled in by the driver */
 

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -281,7 +281,8 @@ typedef struct maple_device {
     uint8                   dev_mask;       /**< \brief Device-present mask for unit 0's */
 
     volatile uint8          status_valid;   /**< \brief Have we got our first status update? */
-    uint8                   *status;        /**< \brief Status buffer (for pollable devices) */
+
+    uint32                  status[];       /**< \brief Status buffer (for pollable devices) */
 } maple_device_t;
 
 #define MAPLE_PORT_COUNT    4   /**< \brief Number of ports on the bus */

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -275,11 +275,13 @@ typedef struct maple_device {
     maple_devinfo_t info;   /**< \brief Device info struct */
 
     /* Private */
-    int                     dev_mask;       /**< \brief Device-present mask for unit 0's */
     maple_frame_t           frame;          /**< \brief One rx/tx frame */
     struct maple_driver     *drv;           /**< \brief Driver which handles this device */
 
-    volatile int            status_valid;   /**< \brief Have we got our first status update? */
+    uint8                   probe_mask;     /**< \brief Mask of sub-devices left to probe */
+    uint8                   dev_mask;       /**< \brief Device-present mask for unit 0's */
+
+    volatile uint8          status_valid;   /**< \brief Have we got our first status update? */
     uint8                   *status;        /**< \brief Status buffer (for pollable devices) */
 } maple_device_t;
 
@@ -383,13 +385,10 @@ typedef struct maple_state_str {
     volatile int                dma_in_progress;
 
     /** \brief  Next port that will be auto-detected */
-    int                         detect_port_next;
+    uint8                       detect_port_next;
 
-    /** \brief  Next unit which will be auto-detected */
-    int                         detect_unit_next;
-
-    /** \brief  Did the detect wrap? */
-    volatile int                detect_wrapped;
+    /** \brief  Mask of ports that completed the initial scan */
+    volatile uint8              scan_ready_mask;
 
     /** \brief  Our vblank handler handle */
     int                         vbl_handle;


### PR DESCRIPTION
This PR updates the maple code to use smaller amounts of dynamically allocated memory, instead of huge amounts of statically allocated memory.

- Status buffers are now allocated to the right size;
- Maple device structures are only created for connected devices.

This required to change the detection mechanism, as it was now impossible to use a different maple frame for each possible combination of [port]x[unit]. The periodic detection will now use its own statically allocated maple frame and will only detect unit 0s; sub-devices will be detected using the unit 0's frame.

Additionally, maple devices are now properly detached on shutdown.

This saves about 48 KiB of static RAM.