### PR TITLE
DBGIO Cleanup + Auxiliary Output Devices

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_dclsocket.c
+++ b/kernel/arch/dreamcast/fs/fs_dclsocket.c
@@ -66,6 +66,8 @@ static struct {
     unsigned char map[16384];
 } bin_info;
 
+extern dbgio_handler_t dbgio_null;
+
 extern int dcload_type;
 static int initted = 0;
 static int escape = 0;
@@ -622,7 +624,7 @@ static int dcls_stat(vfs_handler_t *vfs, const char *fn, struct stat *rv,
 }
 
 /* dbgio interface */
-static int dcls_detected(void) {
+static bool dcls_detected(void) {
     return initted > 0;
 }
 
@@ -634,7 +636,7 @@ static int dcls_fake_shutdown(void) {
     return 0;
 }
 
-static int dcls_writebuf(const uint8 *buf, int len, int xlat) {
+static int dcls_writebuf(const uint8_t *buf, size_t len, bool xlat) {
     int locked;
     command_3int_t cmd;
 
@@ -745,7 +747,8 @@ dbgio_handler_t dbgio_dcls = {
     NULL,
     NULL,
     dcls_writebuf,
-    NULL
+    NULL,
+    { NULL }
 };
 
 /* This function must be called prior to calling fs_dclsocket_init() */

--- a/kernel/arch/dreamcast/hardware/scif.c
+++ b/kernel/arch/dreamcast/hardware/scif.c
@@ -154,7 +154,7 @@ static void scif_data_irq(irq_t src, irq_context_t *cxt, void *data) {
 
 /* Are we using IRQs? */
 static int scif_irq_usage = 0;
-int scif_set_irq_usage(int on) {
+int scif_set_irq_usage(dbgio_mode_t on) {
     scif_irq_usage = on;
 
     /* Clear out the buffer in any case */
@@ -186,8 +186,8 @@ int scif_set_irq_usage(int on) {
 
 /* We are always detected, though we might end up realizing there's no
    cable connected later... */
-int scif_detected(void) {
-    return 1;
+bool scif_detected(void) {
+    return true;
 }
 
 /* We use this for the dbgio interface because we always init SCIF. */
@@ -359,7 +359,7 @@ int scif_flush(void) {
 }
 
 /* Send an entire buffer */
-int scif_write_buffer(const uint8 *data, int len, int xlat) {
+int scif_write_buffer(const uint8_t *data, size_t len, bool xlat) {
     int rv, i = 0, c;
 
     while(len-- > 0) {
@@ -389,7 +389,7 @@ int scif_write_buffer(const uint8 *data, int len, int xlat) {
 }
 
 /* Read an entire buffer (block) */
-int scif_read_buffer(uint8 *data, int len) {
+int scif_read_buffer(uint8_t *data, size_t len) {
     int c, i = 0;
 
     while(len-- > 0) {
@@ -416,5 +416,6 @@ dbgio_handler_t dbgio_scif = {
     scif_write,
     scif_flush,
     scif_write_buffer,
-    scif_read_buffer
+    scif_read_buffer,
+    { NULL }
 };

--- a/kernel/arch/dreamcast/include/dc/fb_console.h
+++ b/kernel/arch/dreamcast/include/dc/fb_console.h
@@ -29,10 +29,6 @@ __BEGIN_DECLS
 
 #include <kos/dbgio.h>
 
-/* \cond */
-extern dbgio_handler_t dbgio_fb;
-/* \endcond */
-
 /** \brief  Set the target for the framebuffer dbgio device.
 
     This function allows you to set a target for the dbgio device on the
@@ -52,7 +48,8 @@ extern dbgio_handler_t dbgio_fb;
     \param  bordery         How much border to leave around the target in the
                             Y direction.
 */
-void dbgio_fb_set_target(uint16 *t, int w, int h, int borderx, int bordery);
+void dbgio_fb_set_target(uint16_t *t, unsigned int w, unsigned int h, 
+                         unsigned int borderx, unsigned int bordery);
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/include/dc/fs_dcload.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dcload.h
@@ -37,10 +37,6 @@ __BEGIN_DECLS
     @{
 */
 
-/* \cond */
-extern dbgio_handler_t dbgio_dcload;
-/* \endcond */
-
 /* dcload magic value */
 /** \brief  The dcload magic value! */
 #define DCLOADMAGICVALUE 0xdeadbeef

--- a/kernel/arch/dreamcast/include/dc/fs_dclsocket.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dclsocket.h
@@ -30,8 +30,6 @@ __BEGIN_DECLS
 */
 
 /* \cond */
-extern dbgio_handler_t dbgio_dcls;
-
 /* Initialization */
 void fs_dclsocket_init_console(void);
 int fs_dclsocket_init(void);

--- a/kernel/arch/dreamcast/include/dc/scif.h
+++ b/kernel/arch/dreamcast/include/dc/scif.h
@@ -46,12 +46,12 @@ void scif_set_parameters(int baud, int fifo);
     \param  on              1 to enable IRQ usage, 0 for polled I/O.
     \retval 0               On success (no error conditions defined).
 */
-int scif_set_irq_usage(int on);
+int scif_set_irq_usage(dbgio_mode_t on);
 
 /** \brief  Is the SCIF port detected? Of course it is!
     \return                 1
 */
-int scif_detected(void);
+bool scif_detected(void);
 
 /** \brief  Initialize the SCIF port.
 
@@ -104,7 +104,7 @@ int scif_flush(void);
     \param  xlat            If set to 1, all newlines will be written as CRLF.
     \return                 The number of bytes written on success, -1 on error.
 */
-int scif_write_buffer(const uint8 *data, int len, int xlat);
+int scif_write_buffer(const uint8_t *data, size_t len, bool xlat);
 
 /** \brief  Read a buffer of data from the SCIF port.
 
@@ -115,10 +115,7 @@ int scif_write_buffer(const uint8 *data, int len, int xlat);
     \param  len             The number of bytes to read.
     \return                 The number of bytes read on success, -1 on error.
 */
-int scif_read_buffer(uint8 *data, int len);
-
-/** \brief  SCIF debug I/O handler. Do not modify! */
-extern dbgio_handler_t dbgio_scif;
+int scif_read_buffer(uint8_t *data, size_t len);
 
 /* Low-level SPI related functionality below here... */
 /** \brief  Initialize the SCIF port for use of an SPI peripheral.
@@ -161,7 +158,7 @@ void scif_spi_set_cs(int v);
     \param  b               The byte to write out to the port.
     \return                 The byte returned from the card.
 */
-uint8 scif_spi_rw_byte(uint8 b);
+uint8_t scif_spi_rw_byte(uint8_t b);
 
 /** \brief  Read and write one byte from the SPI device, slowly.
 
@@ -175,7 +172,7 @@ uint8 scif_spi_rw_byte(uint8 b);
     \param  b               The byte to write out to the port.
     \return                 The byte returned from the card.
 */
-uint8 scif_spi_slow_rw_byte(uint8 b);
+uint8_t scif_spi_slow_rw_byte(uint8_t b);
 
 
 /** \brief  Write a byte to the SPI device.
@@ -185,7 +182,7 @@ uint8 scif_spi_slow_rw_byte(uint8 b);
 
     \param  b               The byte to write out to the port.
 */
-void scif_spi_write_byte(uint8 b);
+void scif_spi_write_byte(uint8_t b);
 
 /** \brief  Read a byte from the SPI device.
 
@@ -194,7 +191,7 @@ void scif_spi_write_byte(uint8 b);
 
     \return                 The byte returned from the device.
 */
-uint8 scif_spi_read_byte(void);
+uint8_t scif_spi_read_byte(void);
 
 /** \brief  Read a data from the SPI device.
 
@@ -204,7 +201,7 @@ uint8 scif_spi_read_byte(void);
     \param  buffer          Buffer to store read data into.
     \param  len             Number of bytes to read from the device.
 */
-void scif_spi_read_data(uint8 *buffer, size_t len);
+void scif_spi_read_data(uint8_t *buffer, size_t len);
 
 /** @} */
 

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -48,6 +48,12 @@ uint32 _fs_dclsocket_get_ip(void);
 #define CHCR2   ((vuint32 *)0xFFA0002C)
 #define DMAOR   ((vuint32 *)0xFFA00040)
 
+extern dbgio_handler_t dbgio_dcload;
+extern dbgio_handler_t dbgio_dcls;
+extern dbgio_handler_t dbgio_scif;
+extern dbgio_handler_t dbgio_null;
+extern dbgio_handler_t dbgio_fb;
+
 /* We have to put this here so we can include plat-specific devices */
 dbgio_handler_t * dbgio_handlers[] = {
     &dbgio_dcload,
@@ -56,7 +62,7 @@ dbgio_handler_t * dbgio_handlers[] = {
     &dbgio_null,
     &dbgio_fb
 };
-int dbgio_handler_cnt = sizeof(dbgio_handlers) / sizeof(dbgio_handler_t *);
+size_t const dbgio_handler_cnt = sizeof(dbgio_handlers) / sizeof(dbgio_handler_t *);
 
 void arch_init_net_dcload_ip(void) {
     union {

--- a/kernel/arch/dreamcast/util/fb_console.c
+++ b/kernel/arch/dreamcast/util/fb_console.c
@@ -18,16 +18,16 @@
    the network stack, and I figured other people would probably get some use out
    of it as well. */
 
-static uint16 *fb;
-static int fb_w, fb_h;
-static int cur_x, cur_y;
-static int min_x, min_y, max_x, max_y;
+static uint16_t *fb;
+static unsigned int fb_w, fb_h;
+static unsigned int cur_x, cur_y;
+static unsigned int min_x, min_y, max_x, max_y;
 
 #define FONT_CHAR_WIDTH 12
 #define FONT_CHAR_HEIGHT 24
 
-static int fb_detected(void) {
-    return 1;
+static bool fb_detected(void) {
+    return true;
 }
 
 static int fb_init(void) {
@@ -46,7 +46,7 @@ static int fb_shutdown(void) {
     return 0;
 }
 
-static int fb_set_irq_usage(int mode) {
+static int fb_set_irq_usage(dbgio_mode_t mode) {
     (void)mode;
     return 0;
 }
@@ -90,7 +90,7 @@ static int fb_flush(void) {
     return 0;
 }
 
-static int fb_write_buffer(const uint8 *data, int len, int xlat) {
+static int fb_write_buffer(const uint8_t *data, size_t len, bool xlat) {
     int rv = len;
 
     (void)xlat;
@@ -102,7 +102,7 @@ static int fb_write_buffer(const uint8 *data, int len, int xlat) {
     return rv;
 }
 
-static int fb_read_buffer(uint8 * data, int len) {
+static int fb_read_buffer(uint8_t *data, size_t len) {
     (void)data;
     (void)len;
     errno = EAGAIN;
@@ -119,10 +119,12 @@ dbgio_handler_t dbgio_fb = {
     fb_write,
     fb_flush,
     fb_write_buffer,
-    fb_read_buffer
+    fb_read_buffer,
+    { NULL }
 };
 
-void dbgio_fb_set_target(uint16 *t, int w, int h, int borderx, int bordery) {
+void dbgio_fb_set_target(uint16_t *t, unsigned int w, unsigned int h, 
+                         unsigned int borderx, unsigned int bordery) {
     /* Set up all the new parameters. */
     fb = t;
 


### PR DESCRIPTION
Sick of your `stdout` options being:
     1. dcload-only: Too bad your output doesn't show up by default in emulators, and it looks like something is wrong to users.
     2.  fb-only: Too bad then you can't read your output in the console
     
Presenting:`dbgio_aux_select("fb")` Which allows you to select an optional dbgio device for auxiliary output which is just a secondary output device... As oppposed to `dbgio_dev_select("fb");` which makes it the primary device with no other output.

- Cleaned up dbgio API, source file, and drivers
- Got rid of annoying declarations to private internal structures only
  used in init.c
- Added API for auxiliary output device
- Modified API to allow for runtime dbgio device registry
