### PR TITLE
Fixed warnings when compiling with builtins

### DIFF
--- a/kernel/libc/koslib/readdir.c
+++ b/kernel/libc/koslib/readdir.c
@@ -33,9 +33,7 @@ struct dirent *readdir(DIR *dir) {
     else
         dir->d_ent.d_type = DT_REG;
 
-    len = strlen(d->name);
-    if(len > sizeof(dir->d_name) - 1)
-        len = sizeof(dir->d_name) - 1;
+    len = strnlen(d->name, sizeof(dir->d_name) - 1);
 
     strncpy(dir->d_ent.d_name, d->name, len);
     dir->d_ent.d_name[len] = '\0';

--- a/kernel/libc/newlib/newlib_exit.c
+++ b/kernel/libc/newlib/newlib_exit.c
@@ -6,14 +6,14 @@
 */
 
 #include <arch/arch.h>
+#include <kos/dbglog.h>
 #include <stdbool.h>
 
 extern void arch_exit_handler(int ret_code) __noreturn;
 
 static int ret_code;
 
-void kos_shutdown(void)
-{
+static void kos_shutdown(void) {
     arch_exit_handler(ret_code);
 
     __builtin_unreachable();
@@ -25,4 +25,10 @@ void _exit(int code) {
     ret_code = code;
 
     KOS_INIT_FLAG_CALL(kos_shutdown);
+
+    dbglog(DBG_WARNING,
+           "arch: _exit(%d) called without SHUTDOWN flag enabled!\n",
+           code);
+
+    arch_menu();
 }


### PR DESCRIPTION
- First warning was about using the string-length of the source of a strncpy() operation as its length... but its a bullshit, because we were correctly doing a range check afterwards... oh well, using strnlen() for the length seemed to appese the gumpy compiler.
- Second warning was legit. _exit(int) without building with INIT_SHUTDOWN was still returning from a function maked __noreturn. Added code following the conditional regular shutdown path for when it's not present to simply log a warning then return back to the BIOS menu.