### PR TITLE
Avoid returning error code when examples are too old for toolchain version

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -91,3 +91,6 @@ $(shell \
 	}')
 endef
 
+define KOS_GCCVER_MIN_WARNING
+@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
+endef

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -76,20 +76,18 @@ romdisk.o: romdisk.img
 	rm romdisk_tmp.o
 endif
 
-# Define KOS_GCCVER_MIN in your Makefile if you want to enforce a minimum GCC version.
-ifdef KOS_GCCVER_MIN
-  ifeq ($(shell \
-    awk 'BEGIN { \
-        split("$(KOS_GCCVER_MIN)", min, "."); \
-        split("$(KOS_GCCVER)", cur, "."); \
-        if (cur[1] > min[1] || \
-           (cur[1] == min[1] && cur[2] > min[2]) || \
-           (cur[1] == min[1] && cur[2] == min[2] && cur[3] >= min[3])) { \
-            print 1; \
-        } else { \
-            print 0; \
-        } \
-    }'), 0)
-    $(error A minimum GCC version of $(KOS_GCCVER_MIN) is required, but $(KOS_GCCVER) is currently in use.)
-  endif
-endif
+define KOS_GCCVER_MIN_CHECK
+$(shell \
+	awk 'BEGIN { \
+		split("$(1)", min, "."); \
+		split("$(KOS_GCCVER)", cur, "."); \
+		if (cur[1] > min[1] || \
+			(cur[1] == min[1] && cur[2] > min[2]) || \
+			(cur[1] == min[1] && cur[2] == min[2] && cur[3] >= min[3])) { \
+			print 1; \
+		} else { \
+			print 0; \
+		} \
+	}')
+endef
+

--- a/examples/dreamcast/basic/breaking/Makefile
+++ b/examples/dreamcast/basic/breaking/Makefile
@@ -35,6 +35,6 @@ dist: $(TARGET)
 
 else
   all $(TARGET) clean rm-elf run dist:
-	@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
+	$(KOS_GCCVER_MIN_WARNING)
 endif
 

--- a/examples/dreamcast/basic/breaking/Makefile
+++ b/examples/dreamcast/basic/breaking/Makefile
@@ -9,9 +9,13 @@ OBJS = breaking.o
 KOS_CFLAGS += -std=gnu2x -Wno-strict-aliasing
 KOS_GCCVER_MIN = 13.0.0
 
-all: rm-elf $(TARGET)
+
 
 include $(KOS_BASE)/Makefile.rules
+
+ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
+
+all: rm-elf $(TARGET)
 
 clean: rm-elf
 	-rm -f $(OBJS)
@@ -28,3 +32,9 @@ run: $(TARGET)
 dist: $(TARGET)
 	-rm -f $(OBJS)
 	$(KOS_STRIP) $(TARGET)
+
+else
+  all $(TARGET) clean rm-elf run dist:
+	@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
+endif
+

--- a/examples/dreamcast/basic/fpu/exc/Makefile
+++ b/examples/dreamcast/basic/fpu/exc/Makefile
@@ -8,9 +8,13 @@ TARGET = fpu_exc.elf
 OBJS = fpu_exc.o
 KOS_GCCVER_MIN = 5.0.0
 
-all: rm-elf $(TARGET)
+
 
 include $(KOS_BASE)/Makefile.rules
+
+ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
+
+all: rm-elf $(TARGET)
 
 clean: rm-elf
 	-rm -f $(OBJS)
@@ -28,3 +32,7 @@ dist: $(TARGET)
 	-rm -f $(OBJS)
 	$(KOS_STRIP) $(TARGET)
 
+else
+  all $(TARGET) clean rm-elf run dist:
+	@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
+endif

--- a/examples/dreamcast/basic/fpu/exc/Makefile
+++ b/examples/dreamcast/basic/fpu/exc/Makefile
@@ -34,5 +34,5 @@ dist: $(TARGET)
 
 else
   all $(TARGET) clean rm-elf run dist:
-	@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
+	$(KOS_GCCVER_MIN_WARNING)
 endif

--- a/examples/dreamcast/basic/stackprotector/Makefile
+++ b/examples/dreamcast/basic/stackprotector/Makefile
@@ -9,9 +9,11 @@ OBJS = stackprotector.o
 KOS_CFLAGS += -fstack-protector-all
 KOS_GCCVER_MIN = 4.0.0
 
-all: rm-elf $(TARGET)
-
 include $(KOS_BASE)/Makefile.rules
+
+ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
+
+all: rm-elf $(TARGET)
 
 clean: rm-elf
 	-rm -f $(OBJS)
@@ -29,6 +31,10 @@ dist: $(TARGET)
 	-rm -f $(OBJS)
 	$(KOS_STRIP) $(TARGET)
 
+else
+  all $(TARGET) clean rm-elf run dist:
+	@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
+endif
 
 .PHONY: run dist clean rm-elf
 

--- a/examples/dreamcast/basic/stackprotector/Makefile
+++ b/examples/dreamcast/basic/stackprotector/Makefile
@@ -33,7 +33,7 @@ dist: $(TARGET)
 
 else
   all $(TARGET) clean rm-elf run dist:
-	@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
+	$(KOS_GCCVER_MIN_WARNING)
 endif
 
 .PHONY: run dist clean rm-elf

--- a/examples/dreamcast/cpp/concurrency/Makefile
+++ b/examples/dreamcast/cpp/concurrency/Makefile
@@ -32,5 +32,5 @@ dist:
 
 else
   all $(TARGET) clean rm-elf run dist:
-	@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
+	$(KOS_GCCVER_MIN_WARNING)
 endif

--- a/examples/dreamcast/cpp/concurrency/Makefile
+++ b/examples/dreamcast/cpp/concurrency/Makefile
@@ -8,9 +8,11 @@ OBJS = concurrency.o
 KOS_CPPFLAGS += -std=c++20
 KOS_GCCVER_MIN = 12.0.0
 
-all: rm-elf $(TARGET)
-
 include $(KOS_BASE)/Makefile.rules
+
+ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
+
+all: rm-elf $(TARGET)
 
 clean:
 	-rm -f $(TARGET) $(OBJS) 
@@ -28,3 +30,7 @@ dist:
 	rm -f $(OBJS)
 	$(KOS_STRIP) $(TARGET)
 
+else
+  all $(TARGET) clean rm-elf run dist:
+	@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
+endif


### PR DESCRIPTION
Currently the following command will fail on older toolchain versions `cd $KOS_BASE/examples/dreamcast && make` as the error in `Makefile.rules` would be detected as a build failure and return a failure error code. This change makes the targets just print a message about skipping the build so the user is notified while allowing a success return code.