### PR TITLE
Ensure thd_current does not get set to null

### DIFF
--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -20,11 +20,9 @@
 #include <assert.h>
 #include <errno.h>
 
-#include <arch/arch.h>
 #include <arch/timer.h>
 #include <kos/genwait.h>
 #include <kos/sem.h>
-#include <kos/dbgio.h>
 
 /* Our sleep queues table. This is also modeled after the BSD numbers. I
    figure if they've been using it as long as they have, they must be

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -20,9 +20,11 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <arch/arch.h>
 #include <arch/timer.h>
 #include <kos/genwait.h>
 #include <kos/sem.h>
+#include <kos/dbgio.h>
 
 /* Our sleep queues table. This is also modeled after the BSD numbers. I
    figure if they've been using it as long as they have, they must be
@@ -81,7 +83,6 @@ int genwait_wait(void * obj, const char * mesg, int timeout, void (*callback)(vo
 
     /* Prepare us for sleep */
     me = thd_current;
-    thd_current = NULL;
     me->state = STATE_WAIT;
     me->wait_obj = obj;
     me->wait_msg = mesg;


### PR DESCRIPTION
Before this `genwait_wait` was setting `thd_current` to NULL as a way to signal to the scheduler that it should not be re-enqueued. This would cause the thread time updating introduced in #506 to write null deref on any genwait_wait.

It seems very much like that check was pointless, and perhaps a relic of older threading modes. The setting to null would be used to set the variable `dontenq` to 1 which would exempt the thread from getting rescheduled. Each of the two checks that checked against that though would always then validate that the `thd_current->state == STATE_RUNNING` which is always false while `thd_current` is null because that was always followed by setting `thd_current->state == STATE_WAIT`.

So have entirely removed that set of checks that seemed to be redundant. This allows thd_current to not get set to null ever and `thd_update_cpu_time` to work correctly.