### PR TITLE
Support chained LBA28 DMA transfers in IDE and DMA transfers in FAT

### DIFF
--- a/addons/libkosfat/bpb.c
+++ b/addons/libkosfat/bpb.c
@@ -4,6 +4,7 @@
    Copyright (C) 2012, 2019 Lawrence Sebald
 */
 
+#include <malloc.h>
 #include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -18,7 +19,7 @@ static int fat_read_raw_boot(fat_bootblock_t *sb, kos_blockdev_t *bd) {
     if(bd->l_block_size > 9) {
         uint8_t *buf;
 
-        if(!(buf = (uint8_t *)malloc(1 << bd->l_block_size)))
+        if(!(buf = (uint8_t *)memalign(32, 1 << bd->l_block_size)))
             return -ENOMEM;
 
         if(bd->read_blocks(bd, 0, 1, buf))
@@ -27,9 +28,6 @@ static int fat_read_raw_boot(fat_bootblock_t *sb, kos_blockdev_t *bd) {
         memcpy(sb, buf, 512);
         free(buf);
         return 0;
-    }
-    else if(bd->l_block_size == 9) {
-        return bd->read_blocks(bd, 0, 1, sb);
     }
     else {
         return bd->read_blocks(bd, 0, 512 >> bd->l_block_size, sb);

--- a/addons/libkosfat/bpb.h
+++ b/addons/libkosfat/bpb.h
@@ -64,7 +64,7 @@ typedef struct fat_bootblock {
         fat16_ebpb_t fat16;
         fat32_ebpb_t fat32;
     } ebpb;
-} __attribute__((packed)) fat_bootblock_t;
+} __attribute__((packed,aligned(32))) fat_bootblock_t;
 
 typedef struct fat32_fsinfo {
     uint32_t fsinfo_sig1;
@@ -74,7 +74,7 @@ typedef struct fat32_fsinfo {
     uint32_t last_alloc_cluster;
     uint8_t reserved2[12];
     uint32_t fsinfo_sig3;
-} __attribute__((packed)) fat32_fsinfo_t;
+} __attribute__((packed,aligned(32))) fat32_fsinfo_t;
 
 #define FAT32_FSINFO_SIG1 0x41615252
 #define FAT32_FSINFO_SIG2 0x61417272

--- a/addons/libkosfat/fatfs.c
+++ b/addons/libkosfat/fatfs.c
@@ -4,6 +4,7 @@
    Copyright (C) 2012, 2013, 2019 Lawrence Sebald
 */
 
+#include <malloc.h>
 #include <stdio.h>
 #include <errno.h>
 #include <stdint.h>
@@ -315,7 +316,7 @@ fat_fs_t *fat_fs_init_ex(kos_blockdev_t *bd, uint32_t flags, int cache_sz,
     }
 
     for(j = 0; j < cache_sz; ++j) {
-        if(!(rv->bcache[j]->data = (uint8_t *)malloc(cluster_size))) {
+        if(!(rv->bcache[j]->data = (uint8_t *)memalign(32, cluster_size))) {
             goto out_bcache;
         }
 
@@ -337,7 +338,7 @@ fat_fs_t *fat_fs_init_ex(kos_blockdev_t *bd, uint32_t flags, int cache_sz,
     }
 
     for(j = 0; j < fcache_sz; ++j) {
-        if(!(rv->fcache[j]->data = (uint8_t *)malloc(block_size))) {
+        if(!(rv->fcache[j]->data = (uint8_t *)memalign(32, block_size))) {
             goto out_fcache2;
         }
 


### PR DESCRIPTION
Add support for transferring more than 256 sectors worth of data using DMA on devices that don't support LBA48.

This works by cutting the DMA transfer into chunks of 256 sectors, that are transferred automatically: every time a 256-sectors transfer is done, the DMA complete IRQ will start the next one.