### PR TITLE
timers: Add timer_spin_delay_{us,ns}

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -224,6 +224,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added support for modifying scheduler frequency at runtime [FG]
 - *** Add support for worker threads [PC]
 - DC  Added new System Calls module [AB]
+- DC  Add timer_spin_delay_{us,ns} [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -224,7 +224,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added support for modifying scheduler frequency at runtime [FG]
 - *** Add support for worker threads [PC]
 - DC  Added new System Calls module [AB]
-- DC  Add timer_spin_delay_{us,ns} [PC]
+- DC  Add timer_spin_delay_{us,ns} and use them in scif-spi [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/kernel/arch/dreamcast/hardware/scif-spi.c
+++ b/kernel/arch/dreamcast/hardware/scif-spi.c
@@ -3,6 +3,7 @@
    hardware/scif-spi.c
    Copyright (C) 2012 Lawrence Sebald
    Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2024 Paul Cercueil
 */
 
 #include <dc/scif.h>
@@ -122,17 +123,7 @@ uint8 scif_spi_rw_byte(uint8 b) {
 
 /* Very accurate 1.5usec delay... */
 static void slow_rw_delay(void) {
-    timer_prime(TMU1, 2000000, 0);
-    timer_clear(TMU1);
-    timer_start(TMU1);
-
-    while(!timer_clear(TMU1))
-        ;
-    while(!timer_clear(TMU1))
-        ;
-    while(!timer_clear(TMU1))
-        ;
-    timer_stop(TMU1);
+    timer_spin_delay_ns(1500);
 }
 
 uint8 scif_spi_slow_rw_byte(uint8 b) {

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -3,7 +3,8 @@
    arch/dreamcast/include/timer.h
    Copyright (c) 2000, 2001 Megan Potter
    Copyright (c) 2023 Falco Girgis
-   
+   Copyright (c) 2024 Paul Cercueil
+
 */
 
 /** \file    arch/timer.h
@@ -347,6 +348,31 @@ uint64_t timer_ns_gettime64(void);
     \param  ms              The number of milliseconds to sleep.
 */
 void timer_spin_sleep(int ms);
+
+/** \brief  Spin-loop delay function with microsecond granularity
+    \ingroup tmu_sleep
+
+    This function is meant as a very accurate delay function, even if threading
+    and interrupts are disabled. It is a delay and not a sleep, which means that
+    the CPU will be busy-looping during that time frame. For any time frame
+    bigger than a few hundred microseconds, it is recommended to sleep instead.
+
+    \param  us              The number of microseconds to wait for.
+    \sa timer_spin_delay_ns, thd_sleep
+*/
+void timer_spin_delay_us(unsigned short us);
+
+/** \brief  Spin-loop delay function with nanosecond granularity
+    \ingroup tmu_sleep
+
+    This function is meant as a very accurate delay function, even if threading
+    and interrupts are disabled. It is a delay and not a sleep, which means that
+    the CPU will be busy-looping during that time frame.
+
+    \param  ns              The number of nanoseconds to wait for.
+    \sa timer_spin_delay_us, thd_sleep
+*/
+void timer_spin_delay_ns(unsigned short ns);
 
 /** \defgroup tmu_primary   Primary Timer
     \brief                  Primary timer used by the kernel.

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -3,7 +3,7 @@
    timer.c
    Copyright (C) 2000, 2001, 2002 Megan Potter
    Copyright (C) 2023 Falco Girgis
-   Copyright (C) 2023 Paul Cercueil <paul@crapouillou.net>
+   Copyright (C) 2023, 2024 Paul Cercueil <paul@crapouillou.net>
 */
 
 #include <assert.h>
@@ -169,6 +169,22 @@ void timer_spin_sleep(int ms) {
     }
 
     timer_stop(TMU1);
+}
+
+void timer_spin_delay_ns(unsigned short ns) {
+    uint64_t timeout = timer_ns_gettime64() + ns;
+
+    /* Note that we don't actually care about the counter overflowing.
+       Nobody will run their Dreamcast straight for 585 years. */
+    while(timer_ns_gettime64() < timeout);
+}
+
+void timer_spin_delay_us(unsigned short us) {
+    uint64_t timeout = timer_us_gettime64() + us;
+
+    /* Note that we don't actually care about the counter overflowing.
+       Nobody will run their Dreamcast straight for 584942 years. */
+    while(timer_us_gettime64() < timeout);
 }
 
 /* Enable timer interrupts; needs to move to irq.c sometime. */


### PR DESCRIPTION
These two functions can be used to busy-wait until a given timeout expires. They are similar to timer_spin_sleep(), except that they are much more precise and don't use a dedicated TIMER UNIT channel, which makes them inherently thread-safe.