### PR TITLE
fs_dcload: Set errno on error in dcload_stat()

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -229,6 +229,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added support for one-shot timers [PC]
 - DC  Use one-shot timers for timeout and a proper polling mechanism in modem [PC]
 - *** Added full support for <time.h> additions from C23 standard. [FG]
+- DC  fs_dcload: Set errno on error in dcload_stat() [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -397,6 +397,7 @@ static int dcload_stat(vfs_handler_t *vfs, const char *fn, struct stat *rv,
         return 0;
     }
 
+    errno = ENOENT;
     return -1;
 }
 


### PR DESCRIPTION
The fs_dcload code doesn't seem to set errno anywhere. It means that on error, the calling code will get whatever errno value was set by anything that came before it.

In dcload_stat(), if the PC communication could not be done, set errno to ENOENT - "No such file or directory". This will cause the upper layers to not attempt to open the directory.