### PR TITLE
Add lock-less implementation of compare-and-swap atomic

### DIFF
--- a/include/kos/atomic.h
+++ b/include/kos/atomic.h
@@ -1,0 +1,38 @@
+/* KallistiOS ##version##
+
+   include/kos/atomic.h
+   Copyright (C) 2024 Paul Cercueil
+*/
+
+/** \file    kos/atomic.h
+    \brief   Atomic compare-and-swap support.
+    \ingroup kthreads
+
+    This file contains KOS' atomic API.
+ */
+
+#ifndef __KOS_ATOMIC_H
+#define __KOS_ATOMIC_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+#include <stdint.h>
+
+/** \brief  Atomically compare and swap values
+
+    This function will atomically read the value pointed to by the "addr"
+    pointer, and if it is equal to the "old" value, it will replace the
+    pointed value with the "new" value.
+
+    \param  addr            A pointer to the atomic value
+    \param  old             The expected value
+    \param  new             The new value
+
+    \retval                 The value read from the "addr" pointer
+*/
+uint32_t compare_and_swap(uint32_t *addr, uint32_t old, uint32_t new);
+
+__END_DECLS
+
+#endif /* __KOS_ATOMIC_H */

--- a/kernel/thread/Makefile
+++ b/kernel/thread/Makefile
@@ -6,7 +6,7 @@
 
 OBJS =  sem.o cond.o mutex.o genwait.o
 OBJS += thread.o rwsem.o recursive_lock.o once.o tls.o
-OBJS += worker.o
+OBJS += worker.o atomic.o cas.o
 SUBDIRS = 
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/thread/atomic.c
+++ b/kernel/thread/atomic.c
@@ -1,0 +1,16 @@
+/* KallistiOS ##version##
+
+   kernel/thread/atomic.c
+   Copyright (C) 2024 Paul Cercueil <paul@crapouillou.net>
+*/
+
+/* Lock-less compare-and-swap implementation */
+
+#include <kos/atomic.h>
+
+#include "cas.h"
+
+uint32_t compare_and_swap(uint32_t *addr, uint32_t old, uint32_t new)
+{
+	return _sh_cas_atomic_begin(addr, old, new);
+}

--- a/kernel/thread/cas.h
+++ b/kernel/thread/cas.h
@@ -1,0 +1,16 @@
+/* KallistiOS ##version##
+
+   kernel/thread/cas.h
+   Copyright (C) 2024 Paul Cercueil
+*/
+
+#ifndef __KOS_KERNEL_CAS_H
+#define __KOS_KERNEL_CAS_H
+
+#include <stdint.h>
+
+/* Compare-and-swap labels exported from cas.s */
+extern uint32_t _sh_cas_atomic_begin(uint32_t *addr, uint32_t old, uint32_t new);
+extern uint32_t _sh_cas_atomic_end;
+
+#endif /* __KOS_KERNEL_CAS_H */

--- a/kernel/thread/cas.s
+++ b/kernel/thread/cas.s
@@ -1,0 +1,23 @@
+! KallistiOS ##version##
+!
+!   arch/dreamcast/kernel/entry.s
+!   Copyright (C) 2024 Paul Cercueil <paul@crapouillou.net>
+!
+! Assembler code to implement atomic compare-and-swap
+!
+
+.text
+.align 2
+
+.globl __sh_cas_atomic_begin
+.globl __sh_cas_atomic_end
+
+__sh_cas_atomic_begin:
+	mov.l @r4,r0
+	cmp/eq r4,r5
+	bf __sh_cas_atomic_end
+	mov.l r6,@r4
+
+__sh_cas_atomic_end:
+	rts
+	nop


### PR DESCRIPTION
This commit introduces an implementation of an atomic compare-and-swap, that does not use any locking mechanism.

Instead, a tiny ASM function is added, with labels delimiting the beginning and end of the atomic section.

In the unlikely event that a thread is preempted in that tiny time frame, the next time it is scheduled its PC address will be reset to the beginning of the atomic section.

This compare-and-swap atomic can in turn be used to implement lock-less C11 atomics, which can therefore be used both inside and outside IRQ contexts.