### PR TITLE
Add Makefile rule to check minimum GCC version

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1,7 +1,8 @@
 # KallistiOS ##version##
 #
 # Makefile.rules
-# (c)2000-2001 Megan Potter
+# Copyright (c) 2000, 2001 Megan Potter
+# Copyright (c) 2024 Eric Fradella
 #
 
 # Global KallistiOS Makefile include
@@ -73,4 +74,22 @@ romdisk.o: romdisk.img
 	$(KOS_BASE)/utils/bin2o/bin2o romdisk.img romdisk romdisk_tmp.o
 	$(KOS_CC) -o romdisk.o -r romdisk_tmp.o $(KOS_LIB_PATHS) -Wl,--whole-archive -lromdiskbase
 	rm romdisk_tmp.o
+endif
+
+# Define KOS_GCCVER_MIN in your Makefile if you want to enforce a minimum GCC version.
+ifdef KOS_GCCVER_MIN
+  ifeq ($(shell \
+    awk 'BEGIN { \
+        split("$(KOS_GCCVER_MIN)", min, "."); \
+        split("$(KOS_GCCVER)", cur, "."); \
+        if (cur[1] > min[1] || \
+           (cur[1] == min[1] && cur[2] > min[2]) || \
+           (cur[1] == min[1] && cur[2] == min[2] && cur[3] >= min[3])) { \
+            print 1; \
+        } else { \
+            print 0; \
+        } \
+    }'), 0)
+    $(error A minimum GCC version of $(KOS_GCCVER_MIN) is required, but $(KOS_GCCVER) is currently in use.)
+  endif
 endif

--- a/examples/dreamcast/basic/breaking/Makefile
+++ b/examples/dreamcast/basic/breaking/Makefile
@@ -7,6 +7,7 @@
 TARGET = breaking.elf
 OBJS = breaking.o
 KOS_CFLAGS += -std=gnu2x -Wno-strict-aliasing
+KOS_GCCVER_MIN = 13.0.0
 
 all: rm-elf $(TARGET)
 

--- a/examples/dreamcast/basic/fpu/exc/Makefile
+++ b/examples/dreamcast/basic/fpu/exc/Makefile
@@ -1,10 +1,12 @@
 #
 # FPU Exception Tests
-# (c)2002 Megan Potter
-#   
+# Copyright (C) 2002 Megan Potter
+# Copyright (C) 2024 Falco Girgis
+#
 
 TARGET = fpu_exc.elf
 OBJS = fpu_exc.o
+KOS_GCCVER_MIN = 5.0.0
 
 all: rm-elf $(TARGET)
 

--- a/examples/dreamcast/basic/stackprotector/Makefile
+++ b/examples/dreamcast/basic/stackprotector/Makefile
@@ -1,15 +1,13 @@
+#
+# Stack Protector Test/Example
+# Copyright (C) 2021 Lawrence Sebald
+# Copyright (C) 2024 Falco Girgis
+#
+
 TARGET = stackprotector.elf
 OBJS = stackprotector.o
 KOS_CFLAGS += -fstack-protector-all
-
-GCC_MAJOR = $(basename $(basename $(KOS_GCCVER)))
-
-ifeq ($(GCC_MAJOR), 4) 
-
-all dist clean:
-	$(warning GCC4 missing stackprotector patch, skipping)
-
-else
+KOS_GCCVER_MIN = 4.0.0
 
 all: rm-elf $(TARGET)
 
@@ -34,4 +32,3 @@ dist: $(TARGET)
 
 .PHONY: run dist clean rm-elf
 
-endif

--- a/examples/dreamcast/cpp/concurrency/Makefile
+++ b/examples/dreamcast/cpp/concurrency/Makefile
@@ -1,11 +1,12 @@
 #
 # C++ Concurrency Test/Example
-# (c) 2023 Falco Girgis
-#   
+# Copyright (C) 2023, 2024 Falco Girgis
+#
 
 TARGET = concurrency.elf
 OBJS = concurrency.o
-KOS_CPPFLAGS += -std=c++20 
+KOS_CPPFLAGS += -std=c++20
+KOS_GCCVER_MIN = 12.0.0
 
 all: rm-elf $(TARGET)
 


### PR DESCRIPTION
If `$KOS_GCCVER_MIN` is defined in your project's `Makefile`, this addition will check the current `$KOS_GCCVER` against it to determine if your GCC version meets the minimum necessary for the project.