### PR TITLE
Don't allow dbgio until it is initted

### DIFF
--- a/kernel/debug/dbgio.c
+++ b/kernel/debug/dbgio.c
@@ -51,7 +51,7 @@ const char * dbgio_dev_get(void) {
         return dbgio->name;
 }
 
-static int dbgio_enabled = 1;
+static int dbgio_enabled = 0;
 void dbgio_enable(void) {
     dbgio_enabled = 1;
 }
@@ -72,6 +72,7 @@ int dbgio_init(void) {
             // next one anyway.
             if(!dbgio->init()) {
                 // Worked.
+                dbgio_enable();
                 return 0;
             }
 


### PR DESCRIPTION
Opened #798 to track the ongoing issue and moving this one along.

This change ensures that dbgio is marked as disabled until it is initted. Before this it was always on from the start which would break the rare use of it prior to `dbgio_init` being called (such as malloc debugging).