### PR TITLE
Fix cpp/clock example on GCC9&10

### DIFF
--- a/examples/dreamcast/cpp/clock/Makefile
+++ b/examples/dreamcast/cpp/clock/Makefile
@@ -8,6 +8,8 @@ TARGET = clock.elf
 OBJS = clock.o romdisk.o
 KOS_ROMDISK_DIR = romdisk
 
+KOS_CPPFLAGS += -std=gnu++17
+
 all: rm-elf $(TARGET)
 
 include $(KOS_BASE)/Makefile.rules


### PR DESCRIPTION
`cpp/clock` example failed to build on GCC9&10 with the following error
```
kos-c++   -c clock.cc -o clock.o
clock.cc: In function 'void drawFrame()':
clock.cc:66:25: error: 'TIME_UTC' was not declared in this scope
   66 |     timespec_get(&spec, TIME_UTC);
      |                         ^~~~~~~~
clock.cc:66:5: error: 'timespec_get' was not declared in this scope; did you mean 'timespec'?
   66 |     timespec_get(&spec, TIME_UTC);
      |     ^~~~~~~~~~~~
      |     timespec
make[3]: *** [/opt/toolchains/dc/kos/Makefile.rules:17: clock.o] Error 1
```
Building with the `gnu++17` standard allows this example to build again under GCC9&10.