### PR TITLE
Revert "Update KOS_PORTS path so its prettier in error messages"

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -43,7 +43,7 @@ export KOS_BASE="/opt/toolchains/dc/kos"
 #
 # Specifies the path to the KOS-ports directory
 #
-export KOS_PORTS="/opt/toolchains/dc/kos-ports"
+export KOS_PORTS="${KOS_BASE}/../kos-ports"
 
 # SH Compiler Prefixes
 #


### PR DESCRIPTION
Reverts KallistiOS/KallistiOS#556

This change broke DreamSDK as it changes `KOS_BASE` but `KOS_PORTS` has always been a relative path, so it wasn't being rewritten. We can revisit this, but it should be in tandem with @sizious 

Reported here: https://discord.com/channels/488332893324836864/755840673780990165/1250261650250924114

``/usr/bin/python.exe: can't open file '/c/DreamSDK/msys/1.0/opt/toolchains/dc/kos-ports/SDL//opt/toolchains/dc/kos-ports/scripts/validate_dist.py': [Errno 2] No such file or directory``