### PR TITLE
Expanded VFS documentation

### DIFF
--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -15,9 +15,27 @@
     with the genromfs program that is included in the utils portion of the tree.
 
     You can choose to automount one ROMFS image by embedding it into your binary
-    and using the appropriate KOS_INIT_FLAGS() setting. The embedded ROMFS will
-    mount itself on /rd. You can also mount additional images that you load
-    from some other source on whatever mountpoint you want.
+    and using INIT_DEFAULT() when calling  KOS_INIT_FLAGS(), or passing INIT_FS_ROMDISK()
+    when calling the INIT macro with a custom flag selection. The embedded ROMFS
+    will mount itself on /rd.
+
+    \warning
+    An embedded romdisk image is linked to your executable and cannot be evicted from
+    system RAM!
+    
+    Mounting additional images that you load from some other sources (such as a modified BIOS)
+    on whatever mountpoint you want, is also possible. Using fs_romdisk_mount() and passing a
+    pointer to the location of a romdisk image will mount it.
+
+    \remark 
+    Mounted images will reside in system RAM for as long as your program is running
+    or until you unmount them with fs_romdisk_unmount().The size of your generated
+    ROMFS image must be kept below 16MB, with 14MB being the maximum recommended size, 
+    as your binary will also reside in RAM and you need to leave some memory available
+    for it. Generating filles larger than the available RAM will lead to system crashes.
+
+    \see INIT_FS_ROMDISK()
+    \see KOS_INIT_FLAGS()
 
     \author Megan Potter
 */

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -29,7 +29,7 @@
 
     \remark 
     Mounted images will reside in system RAM for as long as your program is running
-    or until you unmount them with fs_romdisk_unmount().The size of your generated
+    or until you unmount them with fs_romdisk_unmount(). The size of your generated
     ROMFS image must be kept below 16MB, with 14MB being the maximum recommended size, 
     as your binary will also reside in RAM and you need to leave some memory available
     for it. Generating filles larger than the available RAM will lead to system crashes.

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -34,7 +34,7 @@
     as your binary will also reside in RAM and you need to leave some memory available
     for it. Generating files larger than the available RAM will lead to system crashes.
 
-    \see INIT_FS_ROMDISK()
+    \see INIT_FS_ROMDISK
     \see KOS_INIT_FLAGS()
 
     \author Megan Potter

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -16,7 +16,7 @@
 
     You can choose to automount one ROMFS image by embedding it into your binary
     and using the appropriate flags (INIT_DEFAULT by itself or INIT_FS_ROMDISK with other flags) when calling KOS_INIT_FLAGS().
-    when calling the INIT macro with a custom flag selection. The embedded ROMFS
+    when calling the KOS_INIT_FLAGS() macro with a custom flag selection. The embedded ROMFS
     will mount itself on /rd.
 
     \warning

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -33,7 +33,13 @@
     ROMFS image must be kept below 16MB, with 14MB being the maximum recommended size, 
     as your binary will also reside in RAM and you need to leave some memory available
     for it. Generating files larger than the available RAM will lead to system crashes.
-
+    
+    A romdisk filesystem image can be created by adding "KOS_ROMDISK_DIR=" to your Makefile
+    and pointing it to the directory contaning all the resources you wish to have embeded in
+    filesystem image. A rule to create the image is provided in the rules provided in Makefile.rules.
+    The created object file can be linked with your binary file by adding romdisk.o to your
+    list of objects.
+    
     \see INIT_FS_ROMDISK
     \see KOS_INIT_FLAGS()
 

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -15,7 +15,7 @@
     with the genromfs program that is included in the utils portion of the tree.
 
     You can choose to automount one ROMFS image by embedding it into your binary
-    and using INIT_DEFAULT() when calling  KOS_INIT_FLAGS(), or passing INIT_FS_ROMDISK()
+    and using the appropriate flags (INIT_DEFAULT by itself or INIT_FS_ROMDISK with other flags) when calling KOS_INIT_FLAGS().
     when calling the INIT macro with a custom flag selection. The embedded ROMFS
     will mount itself on /rd.
 

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -32,7 +32,7 @@
     or until you unmount them with fs_romdisk_unmount(). The size of your generated
     ROMFS image must be kept below 16MB, with 14MB being the maximum recommended size, 
     as your binary will also reside in RAM and you need to leave some memory available
-    for it. Generating filles larger than the available RAM will lead to system crashes.
+    for it. Generating files larger than the available RAM will lead to system crashes.
 
     \see INIT_FS_ROMDISK()
     \see KOS_INIT_FLAGS()

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -15,7 +15,7 @@
     with the genromfs program that is included in the utils portion of the tree.
 
     You can choose to automount one ROMFS image by embedding it into your binary
-    and using the appropriate flags (INIT_DEFAULT by itself or INIT_FS_ROMDISK with other flags) when calling KOS_INIT_FLAGS().
+    and using the appropriate flags (INIT_DEFAULT by itself or INIT_FS_ROMDISK with other flags)
     when calling the KOS_INIT_FLAGS() macro with a custom flag selection. The embedded ROMFS
     will mount itself on /rd.
 

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -36,8 +36,8 @@
     
     A romdisk filesystem image can be created by adding "KOS_ROMDISK_DIR=" to your Makefile
     and pointing it to the directory contaning all the resources you wish to have embeded in
-    filesystem image. A rule to create the image is provided in the rules provided in Makefile.rules.
-    The created object file can be linked with your binary file by adding romdisk.o to your
+    filesystem image. A rule to create the image is provided in the rules provided in Makefile.rules,
+    the created object file must be linked with your binary file by adding romdisk.o to your 
     list of objects.
     
     \see INIT_FS_ROMDISK


### PR DESCRIPTION
Expanded the VFS documentation to include some information on how it works, how to start it and image size limitations.

Things I want address later still in the VFS doc:
- First part about the mkdisc tool, apparently it's not entirely accurate
- Documenting the effects of umounting a VFS image without closing all opened handles; it is currently unknown what happens when a user does this. 
