### PR TITLE
Add the option to prefer static IPs over DHCP

### DIFF
--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -140,6 +140,8 @@ extern const void * __kos_romdisk;
 #define INIT_EXPORT      0x00000020  /**< \brief Export kernel symbols */
 #define INIT_FS_ROMDISK  0x00000040  /**< \brief Enable support for romdisks */
 #define INIT_NO_SHUTDOWN 0x00000080  /**< \brief Disable hardware shutdown */
+#define INIT_NET_STATIC  0x00000104  /**< \brief Enable networking with a 
+                                           preference for static IP configuration */
 /** @} */
 
 __END_DECLS

--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -140,7 +140,7 @@ extern const void * __kos_romdisk;
 #define INIT_EXPORT      0x00000020  /**< \brief Export kernel symbols */
 #define INIT_FS_ROMDISK  0x00000040  /**< \brief Enable support for romdisks */
 #define INIT_NO_SHUTDOWN 0x00000080  /**< \brief Disable hardware shutdown */
-#define INIT_NET_STATIC  0x00000104  /**< \brief Enable networking with a 
+#define INIT_NET_STATIC  (0x00000100 | INIT_NET) /**< \brief Enable networking with a 
                                            preference for static IP configuration */
 /** @} */
 

--- a/include/kos/net.h
+++ b/include/kos/net.h
@@ -977,19 +977,35 @@ int net_reg_device(netif_t *device);
 */
 int net_unreg_device(netif_t *device);
 
-/** \brief   Init network support.
+/** \brief   Init network support, preferring DHCP over static methods.
     \ingroup networking_drivers
     
     \note                   To auto-detect the IP address to assign to the
-                            default device (i.e, over DHCP or from the flashrom
-                            on the Dreamcast), pass 0 as the IP parameter.
+                            default device (i.e., over DHCP first and then 
+                            from the flashrom on the Dreamcast), pass 0 as 
+                            the IP parameter.
 
     \param  ip              The IPv4 address to set on the default device, in
                             host byte order.
 
     \return                 0 on success, <0 on failure.
 */
-int net_init(uint32 ip);
+int net_init(uint32_t ip);
+
+/** \brief   Init network support, preferring static methods over DHCP.
+    \ingroup networking_drivers
+    
+    \note                   To auto-detect the IP address to assign to the
+                            default device (i.e., from the flashrom
+                            on the Dreamcast first, then DHCP if we have to), 
+                            pass 0 as the IP parameter.
+
+    \param  ip              The IPv4 address to set on the default device, in
+                            host byte order.
+
+    \return                 0 on success, <0 on failure.
+*/
+int net_init_static(uint32_t ip);
 
 /** \brief   Shutdown network support. 
     \ingroup networking_drivers

--- a/kernel/net/net_core.c
+++ b/kernel/net/net_core.c
@@ -108,7 +108,7 @@ netif_t *net_set_default(netif_t *n) {
 }
 
 /* Device detect / init */
-int net_dev_init(void) {
+static int net_dev_init(void) {
     int detected = 0;
     netif_t *cur;
 
@@ -136,7 +136,7 @@ int net_dev_init(void) {
 
     dbglog(DBG_DEBUG, "net_dev_init: detected %d usable network device(s)\n", detected);
 
-    return 0;
+    return detected == 0 ? -1 : 0;
 }
 
 /* Init */


### PR DESCRIPTION
This PR is developer focused and helps developers who don't have their setup configured for DHCP.  This PR was created to partially address this issue (https://github.com/KallistiOS/KallistiOS/issues/617). It might be a while before dcload-ip catches up to even implement the ideas in this issue.  Even with taking an asynchronous approach, static configurations will still have to wait for DHCP requests to timeout (45-60 seconds).  This PR gives preference to initialize the network device using static options before defaulting to DHCP.

1. Added new INIT_NET_STATIC kos init flag that will use static methods first to initialize the network device. 
2. Added new net_init_static() that will try static methods before default to DHCP.
3. No behavior change for people using INIT_NET flag or net_init().

It still needs more testing so I will leave it in draft and see what everyone thinks about this approach.

Oh I also fixed some references to DMAC registers by using the existing header file dmac.h instead of redefining in init.c