### PR TITLE
Clean up CD-ROM code

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -926,10 +926,11 @@ int iso_reset(void) {
    be careful about modifying variables that are in use in the
    foreground, so instead we'll just set a "dead" flag and next
    time someone calls in it'll get reset. */
-static int iso_last_status;
+static enum cd_status_values iso_last_status;
 static int iso_vblank_hnd;
 static void iso_vblank(uint32 evt, void *data) {
-    int status, disc_type;
+    enum cd_status_values status;
+    enum cd_disc_types disc_type;
 
     (void)evt;
     (void)data;
@@ -1075,7 +1076,7 @@ void fs_iso9660_init(void) {
     }
 
     percd_done = 0;
-    iso_last_status = -1;
+    iso_last_status = CD_STATUS_READ_FAIL;
 
     /* Register with the vblank */
     iso_vblank_hnd = vblank_handler_add(iso_vblank, NULL);

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -203,11 +203,6 @@ int cdrom_get_status(int *status, int *disc_type) {
     return rv;
 }
 
-/* Helper function to account for long-standing typo */
-int cdrom_change_dataype(int sector_part, int cdxa, int sector_size) {
-    return cdrom_change_datatype(sector_part, cdxa, sector_size);
-}
-
 /* Wrapper for the change datatype syscall */
 int cdrom_change_datatype(int sector_part, int cdxa, int sector_size) {
     int rv = ERR_OK;

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -42,11 +42,11 @@ normally the case with the default options. If in doubt, decompile the
 output and look to make sure.
 
 XXX: This could all be done in a non-blocking way by taking advantage of
-command queuing. Every call to syscall_gdrom_send_command returns a 
-'request id' which just needs to eventually be checked by cmd_stat. A 
-non-blocking version of all functions would simply require manual calls 
-to check the status. Doing this would probably allow data reading while 
-cdda is playing without hiccups (by severely reducing the number of gd 
+command queuing. Every call to syscall_gdrom_send_command returns a
+'request id' which just needs to eventually be checked by cmd_stat. A
+non-blocking version of all functions would simply require manual calls
+to check the status. Doing this would probably allow data reading while
+cdda is playing without hiccups (by severely reducing the number of gd
 commands being sent).
 */
 
@@ -207,7 +207,7 @@ int cdrom_change_datatype(int sector_part, int cdxa, int sector_size) {
     }
     else {
         if(cdxa == -1) {
-            /* If not overriding cdxa, check what the drive thinks we should 
+            /* If not overriding cdxa, check what the drive thinks we should
                use */
             syscall_gdrom_check_drive(params);
             cdxa = (params[1] == 32 ? 2048 : 1024);
@@ -284,7 +284,7 @@ int cdrom_read_sectors_ex(void *buffer, int sector, int cnt, int mode) {
 
     /* The DMA mode blocks the thread it is called in by the way we execute
        gd syscalls. It does however allow for other threads to run. */
-    /* XXX: DMA Mode may conflict with using a second G1ATA device. More 
+    /* XXX: DMA Mode may conflict with using a second G1ATA device. More
        testing is needed from someone with such a device.
     */
     if(mode == CDROM_READ_DMA)
@@ -302,9 +302,9 @@ int cdrom_read_sectors(void *buffer, int sector, int cnt) {
 
 
 /* Read a piece of or all of the Q byte of the subcode of the last sector read.
-   If you need the subcode from every sector, you cannot read more than one at 
+   If you need the subcode from every sector, you cannot read more than one at
    a time. */
-/* XXX: Use some CD-Gs and other stuff to test if you get more than just the 
+/* XXX: Use some CD-Gs and other stuff to test if you get more than just the
    Q byte */
 int cdrom_get_subcode(void *buffer, int buflen, int which) {
     struct {

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -41,14 +41,12 @@ __BEGIN_DECLS
     \ingroup            vfs
 */
 
-/** \defgroup cd_cmd_codes          Syscall Command Codes
-    \brief                          Command codes for GD-ROM syscalsl
+/** \enum cd_cmd_code
+    \brief                          Command codes for GD-ROM syscalls
     \ingroup  gdrom
 
     These are the syscall command codes used to actually do stuff with the
     GD-ROM drive. These were originally provided by maiwe.
-
-    @{
 */
 enum cd_cmd_code {
     CMD_CHECK_LICENSE     =  2,  /**< \brief Check license */
@@ -80,14 +78,12 @@ enum cd_cmd_code {
     CMD_GET_VERS          = 40,  /**< \brief Get syscall driver version */
     CMD_MAX               = 47,  /**< \brief Max of GD syscall commands */
 };
-/** @} */
 
-/** \defgroup cd_cmd_response       Command Responses
+/** \enum cd_cmd_response
     \brief                          Responses from GD-ROM syscalls
     \ingroup  gdrom
 
     These are the values that the various functions can return as error codes.
-    @{
 */
 enum cd_cmd_response {
     ERR_OK        = 0,   /**< \brief No error */
@@ -98,14 +94,12 @@ enum cd_cmd_response {
     ERR_NO_ACTIVE = 5,   /**< \brief System inactive? */
     ERR_TIMEOUT   = 6,   /**< \brief Aborted due to timeout */
 };
-/** @} */
 
-/** \defgroup cd_cmd_status         Command Status Responses
+/** \enum cd_cmd_status
     \brief                          GD-ROM status responses
     \ingroup  gdrom
 
     These are the raw values the status syscall returns.
-    @{
 */
 enum cd_cmd_status {
     FAILED     = -1,   /**< \brief Command failed */
@@ -115,13 +109,10 @@ enum cd_cmd_status {
     STREAMING  =  3,   /**< \brief Stream type command is in progress */
     BUSY       =  4,   /**< \brief GD syscalls is busy */
 };
-/** @} */
 
-/** \defgroup cd_cmd_ata_status       ATA Statuses
+/** \enum cd_cmd_ata_status
     \brief                            ATA statuses for GD-ROM driver
     \ingroup  gdrom
-
-    @{
 */
 enum cd_cmd_ata_status {
     ATA_STAT_INTERNAL  = 0,
@@ -130,43 +121,55 @@ enum cd_cmd_ata_status {
     ATA_STAT_DRQ_1     = 3,
     ATA_STAT_BUSY      = 4,
 };
-/** @} */
 
-/** \defgroup cdda_read_modes       CDDA Read Modes
+/** \enum cdda_read_modes
     \brief                          Read modes for CDDA
     \ingroup  gdrom
 
     Valid values to pass to the cdrom_cdda_play() function for the mode
     parameter.
-    @{
 */
 enum cdda_read_modes {
     CDDA_TRACKS   = 1,   /**< \brief Play by track number */
     CDDA_SECTORS  = 2,   /**< \brief Play by sector number */
 };
-/** @} */
 
-/** \defgroup cd_read_sector_part    Read Sector Part
+/** \enum cd_read_sector_part
     \brief                           Whether to read data or whole sector
     \ingroup  gdrom
 
     Parts of the a CD-ROM sector to read. These are possible values for the
     third parameter word sent with the change data type syscall.
-    @{
 */
 enum cd_read_sector_part {
     CDROM_READ_WHOLE_SECTOR = 0x1000,    /**< \brief Read the whole sector */
     CDROM_READ_DATA_AREA    = 0x2000,    /**< \brief Read the data area */
 };
-/** @} */
 
-/** \defgroup cd_read_subcode_type    Read Subcode Type
+/** \enum cd_track_type
+    \brief                           Track type to read as (if applicable).
+    \ingroup  gdrom
+
+    Track type used to read a sector. These are possible values for the
+    second parameter word sent with the change data type syscall.
+*/
+enum cd_track_type {
+    CD_TRACK_TYPE_UNKNOWN     = 0x0e00,
+    CD_TRACK_TYPE_MODE2_NONXA = 0x0c00,
+    CD_TRACK_TYPE_MODE2_FORM2 = 0x0a00,
+    CD_TRACK_TYPE_MODE2_FORM1 = 0x0800,
+    CD_TRACK_TYPE_MODE2       = 0x0600,
+    CD_TRACK_TYPE_MODE1       = 0x0400,
+    CD_TRACK_TYPE_CDDA        = 0x0200,
+    CD_TRACK_TYPE_ANY         = 0x0000,
+};
+
+/** \enum cd_read_subcode_type
     \brief                            Types of data to read from sector subcode
     \ingroup  gdrom
 
     Types of data available to read from the sector subcode. These are
     possible values for the first parameter sent to the GETSCD syscall.
-    @{
 */
 enum cd_read_subcode_type {
     CD_SUB_Q_ALL          = 0,    /**< \brief Read all Subcode Data */
@@ -175,14 +178,12 @@ enum cd_read_subcode_type {
     CD_SUB_TRACK_ISRC     = 3,    /**< \brief Read the ISRC Subcode Data */
     CD_SUB_RESERVED       = 4,    /**< \brief Reserved */
 };
-/** @} */
 
-/** \defgroup cd_subcode_audio    Subcode Audio Status
-    \brief                        GETSCD syscall response codes
+/** \enum cd_subcode_audio
+    \brief                        Subcode Audio Status
     \ingroup  gdrom
 
     Information about CDDA playback from GETSCD syscall.
-    @{
 */
 enum cd_subcode_audio {
     CD_SUB_AUDIO_STATUS_INVALID    = 0x00,
@@ -192,29 +193,25 @@ enum cd_subcode_audio {
     CD_SUB_AUDIO_STATUS_ERROR      = 0x14,
     CD_SUB_AUDIO_STATUS_NO_INFO    = 0x15,
 };
-/** @} */
 
-/** \defgroup cd_read_sector_mode    Read Sector Mode
+/** \enum cd_read_sector_mode
     \brief                           Mode to use when reading sectors
     \ingroup  gdrom
 
     How to read the sectors of a CD, via PIO or DMA. 4th parameter of
     cdrom_read_sectors_ex.
-    @{
 */
 enum cd_read_sector_mode {
     CDROM_READ_PIO = 0,    /**< \brief Read sector(s) in PIO mode */
     CDROM_READ_DMA = 1,    /**< \brief Read sector(s) in DMA mode */
 };
-/** @} */
 
-/** \defgroup cd_status_values      Status Values
+/** \enum cd_status_values
     \brief                          Status values for GD-ROM drive
     \ingroup  gdrom
 
     These are the values that can be returned as the status parameter from the
     cdrom_get_status() function.
-    @{
 */
 enum cd_status_values {
     CD_STATUS_READ_FAIL = -1,   /**< \brief Can't read status */
@@ -230,15 +227,13 @@ enum cd_status_values {
     CD_STATUS_ERROR     =  9,   /**< \brief System error */
     CD_STATUS_FATAL     =  12,  /**< \brief Need reset syscalls */
 };
-/** @} */
 
-/** \defgroup cd_disc_types         Drive Disc Types
+/** \enum cd_disc_types
     \brief                          Disc types within GD-ROM drive
     \ingroup  gdrom
 
     These are the values that can be returned as the disc_type parameter from
     the cdrom_get_status() function.
-    @{
 */
 enum cd_disc_types {
     CD_CDDA     = 0x00,    /**< \brief Audio CD (Red book) or no disc */
@@ -248,7 +243,6 @@ enum cd_disc_types {
     CD_GDROM    = 0x80,    /**< \brief GD-ROM */
     CD_FAIL     = 0xf0,    /**< \brief Need reset syscalls */
 };
-/** @} */
 
 /** \brief  TOC structure returned by the BIOS.
     \ingroup gdrom
@@ -308,7 +302,7 @@ typedef struct {
 
     \return                 \ref cd_cmd_response
 */
-int cdrom_set_sector_size(int size);
+enum cd_cmd_response cdrom_set_sector_size(size_t size);
 
 /** \brief    Execute a CD-ROM command.
     \ingroup  gdrom
@@ -321,7 +315,7 @@ int cdrom_set_sector_size(int size);
 
     \return                 \ref cd_cmd_response
 */
-int cdrom_exec_cmd(int cmd, void *param);
+enum cd_cmd_response cdrom_exec_cmd(enum cd_cmd_code cmd, void *param);
 
 /** \brief    Execute a CD-ROM command with timeout.
     \ingroup  gdrom
@@ -335,7 +329,8 @@ int cdrom_exec_cmd(int cmd, void *param);
 
     \return                 \ref cd_cmd_response
 */
-int cdrom_exec_cmd_timed(int cmd, void *param, int timeout);
+enum cd_cmd_response
+cdrom_exec_cmd_timed(enum cd_cmd_code cmd, void *param, unsigned long timeout);
 
 /** \brief    Get the status of the GD-ROM drive.
     \ingroup  gdrom
@@ -347,7 +342,8 @@ int cdrom_exec_cmd_timed(int cmd, void *param, int timeout);
     \see    cd_status_values
     \see    cd_disc_types
 */
-int cdrom_get_status(int *status, int *disc_type);
+enum cd_cmd_response
+cdrom_get_status(enum cd_status_values *status, enum cd_disc_types *disc_type);
 
 /** \brief    Change the datatype of disc.
     \ingroup  gdrom
@@ -362,12 +358,15 @@ int cdrom_get_status(int *status, int *disc_type);
     \return                 \ref cd_cmd_response
     \see    cd_read_sector_part
 */
-int cdrom_change_datatype(int sector_part, int cdxa, int sector_size);
+enum cd_cmd_response
+cdrom_change_datatype(enum cd_read_sector_part sector_part,
+                      enum cd_track_type cdxa, size_t sector_size);
 
 /** \cond */
-static inline int
+static inline enum cd_cmd_response
 __depr("Use cdrom_change_datatype instead.")
-cdrom_change_dataype(int sector_part, int cdxa, int sector_size) {
+cdrom_change_dataype(enum cd_read_sector_part sector_part,
+                     enum cd_track_type cdxa, size_t sector_size) {
     return cdrom_change_datatype(sector_part, cdxa, sector_size);
 }
 /** \endcond */
@@ -381,7 +380,7 @@ cdrom_change_dataype(int sector_part, int cdxa, int sector_size) {
     \return                 \ref cd_cmd_response
     \see    cdrom_reinit_ex
 */
-int cdrom_reinit(void);
+enum cd_cmd_response cdrom_reinit(void);
 
 /** \brief    Re-initialize the GD-ROM drive with custom parameters.
     \ingroup  gdrom
@@ -398,7 +397,9 @@ int cdrom_reinit(void);
     \see    cd_read_sector_part
     \see    cdrom_change_datatype
 */
-int cdrom_reinit_ex(int sector_part, int cdxa, int sector_size);
+enum cd_cmd_response
+cdrom_reinit_ex(enum cd_read_sector_part sector_part,
+                enum cd_track_type cdxa, size_t sector_size);
 
 /** \brief    Read the table of contents from the disc.
     \ingroup  gdrom
@@ -409,7 +410,8 @@ int cdrom_reinit_ex(int sector_part, int cdxa, int sector_size);
     \param  session         The session of the disc to read.
     \return                 \ref cd_cmd_response
 */
-int cdrom_read_toc(CDROM_TOC *toc_buffer, int session);
+enum cd_cmd_response
+cdrom_read_toc(CDROM_TOC *toc_buffer, unsigned int session);
 
 /** \brief    Read one or more sector from a CD-ROM.
     \ingroup  gdrom
@@ -426,7 +428,9 @@ int cdrom_read_toc(CDROM_TOC *toc_buffer, int session);
     \return                 \ref cd_cmd_response
     \see    cd_read_sector_mode
 */
-int cdrom_read_sectors_ex(void *buffer, int sector, int cnt, int mode);
+enum cd_cmd_response
+cdrom_read_sectors_ex(void *buffer, unsigned int sector, size_t cnt,
+                      enum cd_read_sector_mode mode);
 
 /** \brief    Read one or more sector from a CD-ROM in PIO mode.
     \ingroup  gdrom
@@ -439,7 +443,8 @@ int cdrom_read_sectors_ex(void *buffer, int sector, int cnt, int mode);
     \return                 \ref cd_cmd_response
     \see    cdrom_read_sectors_ex
 */
-int cdrom_read_sectors(void *buffer, int sector, int cnt);
+enum cd_cmd_response
+cdrom_read_sectors(void *buffer, unsigned int sector, size_t cnt);
 
 /** \brief    Read subcode data from the most recently read sectors.
     \ingroup  gdrom
@@ -455,7 +460,8 @@ int cdrom_read_sectors(void *buffer, int sector, int cnt);
     \return                 \ref cd_cmd_response
     \see    cd_read_subcode_type
 */
-int cdrom_get_subcode(void *buffer, int buflen, int which);
+enum cd_cmd_response
+cdrom_get_subcode(void *buffer, size_t buflen, enum cd_read_subcode_type which);
 
 /** \brief    Locate the sector of the data track.
     \ingroup  gdrom
@@ -479,21 +485,23 @@ uint32 cdrom_locate_data_track(CDROM_TOC *toc);
     \param  mode            The mode to play (see \ref cdda_read_modes).
     \return                 \ref cd_cmd_response
 */
-int cdrom_cdda_play(uint32 start, uint32 end, uint32 loops, int mode);
+enum cd_cmd_response
+cdrom_cdda_play(uint32 start, uint32 end, uint32 loops,
+                enum cdda_read_modes mode);
 
 /** \brief    Pause CDDA audio playback.
     \ingroup  gdrom
 
     \return                 \ref cd_cmd_response
 */
-int cdrom_cdda_pause(void);
+enum cd_cmd_response cdrom_cdda_pause(void);
 
 /** \brief    Resume CDDA audio playback after a pause.
     \ingroup  gdrom
 
     \return                 \ref cd_cmd_response
 */
-int cdrom_cdda_resume(void);
+enum cd_cmd_response cdrom_cdda_resume(void);
 
 /** \brief    Spin down the CD.
     \ingroup  gdrom
@@ -502,7 +510,7 @@ int cdrom_cdda_resume(void);
 
     \return                 \ref cd_cmd_response
 */
-int cdrom_spin_down(void);
+enum cd_cmd_response cdrom_spin_down(void);
 
 /** \brief    Initialize the GD-ROM for reading CDs.
     \ingroup  gdrom

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -50,34 +50,36 @@ __BEGIN_DECLS
 
     @{
 */
-#define CMD_CHECK_LICENSE       2  /**< \brief Check license */
-#define CMD_REQ_SPI_CMD         4  /**< \brief Request to Sega Packet Interface */
-#define CMD_PIOREAD            16  /**< \brief Read via PIO */
-#define CMD_DMAREAD            17  /**< \brief Read via DMA */
-#define CMD_GETTOC             18  /**< \brief Read TOC */
-#define CMD_GETTOC2            19  /**< \brief Read TOC */
-#define CMD_PLAY               20  /**< \brief Play track */
-#define CMD_PLAY2              21  /**< \brief Play sectors */
-#define CMD_PAUSE              22  /**< \brief Pause playback */
-#define CMD_RELEASE            23  /**< \brief Resume from pause */
-#define CMD_INIT               24  /**< \brief Initialize the drive */
-#define CMD_DMA_ABORT          25  /**< \brief Abort DMA transfer */
-#define CMD_OPEN_TRAY          26  /**< \brief Open CD tray (on DevBox?) */
-#define CMD_SEEK               27  /**< \brief Seek to a new position */
-#define CMD_DMAREAD_STREAM     28  /**< \brief Stream DMA until end/abort */
-#define CMD_NOP                29  /**< \brief No operation */
-#define CMD_REQ_MODE           30  /**< \brief Request mode */
-#define CMD_SET_MODE           31  /**< \brief Setup mode */
-#define CMD_SCAN_CD            32  /**< \brief Scan CD */
-#define CMD_STOP               33  /**< \brief Stop the disc from spinning */
-#define CMD_GETSCD             34  /**< \brief Get subcode data */
-#define CMD_GETSES             35  /**< \brief Get session */
-#define CMD_REQ_STAT           36  /**< \brief Request stat */
-#define CMD_PIOREAD_STREAM     37  /**< \brief Stream PIO until end/abort */
-#define CMD_DMAREAD_STREAM_EX  38  /**< \brief Stream DMA transfer */
-#define CMD_PIOREAD_STREAM_EX  39  /**< \brief Stream PIO transfer */
-#define CMD_GET_VERS           40  /**< \brief Get syscall driver version */
-#define CMD_MAX                47  /**< \brief Max of GD syscall commands */
+enum cd_cmd_code {
+    CMD_CHECK_LICENSE     =  2,  /**< \brief Check license */
+    CMD_REQ_SPI_CMD       =  4,  /**< \brief Request to Sega Packet Interface */
+    CMD_PIOREAD           = 16,  /**< \brief Read via PIO */
+    CMD_DMAREAD           = 17,  /**< \brief Read via DMA */
+    CMD_GETTOC            = 18,  /**< \brief Read TOC */
+    CMD_GETTOC2           = 19,  /**< \brief Read TOC */
+    CMD_PLAY              = 20,  /**< \brief Play track */
+    CMD_PLAY2             = 21,  /**< \brief Play sectors */
+    CMD_PAUSE             = 22,  /**< \brief Pause playback */
+    CMD_RELEASE           = 23,  /**< \brief Resume from pause */
+    CMD_INIT              = 24,  /**< \brief Initialize the drive */
+    CMD_DMA_ABORT         = 25,  /**< \brief Abort DMA transfer */
+    CMD_OPEN_TRAY         = 26,  /**< \brief Open CD tray (on DevBox?) */
+    CMD_SEEK              = 27,  /**< \brief Seek to a new position */
+    CMD_DMAREAD_STREAM    = 28,  /**< \brief Stream DMA until end/abort */
+    CMD_NOP               = 29,  /**< \brief No operation */
+    CMD_REQ_MODE          = 30,  /**< \brief Request mode */
+    CMD_SET_MODE          = 31,  /**< \brief Setup mode */
+    CMD_SCAN_CD           = 32,  /**< \brief Scan CD */
+    CMD_STOP              = 33,  /**< \brief Stop the disc from spinning */
+    CMD_GETSCD            = 34,  /**< \brief Get subcode data */
+    CMD_GETSES            = 35,  /**< \brief Get session */
+    CMD_REQ_STAT          = 36,  /**< \brief Request stat */
+    CMD_PIOREAD_STREAM    = 37,  /**< \brief Stream PIO until end/abort */
+    CMD_DMAREAD_STREAM_EX = 38,  /**< \brief Stream DMA transfer */
+    CMD_PIOREAD_STREAM_EX = 39,  /**< \brief Stream PIO transfer */
+    CMD_GET_VERS          = 40,  /**< \brief Get syscall driver version */
+    CMD_MAX               = 47,  /**< \brief Max of GD syscall commands */
+};
 /** @} */
 
 /** \defgroup cd_cmd_response       Command Responses
@@ -87,13 +89,15 @@ __BEGIN_DECLS
     These are the values that the various functions can return as error codes.
     @{
 */
-#define ERR_OK          0   /**< \brief No error */
-#define ERR_NO_DISC     1   /**< \brief No disc in drive */
-#define ERR_DISC_CHG    2   /**< \brief Disc changed, but not reinitted yet */
-#define ERR_SYS         3   /**< \brief System error */
-#define ERR_ABORTED     4   /**< \brief Command aborted */
-#define ERR_NO_ACTIVE   5   /**< \brief System inactive? */
-#define ERR_TIMEOUT     6   /**< \brief Aborted due to timeout */
+enum cd_cmd_response {
+    ERR_OK        = 0,   /**< \brief No error */
+    ERR_NO_DISC   = 1,   /**< \brief No disc in drive */
+    ERR_DISC_CHG  = 2,   /**< \brief Disc changed, but not reinitted yet */
+    ERR_SYS       = 3,   /**< \brief System error */
+    ERR_ABORTED   = 4,   /**< \brief Command aborted */
+    ERR_NO_ACTIVE = 5,   /**< \brief System inactive? */
+    ERR_TIMEOUT   = 6,   /**< \brief Aborted due to timeout */
+};
 /** @} */
 
 /** \defgroup cd_cmd_status         Command Status Responses
@@ -103,12 +107,14 @@ __BEGIN_DECLS
     These are the raw values the status syscall returns.
     @{
 */
-#define FAILED      -1  /**< \brief Command failed */
-#define NO_ACTIVE   0   /**< \brief System inactive? */
-#define PROCESSING  1   /**< \brief Processing command */
-#define COMPLETED   2   /**< \brief Command completed successfully */
-#define STREAMING   3   /**< \brief Stream type command is in progress */
-#define BUSY        4   /**< \brief GD syscalls is busy */
+enum cd_cmd_status {
+    FAILED     = -1,   /**< \brief Command failed */
+    NO_ACTIVE  =  0,   /**< \brief System inactive? */
+    PROCESSING =  1,   /**< \brief Processing command */
+    COMPLETED  =  2,   /**< \brief Command completed successfully */
+    STREAMING  =  3,   /**< \brief Stream type command is in progress */
+    BUSY       =  4,   /**< \brief GD syscalls is busy */
+};
 /** @} */
 
 /** \defgroup cd_cmd_ata_status       ATA Statuses
@@ -117,11 +123,13 @@ __BEGIN_DECLS
 
     @{
 */
-#define ATA_STAT_INTERNAL   0x00
-#define ATA_STAT_IRQ        0x01
-#define ATA_STAT_DRQ_0      0x02
-#define ATA_STAT_DRQ_1      0x03
-#define ATA_STAT_BUSY       0x04
+enum cd_cmd_ata_status {
+    ATA_STAT_INTERNAL  = 0,
+    ATA_STAT_IRQ       = 1,
+    ATA_STAT_DRQ_0     = 2,
+    ATA_STAT_DRQ_1     = 3,
+    ATA_STAT_BUSY      = 4,
+};
 /** @} */
 
 /** \defgroup cdda_read_modes       CDDA Read Modes
@@ -132,8 +140,10 @@ __BEGIN_DECLS
     parameter.
     @{
 */
-#define CDDA_TRACKS     1   /**< \brief Play by track number */
-#define CDDA_SECTORS    2   /**< \brief Play by sector number */
+enum cdda_read_modes {
+    CDDA_TRACKS   = 1,   /**< \brief Play by track number */
+    CDDA_SECTORS  = 2,   /**< \brief Play by sector number */
+};
 /** @} */
 
 /** \defgroup cd_read_sector_part    Read Sector Part
@@ -144,8 +154,10 @@ __BEGIN_DECLS
     third parameter word sent with the change data type syscall.
     @{
 */
-#define CDROM_READ_WHOLE_SECTOR 0x1000    /**< \brief Read the whole sector */
-#define CDROM_READ_DATA_AREA    0x2000    /**< \brief Read the data area */
+enum cd_read_sector_part {
+    CDROM_READ_WHOLE_SECTOR = 0x1000,    /**< \brief Read the whole sector */
+    CDROM_READ_DATA_AREA    = 0x2000,    /**< \brief Read the data area */
+};
 /** @} */
 
 /** \defgroup cd_read_subcode_type    Read Subcode Type
@@ -156,12 +168,13 @@ __BEGIN_DECLS
     possible values for the first parameter sent to the GETSCD syscall.
     @{
 */
-#define CD_SUB_Q_ALL            0    /**< \brief Read all Subcode Data */
-#define CD_SUB_Q_CHANNEL        1    /**< \brief Read Q Channel Subcode Data */
-#define CD_SUB_MEDIA_CATALOG    2    /**< \brief Read the Media Catalog 
-                                                 Subcode Data */
-#define CD_SUB_TRACK_ISRC       3    /**< \brief Read the ISRC Subcode Data */
-#define CD_SUB_RESERVED         4    /**< \brief Reserved */
+enum cd_read_subcode_type {
+    CD_SUB_Q_ALL          = 0,    /**< \brief Read all Subcode Data */
+    CD_SUB_Q_CHANNEL      = 1,    /**< \brief Read Q Channel Subcode Data */
+    CD_SUB_MEDIA_CATALOG  = 2,    /**< \brief Read the Media Catalog Subcode Data */
+    CD_SUB_TRACK_ISRC     = 3,    /**< \brief Read the ISRC Subcode Data */
+    CD_SUB_RESERVED       = 4,    /**< \brief Reserved */
+};
 /** @} */
 
 /** \defgroup cd_subcode_audio    Subcode Audio Status
@@ -171,12 +184,14 @@ __BEGIN_DECLS
     Information about CDDA playback from GETSCD syscall.
     @{
 */
-#define CD_SUB_AUDIO_STATUS_INVALID    0x00
-#define CD_SUB_AUDIO_STATUS_PLAYING    0x11
-#define CD_SUB_AUDIO_STATUS_PAUSED     0x12
-#define CD_SUB_AUDIO_STATUS_ENDED      0x13
-#define CD_SUB_AUDIO_STATUS_ERROR      0x14
-#define CD_SUB_AUDIO_STATUS_NO_INFO    0x15
+enum cd_subcode_audio {
+    CD_SUB_AUDIO_STATUS_INVALID    = 0x00,
+    CD_SUB_AUDIO_STATUS_PLAYING    = 0x11,
+    CD_SUB_AUDIO_STATUS_PAUSED     = 0x12,
+    CD_SUB_AUDIO_STATUS_ENDED      = 0x13,
+    CD_SUB_AUDIO_STATUS_ERROR      = 0x14,
+    CD_SUB_AUDIO_STATUS_NO_INFO    = 0x15,
+};
 /** @} */
 
 /** \defgroup cd_read_sector_mode    Read Sector Mode
@@ -187,8 +202,10 @@ __BEGIN_DECLS
     cdrom_read_sectors_ex.
     @{
 */
-#define CDROM_READ_PIO 0    /**< \brief Read sector(s) in PIO mode */
-#define CDROM_READ_DMA 1    /**< \brief Read sector(s) in DMA mode */
+enum cd_read_sector_mode {
+    CDROM_READ_PIO = 0,    /**< \brief Read sector(s) in PIO mode */
+    CDROM_READ_DMA = 1,    /**< \brief Read sector(s) in DMA mode */
+};
 /** @} */
 
 /** \defgroup cd_status_values      Status Values
@@ -199,18 +216,20 @@ __BEGIN_DECLS
     cdrom_get_status() function.
     @{
 */
-#define CD_STATUS_READ_FAIL -1  /**< \brief Can't read status */
-#define CD_STATUS_BUSY      0   /**< \brief Drive is busy */
-#define CD_STATUS_PAUSED    1   /**< \brief Disc is paused */
-#define CD_STATUS_STANDBY   2   /**< \brief Drive is in standby */
-#define CD_STATUS_PLAYING   3   /**< \brief Drive is currently playing */
-#define CD_STATUS_SEEKING   4   /**< \brief Drive is currently seeking */
-#define CD_STATUS_SCANNING  5   /**< \brief Drive is scanning */
-#define CD_STATUS_OPEN      6   /**< \brief Disc tray is open */
-#define CD_STATUS_NO_DISC   7   /**< \brief No disc inserted */
-#define CD_STATUS_RETRY     8   /**< \brief Retry is needed */
-#define CD_STATUS_ERROR     9   /**< \brief System error */
-#define CD_STATUS_FATAL     12  /**< \brief Need reset syscalls */
+enum cd_status_values {
+    CD_STATUS_READ_FAIL = -1,   /**< \brief Can't read status */
+    CD_STATUS_BUSY      =  0,   /**< \brief Drive is busy */
+    CD_STATUS_PAUSED    =  1,   /**< \brief Disc is paused */
+    CD_STATUS_STANDBY   =  2,   /**< \brief Drive is in standby */
+    CD_STATUS_PLAYING   =  3,   /**< \brief Drive is currently playing */
+    CD_STATUS_SEEKING   =  4,   /**< \brief Drive is currently seeking */
+    CD_STATUS_SCANNING  =  5,   /**< \brief Drive is scanning */
+    CD_STATUS_OPEN      =  6,   /**< \brief Disc tray is open */
+    CD_STATUS_NO_DISC   =  7,   /**< \brief No disc inserted */
+    CD_STATUS_RETRY     =  8,   /**< \brief Retry is needed */
+    CD_STATUS_ERROR     =  9,   /**< \brief System error */
+    CD_STATUS_FATAL     =  12,  /**< \brief Need reset syscalls */
+};
 /** @} */
 
 /** \defgroup cd_disc_types         Drive Disc Types
@@ -221,12 +240,14 @@ __BEGIN_DECLS
     the cdrom_get_status() function.
     @{
 */
-#define CD_CDDA     0x00    /**< \brief Audio CD (Red book) or no disc */
-#define CD_CDROM    0x10    /**< \brief CD-ROM or CD-R (Yellow book) */
-#define CD_CDROM_XA 0x20    /**< \brief CD-ROM XA (Yellow book extension) */
-#define CD_CDI      0x30    /**< \brief CD-i (Green book) */
-#define CD_GDROM    0x80    /**< \brief GD-ROM */
-#define CD_FAIL     0xf0    /**< \brief Need reset syscalls */
+enum cd_disc_types {
+    CD_CDDA     = 0x00,    /**< \brief Audio CD (Red book) or no disc */
+    CD_CDROM    = 0x10,    /**< \brief CD-ROM or CD-R (Yellow book) */
+    CD_CDROM_XA = 0x20,    /**< \brief CD-ROM XA (Yellow book extension) */
+    CD_CDI      = 0x30,    /**< \brief CD-i (Green book) */
+    CD_GDROM    = 0x80,    /**< \brief GD-ROM */
+    CD_FAIL     = 0xf0,    /**< \brief Need reset syscalls */
+};
 /** @} */
 
 /** \brief  TOC structure returned by the BIOS.

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -365,8 +365,6 @@ int cdrom_change_dataype(int sector_part, int cdxa, int sector_size)
 
     This function will take in all parameters to pass to the change_datatype
     syscall. This allows these parameters to be modified without a reinit.
-    Each parameter allows -1 as a default, which is tied to the former static
-    values provided by cdrom_reinit and cdrom_set_sector_size.
 
     \param sector_part      How much of each sector to return.
     \param cdxa             What CDXA mode to read as (if applicable).
@@ -381,7 +379,7 @@ int cdrom_change_datatype(int sector_part, int cdxa, int sector_size);
     \ingroup  gdrom
 
     This function is for reinitializing the GD-ROM drive after a disc change to
-    its default settings. Calls cdrom_reinit(-1,-1,-1)
+    its default settings.
 
     \return                 \ref cd_cmd_response
     \see    cdrom_reinit_ex

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -352,7 +352,7 @@ cdrom_get_status(enum cd_status_values *status, enum cd_disc_types *disc_type);
     syscall. This allows these parameters to be modified without a reinit.
 
     \param sector_part      How much of each sector to return.
-    \param cdxa             What CDXA mode to read as (if applicable).
+    \param track_type       What track type to read as (if applicable).
     \param sector_size      What sector size to read (eg. - 2048, 2532).
 
     \return                 \ref cd_cmd_response
@@ -360,14 +360,14 @@ cdrom_get_status(enum cd_status_values *status, enum cd_disc_types *disc_type);
 */
 enum cd_cmd_response
 cdrom_change_datatype(enum cd_read_sector_part sector_part,
-                      enum cd_track_type cdxa, size_t sector_size);
+                      enum cd_track_type track_type, size_t sector_size);
 
 /** \cond */
 static inline enum cd_cmd_response
 __depr("Use cdrom_change_datatype instead.")
 cdrom_change_dataype(enum cd_read_sector_part sector_part,
-                     enum cd_track_type cdxa, size_t sector_size) {
-    return cdrom_change_datatype(sector_part, cdxa, sector_size);
+                     enum cd_track_type track_type, size_t sector_size) {
+    return cdrom_change_datatype(sector_part, track_type, sector_size);
 }
 /** \endcond */
 
@@ -390,7 +390,7 @@ enum cd_cmd_response cdrom_reinit(void);
     reinitialization, as opposed to defaults.
 
     \param sector_part      How much of each sector to return.
-    \param cdxa             What CDXA mode to read as (if applicable).
+    \param track_type       What track type to read as (if applicable).
     \param sector_size      What sector size to read (eg. - 2048, 2532).
 
     \return                 \ref cd_cmd_response
@@ -399,7 +399,7 @@ enum cd_cmd_response cdrom_reinit(void);
 */
 enum cd_cmd_response
 cdrom_reinit_ex(enum cd_read_sector_part sector_part,
-                enum cd_track_type cdxa, size_t sector_size);
+                enum cd_track_type track_type, size_t sector_size);
 
 /** \brief    Read the table of contents from the disc.
     \ingroup  gdrom

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -27,7 +27,7 @@ __BEGIN_DECLS
     CD, it will automatically detect and react to disc changes for you.
 
     This file only facilitates reading raw sectors and doing other fairly low-
-    level things with CDs. If you're looking for higher-level stuff, like 
+    level things with CDs. If you're looking for higher-level stuff, like
     normal file reading, consult with the stuff for the fs and for fs_iso9660.
 
     \author Megan Potter
@@ -36,7 +36,7 @@ __BEGIN_DECLS
     \see    dc/fs_iso9660.h
 */
 
-/** \defgroup gdrom     GD-ROM 
+/** \defgroup gdrom     GD-ROM
     \brief              Driver for the Dreamcast's GD-ROM drive
     \ingroup            vfs
 */
@@ -113,7 +113,7 @@ __BEGIN_DECLS
 
 /** \defgroup cd_cmd_ata_status       ATA Statuses
     \brief                            ATA statuses for GD-ROM driver
-    \ingroup  gdrom 
+    \ingroup  gdrom
 
     @{
 */
@@ -141,7 +141,7 @@ __BEGIN_DECLS
     \ingroup  gdrom
 
     Parts of the a CD-ROM sector to read. These are possible values for the
-    third parameter word sent with the change data type syscall. 
+    third parameter word sent with the change data type syscall.
     @{
 */
 #define CDROM_READ_WHOLE_SECTOR 0x1000    /**< \brief Read the whole sector */
@@ -152,7 +152,7 @@ __BEGIN_DECLS
     \brief                            Types of data to read from sector subcode
     \ingroup  gdrom
 
-    Types of data available to read from the sector subcode. These are 
+    Types of data available to read from the sector subcode. These are
     possible values for the first parameter sent to the GETSCD syscall.
     @{
 */
@@ -183,7 +183,7 @@ __BEGIN_DECLS
     \brief                           Mode to use when reading sectors
     \ingroup  gdrom
 
-    How to read the sectors of a CD, via PIO or DMA. 4th parameter of 
+    How to read the sectors of a CD, via PIO or DMA. 4th parameter of
     cdrom_read_sectors_ex.
     @{
 */
@@ -342,9 +342,9 @@ int cdrom_change_dataype(int sector_part, int cdxa, int sector_size)
 /** \brief    Change the datatype of disc.
     \ingroup  gdrom
 
-    This function will take in all parameters to pass to the change_datatype 
-    syscall. This allows these parameters to be modified without a reinit. 
-    Each parameter allows -1 as a default, which is tied to the former static 
+    This function will take in all parameters to pass to the change_datatype
+    syscall. This allows these parameters to be modified without a reinit.
+    Each parameter allows -1 as a default, which is tied to the former static
     values provided by cdrom_reinit and cdrom_set_sector_size.
 
     \param sector_part      How much of each sector to return.
@@ -370,8 +370,8 @@ int cdrom_reinit(void);
 /** \brief    Re-initialize the GD-ROM drive with custom parameters.
     \ingroup  gdrom
 
-    At the end of each cdrom_reinit(), cdrom_change_datatype is called. 
-    This passes in the requested values to that function after 
+    At the end of each cdrom_reinit(), cdrom_change_datatype is called.
+    This passes in the requested values to that function after
     reinitialization, as opposed to defaults.
 
     \param sector_part      How much of each sector to return.
@@ -428,8 +428,8 @@ int cdrom_read_sectors(void *buffer, int sector, int cnt);
 /** \brief    Read subcode data from the most recently read sectors.
     \ingroup  gdrom
 
-    After reading sectors, this can pull subcode data regarding the sectors 
-    read. If reading all subcode data with CD_SUB_CURRENT_POSITION, this needs 
+    After reading sectors, this can pull subcode data regarding the sectors
+    read. If reading all subcode data with CD_SUB_CURRENT_POSITION, this needs
     to be performed one sector at a time.
 
     \param  buffer          Space to store the read subcode data.

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -352,17 +352,6 @@ int cdrom_get_status(int *status, int *disc_type);
 /** \brief    Change the datatype of disc.
     \ingroup  gdrom
 
-    \note                   This function is formally deprecated. It should not
-                            be used in any future code, and may be removed in
-                            the future. You should instead use
-                            cdrom_change_datatype.
-*/
-int cdrom_change_dataype(int sector_part, int cdxa, int sector_size)
-                        __depr("Use cdrom_change_datatype instead.");
-
-/** \brief    Change the datatype of disc.
-    \ingroup  gdrom
-
     This function will take in all parameters to pass to the change_datatype
     syscall. This allows these parameters to be modified without a reinit.
 
@@ -374,6 +363,14 @@ int cdrom_change_dataype(int sector_part, int cdxa, int sector_size)
     \see    cd_read_sector_part
 */
 int cdrom_change_datatype(int sector_part, int cdxa, int sector_size);
+
+/** \cond */
+static inline int
+__depr("Use cdrom_change_datatype instead.")
+cdrom_change_dataype(int sector_part, int cdxa, int sector_size) {
+    return cdrom_change_datatype(sector_part, cdxa, sector_size);
+}
+/** \endcond */
 
 /** \brief    Re-initialize the GD-ROM drive.
     \ingroup  gdrom


### PR DESCRIPTION
Change the macro lists to enums, and use enums as return codes / parameters for API functions.

Note the slight behavior change, `cdrom_change_datatype()` will no longer accept -1 as the "use default values" wildcard.