### PR TITLE
Update startup

### DIFF
--- a/kernel/arch/dreamcast/kernel/Makefile
+++ b/kernel/arch/dreamcast/kernel/Makefile
@@ -18,12 +18,12 @@ COPYOBJS += uname.o
 OBJS = $(COPYOBJS) startup.o
 SUBDIRS =
 
-CRT1_DIR = $(shell $(KOS_CC) $(KOS_SH4_PRECISION) -print-file-name=crt1.o | sed 's/crt1.o//')
+CRT1_PATH = $(shell $(KOS_CC) $(KOS_CFLAGS) -print-file-name=crt1.o)
 
 myall: $(OBJS)
 	-cp $(COPYOBJS) $(KOS_BASE)/kernel/build/
 	-rm banner.h authors.h banner.o uname.o
-	-cp startup.o $(CRT1_DIR)crt1.o
+	-cp startup.o $(CRT1_PATH)
 
 include $(KOS_BASE)/Makefile.prefab
 

--- a/kernel/arch/dreamcast/kernel/Makefile
+++ b/kernel/arch/dreamcast/kernel/Makefile
@@ -23,7 +23,7 @@ CRT1_DIR = $(shell $(KOS_CC) $(KOS_SH4_PRECISION) -print-file-name=crt1.o | sed 
 myall: $(OBJS)
 	-cp $(COPYOBJS) $(KOS_BASE)/kernel/build/
 	-rm banner.h authors.h banner.o uname.o
-	cp startup.o $(CRT1_DIR)crt1.o
+	-cp startup.o $(CRT1_DIR)crt1.o
 
 include $(KOS_BASE)/Makefile.prefab
 

--- a/kernel/arch/dreamcast/kernel/Makefile
+++ b/kernel/arch/dreamcast/kernel/Makefile
@@ -18,9 +18,12 @@ COPYOBJS += uname.o
 OBJS = $(COPYOBJS) startup.o
 SUBDIRS =
 
+CRT1_DIR = $(shell $(KOS_CC) $(KOS_SH4_PRECISION) -print-file-name=crt1.o | sed 's/crt1.o//')
+
 myall: $(OBJS)
 	-cp $(COPYOBJS) $(KOS_BASE)/kernel/build/
 	-rm banner.h authors.h banner.o uname.o
+	cp startup.o $(CRT1_DIR)crt1.o
 
 include $(KOS_BASE)/Makefile.prefab
 


### PR DESCRIPTION
Each time startup.o is built we can copy it over so whenever there is an issue with startup.s, the toolchain doesnt have to be rebuilt to fix it.