### PR TITLE
Replace realpath() for a better license

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,35 +71,6 @@ include/pthread.h:
  *
  */
 
-kernel/libc/koslib/realpath.c:
-/*
- * Copyright (c) 2003 Constantin S. Svintsoff <kostik@iclub.nsu.ru>
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. The names of the authors may not be used to endorse or promote
- *    products derived from this software without specific prior written
- *    permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- */
-
 kernel/arch/dreamcast/kernel/gdb_stub.c:
 /*   This is originally based on an m68k software stub written by Glenn
      Engel at HP, but has changed quite a bit.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@ Platform-specific changes are prefixed with the platform name, otherwise the cha
 ## KallistiOS version 2.2.0
 - Added pvrtex utility by TapamN to utils [DF == Daniel Fairchild]
 - Added . & .. directories to filesystems that lack it [AB]
+- Replaced previous implementation of realpath() to remove license from AUTHORS [AB]
 
 ## KallistiOS version 2.1.0
 - Cleaned up generated stubs files on a make clean [Lawrence Sebald == LS]

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -735,6 +735,23 @@ ssize_t fs_load(const char *src, void **out_ptr);
 */
 ssize_t fs_path_append(char *dst, const char *src, size_t len);
 
+/** \brief   Normalize the specified path. 
+    This function acts mostly like the function realpath() but it only simplifies
+    a path by resolving . and .. components and removing redundant slashes.  It 
+    doesn't check if the path exists or resolve symbolic links.
+    \param  path            The path to normalize.
+    \param  resolved        The buffer to store resolved normalized path. It has 
+                            to be PATH_MAX bytes in size.
+    
+    \return                 A pointer to the normalized path on success, 
+                            or NULL on failure, in which case the path which 
+                            caused trouble is left in resolved.
+    \par    Error Conditions:
+    \em     EINVAL - path or resolved is a NULL pointer \n
+    \em     ENAMETOOLONG - the resulting path would be longer than PATH_MAX bytes \n
+*/
+char *fs_normalize_path(const char *__RESTRICT path, char *__RESTRICT resolved);
+
 /** \brief   Initialize the virtual filesystem.
 
     This is normally done for you by default when KOS starts. In general, there

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -106,7 +106,7 @@ static fs_hnd_t * fs_hnd_open(const char *fn, int mode) {
     fs_hnd_t    *hnd;
     char        rfn[PATH_MAX];
 
-    if(!realpath(fn, rfn))
+    if(!fs_normalize_path(fn, rfn))
         return NULL;
 
     /* Are they trying to open the root? */
@@ -609,7 +609,7 @@ int fs_rename(const char *fn1, const char *fn2) {
     vfs_handler_t   *fh1, *fh2;
     char        rfn1[PATH_MAX], rfn2[PATH_MAX];
 
-    if(!realpath(fn1, rfn1) || !realpath(fn2, rfn2))
+    if(!fs_normalize_path(fn1, rfn1) || !fs_normalize_path(fn2, rfn2))
         return -1;
 
     /* Look for handlers */
@@ -645,7 +645,7 @@ int fs_unlink(const char *fn) {
     vfs_handler_t   *cur;
     char        rfn[PATH_MAX];
 
-    if(!realpath(fn, rfn))
+    if(!fs_normalize_path(fn, rfn))
         return -1;
 
     /* Look for a handler */
@@ -664,7 +664,7 @@ int fs_unlink(const char *fn) {
 int fs_chdir(const char *fn) {
     char        rfn[PATH_MAX];
 
-    if(!realpath(fn, rfn))
+    if(!fs_normalize_path(fn, rfn))
         return -1;
 
     thd_set_pwd(thd_get_current(), rfn);
@@ -705,7 +705,7 @@ int fs_mkdir(const char * fn) {
     vfs_handler_t   *cur;
     char        rfn[PATH_MAX];
 
-    if(!realpath(fn, rfn))
+    if(!fs_normalize_path(fn, rfn))
         return -1;
 
     /* Look for a handler */
@@ -725,7 +725,7 @@ int fs_rmdir(const char * fn) {
     vfs_handler_t   *cur;
     char        rfn[PATH_MAX];
 
-    if(!realpath(fn, rfn))
+    if(!fs_normalize_path(fn, rfn))
         return -1;
 
     /* Look for a handler */
@@ -774,7 +774,7 @@ int fs_link(const char *path1, const char *path2) {
     vfs_handler_t *fh1, *fh2;
     char rfn1[PATH_MAX], rfn2[PATH_MAX];
 
-    if(!realpath(path1, rfn1) || !realpath(path2, rfn2))
+    if(!fs_normalize_path(path1, rfn1) || !fs_normalize_path(path2, rfn2))
         return -1;
 
     /* Look for handlers */
@@ -811,7 +811,7 @@ int fs_symlink(const char *path1, const char *path2) {
     vfs_handler_t *vfs;
     char rfn[PATH_MAX];
 
-    if(!realpath(path2, rfn))
+    if(!fs_normalize_path(path2, rfn))
         return -1;
 
     /* Look for the handler */


### PR DESCRIPTION
The purpose of this PR was to make our AUTHORS file a little lighter.  The current implementation of realpath() just normalized a path without checking if a path exists or handling symlinks like its supposed to do: https://pubs.opengroup.org/onlinepubs/009696799/functions/realpath.html.

With this new correct implementation, I found that I needed to create a replacement for how the old implementation behaved, fs_normalize_path().  

All-in-all, no behavior change. We just free up realpath() to work like it is supposed to.