### PR TITLE
Fix ramdisk_find

### DIFF
--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -107,7 +107,7 @@ static rd_file_t *ramdisk_find(rd_dir_t *parent, const char *name, size_t namele
     rd_file_t   *f;
 
     LIST_FOREACH(f, parent, dirlist) {
-        if(!strncasecmp(name, f->name, namelen) && strlen(f->name) == namelen)
+        if((strlen(f->name) == namelen) && !strncasecmp(name, f->name, namelen))
             return f;
     }
 

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -103,11 +103,11 @@ static mutex_t rd_mutex;
 
 /* Search a directory for the named file; return the struct if
    we find it. Assumes we hold rd_mutex. */
-static rd_file_t * ramdisk_find(rd_dir_t * parent, const char * name, int namelen) {
+static rd_file_t *ramdisk_find(rd_dir_t *parent, const char *name, size_t namelen) {
     rd_file_t   *f;
 
     LIST_FOREACH(f, parent, dirlist) {
-        if(!strncasecmp(name, f->name, namelen))
+        if(!strncasecmp(name, f->name, namelen) && strlen(f->name) == namelen)
             return f;
     }
 


### PR DESCRIPTION
Fix ramdisk_find by making sure we also compare the filename lengths so false positives wont occur.

Fixes issue #686