### PR TITLE
Fixed GCC9+10 Build Failures: pthread_atfork()

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -62,7 +62,8 @@ extern "C" {
         NOTE: RTEMS does not provide pthread_atfork().  */
 
 #if !defined(__rtems__)
-// #warning "Add pthread_atfork() prototype"
+    int pthread_atfork(void (*prepare)(void), void (*parent)(void),
+                    void (*child)(void));
 #endif
 
     /* Mutex Initialization Attributes, P1003.1c/Draft 10, p. 81 */

--- a/kernel/libc/pthreads/pthread_thd.c
+++ b/kernel/libc/pthreads/pthread_thd.c
@@ -71,7 +71,8 @@ int pthread_equal(pthread_t t1, pthread_t t2) {
     return t1 == t2;
 }
 
-int pthread_atfork(void (*)(void), void (*)(void), void (*)(void))
-{
+int pthread_atfork(void (*prepare)(void), void (*parent)(void),
+                   void (*child)(void)) {
+    (void)prepare; (void)parent; (void)child;
     return 0;
 }


### PR DESCRIPTION
1) pthread_atfork()'s implementation was not declaring agument variables
   by name, which was not supported in ancient GCC9 and GCC10,
apparently.
2) pthread_atfork() was added as a symbol for CMake checks for pthreads
   to pass, yet we were never declaring the symbol publicly anywhere,
and implicit declarations of C functions are now deprecated in GCC14+.