### PR TITLE
Thread bugfixes: Stack ownership, Genwait object release upon death

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -131,6 +131,7 @@ LIST_HEAD(ktlist, kthread);
 #define THD_USER        1  /**< \brief Thread runs in user mode */
 #define THD_QUEUED      2  /**< \brief Thread is in the run queue */
 #define THD_DETACHED    4  /**< \brief Thread is detached */
+#define THD_OWNS_STACK  8  /**< \brief Thread manages stack lifetime */
 /** @} */
 
 /** \brief Kernel thread flags type */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -67,6 +67,9 @@ extern uint32 _arch_mem_top;
 /** \brief  Default thread stack size. */
 #define THD_STACK_SIZE  32768
 
+/** \brief Main/kernel thread's stack size. */
+#define THD_KERNEL_STACK_SIZE (64 * 1024)
+
 /** \brief  Default video mode. */
 #define DEFAULT_VID_MODE    DM_640x480
 

--- a/kernel/arch/dreamcast/kernel/mm.c
+++ b/kernel/arch/dreamcast/kernel/mm.c
@@ -47,7 +47,7 @@ void* mm_sbrk(unsigned long increment) {
 
     sbrk_base = (void *)(increment + (unsigned long)sbrk_base);
 
-    if(((uint32)sbrk_base) >= (_arch_mem_top - 65536)) {
+    if(((uint32)sbrk_base) >= (_arch_mem_top - THD_KERNEL_STACK_SIZE)) {
         dbglog(DBG_CRITICAL, "Out of memory. Requested sbrk_base %p, was %p, diff %lu\n",
                sbrk_base, base, increment);
         sbrk_base = base;  /* Restore old value and mark failed */

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -409,7 +409,7 @@ static void *thd_create_tls_data(void) {
     assert(!((uintptr_t)tcbhead % 8)); 
 
     /* Since we aren't using either member within it, zero out tcbhead. */
-    bzero(tcbhead, sizeof(tcbhead_t));
+    memset(tcbhead, 0, sizeof(tcbhead_t));
 
     /* Initialize .TDATA */
     if(tdata_size) { 
@@ -430,7 +430,7 @@ static void *thd_create_tls_data(void) {
         assert(!((uintptr_t)tbss_segment % tbss_align));
            
         /* Zero-initialize tbss_segment. */
-        bzero(tbss_segment, tbss_size);
+        memset(tbss_segment, 0, tbss_size);
     }
 
     /* Return segment head: this is what GBR points to. */
@@ -475,7 +475,7 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
 
         if(nt != NULL) {
             /* Clear out potentially unused stuff */
-            bzero(nt, sizeof(kthread_t));
+            memset(nt, 0, sizeof(kthread_t));
 
             /* Initialize the flags to defaults immediately. */
             nt->flags = THD_DEFAULTS;

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -40,8 +40,6 @@ also using their queue library verbatim (sys/queue.h).
 
 */
 
-#define THD_KERNEL_STACK_SIZE (64 * 1024)
-
 /* TLS Section ELF data - exported from linker script. */
 extern int _tdata_start, _tdata_size;
 extern int _tbss_size;


### PR DESCRIPTION
These are two really important bugfixes that I think need to get into `master` ASAP for the upcoming release. One was found by me, and one was found by @QuzarDC, who is currently busy with other concurrency stuff atm, so I figured I'd take care of it while I was handling the other bug...

In regards to the first bugfix: the kernel stack duplication... Upon pondering feedback from @QuzarDC and @ljsebald, who didn't like the user-facing flag for signalling to the kernel whether it is supposed to free the stack or not, and after studying how POSIX threads handle the issue, I came to agree with them... that shit's janky and unnecessary.

What we are doing instead is just utilizing one more bit in our thread's existing flags (no new storage anywhere) that gets set *internally* when the kernel allocates a new stack for a new thread.  Then upon destruction, if the flag is set, the kernel calls `free()` on the thread's stack pointer. With this new model, the user does nothing differently, and it's just assumed that when you provide your own stack to the kernel, since you've allocated it yourself, you're managing its lifetime yourself and are freeing it when the thread dies yourself. This seems to be how POSIX works, and it's simpler and more intuitive. 

1) Stack ownership
    - We were previously creating a thread for the main kernel thread
      using thd_create() which gave it a duplicated, default-initialized
32KB stack rather than having it utilize its static 64KB stack range.
    - To utilize its own stack, we have to internally maintain whether
      or not we are the owner of the stack (ie we allocated it), so that
we know not to free it.
    - This model also fixes issues created by supporting POSIX threads
      via the pthread API which assign their own stacks.
    - The new model/rule: you allocate and provide your own stack, you
      clean up your own stack too!
2) Genwait cleanup upon thread death
    - We were properly notifying other threads waiting upon the dying
      thread that they should wake up.
    - We were NOT properly cancelling any pending genwait objects that the
      dying thread was awaiting! So it could potentially later try to
wake up + notify a dead thread when the object becomes available.
    - We now remove the thread's genwait object (if it has one) upon its
      death.
      
 EDIT: Oh, shaved a few (like... barely anything) clock cycles off of some stuff by swapping from `memset(ptr, value, size)` to `bzero(ptr, size)`, which is like... molecularly faster (as verified via Compiler Explorer), because, at very least, a `value` argument is not present, not inspected, and is not wasting a register.
 
 Also cleaned up some comments a bit and added an actual `#define` for how large the kernel stack should be. 