### PR TITLE
Add watchdog timers + use watchdog timer in modem code

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -227,6 +227,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Add timer_spin_delay_{us,ns} and use them in scif-spi [PC]
 - *** Added thread support for tracking CPU time + updated clock_gettime() [FG]
 - *** Added support for one-shot timers [PC]
+- DC  Use one-shot timers for timeout and a proper polling mechanism in modem [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -226,6 +226,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - DC  Added new System Calls module [AB]
 - DC  Add timer_spin_delay_{us,ns} and use them in scif-spi [PC]
 - *** Added thread support for tracking CPU time + updated clock_gettime() [FG]
+- *** Added support for one-shot timers [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/oneshot_timer.h
+++ b/include/kos/oneshot_timer.h
@@ -1,0 +1,124 @@
+/* KallistiOS ##version##
+
+   include/kos/oneshot_timer.h
+   Copyright (C) 2024 Paul Cercueil
+*/
+
+/** \file    kos/oneshot_timer.h
+    \brief   One-shot timer support.
+    \ingroup kthreads
+
+    This file contains the one-shot timer API. A one-shot timer is a timer that
+    will trigger an action (through a pre-registered callback) after a timeout
+    expires.
+
+    \author Paul Cercueil
+
+    \see    kos/thread.h
+    \see    kos/worker_thread.h
+*/
+
+#ifndef __KOS_ONESHOT_TIMER_H
+#define __KOS_ONESHOT_TIMER_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+struct oneshot_timer;
+
+/** \struct  oneshot_timer_t
+    \brief   Opaque structure describing one one-shot timer.
+*/
+typedef struct oneshot_timer oneshot_timer_t;
+
+/** \brief       Create a new one-shot timer.
+    \relatesalso oneshot_timer_t
+
+    This function will create a one-shot timer using the specified callback,
+    programmed to expire after the given timeout. The timer will be stopped
+    by default and still need to be started using oneshot_timer_start().
+
+    \param  cb              The function to call in case the one-shot timer
+                            expires.
+    \param  data            A parameter to pass to the function called.
+    \param  timeout_ms      The timeout value for the one-shot timer, in
+                            milliseconds.
+
+    \return                 The new one-shot timer on success, NULL on failure.
+
+    \sa oneshot_timer_destroy, oneshot_timer_start
+*/
+oneshot_timer_t *oneshot_timer_create(void (*cb)(void *), void *data,
+                                      unsigned int timeout_ms);
+
+/** \brief       Stop and destroy a one-shot timer.
+    \relatesalso oneshot_timer_t
+
+    This function will stop the one-shot timer and free its memory.
+
+    \param  timer           A pointer to the one-shot timer.
+
+    \sa oneshot_timer_create
+*/
+void oneshot_timer_destroy(oneshot_timer_t *timer);
+
+/** \brief       Re-configure a one-shot timer.
+    \relatesalso oneshot_timer_t
+
+    This function can be used to change the registered callback or the timeout.
+    Using it on a running timer is unsupported.
+
+    \param  timer           A pointer to the one-shot timer.
+    \param  cb              The function to call in case the one-shot timer
+                            expires.
+    \param  data            A parameter to pass to the function called.
+    \param  timeout_ms      The timeout value for the one-shot timer, in
+                            milliseconds.
+
+    \sa oneshot_timer_stop, oneshot_timer_start
+*/
+void oneshot_timer_setup(oneshot_timer_t *timer, void (*cb)(void *),
+                         void *data, unsigned int timeout_ms);
+
+/** \brief       Start a one-shot timer.
+    \relatesalso oneshot_timer_t
+
+    This function will start the one-shot timer. If not stopped until the
+    timeout value expires, the one-shot timer will call the registered
+    callback function.
+
+    \param  timer           A pointer to the one-shot timer.
+
+    \sa oneshot_timer_stop, oneshot_timer_reset
+*/
+void oneshot_timer_start(oneshot_timer_t *timer);
+
+/** \brief       Stop a one-shot timer.
+    \relatesalso oneshot_timer_t
+
+    This function will stop the one-shot timer. If it already expired, this
+    function does nothing. If it did not expire yet, the one-shot timer is
+    stopped and the registered callback won't be called.
+
+    \param  timer           A pointer to the one-shot timer.
+
+    \sa oneshot_timer_start, oneshot_timer_reset
+*/
+void oneshot_timer_stop(oneshot_timer_t *timer);
+
+/** \brief       Reset a one-shot timer.
+    \relatesalso oneshot_timer_t
+
+    A convenience function to reset the one-shot timer by stopping it then
+    starting it again.
+
+    \param  timer           A pointer to the one-shot timer.
+
+    \sa oneshot_timer_start, oneshot_timer_stop
+*/
+static inline void oneshot_timer_reset(oneshot_timer_t *timer) {
+    oneshot_timer_stop(timer);
+    oneshot_timer_start(timer);
+}
+
+#endif /* __KOS_ONESHOT_TIMER_H */

--- a/kernel/arch/dreamcast/hardware/modem/mintern.h
+++ b/kernel/arch/dreamcast/hardware/modem/mintern.h
@@ -37,8 +37,8 @@
 /* Internal flag bits */
 #define MODEM_INTERNAL_FLAG_INIT_ATEXIT       0x1 /* Set when atexit from modem_init is called */
 #define MODEM_INTERNAL_FLAG_INT_INIT_ATEXIT   0x2 /* Set when atexit from modemIntInit is called */
-#define MODEM_INTERNAL_FLAG_TIMER_HANDLER_SET 0x4 /* The interrupt handler for TMU1 has been set */
-#define MODEM_INTERNAL_FLAG_TIMER_RUNNING     0x8 /* TMU1 is running */
+#define MODEM_INTERNAL_FLAG_TIMER_HANDLER_SET 0x4 /* The timeout callback has been registered */
+#define MODEM_INTERNAL_FLAG_TIMER_RUNNING     0x8 /* The timeout timer is running */
 
 /* Configuration flag bits */
 #define MODEM_CFG_FLAG_ORIGINATE       0x1  /* Set if the MDP is originating, clear when the MDP is answering */

--- a/kernel/arch/dreamcast/hardware/modem/mintern.h
+++ b/kernel/arch/dreamcast/hardware/modem/mintern.h
@@ -112,11 +112,6 @@ void modemIntSetupProtocolInterrupts(int clear);
 void modemIntConfigModem(void);
 void modemIntSetHandler(int protocol, int mode);
 void modemIntResetControlCode(void);
-void modemIntSetupTimeoutTimer(int bps, unsigned char *callbackFlag,
-                               void (*callbackCode)(void));
-void modemIntStartTimeoutTimer(void);
-void modemIntResetTimeoutTimer(void);
-void modemIntShutdownTimeoutTimer(void);
 void modemInternalSetupDialingInts(int clear);
 
 /* From modem.c */

--- a/kernel/arch/dreamcast/hardware/modem/mintr.c
+++ b/kernel/arch/dreamcast/hardware/modem/mintr.c
@@ -1,7 +1,8 @@
 /* KallistiOS ##version##
 
    mintr.c
-   Copyright (C)2002, 2004 Nick Kochakian
+   Copyright (C) 2002, 2004 Nick Kochakian
+   Copyright (C) 2024 Paul Cercueil
 
    Distributed under the terms of the KOS license.
 */
@@ -12,55 +13,48 @@
 #include <dc/asic.h>
 #include <arch/rtc.h>
 #include <kos.h>
+#include <kos/oneshot_timer.h>
 #include "dc/modem/modem.h"
 #include "mintern.h"
 
 /* Forward declarations */
 static void modemIntResetTimeoutTimer(void);
 static void modemIntShutdownTimeoutTimer(void);
-static void modemIntSetupTimeoutTimer(int bps, void (*callbackCode)(void));
+static void modemIntSetupTimeoutTimer(unsigned int timeout_secs,
+                                      void (*callbackCode)(void *));
 static void modemIntStartTimeoutTimer(void);
+
+static oneshot_timer_t *oneshot;
 
 /* This controls the code that's executed during a modem generated interrupt */
 void (*modemCallbackCode)(void) = NULL;
 
-/* Flag pointer and function callback used by the timeout timer */
-void (*modemTimeoutCallbackCode)(void) = NULL;
+void mintDelayCallback(void *d) {
+    (void)d;
 
-/* This is used for a slight delay after connection. The Dreamcast's modem
-   seems to jump into a ready state faster than my computer's modem which
-   can cause problems if nothing's done about it. */
-int mintCounter = 0; /* mm mints */
+    modemIntResetTimeoutTimer();
+    modemIntShutdownTimeoutTimer();
 
-void mintDelayCallback(void) {
-    mintCounter++;
+    modemCfg.flags &= ~MODEM_CFG_FLAG_CONNECTING;
+    modemCfg.flags |= MODEM_CFG_FLAG_CONNECTED;
 
-    if(mintCounter >= 5) {
-        modemIntResetTimeoutTimer();
-        modemIntShutdownTimeoutTimer();
-        mintCounter = 0; /* Reset the counter for subsequent connections */
+    /* Reset the EQM configuration data */
+    modemCfg.eqm.flags       = 0;
+    modemCfg.eqm.attempts    = 0;
+    modemCfg.eqm.counter     = 0;
+    modemCfg.eqm.lastCounter = 0;
+    modemCfg.eqm.auxCounter  = 0;
 
-        modemCfg.flags &= ~MODEM_CFG_FLAG_CONNECTING;
-        modemCfg.flags |= MODEM_CFG_FLAG_CONNECTED;
+    /* Setup the connection interrupts */
+    modemIntSetupConnectionInterrupts(0);
 
-        /* Reset the EQM configuration data */
-        modemCfg.eqm.flags       = 0;
-        modemCfg.eqm.attempts    = 0;
-        modemCfg.eqm.counter     = 0;
-        modemCfg.eqm.lastCounter = 0;
-        modemCfg.eqm.auxCounter  = 0;
+    modemDataClearBuffers();
 
-        /* Setup the connection interrupts */
-        modemIntSetupConnectionInterrupts(0);
+    modemDataUpdateTXBuffer();
+    modemDataUpdateRXBuffer();
 
-        modemDataClearBuffers();
-
-        modemDataUpdateTXBuffer();
-        modemDataUpdateRXBuffer();
-
-        if(modemCfg.eventHandler)
-            modemCfg.eventHandler(MODEM_EVENT_CONNECTED);
-    }
+    if(modemCfg.eventHandler)
+        modemCfg.eventHandler(MODEM_EVENT_CONNECTED);
 }
 
 /* Aborts any connection that is currently being made */
@@ -75,7 +69,9 @@ void modemConnectionAbort(void) {
         modemCfg.eventHandler(MODEM_EVENT_CONNECTION_FAILED);
 }
 
-void mintInitialConnectionTimeoutCallback(void) {
+void mintInitialConnectionTimeoutCallback(void *d) {
+    (void)d;
+
     /* If the modem is in the state MODEM_STATE_CONNECTING and the timeout
        counter goes over a certain value, then it's assumed that nothing useful
        is going to happen and the connection should be aborted */
@@ -83,16 +79,16 @@ void mintInitialConnectionTimeoutCallback(void) {
     /* It only takes about 10 seconds to connect from this state, so this
        should be a long enough time to wait before aborting */
 
-    mintCounter++;
-
-    if(modemCfg.actual.state == MODEM_STATE_CONNECTING && mintCounter >= 25)
+    if(modemCfg.actual.state == MODEM_STATE_CONNECTING)
         modemConnectionAbort();
 }
 
 /* This is called after a timer interrupt is generated after a period of one
    second after the answer tone is detected. This is also called by answering
    modes when a connection should be established. */
-void modemConnectionAnswerCallback(void) {
+void modemConnectionAnswerCallback(void *d) {
+    (void)d;
+
     modemIntShutdownTimeoutTimer();
 
     /* Establish a connection */
@@ -104,8 +100,7 @@ void modemConnectionAnswerCallback(void) {
 
     /* Set up the counter so that after a period of time, the
        connection can be aborted if no progress is being made */
-    mintCounter = 0;
-    modemIntSetupTimeoutTimer(1, mintInitialConnectionTimeoutCallback);
+    modemIntSetupTimeoutTimer(25, mintInitialConnectionTimeoutCallback);
     modemIntStartTimeoutTimer();
 }
 
@@ -446,7 +441,7 @@ int modemConnectionErrorHandler(void) {
         /* Unless an abort is about to happen, errors that can be recovered from
            reset the timeout counter */
         if(!abort)
-            mintCounter = 0;
+            oneshot_timer_reset(oneshot);
     }
 
     /* Phase state monitoring */
@@ -459,7 +454,7 @@ int modemConnectionErrorHandler(void) {
         if((data & 0xE0) != (modemCfg.actual.phaseState & 0xE0)) {
             /* Phase change */
             if((data & 0xE0) < (modemCfg.actual.phaseState & 0xE0))
-                mintCounter = 0; /* Phase fallback, reset the timeout counter */
+                oneshot_timer_reset(oneshot); /* Phase fallback, reset the timeout counter */
 
             /* Update both the phase and the phase state */
             modemCfg.actual.phaseState = data;
@@ -468,9 +463,7 @@ int modemConnectionErrorHandler(void) {
         if((data & 0x1F) != (modemCfg.actual.phaseState & 0x1F)) {
             /* Phase state change */
             if((data & 0x1F) < (modemCfg.actual.phaseState & 0x1F))
-                mintCounter = 0; /* Phase state fallback, reset the timeout
-
-                                 counter */
+                oneshot_timer_reset(oneshot); /* Phase state fallback, reset the timeout counter */
 
             /* Update the phase state */
             modemCfg.actual.phaseState &= ~0x1F;
@@ -495,7 +488,7 @@ void modemConnection(void) {
             /* For answering modes only. Waits for a ring before
                attempting a connection. */
             if(modemRead(REGLOC(0xF)) & 0x8)
-                modemConnectionAnswerCallback();
+                modemConnectionAnswerCallback(NULL);
 
             break;
 
@@ -563,8 +556,7 @@ void modemConnection(void) {
                 modemCfg.actual.state = MODEM_STATE_NULL;
                 modemCallbackCode     = modemConnectedUpdate;
 
-                mintCounter = 0;
-                modemIntSetupTimeoutTimer(1, mintDelayCallback);
+                modemIntSetupTimeoutTimer(5, mintDelayCallback);
                 modemIntStartTimeoutTimer();
             }
 
@@ -604,11 +596,16 @@ void modemIntInit(void) {
     modemCallbackCode = NULL;
     asic_evt_set_handler(ASIC_EVT_EXP_8BIT, modemCallback, NULL);
     asic_evt_enable(ASIC_EVT_EXP_8BIT, ASIC_IRQB);
+
+    /* Oneshot timer will be configured later. */
+    oneshot = oneshot_timer_create(NULL, NULL, 0);
 }
 
 void modemIntShutdown(void) {
     asic_evt_disable(ASIC_EVT_EXP_8BIT, ASIC_IRQB);
     asic_evt_remove_handler(ASIC_EVT_EXP_8BIT);
+
+    oneshot_timer_destroy(oneshot);
 }
 
 #define dspSetClear8(addr, mask, clear)\
@@ -747,30 +744,10 @@ void modemIntResetControlCode(void) {
     modemCallbackCode = NULL;
 }
 
-/* Timeout timer interrupt code. It uses TMU1 and can be setup to either set
-   a flag to a non zero value, call a function, or both when a timer interrupt
-   is generated until it's stopped. */
-
-static void modemIntrTimeoutCallback(irq_t source, irq_context_t *context,
-                                     void *data) {
-    (void)source;
-    (void)context;
-    (void)data;
-
-    if(modemTimeoutCallbackCode != NULL)
-        modemTimeoutCallbackCode();
-}
-
-void modemIntSetupTimeoutTimer(int bps, void (*callbackCode)(void)) {
-    modemTimeoutCallbackCode = callbackCode;
-
-    /* Setup TMU1 so it can act as a timeout indicator */
-    timer_stop(TMU1);
-
-    /* Modify TMU1 so that it can be used for a timeout */
-    irq_set_handler(EXC_TMU1_TUNI1, modemIntrTimeoutCallback, NULL);
-    timer_prime(TMU1, bps, 1);
-    timer_clear(TMU1);
+static void modemIntSetupTimeoutTimer(unsigned int timeout_secs,
+                                      void (*callbackCode)(void *)) {
+    oneshot_timer_stop(oneshot);
+    oneshot_timer_setup(oneshot, callbackCode, NULL, timeout_secs * 1000);
 
     /* It doesn't matter if this is called more than once consecutively even
        if the timer is still running */
@@ -780,15 +757,14 @@ void modemIntSetupTimeoutTimer(int bps, void (*callbackCode)(void)) {
 
 static void modemIntStartTimeoutTimer(void) {
     if(!(modemInternalFlags & MODEM_INTERNAL_FLAG_TIMER_RUNNING)) {
-        timer_start(TMU1);
         modemInternalFlags |= MODEM_INTERNAL_FLAG_TIMER_RUNNING;
+        oneshot_timer_start(oneshot);
     }
 }
 
 static void modemIntResetTimeoutTimer(void) {
     if(modemInternalFlags & MODEM_INTERNAL_FLAG_TIMER_RUNNING) {
-        timer_stop(TMU1);
-        timer_clear(TMU1);
+        oneshot_timer_stop(oneshot);
         modemInternalFlags &= ~MODEM_INTERNAL_FLAG_TIMER_RUNNING;
     }
 }
@@ -798,7 +774,6 @@ static void modemIntShutdownTimeoutTimer(void) {
     modemIntResetTimeoutTimer();
 
     if(modemInternalFlags & MODEM_INTERNAL_FLAG_TIMER_HANDLER_SET) {
-        irq_set_handler(EXC_TMU1_TUNI1, NULL, NULL);
         modemInternalFlags &= ~MODEM_INTERNAL_FLAG_TIMER_HANDLER_SET;
     }
 }

--- a/kernel/thread/Makefile
+++ b/kernel/thread/Makefile
@@ -6,7 +6,7 @@
 
 OBJS =  sem.o cond.o mutex.o genwait.o
 OBJS += thread.o rwsem.o recursive_lock.o once.o tls.o
-OBJS += worker.o
+OBJS += oneshot_timer.o worker.o
 SUBDIRS = 
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/thread/oneshot_timer.c
+++ b/kernel/thread/oneshot_timer.c
@@ -1,0 +1,64 @@
+/* KallistiOS ##version##
+
+   oneshot_timer.c
+   Copyright (C) 2024 Paul Cercueil
+*/
+
+#include <kos/genwait.h>
+#include <kos/worker_thread.h>
+#include <kos/oneshot_timer.h>
+#include <stdlib.h>
+
+struct oneshot_timer {
+    kthread_worker_t *worker;
+    void (*cb)(void *);
+    void *data;
+    unsigned int timeout_ms;
+};
+
+static void oneshot_timer_timeout(void *d) {
+    oneshot_timer_t *timer = d;
+    int ret;
+
+    ret = genwait_wait(timer, "One-shot timer", timer->timeout_ms, NULL);
+    if (ret < 0)
+        timer->cb(timer->data);
+}
+
+void oneshot_timer_setup(oneshot_timer_t *timer, void (*cb)(void *),
+                         void *data, unsigned int timeout_ms) {
+    timer->timeout_ms = timeout_ms;
+    timer->cb = cb;
+    timer->data = data;
+}
+
+oneshot_timer_t *oneshot_timer_create(void (*cb)(void *), void *data,
+                                      unsigned int timeout_ms) {
+    oneshot_timer_t *timer = malloc(sizeof(*timer));
+    if(!timer)
+        return NULL;
+
+    oneshot_timer_setup(timer, cb, data, timeout_ms);
+
+    timer->worker = thd_worker_create(oneshot_timer_timeout, timer);
+    if (!timer->worker) {
+        free(timer);
+        return NULL;
+    }
+
+    return timer;
+}
+
+void oneshot_timer_destroy(oneshot_timer_t *timer) {
+    oneshot_timer_stop(timer);
+    thd_worker_destroy(timer->worker);
+    free(timer);
+}
+
+void oneshot_timer_start(oneshot_timer_t *timer) {
+    thd_worker_wakeup(timer->worker);
+}
+
+void oneshot_timer_stop(oneshot_timer_t *timer) {
+    genwait_wake_all(timer);
+}


### PR DESCRIPTION
A watchdog timer is a timer that will trigger an action (through a
pre-registered callback) after a timeout expires. The code using a
watchdog timer will typically reset it periodically to prevent the
action from happening.

Note that this code compiles but it UNTESTED! I don't have the infrastructure to test modem code.