### PR TITLE
Avoid conditionally-compiled code & fix NAOMI build

### DIFF
--- a/include/kos/platform.h
+++ b/include/kos/platform.h
@@ -1,0 +1,28 @@
+/* KallistiOS ##version##
+
+   include/kos/platform.h
+   Copyright (C) 2024 Paul Cercueil
+
+*/
+
+/** \file   kos/platform.h
+    \brief  Platform detection macros.
+    \author Paul Cercueil
+*/
+
+#ifndef __KOS_PLATFORM_H
+#define __KOS_PLATFORM_H
+
+#ifdef __NAOMI__
+#  define KOS_PLATFORM_IS_NAOMI 1
+#else
+#  define KOS_PLATFORM_IS_NAOMI 0
+#endif
+
+#ifdef __DREAMCAST__
+#  define KOS_PLATFORM_IS_DREAMCAST 1
+#else
+#  define KOS_PLATFORM_IS_DREAMCAST 0
+#endif
+
+#endif /* __KOS_PLATFORM_H */

--- a/kernel/arch/dreamcast/hardware/hardware.c
+++ b/kernel/arch/dreamcast/hardware/hardware.c
@@ -93,7 +93,8 @@ void hardware_shutdown(void) {
             if (!KOS_PLATFORM_IS_NAOMI)
                 KOS_INIT_FLAG_CALL(bba_la_shutdown);
             KOS_INIT_FLAG_CALL(maple_shutdown);
-            KOS_INIT_FLAG_CALL(cdrom_shutdown);
+            if (!KOS_PLATFORM_IS_NAOMI)
+                KOS_INIT_FLAG_CALL(cdrom_shutdown);
             g2_dma_shutdown();
             spu_shutdown();
             vid_shutdown();

--- a/kernel/arch/dreamcast/hardware/hardware.c
+++ b/kernel/arch/dreamcast/hardware/hardware.c
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <arch/arch.h>
 #include <kos/init.h>
+#include <kos/platform.h>
 #include <dc/spu.h>
 #include <dc/video.h>
 #include <dc/cdrom.h>
@@ -57,21 +58,18 @@ void bba_la_shutdown(void) {
 KOS_INIT_FLAG_WEAK(bba_la_init, false);
 KOS_INIT_FLAG_WEAK(bba_la_shutdown, false);
 KOS_INIT_FLAG_WEAK(maple_init, true);
-
-#ifndef _arch_sub_naomi
 KOS_INIT_FLAG_WEAK(cdrom_init, true);
 KOS_INIT_FLAG_WEAK(cdrom_shutdown, true);
-#endif
 
 int hardware_periph_init(void) {
     /* Init sound */
     spu_init();
     g2_dma_init();
 
-#ifndef _arch_sub_naomi
-    /* Init CD-ROM.. NOTE: NO GD-ROM SUPPORT. ONLY CDs/CDRs. */
-    KOS_INIT_FLAG_CALL(cdrom_init);
-#endif
+    if (!KOS_PLATFORM_IS_NAOMI) {
+        /* Init CD-ROM.. NOTE: NO GD-ROM SUPPORT. ONLY CDs/CDRs. */
+        KOS_INIT_FLAG_CALL(cdrom_init);
+    }
 
     /* Setup maple bus */
     KOS_INIT_FLAG_CALL(maple_init);
@@ -79,9 +77,8 @@ int hardware_periph_init(void) {
     /* Init video */
     vid_init(DEFAULT_VID_MODE, DEFAULT_PIXEL_MODE);
 
-#ifndef _arch_sub_naomi
-    KOS_INIT_FLAG_CALL(bba_la_init);
-#endif
+    if (!KOS_PLATFORM_IS_NAOMI)
+        KOS_INIT_FLAG_CALL(bba_la_init);
 
     initted = 2;
 
@@ -93,9 +90,8 @@ KOS_INIT_FLAG_WEAK(maple_shutdown, true);
 void hardware_shutdown(void) {
     switch(initted) {
         case 2:
-#ifndef _arch_sub_naomi
-            KOS_INIT_FLAG_CALL(bba_la_shutdown);
-#endif
+            if (!KOS_PLATFORM_IS_NAOMI)
+                KOS_INIT_FLAG_CALL(bba_la_shutdown);
             KOS_INIT_FLAG_CALL(maple_shutdown);
             KOS_INIT_FLAG_CALL(cdrom_shutdown);
             g2_dma_shutdown();

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <kos/thread.h>
 #include <kos/genwait.h>
+#include <kos/platform.h>
 #include <dc/maple.h>
 #include <dc/maple/vmu.h>
 #include <dc/math.h>
@@ -237,8 +238,10 @@ int vmu_set_custom_color(maple_device_t *dev, uint8_t red, uint8_t green, uint8_
    for icon_shape are listed in the biosfont.h and start with
    BFONT_ICON_VMUICON. */
 int vmu_set_icon_shape(maple_device_t *dev, uint8_t icon_shape) {
-#ifndef _arch_sub_naomi
     vmu_root_t root;
+
+    if (KOS_PLATFORM_IS_NAOMI)
+        return -1;
 
     if(icon_shape < BFONT_ICON_VMUICON || icon_shape > BFONT_ICON_EMBROIDERY)
         return -1;
@@ -255,11 +258,6 @@ int vmu_set_icon_shape(maple_device_t *dev, uint8_t icon_shape) {
         return -1;
 
     return 0;
-#else
-    (void)dev;
-    (void)icon_shape;
-    return -1;
-#endif
 }
 
 /* These interfaces will probably change eventually, but for now they

--- a/kernel/arch/dreamcast/hardware/video.c
+++ b/kernel/arch/dreamcast/hardware/video.c
@@ -10,6 +10,7 @@
 #include <dc/video.h>
 #include <dc/pvr.h>
 #include <dc/sq.h>
+#include <kos/platform.h>
 #include <string.h>
 #include <stdio.h>
 
@@ -210,18 +211,18 @@ uint32_t      *vram_l;
    [This is the old KOS function by Megan.]
 */
 int8_t vid_check_cable(void) {
-#ifndef _arch_sub_naomi
     volatile uint32_t * porta = (vuint32 *)0xff80002c;
+
+    if (KOS_PLATFORM_IS_NAOMI) {
+        /* XXXX: This still needs to be figured out for NAOMI. For now, assume
+           VGA mode. */
+        return CT_VGA;
+    }
 
     *porta = (*porta & 0xfff0ffff) | 0x000a0000;
 
     /* Read port8 and port9 */
     return (*((volatile uint16_t*)(porta + 1)) >> 8) & 3;
-#else
-    /* XXXX: This still needs to be figured out for NAOMI. For now, assume
-       VGA mode. */
-    return CT_VGA;
-#endif
 }
 
 /*-----------------------------------------------------------------------------*/


### PR DESCRIPTION
Conditionally-compiled code (wrapped by #ifdef/#ifndef guards) is
problematic; because it is very difficult to compile-test all possible
combinations of the various flags verified by the guard macros.

Instead, evaluate compile-time constants, which will cause the compiler
to compile the exact same code independently of the configuration, which
means if it compiles for one configuration, it will compile for all
configurations. The compiler will then be smart enough to
garbage-collect dead code, dropping everything not included in the
current configuration.