### PR TITLE
Add DC_TOOLS_BASE env variable for external tools

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -61,6 +61,15 @@ export KOS_CC_PREFIX="sh-elf"
 export DC_ARM_BASE="/opt/toolchains/dc/arm-eabi"
 export DC_ARM_PREFIX="arm-eabi"
 
+# External Dreamcast Tools Path
+#
+# Specifies the path where Dreamcast tools that are not part of KOS are to be
+# installed. This includes, for example, dc-tool-ip, dc-tool-serial, and the
+# mrbc bytecode compiler. This directory, along with SH and ARM compiler
+# toolchains, will be added to your PATH environment variable.
+#
+export DC_TOOLS_BASE="/opt/toolchains/dc/bin"
+
 # CMake Toolchain Path
 #
 # Specifies the path to the toolchain file used to target
@@ -197,16 +206,6 @@ export KOS_SH4_PRECISION="-m4-single-only"
 # Only enable this setting if you understand what you are doing!
 #
 #export KOS_CFLAGS="${KOS_CFLAGS} -mlra"
-
-# Additional Tools Path
-#
-# If not already set, add "bin" directory to PATH variable, which is where
-# additional tools such as dc-tool-ip and dc-tool-serial are typically
-# installed. Comment this out if you don't want this included within your PATH.
-#
-if [[ ":$PATH:" != *":${KOS_CC_BASE}/bin:/opt/toolchains/dc/bin"* ]]; then
-  export PATH="${PATH}:${KOS_CC_BASE}/bin:/opt/toolchains/dc/bin"
-fi
 
 # Shared Compiler Configuration
 #

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -12,7 +12,12 @@ export KOS_ARCH_DIR="${KOS_BASE}/kernel/arch/${KOS_ARCH}"
 # Pull in the arch environ file
 . ${KOS_BASE}/environ_${KOS_ARCH}.sh
 
-# Add the gnu wrappers dir to the path if it is not already
+# Add the compiler bins dir to the path if it is not already
+if [[ ":$PATH:" != *":${KOS_CC_BASE}/bin:"* ]]; then
+  export PATH="${PATH}:${KOS_CC_BASE}/bin"
+fi
+
+# Add the build wrappers dir to the path if it is not already
 if [[ ":$PATH:" != *":${KOS_BASE}/utils/build_wrappers:"* ]]; then
   export PATH="${PATH}:${KOS_BASE}/utils/build_wrappers"
 fi

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -1,6 +1,16 @@
 # KallistiOS environment variable settings. These are the shared pieces
 # for the Dreamcast(tm) platform.
 
+# Add the default external DC tools path if it isn't already set.
+if [ -z "${DC_TOOLS_BASE}" ] ; then
+    export DC_TOOLS_BASE="/opt/toolchains/dc/bin"
+fi
+
+# Add the external DC tools dir to the path if it is not already.
+if [[ ":$PATH:" != *":${DC_TOOLS_BASE}:"* ]]; then
+  export PATH="${PATH}:${DC_TOOLS_BASE}"
+fi
+
 # Default the SH4 floating point precision if it isn't already set.
 if [ -z "${KOS_SH4_PRECISION}" ] ; then
     export KOS_SH4_PRECISION="-m4-single-only"

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -3,7 +3,7 @@
 
 # Add the default external DC tools path if it isn't already set.
 if [ -z "${DC_TOOLS_BASE}" ] ; then
-    export DC_TOOLS_BASE="/opt/toolchains/dc/bin"
+    export DC_TOOLS_BASE="${KOS_CC_BASE}/../bin"
 fi
 
 # Add the external DC tools dir to the path if it is not already.


### PR DESCRIPTION
Somehow, despite adding this path to the `PATH` env variable and installing things to it (`mrbc` in kos-ports, `dc-tool-ip`, etc.), we don't actually have a defined environment variable for the path where tools external to KOS, but installed and used by KOS, are supposed to be installed. 

This has also caused some issues for me, for example in `mruby`, the directory where `mrbc` is to be installed is defined as so:
```make
MRUBY_INSTALL_DIR = $(KOS_CC_BASE)/../bin
```
which means when I do custom compiler work and install toolchains to weird paths and build kos-ports, I end up later finding `bin/mrbc` littered around my Dreamcast tools. 😆 

This PR adds `DC_TOOLS_BASE` to the `environ.sh` sample and better places where the paths are checked and added. I chose `DC_` instead of `KOS_` as a prefix since these tools are not actually part of KOS and are not KOS-specific (similar to how our ARM toolchain is not patched specifically for KOS and is `DC_ARM_BASE`).

A follow-up PR will come for the `mrubyc` kos-port.