### PR TITLE
Work around MMU issue with SQs

### DIFF
--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -8,6 +8,7 @@
 */
 
 #include <arch/cache.h>
+#include <arch/mmu.h>
 #include <dc/sq.h>
 #include <kos/dbglog.h>
 #include <kos/mutex.h>
@@ -40,12 +41,20 @@
 
 static mutex_t sq_mutex = MUTEX_INITIALIZER;
 
+static mmu_token_t mmu_token;
+
 void sq_lock(void *dest) {
     mutex_lock(&sq_mutex);
+
+    /* Disable MMU, because SQs work differently when it's enabled, and we
+     * don't support it. */
+    mmu_token = mmu_disable();
+
     SET_QACR_REGS(dest, dest);
 }
 
 void sq_unlock(void) {
+    mmu_restore(mmu_token);
     mutex_unlock(&sq_mutex);
 }
 

--- a/kernel/arch/dreamcast/include/arch/mmu.h
+++ b/kernel/arch/dreamcast/include/arch/mmu.h
@@ -195,6 +195,9 @@ typedef struct mmucontext {
     to do so.
 */
 extern mmucontext_t *mmu_cxt_current;
+
+struct mmu_token;
+typedef struct mmu_token *mmu_token_t;
 /** \endcond */
 
 /** \brief   Set the "current" page tables for TLB handling.
@@ -369,6 +372,20 @@ void mmu_shutdown(void);
     \ingroup mmu
  */
 void mmu_reset_itlb(void);
+
+/** \brief   Temporarily disable MMU address translation.
+    \ingroup mmu
+
+    \return                 An opaque token to be passed to mmu_restore()
+ */
+mmu_token_t mmu_disable(void);
+
+/** \brief   Restore MMU address translation.
+    \ingroup mmu
+
+    \param  token           The opaque token obtained from mmu_disable()
+ */
+void mmu_restore(mmu_token_t token);
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/kernel/mmu.c
+++ b/kernel/arch/dreamcast/kernel/mmu.c
@@ -766,3 +766,15 @@ void mmu_shutdown(void) {
     irq_set_handler(EXC_DTLB_PV_WRITE, NULL, NULL);
     irq_set_handler(EXC_INITIAL_PAGE_WRITE, NULL, NULL);
 }
+
+mmu_token_t mmu_disable(void) {
+    mmu_token_t token = (mmu_token_t)*mmucr;
+
+    *mmucr &= ~0x1;
+
+    return token;
+}
+
+void mmu_restore(mmu_token_t token) {
+    *mmucr = (uint32)token;
+}


### PR DESCRIPTION
This change makes it possible to use SQs in a program that uses the MMU,
by disabling the MMU in sq_lock(), and re-enable it again in
mmu_restore().

This means that memory-mapped data must not be accessed while the SQ is
locked. This should be fine, as it wasn't working properly before, so
it's not a regression.