### PR TITLE
dc-chain: Update profiles for 13.3.0 release

### DIFF
--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -14,9 +14,10 @@
 # - 11.4.0:       Latest release in the GCC 11 series, released 2023-05-15.
 # - 12.3.0:       Latest release in the GCC 12 series, released 2023-05-08.
 # - stable:       Tested stable; based on GCC 13.2.0, released 2023-07-27.
+# - 13.3.0:       Latest release in the GCC 13 series, released 2024-05-21.
 # - 14.1.0:       Latest release in the GCC 14 series, released 2024-05-07.
 # Development versions:
-# - 13.2.1-dev    Bleeding edge GCC 13 series from git.
+# - 13.3.1-dev    Bleeding edge GCC 13 series from git.
 # - 14.1.1-dev    Bleeding edge GCC 14 series from git.
 # - 15.0.0-dev    Bleeding edge GCC 15 series from git.
 # - gccrs-dev:    GCC fork for development of the GCCRS Rust compiler.

--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -104,8 +104,9 @@ The following toolchain profiles are available for users to select in
 | 11.4.0 | 11.4.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | Latest release in the GCC 11 series, released 2023-05-15 |
 | 12.3.0 | 12.3.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | Latest release in the GCC 12 series, released 2023-05-08 |
 | **stable** | **13.2.0** | **4.3.0** | **2.41** | **8.5.0** | **2.41** | **Tested stable; based on GCC 13.2.0, released 2023-07-27** |
+| 13.3.0 | 13.3.0 | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Latest release in the GCC 13 series, released 2024-05-21 |
 | 14.1.0 | 14.1.0 | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Latest release in the GCC 14 series, released 2024-05-07 |
-| 13.2.1-dev | 13.2.1 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 13 series from git |
+| 13.3.1-dev | 13.3.1 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 13 series from git |
 | 14.1.1-dev | 14.0.1 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 14 series from git |
 | 15.0.0-dev | 15.0.0 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 15 series from git |
 | gccrs-dev | 14.x | 4.4.0 | 2.42 | 8.5.0 | 2.42 | GCC fork for development of the GCCRS Rust compiler |

--- a/utils/dc-chain/patches/gcc-13.3.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-13.3.0-kos.diff
@@ -1,0 +1,162 @@
+diff --color -ruN gcc-13.3.0/gcc/config/sh/sh-c.cc gcc-13.3.0-kos/gcc/config/sh/sh-c.cc
+--- gcc-13.3.0/gcc/config/sh/sh-c.cc	2023-06-04 20:48:46.612552162 -0500
++++ gcc-13.3.0-kos/gcc/config/sh/sh-c.cc	2023-06-04 20:49:03.486606055 -0500
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff --color -ruN gcc-13.3.0/gcc/configure gcc-13.3.0-kos/gcc/configure
+--- gcc-13.3.0/gcc/configure	2023-06-04 20:48:49.679561957 -0500
++++ gcc-13.3.0-kos/gcc/configure	2023-06-04 20:49:03.488606061 -0500
+@@ -13058,7 +13058,7 @@
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32 | mcf)
++  single | tpf | vxworks | win32 | kos | mcf)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff --color -ruN gcc-13.3.0/libgcc/config/sh/t-sh gcc-13.3.0-kos/libgcc/config/sh/t-sh
+--- gcc-13.3.0/libgcc/config/sh/t-sh	2023-06-04 20:48:45.741549380 -0500
++++ gcc-13.3.0-kos/libgcc/config/sh/t-sh	2023-06-04 20:49:03.488606061 -0500
+@@ -23,6 +23,8 @@
+   $(LIB1ASMFUNCS_CACHE)
+ LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
+ 
++LIB2ADD = $(srcdir)/config/sh/fake-kos.S
++
+ crt1.o: $(srcdir)/config/sh/crt1.S
+ 	$(gcc_compile) -c $<
+ 
+diff --color -ruN gcc-13.3.0/libgcc/configure gcc-13.3.0-kos/libgcc/configure
+--- gcc-13.3.0/libgcc/configure	2023-06-04 20:48:45.787549527 -0500
++++ gcc-13.3.0-kos/libgcc/configure	2023-06-04 20:49:03.489606065 -0500
+@@ -5699,6 +5699,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 
+diff --color -ruN gcc-13.3.0/libobjc/configure gcc-13.3.0-kos/libobjc/configure
+--- gcc-13.3.0/libobjc/configure	2023-06-04 20:48:49.902562670 -0500
++++ gcc-13.3.0-kos/libobjc/configure	2023-06-04 20:49:03.489606065 -0500
+@@ -2918,11 +2918,9 @@
+ 
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#include <stdio.h>
+ int
+ main ()
+ {
+-printf ("hello world\n");
+   ;
+   return 0;
+ }
+diff --color -ruN gcc-13.3.0/libobjc/Makefile.in gcc-13.3.0-kos/libobjc/Makefile.in
+--- gcc-13.3.0/libobjc/Makefile.in	2023-06-04 20:48:49.901562666 -0500
++++ gcc-13.3.0-kos/libobjc/Makefile.in	2023-06-04 20:49:03.490606068 -0500
+@@ -308,14 +308,16 @@
+ $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
+ 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+ 
+-install: install-libs install-headers
++install-strip: INSTALL_STRIP_FLAG = -s
++install install-strip: install-libs install-headers
+ 
+ install-libs: installdirs
+ 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
+-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
++	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+ 	if [ "$(OBJC_BOEHM_GC)" ]; then \
+-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
+-				$(DESTDIR)$(toolexeclibdir);\
++	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
+ 	fi
+ 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
+ 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
+@@ -328,7 +330,7 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
+diff --color -ruN gcc-13.3.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-13.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-13.3.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:48:46.047550357 -0500
++++ gcc-13.3.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:49:03.490606068 -0500
+@@ -22,14 +22,40 @@
+ // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ // <http://www.gnu.org/licenses/>.
+ 
+-// Use the default atomicity stuff, which will use __atomic* builtins
+-// if threads are available, or the *_single functions on single-thread
+-// configurations.
+-// Actually we wouldn't need this header at all, but because of PR 53579
+-// libstdc++'s configury will not pickup the -matomic-model= option when
+-// set in the environment.  This makes it impossible to enable the proper
+-// atomic model on SH without modifying GCC itself, because libstdc++ always
+-// thinks the target doesn't do any atomics and uses the default mutex based
+-// implementation from cpu/generic/atomicity_mutex.
++/* This is generic/atomicity.h */
+ 
+ #include <ext/atomicity.h>
++#include <ext/concurrence.h>
++
++namespace 
++{
++  __gnu_cxx::__mutex&
++  get_atomic_mutex()
++  {
++    static __gnu_cxx::__mutex atomic_mutex;
++    return atomic_mutex;
++  }
++} // anonymous namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val) throw ()
++  {
++    __gnu_cxx::__scoped_lock sentry(get_atomic_mutex());
++    _Atomic_word __result;
++    __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word* __mem, int __val) throw ()
++  { __exchange_and_add(__mem, __val); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --color -ruN gcc-13.3.0/libstdc++-v3/configure gcc-13.3.0-kos/libstdc++-v3/configure
+--- gcc-13.3.0/libstdc++-v3/configure	2023-06-04 20:48:46.398551478 -0500
++++ gcc-13.3.0-kos/libstdc++-v3/configure	2023-06-04 20:49:03.493606077 -0500
+@@ -15825,6 +15825,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 

--- a/utils/dc-chain/patches/gcc-13.3.1-kos.diff
+++ b/utils/dc-chain/patches/gcc-13.3.1-kos.diff
@@ -1,6 +1,6 @@
-diff --color -ruN gcc-13.2.1/gcc/config/sh/sh-c.cc gcc-13.2.1-kos/gcc/config/sh/sh-c.cc
---- gcc-13.2.1/gcc/config/sh/sh-c.cc	2023-06-04 20:48:46.612552162 -0500
-+++ gcc-13.2.1-kos/gcc/config/sh/sh-c.cc	2023-06-04 20:49:03.486606055 -0500
+diff --color -ruN gcc-13.3.1/gcc/config/sh/sh-c.cc gcc-13.3.1-kos/gcc/config/sh/sh-c.cc
+--- gcc-13.3.1/gcc/config/sh/sh-c.cc	2023-06-04 20:48:46.612552162 -0500
++++ gcc-13.3.1-kos/gcc/config/sh/sh-c.cc	2023-06-04 20:49:03.486606055 -0500
 @@ -141,4 +141,11 @@
  
    cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
@@ -13,9 +13,9 @@ diff --color -ruN gcc-13.2.1/gcc/config/sh/sh-c.cc gcc-13.2.1-kos/gcc/config/sh/
 +  /* Toolchain supports setting up stack for 32MB */
 +  builtin_define ("__KOS_GCC_32MB__");
  }
-diff --color -ruN gcc-13.2.1/gcc/configure gcc-13.2.1-kos/gcc/configure
---- gcc-13.2.1/gcc/configure	2023-06-04 20:48:49.679561957 -0500
-+++ gcc-13.2.1-kos/gcc/configure	2023-06-04 20:49:03.488606061 -0500
+diff --color -ruN gcc-13.3.1/gcc/configure gcc-13.3.1-kos/gcc/configure
+--- gcc-13.3.1/gcc/configure	2023-06-04 20:48:49.679561957 -0500
++++ gcc-13.3.1-kos/gcc/configure	2023-06-04 20:49:03.488606061 -0500
 @@ -13058,7 +13058,7 @@
      target_thread_file='single'
      ;;
@@ -25,9 +25,9 @@ diff --color -ruN gcc-13.2.1/gcc/configure gcc-13.2.1-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff --color -ruN gcc-13.2.1/libgcc/config/sh/t-sh gcc-13.2.1-kos/libgcc/config/sh/t-sh
---- gcc-13.2.1/libgcc/config/sh/t-sh	2023-06-04 20:48:45.741549380 -0500
-+++ gcc-13.2.1-kos/libgcc/config/sh/t-sh	2023-06-04 20:49:03.488606061 -0500
+diff --color -ruN gcc-13.3.1/libgcc/config/sh/t-sh gcc-13.3.1-kos/libgcc/config/sh/t-sh
+--- gcc-13.3.1/libgcc/config/sh/t-sh	2023-06-04 20:48:45.741549380 -0500
++++ gcc-13.3.1-kos/libgcc/config/sh/t-sh	2023-06-04 20:49:03.488606061 -0500
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -37,9 +37,9 @@ diff --color -ruN gcc-13.2.1/libgcc/config/sh/t-sh gcc-13.2.1-kos/libgcc/config/
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff --color -ruN gcc-13.2.1/libgcc/configure gcc-13.2.1-kos/libgcc/configure
---- gcc-13.2.1/libgcc/configure	2023-06-04 20:48:45.787549527 -0500
-+++ gcc-13.2.1-kos/libgcc/configure	2023-06-04 20:49:03.489606065 -0500
+diff --color -ruN gcc-13.3.1/libgcc/configure gcc-13.3.1-kos/libgcc/configure
+--- gcc-13.3.1/libgcc/configure	2023-06-04 20:48:45.787549527 -0500
++++ gcc-13.3.1-kos/libgcc/configure	2023-06-04 20:49:03.489606065 -0500
 @@ -5699,6 +5699,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -48,9 +48,9 @@ diff --color -ruN gcc-13.2.1/libgcc/configure gcc-13.2.1-kos/libgcc/configure
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
-diff --color -ruN gcc-13.2.1/libobjc/configure gcc-13.2.1-kos/libobjc/configure
---- gcc-13.2.1/libobjc/configure	2023-06-04 20:48:49.902562670 -0500
-+++ gcc-13.2.1-kos/libobjc/configure	2023-06-04 20:49:03.489606065 -0500
+diff --color -ruN gcc-13.3.1/libobjc/configure gcc-13.3.1-kos/libobjc/configure
+--- gcc-13.3.1/libobjc/configure	2023-06-04 20:48:49.902562670 -0500
++++ gcc-13.3.1-kos/libobjc/configure	2023-06-04 20:49:03.489606065 -0500
 @@ -2918,11 +2918,9 @@
  
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -63,9 +63,9 @@ diff --color -ruN gcc-13.2.1/libobjc/configure gcc-13.2.1-kos/libobjc/configure
    ;
    return 0;
  }
-diff --color -ruN gcc-13.2.1/libobjc/Makefile.in gcc-13.2.1-kos/libobjc/Makefile.in
---- gcc-13.2.1/libobjc/Makefile.in	2023-06-04 20:48:49.901562666 -0500
-+++ gcc-13.2.1-kos/libobjc/Makefile.in	2023-06-04 20:49:03.490606068 -0500
+diff --color -ruN gcc-13.3.1/libobjc/Makefile.in gcc-13.3.1-kos/libobjc/Makefile.in
+--- gcc-13.3.1/libobjc/Makefile.in	2023-06-04 20:48:49.901562666 -0500
++++ gcc-13.3.1-kos/libobjc/Makefile.in	2023-06-04 20:49:03.490606068 -0500
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -96,9 +96,9 @@ diff --color -ruN gcc-13.2.1/libobjc/Makefile.in gcc-13.2.1-kos/libobjc/Makefile
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff --color -ruN gcc-13.2.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-13.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-13.2.1/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:48:46.047550357 -0500
-+++ gcc-13.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:49:03.490606068 -0500
+diff --color -ruN gcc-13.3.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-13.3.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-13.3.1/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:48:46.047550357 -0500
++++ gcc-13.3.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-04 20:49:03.490606068 -0500
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -149,9 +149,9 @@ diff --color -ruN gcc-13.2.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-13.2.1-k
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff --color -ruN gcc-13.2.1/libstdc++-v3/configure gcc-13.2.1-kos/libstdc++-v3/configure
---- gcc-13.2.1/libstdc++-v3/configure	2023-06-04 20:48:46.398551478 -0500
-+++ gcc-13.2.1-kos/libstdc++-v3/configure	2023-06-04 20:49:03.493606077 -0500
+diff --color -ruN gcc-13.3.1/libstdc++-v3/configure gcc-13.3.1-kos/libstdc++-v3/configure
+--- gcc-13.3.1/libstdc++-v3/configure	2023-06-04 20:48:46.398551478 -0500
++++ gcc-13.3.1-kos/libstdc++-v3/configure	2023-06-04 20:49:03.493606077 -0500
 @@ -15825,6 +15825,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/profiles/profile.13.3.0.mk
+++ b/utils/dc-chain/profiles/profile.13.3.0.mk
@@ -1,23 +1,11 @@
 # Sega Dreamcast Toolchains Maker (dc-chain)
 # This file is part of KallistiOS.
 
-###############################################################################
-###############################################################################
-### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
-## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2024-04-23.
-###############################################################################
-###############################################################################
-
 # Toolchain versions for SH
 sh_binutils_ver=2.42
-sh_gcc_ver=13.2.1
+sh_gcc_ver=13.3.0
 newlib_ver=4.4.0.20231231
 gdb_ver=14.2
-
-# Overide SH toolchain download type
-sh_gcc_download_type=git
-sh_gcc_git_repo=git://gcc.gnu.org/git/gcc.git
-sh_gcc_git_branch=releases/gcc-13
 
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core

--- a/utils/dc-chain/profiles/profile.13.3.1-dev.mk
+++ b/utils/dc-chain/profiles/profile.13.3.1-dev.mk
@@ -1,0 +1,47 @@
+# Sega Dreamcast Toolchains Maker (dc-chain)
+# This file is part of KallistiOS.
+
+###############################################################################
+###############################################################################
+### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2024-05-21.
+###############################################################################
+###############################################################################
+
+# Toolchain versions for SH
+sh_binutils_ver=2.42
+sh_gcc_ver=13.3.1
+newlib_ver=4.4.0.20231231
+gdb_ver=14.2
+
+# Overide SH toolchain download type
+sh_gcc_download_type=git
+sh_gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+sh_gcc_git_branch=releases/gcc-13
+
+# Toolchain for ARM
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
+arm_binutils_ver=2.42
+arm_gcc_ver=8.5.0
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies for SH
+sh_gmp_ver=6.2.1
+sh_mpfr_ver=4.1.0
+sh_mpc_ver=1.2.1
+sh_isl_ver=0.24
+
+# GCC dependencies for ARM
+arm_gmp_ver=6.1.0
+arm_mpfr_ver=3.1.4
+arm_mpc_ver=1.0.3
+arm_isl_ver=0.18


### PR DESCRIPTION
GCC 13.3.0 was released an hour or two ago; this PR adds `13.3.0` profile/patches and bumps `13.2.1-dev` to `13.3.1-dev`.

In draft as I'm currently building/testing.