### PR TITLE
Ignore `dbglog` with `NDEBUG` set and adjust default logging level

### DIFF
--- a/kernel/libc/koslib/dbglog.c
+++ b/kernel/libc/koslib/dbglog.c
@@ -15,6 +15,19 @@
 #include <kos/fs.h>
 #include <arch/spinlock.h>
 
+#ifdef NDEBUG
+
+/* Don't set the debug level, since we have no debug. */
+void dbglog_set_level(int) {
+    return;
+}
+
+void dbglog(int, const char *, ...) {
+    return;
+}
+
+#else   /* NDEBUG */
+
 /* Not re-entrant */
 static char printf_buf[1024];
 static spinlock_t mutex = SPINLOCK_INITIALIZER;
@@ -22,7 +35,7 @@ static spinlock_t mutex = SPINLOCK_INITIALIZER;
 /* Default kernel debug log level: if a message has a level higher than this,
    it won't be shown. Set to DBG_DEAD to see basically nothing, and set to
    DBG_KDEBUG to see everything. DBG_INFO is generally a decent level. */
-int dbglog_level = DBG_KDEBUG;
+int dbglog_level = DBG_INFO;
 
 /* Set debug level */
 void dbglog_set_level(int level) {
@@ -55,3 +68,5 @@ void dbglog(int level, const char *fmt, ...) {
     if(level >= DBG_ERROR && !irq_inside_int())
         spinlock_unlock(&mutex);
 }
+
+#endif  /* NDEBUG */


### PR DESCRIPTION
EDIT: Scope reduced to just address default logging level and NDEBUG condition (as that would be the most common usage of static levels anyways).
Intended to partially address #543 

Drop dbglog if `NDEBUG` is set and make `DBG_INFO` the default level, as it's noted to be 'generally good' and the higher levels give a lot of noise for typical users.

I would think with this new setup that the strings that are passed to `dbglog` would be optimized out with `NDEBUG` set, but that doesn't seem to be the case. Any suggestions on how to tweak it to better ensure that would be welcome. This should be able to significantly reduce the size of `NDEBUG` programs since we have so many `dbglog` messages. I might be related to it using vargs, or perhaps I'm just not testing correctly. The only difference I was able to see is the 1kb removal of the static buffer with `NDEBUG`