### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ kernel/arch/dreamcast/sound/arm/stream.drv
 lib/dreamcast/*.a
 addons/lib/dreamcast/*.a
 utils/bincnv/bincnv
+utils/bincnv/bincnv.dSYM/
 utils/genromfs/genromfs
 utils/vqenc/vqenc
 utils/wav2adpcm/wav2adpcm

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ utils/naomibintool/naomibintool
 utils/naominetboot/naominetboot
 examples/dreamcast/basic/exec/romdisk/sub.bin
 examples/dreamcast/kgl/basic/vq/fruit.vq
+examples/dreamcast/kgl/nehe/nehe26/data/txt2bin
 examples/dreamcast/conio/adventure/data.c
 examples/dreamcast/conio/adventure/datagen
 examples/dreamcast/png/romdisk_boot.img

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ kernel/arch/dreamcast/sound/arm/stream.drv
 lib/dreamcast/*.a
 addons/lib/dreamcast/*.a
 utils/bincnv/bincnv
-utils/bincnv/bincnv.dSYM/
 utils/genromfs/genromfs
 utils/vqenc/vqenc
 utils/wav2adpcm/wav2adpcm

--- a/utils/bincnv/Makefile
+++ b/utils/bincnv/Makefile
@@ -7,7 +7,7 @@
 all: bincnv
 
 bincnv: bincnv.c
-	gcc -g -o bincnv bincnv.c
+	gcc -o bincnv bincnv.c
 
 clean:
 	-rm -f bincnv


### PR DESCRIPTION
This PR adds two items to .gitignore:
1.  utils/bincnv/bincnv.dSYM/ : This always shows up when compiling kos for me.
2.  examples/dreamcast/kgl/nehe/nehe26/data/txt2bin : When the makefile in data folder ran.