### PR TITLE
/sd directories viewed as files

### DIFF
--- a/addons/libkosfat/fs_fat.c
+++ b/addons/libkosfat/fs_fat.c
@@ -939,7 +939,6 @@ static dirent_t *fs_fat_readdir(void *h) {
     if(dent->attr & FAT_ATTR_DIRECTORY) {
         fh[fd].dent.attr = O_DIR;
         fh[fd].dent.size = -1;
-        fh[fd].dent.time = 0;
     }
 
     /* We're done. Return the static dirent_t. */

--- a/addons/libkosfat/fs_fat.c
+++ b/addons/libkosfat/fs_fat.c
@@ -936,8 +936,11 @@ static dirent_t *fs_fat_readdir(void *h) {
     fh[fd].dent.size = dent->size;
     fh[fd].dent.time = fat_time_to_stat(dent->mdate, dent->mtime);
 
-    if(dent->attr & FAT_ATTR_DIRECTORY)
+    if(dent->attr & FAT_ATTR_DIRECTORY) {
         fh[fd].dent.attr = O_DIR;
+        fh[fd].dent.size = -1;
+        fh[fd].dent.time = 0;
+    }
 
     /* We're done. Return the static dirent_t. */
     mutex_unlock(&fat_mutex);


### PR DESCRIPTION
The directories and subdirectories in /sd would be considered files even with the O_DIR attr set.  This fixes that by setting the correct size and time.