### PR TITLE
Fix erroneous string handling in vqenc

### DIFF
--- a/utils/vqenc/vqenc.c
+++ b/utils/vqenc/vqenc.c
@@ -703,9 +703,8 @@ static const char *figure_outfilename(const char *f, const char *newext) {
         newname = (char *)malloc(len);
 
         if(newname) {
-            strcpy(newname, f);
-            ext = strrchr(newname, '.') + 1;
-            strcpy(ext, newext);
+            strncpy(newname, f, ext - f);
+            sprintf(newname + (ext - f), ".%s", newext);
         }
     }
 


### PR DESCRIPTION
When `vqenc` tries to determine the output filename, it allocates a char buffer for the new filename, writes the old filename to this buffer, and then overwrites the new extension over the old one within the buffer. If the old filename exceeds the length of the new filename (e.g. if converting from a `fruit.jpg` to `fruit.vq`), the char buffer is overflowed. This PR adjusts to write only the base filename before writing the extension.

This PR fixes #559 