### PR TITLE
Clean up after all the allocations done in serpent_dma

### DIFF
--- a/examples/dreamcast/parallax/serpent_dma/perfmeter.c
+++ b/examples/dreamcast/parallax/serpent_dma/perfmeter.c
@@ -7,6 +7,7 @@
 /* Adapted from FoF/Tryptonite */
 
 #include <kos.h>
+#include <stdlib.h>
 #include <plx/font.h>
 #include <plx/prim.h>
 #include <plx/context.h>
@@ -14,9 +15,15 @@
 plx_font_t * font;
 plx_fcxt_t * fcxt;
 
+void pm_shutdown(void) {
+    plx_fcxt_destroy(fcxt);
+    plx_font_destroy(font);
+}
+
 void pm_init(void) {
     font = plx_font_load("/rd/font.txf");
     fcxt = plx_fcxt_create(font, PVR_LIST_TR_POLY);
+    atexit(pm_shutdown);
 }
 
 void pm_drawbar(float pct, float posx, float posy, float posz,

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -44,6 +44,9 @@ typedef struct {
     pvr_vertex_t *data;
 } sphere_t;
 
+static sphere_t big_sphere = { 1.2f, 20, 20, NULL };
+static sphere_t small_sphere = { 0.8f, 20, 20, NULL };
+
 static void sphere(sphere_t *s) { /* {{{ */
     int i, j;
     float   pitch, pitch2;
@@ -153,8 +156,6 @@ static float r = 0;
 static void sphere_frame(void) {
     int i;
     //uint64 start;
-    static sphere_t big_sphere = { 1.2f, 20, 20, NULL };
-    static sphere_t small_sphere = { 0.8f, 20, 20, NULL };
 
     if(!big_sphere.data)
         sphere(&big_sphere);
@@ -293,6 +294,9 @@ int main(int argc, char **argv) {
     pvr_get_stats(&stats);
     dbglog(DBG_DEBUG, "3D Stats: %u vblanks, frame rate ~%f fps, max vertex used %u bytes\n",
            stats.vbl_count, stats.frame_rate, stats.vtx_buffer_used_max);
+
+    free(big_sphere.data);
+    free(small_sphere.data);
 
     return 0;
 }


### PR DESCRIPTION
As on tin. We shouldn't offer examples that leak memory. The example still leaks memory, but in a similar way as described in #629 which may share a root cause and seems like it may be related to the use of printfs. Am adding the details to that issue rather than here.