### PR TITLE
Screenshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ utils/naominetboot/naominetboot
 examples/dreamcast/basic/exec/romdisk/sub.bin
 examples/dreamcast/kgl/basic/vq/fruit.vq
 examples/dreamcast/kgl/nehe/nehe26/data/txt2bin
+examples/dreamcast/gldc/basic/vq/fruit.vq
+examples/dreamcast/gldc/nehe/nehe26/data/txt2bin
 examples/dreamcast/conio/adventure/data.c
 examples/dreamcast/conio/adventure/datagen
 examples/dreamcast/png/romdisk_boot.img

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ examples/dreamcast/pvr/bumpmap/romdisk/bricks.kmg
 examples/dreamcast/pvr/bumpmap/romdisk/bumpmap.raw
 examples/dreamcast/pvr/modifier_volume_tex/romdisk/fruit.kmg
 examples/dreamcast/pvr/texture_render/texture_render.bin
+examples/dreamcast/video/screenshot/screenshot.ppm
 utils/dc-chain/logs
 utils/dc-chain/*.tar.bz2
 utils/dc-chain/*.tar.gz

--- a/examples/dreamcast/video/Makefile
+++ b/examples/dreamcast/video/Makefile
@@ -9,15 +9,18 @@ all:
 	$(KOS_MAKE) -C palmenu
 	$(KOS_MAKE) -C minifont
 	$(KOS_MAKE) -C multibuffer
+	$(KOS_MAKE) -C screenshot
 
 clean:
 	$(KOS_MAKE) -C bfont clean
 	$(KOS_MAKE) -C palmenu clean
 	$(KOS_MAKE) -C minifont clean
 	$(KOS_MAKE) -C multibuffer clean
+	$(KOS_MAKE) -C screenshot clean
 
 dist:
 	$(KOS_MAKE) -C bfont dist
 	$(KOS_MAKE) -C palmenu dist
 	$(KOS_MAKE) -C minifont dist
 	$(KOS_MAKE) -C multibuffer dist
+	$(KOS_MAKE) -C screenshot dist

--- a/examples/dreamcast/video/bfont/Makefile
+++ b/examples/dreamcast/video/bfont/Makefile
@@ -1,7 +1,7 @@
 # KallistiOS ##version##
 #
-# basic/bfont/Makefile
-# (c)2002 Megan Potter
+# video/bfont/Makefile
+# Copyright (C) 2002 Megan Potter
 #
 
 TARGET = bfont.elf

--- a/examples/dreamcast/video/palmenu/Makefile
+++ b/examples/dreamcast/video/palmenu/Makefile
@@ -1,3 +1,8 @@
+# KallistiOS ##version##
+#
+# video/palmenu/Makefile
+#
+
 # Put the filename of the output binary here
 TARGET = palmenu.elf
 

--- a/examples/dreamcast/video/screenshot/Makefile
+++ b/examples/dreamcast/video/screenshot/Makefile
@@ -1,0 +1,31 @@
+# KallistiOS ##version##
+#
+# video/screenshot/Makefile
+# Copyright (C) 2024 Andy Barajas
+#
+
+TARGET = screenshot.elf
+OBJS = screenshot.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+	-rm -f test.ppm
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS) 
+	kos-cc -o $(TARGET) $(OBJS)
+
+# For Mac & Linux, sudo is required with the -c "." command to save data to the PC
+run: $(TARGET)
+	#sudo $(KOS_LOADER) $(TARGET) -c "."
+	$(KOS_LOADER) $(TARGET) -c "."
+
+dist: $(TARGET)
+	-rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/video/screenshot/screenshot.c
+++ b/examples/dreamcast/video/screenshot/screenshot.c
@@ -1,0 +1,84 @@
+/* KallistiOS ##version##
+
+   screenshot.c
+   Copyright (C) 2024 Andy Barajas
+
+*/
+
+/* 
+   This program demonstrates how to use the vid_screen_shot() function
+   to capture and save a screenshot in the PPM format to your computer
+   using the DC Tool. This tool requires the '-c "."' command-line argument
+   to operate correctly.
+
+   The program cycles through a color gradient background and allows user
+   interaction to capture screenshots or exit the program.
+
+   Usage:
+   Ensure the '/pc/' directory path is correctly specified in the vid_screen_shot()
+   function call so that the screenshot.ppm file is saved in the appropriate
+   directory on your computer.
+*/ 
+
+#include <dc/video.h>
+#include <dc/fmath.h>
+#include <dc/maple.h>
+#include <dc/biosfont.h>
+#include <dc/maple/controller.h>
+
+#include <kos/thread.h>
+
+int main(int argc, char **argv) {
+    uint8_t r, g, b;
+    uint32_t t = 0;
+    int font_height_offset = 0;
+
+    /* Adjust frequency for faster or slower transitions */
+    float frequency = 0.01; 
+    
+    maple_device_t *cont;
+    cont_state_t *state;
+
+    /* Set the video mode */
+    vid_set_mode(DM_640x480, PM_RGB565);   
+
+    while(1) {
+        if((cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER)) != NULL) {
+            state = (cont_state_t *)maple_dev_status(cont);
+
+            if(state == NULL)
+                break;
+
+            if(state->buttons & CONT_START)
+                break;
+
+            if(state->buttons & CONT_A)
+                vid_screen_shot("/pc/screenshot.ppm");
+        }
+
+        /* Wait for VBlank */
+        vid_waitvbl();
+        
+        /* Calculate next background color */
+        r = (uint8_t)((fsin(frequency * t + 0) * 127.5) + 127.5);
+        g = (uint8_t)((fsin(frequency * t + 2 * F_PI / 3) * 127.5) + 127.5);
+        b = (uint8_t)((fsin(frequency * t + 4 * F_PI / 3) * 127.5) + 127.5);
+
+        t += 1; /* Increment t to change color in the next cycle */
+        if(t == INT32_MAX) t = 0; /* Reset t to avoid overflow and ensure smooth cycling */
+
+        /* Draw Background */
+        vid_clear(r, g, b);
+
+        /* Draw Foreground */
+        font_height_offset = (640 * (480 - (BFONT_HEIGHT * 6))) + (BFONT_THIN_WIDTH * 2);
+        bfont_draw_str(vram_s + font_height_offset, 640, 1, "Press Start to exit");
+        font_height_offset += 640 * BFONT_HEIGHT * 2;
+        bfont_draw_str(vram_s + font_height_offset, 640, 1, "Press A to take a screen shot");
+
+        /* Without this the bfont wont show on the screen */
+        thd_sleep(10);
+    }
+
+    return 0;
+}

--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -93,7 +93,7 @@ __attribute__((noinline)) void *sq_cpy(void *dest, const void *src, size_t n) {
 }
 
 /* Fills n bytes at dest with byte c, dest must be 32-byte aligned */
-void * sq_set(void *dest, uint32_t c, size_t n) {
+void *sq_set(void *dest, uint32_t c, size_t n) {
     /* Duplicate low 8-bits of c into high 24-bits */
     c = c & 0xff;
     c = (c << 24) | (c << 16) | (c << 8) | c;
@@ -102,7 +102,7 @@ void * sq_set(void *dest, uint32_t c, size_t n) {
 }
 
 /* Fills n bytes at dest with short c, dest must be 32-byte aligned */
-void * sq_set16(void *dest, uint32_t c, size_t n) {
+void *sq_set16(void *dest, uint32_t c, size_t n) {
     /* Duplicate low 16-bits of c into high 16-bits */
     c = c & 0xffff;
     c = (c << 16) | c;
@@ -111,7 +111,7 @@ void * sq_set16(void *dest, uint32_t c, size_t n) {
 }
 
 /* Fills n bytes at dest with int c, dest must be 32-byte aligned */
-void * sq_set32(void *dest, uint32_t c, size_t n) {
+void *sq_set32(void *dest, uint32_t c, size_t n) {
     uint32_t *d = SQ_MASK_DEST(dest);
 
     sq_lock(dest);

--- a/kernel/arch/dreamcast/hardware/syscalls.c
+++ b/kernel/arch/dreamcast/hardware/syscalls.c
@@ -73,8 +73,8 @@
 #define FUNC_GDROM_PIO_CALLBACK     11
 #define FUNC_GDROM_PIO_TRANSFER     12
 #define FUNC_GDROM_PIO_CHECK        13
-#define FUNC_GDROM_UNKNOWN1         14
-#define FUNC_GDROM_UNKNOWN2         15
+#define FUNC_GDROM_STUB1            14
+#define FUNC_GDROM_STUB2            15
 
 /* SYSTEM functions */
 #define FUNC_SYSTEM_RESET           -1

--- a/kernel/arch/dreamcast/util/screenshot.c
+++ b/kernel/arch/dreamcast/util/screenshot.c
@@ -14,7 +14,6 @@
 #include <dc/video.h>
 #include <kos/fs.h>
 #include <arch/irq.h>
-#include <arch/timer.h>
 
 /*
 


### PR DESCRIPTION
1.  Refactors vid_screen_shot() to quit sooner if we cant open a file.  Speeds up 16bpp => 24bpp conversion by 57% by processing two pixels at once.
2.  Added an example that uses vid_screen_shot().
3.  Fix some documentation on the fellow video examples.
4. Updated the .gitignore file to handle some example files we shouldnt care about.
5. Minor styling changes in sq.c and a minor rename in FUNC_* that are currently unused.