### PR TITLE
Minor cleanups in FS

### DIFF
--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -33,7 +33,7 @@ __BEGIN_DECLS
 */
 
 /** \name  Directory File Types
-    \brief POSIX file types for dirent::d_name
+    \brief POSIX file types for dirent::d_type
 
     \remark
     These directory entry types are not part of the POSIX specifican per-se,

--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -573,11 +573,11 @@ static iso_dirent_t *find_object_path(const char *fn, int dir, iso_dirent_t *sta
    too lazy right now. =) */
 static struct {
     uint32      first_extent;   /* First sector */
-    int     dir;        /* >0 if a directory */
-    uint32      ptr;        /* Current read position in bytes */
-    uint32      size;       /* Length of file in bytes */
-    dirent_t    dirent;     /* A static dirent to pass back to clients */
-    int     broken;     /* >0 if the CD has been swapped out since open */
+    bool        dir;            /* True if a directory */
+    uint32      ptr;            /* Current read position in bytes */
+    uint32      size;           /* Length of file in bytes */
+    dirent_t    dirent;         /* A static dirent to pass back to clients */
+    bool        broken;         /* True if the CD has been swapped out since open */
 } fh[FS_CD_MAX_FILES];
 
 /* Mutex for file handles */
@@ -593,7 +593,7 @@ static void iso_break_all(void) {
     mutex_lock(&fh_mutex);
 
     for(i = 0; i < FS_CD_MAX_FILES; i++)
-        fh[i].broken = 1;
+        fh[i].broken = true;
 
     mutex_unlock(&fh_mutex);
 }
@@ -645,10 +645,10 @@ static void * iso_open(vfs_handler_t * vfs, const char *fn, int mode) {
 
     /* Fill in the file handle and return the fd */
     fh[fd].first_extent = iso_733(de->extent);
-    fh[fd].dir = (mode & O_DIR) ? 1 : 0;
+    fh[fd].dir = ((mode & O_DIR) != 0);
     fh[fd].ptr = 0;
     fh[fd].size = iso_733(de->size);
-    fh[fd].broken = 0;
+    fh[fd].broken = false;
 
     return (void *)fd;
 }

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -748,10 +748,9 @@ int fs_vmu_init(void) {
 int fs_vmu_shutdown(void) {
     vmu_fh_t * c, * n;
 
-    c = TAILQ_FIRST(&vmu_fh);
+    mutex_lock(&fh_mutex);
 
-    while(c) {
-        n = TAILQ_NEXT(c, listent);
+    TAILQ_FOREACH_SAFE(c, &vmu_fh, listent, n) {
 
         switch(c->strtype) {
             case VMU_DIR: {
@@ -772,9 +771,9 @@ int fs_vmu_shutdown(void) {
         }
 
         free(c);
-        c = n;
     }
 
+    mutex_unlock(&fh_mutex);
     mutex_destroy(&fh_mutex);
 
     return nmmgr_handler_remove(&vh.nmmgr);

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -333,19 +333,16 @@ static fs_hnd_t * fs_map_hnd(file_t fd) {
 /* Close a file and clean up the handle */
 int fs_close(file_t fd) {
     int retval;
-    fs_hnd_t *hnd = fs_map_hnd(fd);
+    fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(!hnd) {
-        errno = EBADF;
-        return -1;
-    }
+    if(!h) return -1;
 
     /* Deref it and remove it from our table */
-    retval = fs_hnd_unref(hnd);
+    retval = fs_hnd_unref(h);
 
     /* Reset our position */
-    if(hnd->refcnt == 0)
-        hnd->idx = 0;
+    if(h->refcnt == 0)
+        h->idx = 0;
 
     fd_table[fd] = NULL;
     return retval ? -1 : 0;
@@ -355,7 +352,7 @@ int fs_close(file_t fd) {
 ssize_t fs_read(file_t fd, void *buffer, size_t cnt) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) return -1;
+    if(!h) return -1;
 
     if(h->handler == NULL || h->handler->read == NULL) {
         errno = EINVAL;
@@ -370,7 +367,7 @@ ssize_t fs_write(file_t fd, const void *buffer, size_t cnt) {
 
     h = fs_map_hnd(fd);
 
-    if(h == NULL) return -1;
+    if(!h) return -1;
 
     if(h->handler == NULL || h->handler->write == NULL) {
         errno = EINVAL;
@@ -383,7 +380,7 @@ ssize_t fs_write(file_t fd, const void *buffer, size_t cnt) {
 off_t fs_seek(file_t fd, off_t offset, int whence) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) return -1;
+    if(!h) return -1;
 
     if(h->handler == NULL) {
         errno = EINVAL;
@@ -403,7 +400,7 @@ off_t fs_seek(file_t fd, off_t offset, int whence) {
 _off64_t fs_seek64(file_t fd, _off64_t offset, int whence) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) return -1;
+    if(!h) return -1;
 
     if(h->handler == NULL) {
         errno = EINVAL;
@@ -423,7 +420,7 @@ _off64_t fs_seek64(file_t fd, _off64_t offset, int whence) {
 off_t fs_tell(file_t fd) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) return -1;
+    if(!h) return -1;
 
     if(h->handler == NULL) {
         errno = EINVAL;
@@ -443,7 +440,7 @@ off_t fs_tell(file_t fd) {
 _off64_t fs_tell64(file_t fd) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) return -1;
+    if(!h) return -1;
 
     if(h->handler == NULL) {
         errno = EINVAL;
@@ -463,7 +460,7 @@ _off64_t fs_tell64(file_t fd) {
 size_t fs_total(file_t fd) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) return -1;
+    if(!h) return -1;
 
     if(h->handler == NULL) {
         errno = EINVAL;
@@ -483,7 +480,7 @@ size_t fs_total(file_t fd) {
 uint64 fs_total64(file_t fd) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) return -1;
+    if(!h) return -1;
 
     if(h->handler == NULL) {
         errno = EINVAL;
@@ -505,10 +502,7 @@ dirent_t *fs_readdir(file_t fd) {
     static dirent_t *temp_dirent;
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) {
-        errno = EBADF;
-        return NULL;
-    }
+    if(!h) return NULL;
 
     if(h->handler == NULL)
         return fs_root_readdir(h);
@@ -569,10 +563,7 @@ int fs_vioctl(file_t fd, int cmd, va_list ap) {
     fs_hnd_t *h = fs_map_hnd(fd);
     int rv;
 
-    if(!h) {
-        errno = EBADF;
-        return -1;
-    }
+    if(!h) return -1;
 
     if(!h->handler || !h->handler->ioctl) {
         errno = EINVAL;
@@ -678,7 +669,7 @@ const char *fs_getwd(void) {
 void *fs_mmap(file_t fd) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) return NULL;
+    if(!h) return NULL;
 
     if(h->handler == NULL || h->handler->mmap == NULL) {
         errno = EINVAL;
@@ -691,7 +682,7 @@ void *fs_mmap(file_t fd) {
 int fs_complete(file_t fd, ssize_t * rv) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(h == NULL) return -1;
+    if(!h) return -1;
 
     if(h->handler == NULL || h->handler->complete == NULL) {
         errno = EINVAL;
@@ -745,10 +736,7 @@ static int fs_vfcntl(file_t fd, int cmd, va_list ap) {
     fs_hnd_t *h = fs_map_hnd(fd);
     int rv;
 
-    if(!h) {
-        errno = EBADF;
-        return -1;
-    }
+    if(!h) return -1;
 
     if(!h->handler || !h->handler->fcntl) {
         errno = ENOSYS;
@@ -908,10 +896,7 @@ int fs_stat(const char *path, struct stat *buf, int flag) {
 int fs_rewinddir(file_t fd) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(!h) {
-        errno = EBADF;
-        return -1;
-    }
+    if(!h) return -1;
 
     if(h->handler == NULL) {
         h->hnd = (void *)0;
@@ -931,10 +916,7 @@ int fs_rewinddir(file_t fd) {
 int fs_fstat(file_t fd, struct stat *st) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
-    if(!h) {
-        errno = EBADF;
-        return -1;
-    }
+    if(!h) return -1;
 
     if(!st) {
         errno = EFAULT;

--- a/kernel/fs/fs_null.c
+++ b/kernel/fs/fs_null.c
@@ -258,15 +258,14 @@ int fs_null_init(void) {
 int fs_null_shutdown(void) {
     null_fh_t * c, * n;
 
-    /* First, clean up any open files */
-    c = TAILQ_FIRST(&null_fh);
+    mutex_lock(&fh_mutex);
 
-    while(c) {
-        n = TAILQ_NEXT(c, listent);
+    /* First, clean up any open files */
+    TAILQ_FOREACH_SAFE(c, &null_fh, listent, n) {
         free(c);
-        c = n;
     }
 
+    mutex_unlock(&fh_mutex);
     mutex_destroy(&fh_mutex);
 
     nmmgr_handler_remove(&vh.nmmgr);

--- a/kernel/fs/fs_random.c
+++ b/kernel/fs/fs_random.c
@@ -334,15 +334,14 @@ int fs_rnd_init(void) {
 int fs_rnd_shutdown(void) {
     rnd_fh_t * c, * n;
 
-    /* First, clean up any open files */
-    c = TAILQ_FIRST(&rnd_fh);
+    mutex_lock(&fh_mutex);
 
-    while(c) {
-        n = TAILQ_NEXT(c, listent);
+    /* First, clean up any open files */
+    TAILQ_FOREACH_SAFE(c, &rnd_fh, listent, n) {
         free(c);
-        c = n;
     }
 
+    mutex_unlock(&fh_mutex);
     mutex_destroy(&fh_mutex);
 
     nmmgr_handler_remove(&vh.nmmgr);

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -22,31 +22,46 @@ on sunsite.unc.edu in /pub/Linux/system/recovery/, or as a package under Debian 
 #include <kos/fs_romdisk.h>
 #include <kos/opts.h>
 #include <malloc.h>
+#include <stdbool.h>
 #include <string.h>
 #include <strings.h>
 #include <stdio.h>
 #include <assert.h>
 #include <errno.h>
 
+#define ROMFS_MAXFN 128
+#define ROMFH_HRD 0
+#define ROMFH_DIR 1
+#define ROMFH_REG 2
+#define ROMFH_LNK 3
+#define ROMFH_BLK 4
+#define ROMFH_CHR 5
+#define ROMFH_SCK 6
+#define ROMFH_FIF 7
+#define ROMFH_EXEC 8
+
+#define RD_VN_MAX 16
+#define RD_FN_MAX 16
+
 /* Header definitions from Linux ROMFS documentation; all integer quantities are
    expressed in big-endian notation. Unfortunately the ROMFS guys were being
    clever and made this header a variable length depending on the size of
    the volume name *groan*. Its size will be a multiple of 16 bytes though. */
 typedef struct {
-    char    magic[8];       /* Should be "-rom1fs-" */
-    uint32  full_size;      /* Full size of the file system */
-    uint32  checksum;       /* Checksum */
-    char    volume_name[16];    /* Volume name (zero-terminated) */
+    char    magic[8];               /* Should be "-rom1fs-" */
+    uint32  full_size;              /* Full size of the file system */
+    uint32  checksum;               /* Checksum */
+    char    volume_name[RD_VN_MAX]; /* Volume name (zero-terminated) */
 } romdisk_hdr_t;
 
 /* File header info; note that this header plus filename must be a multiple of
    16 bytes, and the following file data must also be a multiple of 16 bytes. */
 typedef struct {
-    uint32  next_header;        /* Offset of next header */
-    uint32  spec_info;      /* Spec info */
-    uint32  size;           /* Data size */
-    uint32  checksum;       /* File checksum */
-    char    filename[16];       /* File name (zero-terminated) */
+    uint32  next_header;            /* Offset of next header */
+    uint32  spec_info;              /* Spec info */
+    uint32  size;                   /* Data size */
+    uint32  checksum;               /* File checksum */
+    char    filename[RD_FN_MAX];    /* File name (zero-terminated) */
 } romdisk_file_t;
 
 
@@ -84,12 +99,15 @@ static rdi_list_t romdisks;
    too lazy right now. =) */
 static struct {
     uint32      index;      /* romfs image index */
-    int     dir;        /* >0 if a directory */
+    bool        dir;        /* true if a directory */
     uint32      ptr;        /* Current read position in bytes */
     uint32      size;       /* Length of file in bytes */
     dirent_t    dirent;     /* A static dirent to pass back to clients */
     rd_image_t  * mnt;      /* Which mount instance are we using? */
 } fh[FS_ROMDISK_MAX_FILES];
+
+#define FH_INDEX_FREE 0
+#define FH_INDEX_RESERVED -1
 
 /* File type */
 #define ROMFH_DIR   1
@@ -102,7 +120,7 @@ static mutex_t fh_mutex;
 /* Given a filename and a starting romdisk directory listing (byte offset),
    search for the entry in the directory and return the byte offset to its
    entry. */
-static uint32 romdisk_find_object(rd_image_t * mnt, const char *fn, size_t fnlen, int dir, uint32 offset) {
+static uint32_t romdisk_find_object(rd_image_t *mnt, const char *fn, size_t fnlen, bool dir, uint32_t offset) {
     uint32          i, ni, type;
     const romdisk_file_t    *fhdr;
 
@@ -156,10 +174,10 @@ static uint32 romdisk_find_object(rd_image_t * mnt, const char *fn, size_t fnlen
    find_object_path in iso9660.
 
    fn:      object filename (absolute path)
-   dir:     0 if looking for a file, 1 if looking for a dir
+   dir:     false if looking for a file, true if looking for a dir
 
    It will return an offset in the romdisk image for the object. */
-static uint32 romdisk_find(rd_image_t * mnt, const char *fn, int dir) {
+static uint32_t romdisk_find(rd_image_t *mnt, const char *fn, bool dir) {
     const char      *cur;
     uint32          i;
     const romdisk_file_t    *fhdr;
@@ -170,7 +188,7 @@ static uint32 romdisk_find(rd_image_t * mnt, const char *fn, int dir) {
 
     while((cur = strchr(fn, '/'))) {
         if(cur != fn) {
-            i = romdisk_find_object(mnt, fn, cur - fn, 1, i);
+            i = romdisk_find_object(mnt, fn, cur - fn, true, i);
 
             if(i == 0) return 0;
 
@@ -223,8 +241,8 @@ static void * romdisk_open(vfs_handler_t * vfs, const char *fn, int mode) {
     mutex_lock(&fh_mutex);
 
     for(fd = 0; fd < FS_ROMDISK_MAX_FILES; fd++)
-        if(fh[fd].index == 0) {
-            fh[fd].index = -1;
+        if(fh[fd].index == FH_INDEX_FREE) {
+            fh[fd].index = FH_INDEX_RESERVED;
             break;
         }
 
@@ -237,8 +255,8 @@ static void * romdisk_open(vfs_handler_t * vfs, const char *fn, int mode) {
 
     /* Fill the fd structure */
     fhdr = (const romdisk_file_t *)(mnt->image + filehdr);
-    fh[fd].index = filehdr + sizeof(romdisk_file_t) + (strlen(fhdr->filename) / 16) * 16;
-    fh[fd].dir = (mode & O_DIR) ? 1 : 0;
+    fh[fd].index = filehdr + sizeof(romdisk_file_t) + (strlen(fhdr->filename) / RD_FN_MAX) * RD_FN_MAX;
+    fh[fd].dir = ((mode & O_DIR) != 0);
     fh[fd].ptr = 0;
     fh[fd].size = ntohl_32(&fhdr->size);
     fh[fd].mnt = mnt;
@@ -253,7 +271,7 @@ static int romdisk_close(void * h) {
     /* Check that the fd is valid */
     if(fd < FS_ROMDISK_MAX_FILES) {
         /* No need to lock the mutex: this is an atomic op */
-        fh[fd].index = 0;
+        fh[fd].index = FH_INDEX_FREE;
     }
     return 0;
 }
@@ -263,7 +281,7 @@ static ssize_t romdisk_read(void * h, void *buf, size_t bytes) {
     file_t fd = (file_t)h;
 
     /* Check that the fd is valid */
-    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == 0 || fh[fd].dir) {
+    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == FH_INDEX_FREE || fh[fd].dir) {
         errno = EINVAL;
         return -1;
     }
@@ -279,12 +297,22 @@ static ssize_t romdisk_read(void * h, void *buf, size_t bytes) {
     return bytes;
 }
 
+/* Just to get the errno that might be better recognized upstream. */
+static ssize_t romdisk_write(void *h, const void *buf, size_t bytes) {
+    (void)h;
+    (void)buf;
+    (void)bytes;
+
+    errno = ENXIO;
+    return -1;
+}
+
 /* Seek elsewhere in a file */
 static off_t romdisk_seek(void * h, off_t offset, int whence) {
     file_t fd = (file_t)h;
 
     /* Check that the fd is valid */
-    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == 0 || fh[fd].dir) {
+    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == FH_INDEX_FREE || fh[fd].dir) {
         errno = EBADF;
         return -1;
     }
@@ -333,7 +361,7 @@ static off_t romdisk_seek(void * h, off_t offset, int whence) {
 static off_t romdisk_tell(void * h) {
     file_t fd = (file_t)h;
 
-    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == 0 || fh[fd].dir) {
+    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == FH_INDEX_FREE || fh[fd].dir) {
         errno = EINVAL;
         return -1;
     }
@@ -345,7 +373,7 @@ static off_t romdisk_tell(void * h) {
 static size_t romdisk_total(void * h) {
     file_t fd = (file_t)h;
 
-    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == 0 || fh[fd].dir) {
+    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == FH_INDEX_FREE || fh[fd].dir) {
         errno = EINVAL;
         return -1;
     }
@@ -359,7 +387,7 @@ static dirent_t *romdisk_readdir(void * h) {
     int type;
     file_t fd = (file_t)h;
 
-    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == 0 || !fh[fd].dir) {
+    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == FH_INDEX_FREE || !fh[fd].dir) {
         errno = EBADF;
         return NULL;
     }
@@ -400,10 +428,19 @@ static dirent_t *romdisk_readdir(void * h) {
     return &fh[fd].dirent;
 }
 
+/* Just to get the errno that might be better recognized upstream. */
+static int romdisk_unlink(vfs_handler_t *vfs, const char *fn) {
+    (void)vfs;
+    (void)fn;
+
+    errno = EROFS;
+    return -1;
+}
+
 static void *romdisk_mmap(void * h) {
     file_t fd = (file_t)h;
 
-    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == 0) {
+    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == FH_INDEX_FREE) {
         errno = EINVAL;
         return NULL;
     }
@@ -477,7 +514,7 @@ static int romdisk_fcntl(void *h, int cmd, va_list ap) {
 
     (void)ap;
 
-    if(fd >= FS_ROMDISK_MAX_FILES || !fh[fd].index) {
+    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == FH_INDEX_FREE) {
         errno = EBADF;
         return -1;
     }
@@ -507,7 +544,7 @@ static int romdisk_fcntl(void *h, int cmd, va_list ap) {
 static int romdisk_rewinddir(void *h) {
     file_t fd = (file_t)h;
 
-    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == 0 || !fh[fd].dir) {
+    if(fd >= FS_ROMDISK_MAX_FILES || fh[fd].index == FH_INDEX_FREE || !fh[fd].dir) {
         errno = EBADF;
         return -1;
     }
@@ -556,14 +593,14 @@ static vfs_handler_t vh = {
     romdisk_open,
     romdisk_close,
     romdisk_read,
-    NULL,                       /* write */
+    romdisk_write,
     romdisk_seek,
     romdisk_tell,
     romdisk_total,
     romdisk_readdir,
     NULL,                       /* ioctl */
     NULL,                       /* rename */
-    NULL,                       /* unlink */
+    romdisk_unlink,
     romdisk_mmap,
     NULL,                       /* complete */
     romdisk_stat,
@@ -596,7 +633,7 @@ void fs_romdisk_init(void) {
     memset(fh, 0, sizeof(fh));
 
     /* Mark the first as active so we can have an error FD of zero */
-    fh[0].index = -1;
+    fh[0].index = FH_INDEX_RESERVED;
 
     /* Init thread mutexes */
     mutex_init(&fh_mutex, MUTEX_TYPE_NORMAL);
@@ -677,7 +714,7 @@ int fs_romdisk_mount(const char * mountpoint, const uint8 *img, int own_buffer) 
     mnt->image = img;
     mnt->hdr = hdr;
     mnt->files = sizeof(romdisk_hdr_t)
-                 + (strlen(hdr->volume_name) / 16) * 16;
+                 + (strlen(hdr->volume_name) / RD_VN_MAX) * RD_VN_MAX;
 
     /* Make a VFS struct */
     vfsh = (vfs_handler_t *)malloc(sizeof(vfs_handler_t));
@@ -706,19 +743,18 @@ int fs_romdisk_mount(const char * mountpoint, const uint8 *img, int own_buffer) 
 /* Unmount a romdisk image */
 int fs_romdisk_unmount(const char * mountpoint) {
     rd_image_t  * n;
-    int     found = 0;
     int     rv = 0;
 
     mutex_lock(&fh_mutex);
 
     LIST_FOREACH(n, &romdisks, list_ent) {
         if(!strcmp(mountpoint, n->vfsh->nmmgr.pathname)) {
-            found = 1;
             break;
         }
     }
 
-    if(found) {
+    /* If the LIST_FOREACH goes to the end n will be NULL */
+    if(n != NULL) {
         /* Remove it from the mount list */
         LIST_REMOVE(n, list_ent);
 


### PR DESCRIPTION
EDIT: Refreshed these changes from spring for the current situation. Collection of mostly formal changes.

- `fs_map_hnd` already sets the errno on its bad paths, so avoid duplicating that.
- Fix typo in dirent documentation.
- Import defines from genromfs and romdisk documentation to fs_romdisk. Demagic volumename/filename maxes.
- Add romdisk write and unlink stubs. Not sure that they're helpful at all, but they enforce more accurate behavior based on the POSIX definitions for what the errnos should be set to.
- Cleanups around shutdowns for some FSes and conversion of some fh values to bools.