### PR TITLE
Add missing __END_DECLS

### DIFF
--- a/addons/libkosext2fs/inode.h
+++ b/addons/libkosext2fs/inode.h
@@ -162,4 +162,6 @@ uint8_t *ext2_inode_read_block(ext2_fs_t *fs, const ext2_inode_t *inode,
 int ext2_resolve_symlink(ext2_fs_t *fs, ext2_inode_t *inode, char *rv,
                          size_t *rv_len);
 
+__END_DECLS
+
 #endif /* !__EXT2_INODE_H */

--- a/addons/libkosfat/bpb.h
+++ b/addons/libkosfat/bpb.h
@@ -112,4 +112,6 @@ int fat_write_fsinfo(fat_fs_t *fs);
 void fat_print_superblock(const fat_superblock_t *sb);
 #endif
 
+__END_DECLS
+
 #endif /* !__FAT_BPB_H */

--- a/addons/libkosfat/directory.h
+++ b/addons/libkosfat/directory.h
@@ -81,4 +81,6 @@ void fat_update_mtime(fat_dentry_t *ent);
 void fat_dentry_print(const fat_dentry_t *ent);
 #endif
 
+__END_DECLS
+
 #endif /* !__FAT_DIRECTORY_H */

--- a/addons/libkosfat/ucs.h
+++ b/addons/libkosfat/ucs.h
@@ -20,4 +20,6 @@ int fat_ucs2_to_utf8(uint8_t *out, const uint16_t *in, size_t olen,
 size_t fat_strlen_ucs2(const uint16_t *in);
 void fat_ucs2_tolower(uint16_t *in, size_t len);
 
+__END_DECLS
+
 #endif /* !__FAT_UCS_H */

--- a/include/kos/oneshot_timer.h
+++ b/include/kos/oneshot_timer.h
@@ -121,4 +121,6 @@ static inline void oneshot_timer_reset(oneshot_timer_t *timer) {
     oneshot_timer_start(timer);
 }
 
+__END_DECLS
+
 #endif /* __KOS_ONESHOT_TIMER_H */

--- a/kernel/arch/dreamcast/include/dc/math.h
+++ b/kernel/arch/dreamcast/include/dc/math.h
@@ -35,4 +35,6 @@ unsigned int bit_reverse(unsigned int value);
 
 /** @} */
 
+__END_DECLS
+
 #endif /* __DC_MATH_H */


### PR DESCRIPTION
This fixes the compilation of libtsunami examples, and other c++ code that broke after #567 . Additionally cleaned up other instances of the same issue.