### PR TITLE
Correct bitmasks in fpu_exc stringify

### DIFF
--- a/examples/dreamcast/basic/fpu/exc/fpu_exc.c
+++ b/examples/dreamcast/basic/fpu/exc/fpu_exc.c
@@ -42,8 +42,8 @@ fpscr_stringify(unsigned int value, char* buffer, size_t bytes) {
             !!(value & (1 << 19)),
             !!(value & (1 << 18)),
             (value >> 12) & 0x3f,
-            (value >> 7) & 0x3f,
-            (value >> 2) & 0x3f,
+            (value >> 7) & 0x1f,
+            (value >> 2) & 0x1f,
             value & 0x3);
 
     return buffer;


### PR DESCRIPTION
Very tiny change. When testing for #600 noticed that the wrong values were being printed for the fpscr data. All were set to the same 6-bit size, but according to the table in the SH4 manual:
![image](https://github.com/KallistiOS/KallistiOS/assets/686781/eaad1e5a-8c13-4f67-8a07-8e00933468ae)
and the bit shifting being done, the flags and enabled are each 5 bits.