### PR TITLE
/dev rewinddir on close

### DIFF
--- a/kernel/fs/fs_dev.c
+++ b/kernel/fs/fs_dev.c
@@ -113,6 +113,11 @@ int dev_close(void *f) {
     }
 
     hnd->refcnt--;
+
+    /* Reset our position */
+    if(hnd->refcnt == 0)
+        hnd->hnd = 0;
+
     return 0;
 }
 


### PR DESCRIPTION
Playing with the sound/ghettoplay-vorbis example.  I found that if I visited the /dev directory and then revisited it again, the directory contents would be missing.  This fixes that.