### PR TITLE
Update minimum macOS version for toolchain build

### DIFF
--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -63,7 +63,7 @@ ifdef MACOS
     sdkroot = $(shell xcrun --sdk macosx --show-sdk-path)
     macos_extra_args = -isysroot $(sdkroot)
     CC += -Wno-nullability-completeness -Wno-missing-braces $(macos_extra_args)
-    CXX += -stdlib=libc++ -mmacosx-version-min=10.7 $(macos_extra_args)
+    CXX += -stdlib=libc++ -mmacosx-version-min=10.14 $(macos_extra_args)
     SH_CC_FOR_TARGET += $(macos_extra_args)
     SH_CXX_FOR_TARGET += $(macos_extra_args)
     macos_gcc_configure_args = --with-sysroot --with-native-system-header=/usr/include


### PR DESCRIPTION
Updated the CXX line to set -mmacosx-version-min to 10.14 from 10.7 to support building the toolchain on M1 Macs. This ensures compatibility with newer macOS versions.