### PR TITLE
CMake: Support romdisks in C++ projects

### DIFF
--- a/utils/bin2c/bin2c.c
+++ b/utils/bin2c/bin2c.c
@@ -26,7 +26,10 @@ void convert(char *ifn, char *ofn, char *prefix) {
     fseek(i, 0, SEEK_SET);
     setbuf(o, buf);
 
+    fprintf(o, "#ifdef __cplusplus\nextern \"C\"\n#endif\n");
     fprintf(o, "const int %s_size = %d;\n", prefix, left);
+
+    fprintf(o, "#ifdef __cplusplus\nextern \"C\"\n#endif\n");
     fprintf(o, "const unsigned char %s_data[%d] =", prefix, left);
     fprintf(o, "{\n\t");
 

--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -66,7 +66,13 @@ function(kos_add_romdisk target romdiskPath)
 
     file(REAL_PATH "${romdiskPath}" romdiskPath)
 
-    set(c_tmp   ${CMAKE_CURRENT_BINARY_DIR}/${romdiskName}_tmp.c)
+    if(CMAKE_CXX_COMPILER_LOADED)
+        set(tmpExt cpp)
+    else()
+        set(tmpExt c)
+    endif()
+
+    set(c_tmp   ${CMAKE_CURRENT_BINARY_DIR}/${romdiskName}_tmp.${tmpExt})
     set(img     ${CMAKE_CURRENT_BINARY_DIR}/${romdiskName}.img)
 
     # Variable holding all files in the romdiskPath folder


### PR DESCRIPTION
When the project is C++ only, any .c file added to the target sources will be ignored by CMake. This meant that the source file generated by kos_add_romdisk() macro would not be compiled.

Address this issue by changing the extension of the generated source file to .cpp when a C++ compiler is used.

This requires a small modification to bin2c so that it generates code that can also be compiled by a C++ compiler.