### PR TITLE
Fix building libstunami examples on GCC9&10

### DIFF
--- a/examples/dreamcast/tsunami/banner/Makefile
+++ b/examples/dreamcast/tsunami/banner/Makefile
@@ -7,6 +7,10 @@ TARGET = banner.elf
 OBJS = banner.o romdisk.o
 KOS_ROMDISK_DIR = romdisk
 
+# GCC versions prior to 11.0 have incomplete C++17 support and need 
+# to be forced to use the GNU dialect for std::filesystem support
+KOS_CPPFLAGS += -std=gnu++17
+
 all: rm-elf $(TARGET)
 
 include $(KOS_BASE)/Makefile.rules

--- a/examples/dreamcast/tsunami/font/Makefile
+++ b/examples/dreamcast/tsunami/font/Makefile
@@ -7,6 +7,10 @@ TARGET = font.elf
 OBJS = font.o romdisk.o
 KOS_ROMDISK_DIR = romdisk
 
+# GCC versions prior to 11.0 have incomplete C++17 support and need 
+# to be forced to use the GNU dialect for std::filesystem support
+KOS_CPPFLAGS += -std=gnu++17
+
 all: rm-elf $(TARGET)
 
 include $(KOS_BASE)/Makefile.rules

--- a/examples/dreamcast/tsunami/genmenu/Makefile
+++ b/examples/dreamcast/tsunami/genmenu/Makefile
@@ -7,6 +7,10 @@ TARGET = genmenu.elf
 OBJS = genmenu.o romdisk.o
 KOS_ROMDISK_DIR = romdisk
 
+# GCC versions prior to 11.0 have incomplete C++17 support and need 
+# to be forced to use the GNU dialect for std::filesystem support
+KOS_CPPFLAGS += -std=gnu++17
+
 all: rm-elf $(TARGET)
 
 include $(KOS_BASE)/Makefile.rules


### PR DESCRIPTION
libtsunami examples fail to build on GCC9&10 due to same issue fixed in KallistiOS/kos-ports/pull/71