### PR TITLE
Fix mke2fs example with Raylib Installed

### DIFF
--- a/examples/dreamcast/sd/mke2fs/Makefile
+++ b/examples/dreamcast/sd/mke2fs/Makefile
@@ -8,7 +8,7 @@ OBJS = mke2fs.o
 
 # We need the private headers from libkosext2fs, since we're not using the
 # facilities of fs_ext2 here.
-KOS_CFLAGS += -I$(KOS_BASE)/addons/libkosext2fs -Werror -W -std=gnu99
+KOS_CFLAGS := -I$(KOS_BASE)/addons/libkosext2fs -Werror -W -std=gnu99 $(KOS_CFLAGS)
 
 all: rm-elf $(TARGET)
 


### PR DESCRIPTION
In a cruel twist of fate, if you have Raylib installed into KOS-ports, the mke2fs example will no longer build... Why? Because the include for "utils.h" will pick up the one in kos-ports from Raylib before picking up the one in the ext2fs addon directory.

- Swapped the order for the Makefile's extra include directory flag to ensure that it comes before kos-ports