### PR TITLE
Improve diagnose message

### DIFF
--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -40,6 +40,10 @@ extern uint32 _arch_mem_top;
 #define _arch_mem_top   ((uint32) 0x8d000000)
 #endif
 
+/** \brief  Start and End address for .text portion of program. */
+extern char _executable_start;
+extern char _etext; 
+
 #define PAGESIZE        4096            /**< \brief Page size (for MMU) */
 #define PAGESIZE_BITS   12              /**< \brief Bits for page size */
 #define PAGEMASK        (PAGESIZE - 1)  /**< \brief Mask for page offset */
@@ -414,6 +418,16 @@ const char *kos_get_authors(void);
                             memory access.
 */
 #define arch_valid_address(ptr) ((ptr_t)(ptr) >= 0x8c010000 && (ptr_t)(ptr) < _arch_mem_top)
+
+/** \brief   Returns true if the passed address is in the text section of your
+             program.
+    \ingroup arch
+
+    \return                 Whether the address is valid or not for text
+                            memory access.
+*/
+#define arch_valid_text_address(ptr) \
+    ((uintptr_t)(ptr) >= (uintptr_t)&_executable_start && (uintptr_t)(ptr) < (uintptr_t)&_etext)
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -124,6 +124,8 @@ extern irq_context_t *irq_srt_addr;
 static void irq_dump_regs(int code, int evt) {
     uint32_t fp;
     uint32_t *regs = irq_srt_addr->r;
+    bool valid_pc;
+    bool valid_pr;
 
     dbglog(DBG_DEAD, "Unhandled exception: PC %08lx, code %d, evt %04x\n",
            irq_srt_addr->pc, code, (uint16)evt);
@@ -138,17 +140,17 @@ static void irq_dump_regs(int code, int evt) {
     if(code == 1) {
         dbglog(DBG_DEAD, "\nEncountered %s. ", irq_exception_string(evt)); 
         
+        valid_pc = arch_valid_text_address(irq_srt_addr->pc);
+        valid_pr = arch_valid_text_address(irq_srt_addr->pr);
         /* Construct template message only if either PC/PR address is valid */
-        if(arch_valid_text_address(irq_srt_addr->pc) || 
-           arch_valid_text_address(irq_srt_addr->pr)) {
-            
+        if(valid_pc || valid_pr) {
             dbglog(DBG_DEAD, "Use this template terminal command to help"
                 " diagnose:\n\n\t$KOS_ADDR2LINE -e prog.elf");
             
-            if(arch_valid_text_address(irq_srt_addr->pc))
+            if(valid_pc)
                 dbglog(DBG_DEAD, " %08lx", irq_srt_addr->pc);
 
-            if(arch_valid_text_address(irq_srt_addr->pr))
+            if(valid_pr)
                 dbglog(DBG_DEAD, " %08lx", irq_srt_addr->pr);
 
 #ifdef FRAME_POINTERS

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -145,7 +145,7 @@ static void irq_dump_regs(int code, int evt) {
         /* Construct template message only if either PC/PR address is valid */
         if(valid_pc || valid_pr) {
             dbglog(DBG_DEAD, "Use this template terminal command to help"
-                " diagnose:\n\n\t$KOS_ADDR2LINE -e prog.elf");
+                " diagnose:\n\n\t$KOS_ADDR2LINE -f -C -i -e prog.elf");
             
             if(valid_pc)
                 dbglog(DBG_DEAD, " %08lx", irq_srt_addr->pc);


### PR DESCRIPTION
1. We didnt handle invalid PC and PR addresses. We do now by excluding them from the list.
2. Use improved address check to make sure addresses are in the text section of program.
3. Impoved spacing by adding a newline before "Encountered ..."
4. your_program.elf => prog.elf because its easier to edit after copying.
5. Add options to demangle C++ symbols, show function names, print inlined function calls