### PR TITLE
Fixed false failure in once_test on 16MB RAM

### DIFF
--- a/examples/dreamcast/basic/threading/once/once_test.c
+++ b/examples/dreamcast/basic/threading/once/once_test.c
@@ -23,7 +23,7 @@
 #include <dc/maple/controller.h>
 
 #define UNUSED __attribute__((unused))
-#define THD_COUNT 600
+#define THD_COUNT (475 * (DBL_MEM? 2 : 1))
 
 static kthread_once_t once = KTHREAD_ONCE_INIT;
 static spinlock_t lock = SPINLOCK_INITIALIZER;
@@ -64,7 +64,7 @@ static void *thd_func(void *param UNUSED) {
     return NULL;
 }
 
-KOS_INIT_FLAGS(INIT_DEFAULT);
+KOS_INIT_FLAGS(INIT_DEFAULT | INIT_MALLOCSTATS);
 
 int main(int argc, char *argv[]) {
     int i, retval, success = 1;
@@ -91,7 +91,7 @@ int main(int argc, char *argv[]) {
     printf("Waiting for the threads to finish\n");
 
     for(i = 0; i < THD_COUNT; ++i) {
-        if((retval = thd_join(thds[i], NULL) < 0)) {
+        if((retval = thd_join(thds[i], NULL)) < 0) {
             fprintf(stderr, "Failed to join thread[%d]: %d\n", 
                     i, retval);
             success = 0;


### PR DESCRIPTION
- Accidentally allocated too many goddamn threads only testing on 32MB units
- Somehow allocation was failing gracefully on 16MB, the program never crashed, and it just returned a real failure code...
- Running out of memory allocating a thread then trying to join on a NULL later is apparently pristinely protected against. Impressive.
- Modified test to allocate 475 threads on 16MB and 950 on 32MB.
- Fixed the error code assignment when failing to join the thread, as it was printing "1" rather than "-1."
- Also enabled `INIT_MALLOCSTATS` to see what the final RAM stats look like with all that thread allocating.