### PR TITLE
Bumped KOS's Default C and C++ Versions to 11

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -41,8 +41,8 @@ export KOS_CPPFLAGS="${KOS_CPPFLAGS} ${KOS_INC_PATHS_CPP} -fno-operator-names"
 # Which standards modes we want to compile for
 # Note that this only covers KOS itself, not necessarily anything else compiled
 # with kos-cc or kos-c++.
-export KOS_CSTD="-std=c99"
-export KOS_CPPSTD="-std=gnu++98"
+export KOS_CSTD="-std=c11"
+export KOS_CPPSTD="-std=gnu++11"
 
 export KOS_GCCVER="`kos-cc -dumpversion`"
 

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -41,7 +41,7 @@ export KOS_CPPFLAGS="${KOS_CPPFLAGS} ${KOS_INC_PATHS_CPP} -fno-operator-names"
 # Which standards modes we want to compile for
 # Note that this only covers KOS itself, not necessarily anything else compiled
 # with kos-cc or kos-c++.
-export KOS_CSTD="-std=c17"
+export KOS_CSTD="-std=gnu17"
 export KOS_CPPSTD="-std=gnu++17"
 
 export KOS_GCCVER="`kos-cc -dumpversion`"

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -41,8 +41,8 @@ export KOS_CPPFLAGS="${KOS_CPPFLAGS} ${KOS_INC_PATHS_CPP} -fno-operator-names"
 # Which standards modes we want to compile for
 # Note that this only covers KOS itself, not necessarily anything else compiled
 # with kos-cc or kos-c++.
-export KOS_CSTD="-std=c11"
-export KOS_CPPSTD="-std=gnu++11"
+export KOS_CSTD="-std=c17"
+export KOS_CPPSTD="-std=gnu++17"
 
 export KOS_GCCVER="`kos-cc -dumpversion`"
 


### PR DESCRIPTION
Yes, this is quite an opinionated change, but enough people have brought it up and have talked about wanting to do it, that I thought now might be a good time to get it in the open...

We're hoping to move KOS to `C11`, because we keep running into things that we're missing from `C99` and would like to leverage, such as:
- `_Alignas()`
- `_Alignof()`
- `_Noreturn`
- `_Generic()` (okay, maybe this one's just me ;) )
- anonymous structures/unions
- `_Static_assert()` (we keep reinventing this)

There are a bunch of arguments that have been made that even the Linux kernel is `C11`, but I'm wondering if, assuming people are okay with this, if we should just go to `C17`, since it's been supported on all compilers, even the ones we deprecated, and it's seen as just a "bugfix" revision to fix up what `C11` added? 

Also... Honestly what is this C++ version even for? It's  not like we have C++ code in KOS or anything, and even GCC9 was defaulting to C++17... so if we're okay with bumping it up even higher, because it's mostly serving as a default for *external code*, I think we should go to 17. 

Yes, I verified that everything builds and works great with C11, at least. 