### PR TITLE
Create romdisks with bin2c instead of bin2o

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -71,9 +71,10 @@ romdisk.img:
 	$(KOS_GENROMFS) -f romdisk.img -d $(KOS_ROMDISK_DIR) -v -x .svn -x .keepme
 
 romdisk.o: romdisk.img
-	$(KOS_BASE)/utils/bin2o/bin2o romdisk.img romdisk romdisk_tmp.o
+	$(KOS_BASE)/utils/bin2c/bin2c romdisk.img romdisk_tmp.c romdisk
+	$(KOS_CC) $(KOS_CFLAGS) -o romdisk_tmp.o -c romdisk_tmp.c
 	$(KOS_CC) -o romdisk.o -r romdisk_tmp.o $(KOS_LIB_PATHS) -Wl,--whole-archive -lromdiskbase
-	rm romdisk_tmp.o
+	rm romdisk_tmp.c romdisk_tmp.o
 endif
 
 # Define KOS_GCCVER_MIN in your Makefile if you want to enforce a minimum GCC version.

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -229,6 +229,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added support for one-shot timers [PC]
 - DC  Use one-shot timers for timeout and a proper polling mechanism in modem [PC]
 - *** Added full support for <time.h> additions from C23 standard. [FG]
+- *** Create romdisks with bin2c instead of bin2o [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -96,13 +96,13 @@ extern const uint32_t __kos_init_flags;
 
 /** \brief  Deprecated and not useful anymore. */
 #define KOS_INIT_ROMDISK(rd) \
-    void *__kos_romdisk = (rd); \
+    const void *__kos_romdisk = (rd); \
     extern void fs_romdisk_mount_builtin_legacy(void); \
     void (*fs_romdisk_mount_builtin_legacy_weak)(void) = fs_romdisk_mount_builtin_legacy
 
 
 /** \brief  Built-in romdisk. Do not modify this directly! */
-extern void * __kos_romdisk;
+extern const void * __kos_romdisk;
 
 /** \brief  State that you don't want a romdisk. */
 #define KOS_INIT_ROMDISK_NONE   NULL

--- a/kernel/romdisk/romdiskbase.c
+++ b/kernel/romdisk/romdiskbase.c
@@ -8,7 +8,7 @@
 
 extern unsigned char romdisk[];
 
-void *__kos_romdisk = romdisk;
+const void *__kos_romdisk = romdisk;
 
 extern void fs_romdisk_mount_builtin(void);
 

--- a/kernel/romdisk/romdiskbase.c
+++ b/kernel/romdisk/romdiskbase.c
@@ -6,9 +6,9 @@
 
 #include <kos/fs_romdisk.h>
 
-extern unsigned char romdisk[];
+extern const unsigned char romdisk_data[];
 
-const void *__kos_romdisk = romdisk;
+const void *__kos_romdisk = romdisk_data;
 
 extern void fs_romdisk_mount_builtin(void);
 

--- a/utils/bin2c/bin2c.c
+++ b/utils/bin2c/bin2c.c
@@ -26,7 +26,7 @@ void convert(char *ifn, char *ofn, char *prefix) {
     fseek(i, 0, SEEK_SET);
     setbuf(o, buf);
 
-    fprintf(o, "const int %s_size = %d\n", prefix, left);
+    fprintf(o, "const int %s_size = %d;\n", prefix, left);
     fprintf(o, "const unsigned char %s_data[%d] =", prefix, left);
     fprintf(o, "{\n\t");
 

--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -1,6 +1,7 @@
 # Auxiliary CMake Utility Functions
 #   Copyright (C) 2023 Colton Pawielski
 #   Copyright (C) 2024 Falco Girgis
+#   Copyright (C) 2024 Paul Cercueil
 #
 # This file implements utilities for the following additional functionality
 # which exists in the KOS Make build system:
@@ -65,8 +66,7 @@ function(kos_add_romdisk target romdiskPath)
 
     file(REAL_PATH "${romdiskPath}" romdiskPath)
 
-    set(obj     ${CMAKE_CURRENT_BINARY_DIR}/${romdiskName}.o)
-    set(obj_tmp ${CMAKE_CURRENT_BINARY_DIR}/${romdiskName}_tmp.o)
+    set(c_tmp   ${CMAKE_CURRENT_BINARY_DIR}/${romdiskName}_tmp.c)
     set(img     ${CMAKE_CURRENT_BINARY_DIR}/${romdiskName}.img)
 
     # Variable holding all files in the romdiskPath folder
@@ -85,15 +85,13 @@ function(kos_add_romdisk target romdiskPath)
         COMMAND ${KOS_BASE}/utils/genromfs/genromfs -f ${img} -d ${romdiskPath} -v
     )
 
-    kos_bin2o(${img} ${romdiskName} ${obj_tmp})
-
-    # Custom Command to generate romdisk object file from image
     add_custom_command(
-        OUTPUT  ${obj}
-        DEPENDS ${obj_tmp}
-        COMMAND ${KOS_CC_BASE}/bin/sh-elf-gcc -o ${obj} -r ${obj_tmp} -L${KOS_BASE}/lib/dreamcast -Wl,--whole-archive -lromdiskbase
+        OUTPUT ${c_tmp}
+        DEPENDS ${img}
+        COMMAND ${KOS_BASE}/utils/bin2c/bin2c ${img} ${c_tmp} romdisk
     )
 
     # Append romdisk object to target
-    target_sources(${target} PRIVATE ${obj})
+    target_sources(${target} PRIVATE ${c_tmp})
+    target_link_options(${target} PRIVATE -Wl,--whole-archive -lromdiskbase -Wl,--no-whole-archive)
 endfunction()


### PR DESCRIPTION
bin2o creates a romdisk.o from a romdisk.img using the linker. On the
other hand, bin2c creates a C file with a char array that contains the
whole romdisk.img.

The problem with the first approach is that the romdisk.o generated has
technically not been compiled. This is a problem when building a project
with LTO, as the linker will refuse to perform whole-program
optimizations if some of the object files haven't been compiled with
LTO.

It then issues the following warning:
`ld: warning: incremental linking of LTO and non-LTO objects; using -flinker-output=nolto-rel which will bypass whole program optimization`

Creating romdisks with bin2c then allows the linker to perform
whole-program optimizations.