### PR TITLE
Return Failure Error Code when examples fail to build

### DIFF
--- a/examples/dreamcast/Makefile
+++ b/examples/dreamcast/Makefile
@@ -20,12 +20,14 @@ all:
 		$(KOS_MAKE) check-dir DIR=$$dir; \
 	done;
 
-	@if [ -f errors.txt ]; then \
+	@error_count=$$(cat error_count.txt 2>/dev/null || echo 0); \
+	if [ -f errors.txt ]; then \
 		echo "\n-------------------------------------------------"; \
-		echo "$$(cat error_count.txt 2>/dev/null || echo 0) error(s) occurred during the build process:"; \
+		echo "$$error_count error(s) occurred during the build process:"; \
 		cat errors.txt; \
-	fi;
-	@rm -f errors.txt error_count.txt
+	fi; \
+	rm -f errors.txt error_count.txt; \
+	exit $$error_count
 
 # ALGORITHM EXPLANATION:
 # This script recursively checks each directory to determine if it should 


### PR DESCRIPTION
I'd like to be able to detect a build failure in the examples using a return code. Currently it reports the build errors but the `make` command returns 0.

@andressbarajas since you just made the change for reporting the build errors recently, I'd appreciate it if you could give this change a look over when you have time.