### PR TITLE
Fixed broken build.

### DIFF
--- a/kernel/libc/newlib/newlib_exit.c
+++ b/kernel/libc/newlib/newlib_exit.c
@@ -13,7 +13,7 @@ extern void arch_exit_handler(int ret_code) __noreturn;
 
 static int ret_code;
 
-static void kos_shutdown(void) {
+void kos_shutdown(void) {
     arch_exit_handler(ret_code);
 
     __builtin_unreachable();


### PR DESCRIPTION
- Accidentally marked kos_shutdown() static and didn't realize I had screwed up an external symbol, because I didn't test linking an example. My bad.