### PR TITLE
Fixed Warnings from realpath() Signature Mismatches

### DIFF
--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -51,10 +51,6 @@ typedef struct fs_hnd {
 /* The global file descriptor table */
 fs_hnd_t * fd_table[FD_SETSIZE] = { NULL };
 
-/* For some reason, Newlib doesn't seem to define this function in stdlib.h. */
-extern char *realpath(const char *, char[PATH_MAX]);
-
-
 /* Internal file commands for root dir reading */
 static fs_hnd_t * fs_root_opendir(void) {
     return calloc(1, sizeof(fs_hnd_t));

--- a/kernel/libc/koslib/realpath.c
+++ b/kernel/libc/koslib/realpath.c
@@ -54,7 +54,7 @@ size_t strlcpy(char *, const char *, size_t);
  * in which case the path which caused trouble is left in (resolved).
  */
 char *
-realpath(const char *path, char resolved[PATH_MAX]) {
+realpath(const char *__restrict path, char *__restrict resolved) {
     char *p, *q, *s;
     size_t left_len, resolved_len;
     char left[PATH_MAX], next_token[PATH_MAX];


### PR DESCRIPTION
- The `realpath()` signature declared within Newlib and the stdlib headers with POSIX extensions has both parameters as pointers with the `__restrict` keyword, versus `realpath.c` which was lacking `__restrict` and made the second argument an array.
- Also removed an unnecessary (and now incorrect) forward declaration in `fs.c` which is no longer necessary now that Newlib is declaring it for us.