### PR TITLE
cache: Fix ranges of i/d cache flush/inval

### DIFF
--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -66,7 +66,7 @@ _icache_flush_range:
     and      r3, r7
 
     add      #32, r4       ! Move on to next cache block
-    cmp/hs   r4, r5
+    cmp/hi   r4, r5
     bt/s     .iflush_loop
     mov.l    r7, @r6       ! *addr = data    
 
@@ -107,9 +107,9 @@ _dcache_inval_range:
 .dinval_loop:
     ! Invalidate the dcache
     ocbi     @r4
-    cmp/hs   r4, r5
-    bt/s     .dinval_loop
     add      #32, r4        ! Move on to next cache block
+    cmp/hi   r4, r5
+    bt       .dinval_loop
 
 .dinval_exit:
     rts
@@ -141,9 +141,9 @@ _dcache_flush_range:
 .dflush_loop:
     ! Write back the dcache
     ocbwb    @r4
-    cmp/hs   r4, r5
-    bt/s     .dflush_loop
     add      #32, r4        ! Move on to next cache block
+    cmp/hi   r4, r5
+    bt       .dflush_loop
 
 .dflush_exit:
     rts
@@ -197,9 +197,9 @@ _dcache_purge_range:
 .dpurge_loop:
     ! Write back and invalidate the D cache
     ocbp     @r4
-    cmp/hs   r4, r5
-    bt/s     .dpurge_loop
     add      #32, r4     ! Move on to next cache block
+    cmp/hi   r4, r5
+    bt       .dpurge_loop
 
 .dpurge_exit:
     rts
@@ -239,9 +239,9 @@ _dcache_purge_all_with_buffer:
     ! Allocate and then invalidate the dcache line
     movca.l  r0, @r4
     ocbi     @r4
-    cmp/hs   r4, r5
-    bt/s     .dpurge_all_buffer_loop
     add      #32, r4        ! Move on to next cache block
+    cmp/hi   r4, r5
+    bt       .dpurge_all_buffer_loop
 
     rts
     nop


### PR DESCRIPTION
The algorithms were flushing / invalidating the data using the start address in r4, and the end address (start + size) in r5.

They would then flush / invalidate using the address in r4, check "r5 >= r4", then add 0x20 to r4 and loop if true.

If we have r4 == 0x0 and r5 == 0x20, it means that the address 0x0 would be flushed / invalidated as expected, but the address 0x20 would also be flushed / invalidated. Even worse, the address 0x40 would be flushed too, as the range check is performed before the 0x20 increment.

This isn't a big deal when just flushing data to cache (it's just slightly more expensive), but is a huge problem when invalidating data. For instance, if we want to invalidate 32 bytes at a given address in preparation of a DMA read, we absolutely do not want to invalidate any data present after the end of the DMA area, or we risk data corruption.

Address this issue by updating the value of r4 before the range check, and using "r5 > r4" instead of "r5 >= r4" as the loop continue condition.