### PR TITLE
Stack Protector environ.sh Option + Example Tweak

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -143,6 +143,17 @@ export KOS_CFLAGS="${KOS_CFLAGS} -O2"
 export KOS_CFLAGS="${KOS_CFLAGS} -fomit-frame-pointer"
 #export KOS_CFLAGS="${KOS_CFLAGS} -fno-omit-frame-pointer -DFRAME_POINTERS"
 
+# Stack Protector
+#
+# Controls whether GCC emits extra code to check for buffer overflows or stack
+# smashing, which can be very useful for debugging. -fstack-protector only
+# covers vulnerable objects, while -fstack-protector-strong provides medium
+# coverage, and -fstack-protector-all provides full coverage. You may also
+# override the default stack excepton handler by providing your own
+# implementation of "void __stack_chk_fail(void)."
+#
+#export KOS_CFLAGS="${KOS_CFLAGS} -fstack-protector-all"
+
 # GCC Builtin Functions
 #
 # Comment out this line to enable GCC to use its own builtin implementations of

--- a/kernel/arch/dreamcast/include/arch/stack.h
+++ b/kernel/arch/dreamcast/include/arch/stack.h
@@ -6,7 +6,7 @@
 */
 
 /** \file    arch/stack.h
-    \brief   Stack traces.
+    \brief   Stack tracing.
     \ingroup debugging_stacktrace
 
     The functions in this file deal with doing stack traces. These functions


### PR DESCRIPTION
So I'm only now stumbling upon the stack protector... and I think it's pretty badass and is extremely useful... I figured we should expose a config option to the laymen who won't even know this bad-boy exists...

I also found that the example didn't actually work correctly with LTO enabled, so I fixed that and tweaked it to be more of an automated test so we can use it as such later.

