### PR TITLE
Update PVR_PACK_COLOR macro to handle expression params

### DIFF
--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -969,10 +969,10 @@ typedef struct {
     \return                 The packed color value
 */
 #define PVR_PACK_COLOR(a, r, g, b) ( \
-                                     ( ((uint8)( a * 255 ) ) << 24 ) | \
-                                     ( ((uint8)( r * 255 ) ) << 16 ) | \
-                                     ( ((uint8)( g * 255 ) ) << 8 ) | \
-                                     ( ((uint8)( b * 255 ) ) << 0 ) )
+                                     ( ((uint8_t)( (a) * 255 ) ) << 24 ) | \
+                                     ( ((uint8_t)( (r) * 255 ) ) << 16 ) | \
+                                     ( ((uint8_t)( (g) * 255 ) ) << 8 ) | \
+                                     ( ((uint8_t)( (b) * 255 ) ) << 0 ) )
 
 /** \brief   Pack two floating point coordinates into one 32-bit value,
              truncating them to 16-bits each.


### PR DESCRIPTION
Fix PVR_PACK_COLOR macro to ensure proper color packing by handling expressions passed to the macro