### PR TITLE
Rebuild docs before viewing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ docs:
 docs_clean:
 	-rm -rf $(KOS_BASE)/doc/reference
 
-docs_open:
+docs_open: docs
 	open $(KOS_BASE)/doc/reference/html/index.html
 
 kos-ports_all:


### PR DESCRIPTION
Make docs_open depends on docs.  We rebuild the docs every time but it only takes a few secs and we always want to look at the latest right?