### PR TITLE
mutex: Fix mutexes not mutexing

### DIFF
--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -229,6 +229,7 @@ KallistiOS version 2.1.0 -----------------------------------------------
 - *** Added support for one-shot timers [PC]
 - DC  Use one-shot timers for timeout and a proper polling mechanism in modem [PC]
 - *** Added full support for <time.h> additions from C23 standard. [FG]
+- *** Fixes mutexes not working properly [PC]
 
 KallistiOS version 2.0.0 -----------------------------------------------
 - DC  Broadband Adapter driver fixes [Megan Potter == MP]

--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -14,6 +14,7 @@
 #include <kos/dbglog.h>
 
 #include <arch/irq.h>
+#include <arch/timer.h>
 
 mutex_t *mutex_create(void) {
     mutex_t *rv;
@@ -83,6 +84,7 @@ int mutex_lock(mutex_t *m) {
 }
 
 int mutex_lock_timed(mutex_t *m, int timeout) {
+    uint64_t deadline = 0;
     int old, rv = 0;
 
     if((rv = irq_inside_int())) {
@@ -123,14 +125,31 @@ int mutex_lock_timed(mutex_t *m, int timeout) {
         rv = -1;
     }
     else {
-        if(!(rv = genwait_wait(m, timeout ? "mutex_lock_timed" : "mutex_lock",
-                               timeout, NULL))) {
-            m->holder = thd_current;
-            m->count = 1;
-        }
-        else {
-            errno = ETIMEDOUT;
-            rv = -1;
+        if(timeout)
+            deadline = timer_ms_gettime64() + timeout;
+
+        for(;;) {
+            rv = genwait_wait(m, timeout ? "mutex_lock_timed" : "mutex_lock",
+                              timeout, NULL);
+            if(rv < 0) {
+                errno = ETIMEDOUT;
+                break;
+            }
+
+            if(!m->holder) {
+                m->holder = thd_current;
+                m->count = 1;
+                break;
+            }
+
+            if(timeout) {
+                timeout = deadline - timer_ms_gettime64();
+                if(timeout <= 0) {
+                    errno = ETIMEDOUT;
+                    rv = -1;
+                    break;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Imagine a scenario where thread #0 holds a lock. Thread #1 attempts to lock it, doesn't get it, and is put to sleep with genwait_wait(). Thread #0 wakes up, releases the lock, which triggers genwait_wake_one(), placing thread #1 back into the running queue. However, before leaving hand, thread #0 gets the lock once again. Thread #1 would then wake up, and incorrectly set itself as the lock owner, without checking first that the lock was free.

Address this issue by checking that the lock is indeed free after being awaken, and if not, go back to sleep.