### PR TITLE
Avoid infinite loop in mouse example (also, is mouse broken?)

### DIFF
--- a/examples/dreamcast/libdream/mouse/mouse.c
+++ b/examples/dreamcast/libdream/mouse/mouse.c
@@ -13,10 +13,6 @@ void mouse_test(void) {
 
         if(!cont) continue;
 
-        mouse = maple_enum_type(0, MAPLE_FUNC_MOUSE);
-
-        if(!mouse) continue;
-
         /* Check for start on the controller */
         cstate = (cont_state_t *)maple_dev_status(cont);
 
@@ -32,11 +28,14 @@ void mouse_test(void) {
 
         thd_sleep(10);
 
+        mouse = maple_enum_type(0, MAPLE_FUNC_MOUSE);
+
+        if(!mouse) continue;
+
         /* Check for mouse input */
         mstate = (mouse_state_t *)maple_dev_status(mouse);
 
-        if(!mstate)
-            continue;
+        if(!mstate) continue;
 
         /* Move the cursor if applicable */
         if(mstate->dx || mstate->dy || mstate->dz) {


### PR DESCRIPTION
Currently, if you start up the mouse example with no mouse, you will go into an inescapable loop. With this adjustment you can now still exit from the example by pressing Start on a controller (if no controller was plugged in, it would always just exit).

Perhaps more importantly, I can't seem to get it to work at all with my Treamcast mouse and @andressbarajas reported similar here: https://github.com/KallistiOS/KallistiOS/pull/551#issuecomment-2118666206 .

If anyone has a functioning mouse it would be great to get it tested but not a prerequisite for this since the behavior only strictly needs a controller to validate (I may open a matching issue but I hope someone is able to give it a quick try).