### PR TITLE
Upgrade to GCC 14.2.0

### DIFF
--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -15,10 +15,10 @@
 # - 12.4.0:       Latest release in the GCC 12 series, released 2023-06-20.
 # - stable:       Tested stable; based on GCC 13.2.0, released 2023-07-27.
 # - 13.3.0:       Latest release in the GCC 13 series, released 2024-05-21.
-# - 14.1.0:       Latest release in the GCC 14 series, released 2024-05-07.
+# - 14.2.0:       Latest release in the GCC 14 series, released 2024-08-01.
 # Development versions:
 # - 13.3.1-dev    Bleeding edge GCC 13 series from git.
-# - 14.1.1-dev    Bleeding edge GCC 14 series from git.
+# - 14.2.1-dev    Bleeding edge GCC 14 series from git.
 # - 15.0.0-dev    Bleeding edge GCC 15 series from git.
 # - gccrs-dev:    GCC fork for development of the GCCRS Rust compiler.
 # - rustc-dev:    GCC fork for development of the libgccjit rustc GCC codegen.

--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -105,9 +105,9 @@ The following toolchain profiles are available for users to select in
 | 12.3.0 | 12.3.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | Latest release in the GCC 12 series, released 2023-05-08 |
 | **stable** | **13.2.0** | **4.3.0** | **2.41** | **8.5.0** | **2.41** | **Tested stable; based on GCC 13.2.0, released 2023-07-27** |
 | 13.3.0 | 13.3.0 | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Latest release in the GCC 13 series, released 2024-05-21 |
-| 14.1.0 | 14.1.0 | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Latest release in the GCC 14 series, released 2024-05-07 |
+| 14.2.0 | 14.2.0 | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Latest release in the GCC 14 series, released 2024-08-01 |
 | 13.3.1-dev | 13.3.1 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 13 series from git |
-| 14.1.1-dev | 14.0.1 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 14 series from git |
+| 14.2.1-dev | 14.2.1 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 14 series from git |
 | 15.0.0-dev | 15.0.0 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 15 series from git |
 | gccrs-dev | 14.x | 4.4.0 | 2.42 | 8.5.0 | 2.42 | GCC fork for development of the GCCRS Rust compiler |
 | rustc-dev | 14.x | 4.4.0 | 2.42 | 8.5.0 | 2.42 | GCC fork for development of the libgccjit rustc GCC codegen |

--- a/utils/dc-chain/patches/gcc-14.2.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-14.2.0-kos.diff
@@ -1,6 +1,6 @@
-diff -ruN gcc-14.1.0/gcc/config/sh/sh-c.cc gcc-14.1.0-kos/gcc/config/sh/sh-c.cc
---- gcc-14.1.0/gcc/config/sh/sh-c.cc	2024-01-04 16:01:33.790051712 -0600
-+++ gcc-14.1.0-kos/gcc/config/sh/sh-c.cc	2024-01-04 16:01:42.910094466 -0600
+diff -ruN gcc-14.2.0/gcc/config/sh/sh-c.cc gcc-14.2.0-kos/gcc/config/sh/sh-c.cc
+--- gcc-14.2.0/gcc/config/sh/sh-c.cc	2024-01-04 16:01:33.790051712 -0600
++++ gcc-14.2.0-kos/gcc/config/sh/sh-c.cc	2024-01-04 16:01:42.910094466 -0600
 @@ -141,4 +141,11 @@
  
    cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
@@ -13,9 +13,9 @@ diff -ruN gcc-14.1.0/gcc/config/sh/sh-c.cc gcc-14.1.0-kos/gcc/config/sh/sh-c.cc
 +  /* Toolchain supports setting up stack for 32MB */
 +  builtin_define ("__KOS_GCC_32MB__");
  }
-diff -ruN gcc-14.1.0/gcc/configure gcc-14.1.0-kos/gcc/configure
---- gcc-14.1.0/gcc/configure	2024-01-04 16:01:33.801051764 -0600
-+++ gcc-14.1.0-kos/gcc/configure	2024-01-04 16:01:42.913094480 -0600
+diff -ruN gcc-14.2.0/gcc/configure gcc-14.2.0-kos/gcc/configure
+--- gcc-14.2.0/gcc/configure	2024-01-04 16:01:33.801051764 -0600
++++ gcc-14.2.0-kos/gcc/configure	2024-01-04 16:01:42.913094480 -0600
 @@ -13220,7 +13220,7 @@
      target_thread_file='single'
      ;;
@@ -25,9 +25,9 @@ diff -ruN gcc-14.1.0/gcc/configure gcc-14.1.0-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff -ruN gcc-14.1.0/libgcc/config/sh/t-sh gcc-14.1.0-kos/libgcc/config/sh/t-sh
---- gcc-14.1.0/libgcc/config/sh/t-sh	2024-01-04 16:01:37.134067388 -0600
-+++ gcc-14.1.0-kos/libgcc/config/sh/t-sh	2024-01-04 16:01:42.914094485 -0600
+diff -ruN gcc-14.2.0/libgcc/config/sh/t-sh gcc-14.2.0-kos/libgcc/config/sh/t-sh
+--- gcc-14.2.0/libgcc/config/sh/t-sh	2024-01-04 16:01:37.134067388 -0600
++++ gcc-14.2.0-kos/libgcc/config/sh/t-sh	2024-01-04 16:01:42.914094485 -0600
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -37,9 +37,9 @@ diff -ruN gcc-14.1.0/libgcc/config/sh/t-sh gcc-14.1.0-kos/libgcc/config/sh/t-sh
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff -ruN gcc-14.1.0/libgcc/configure gcc-14.1.0-kos/libgcc/configure
---- gcc-14.1.0/libgcc/configure	2024-01-04 16:01:37.139067412 -0600
-+++ gcc-14.1.0-kos/libgcc/configure	2024-01-04 16:01:42.914094485 -0600
+diff -ruN gcc-14.2.0/libgcc/configure gcc-14.2.0-kos/libgcc/configure
+--- gcc-14.2.0/libgcc/configure	2024-01-04 16:01:37.139067412 -0600
++++ gcc-14.2.0-kos/libgcc/configure	2024-01-04 16:01:42.914094485 -0600
 @@ -5763,6 +5763,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -48,9 +48,9 @@ diff -ruN gcc-14.1.0/libgcc/configure gcc-14.1.0-kos/libgcc/configure
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
-diff -ruN gcc-14.1.0/libobjc/configure gcc-14.1.0-kos/libobjc/configure
---- gcc-14.1.0/libobjc/configure	2024-01-04 16:01:37.499069099 -0600
-+++ gcc-14.1.0-kos/libobjc/configure	2024-01-04 16:01:42.915094489 -0600
+diff -ruN gcc-14.2.0/libobjc/configure gcc-14.2.0-kos/libobjc/configure
+--- gcc-14.2.0/libobjc/configure	2024-01-04 16:01:37.499069099 -0600
++++ gcc-14.2.0-kos/libobjc/configure	2024-01-04 16:01:42.915094489 -0600
 @@ -2924,11 +2924,9 @@
  
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -63,9 +63,9 @@ diff -ruN gcc-14.1.0/libobjc/configure gcc-14.1.0-kos/libobjc/configure
    ;
    return 0;
  }
-diff -ruN gcc-14.1.0/libobjc/Makefile.in gcc-14.1.0-kos/libobjc/Makefile.in
---- gcc-14.1.0/libobjc/Makefile.in	2024-01-04 16:01:37.499069099 -0600
-+++ gcc-14.1.0-kos/libobjc/Makefile.in	2024-01-04 16:01:42.915094489 -0600
+diff -ruN gcc-14.2.0/libobjc/Makefile.in gcc-14.2.0-kos/libobjc/Makefile.in
+--- gcc-14.2.0/libobjc/Makefile.in	2024-01-04 16:01:37.499069099 -0600
++++ gcc-14.2.0-kos/libobjc/Makefile.in	2024-01-04 16:01:42.915094489 -0600
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -96,9 +96,9 @@ diff -ruN gcc-14.1.0/libobjc/Makefile.in gcc-14.1.0-kos/libobjc/Makefile.in
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff -ruN gcc-14.1.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-14.1.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-14.1.0/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:37.608069611 -0600
-+++ gcc-14.1.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:42.916094494 -0600
+diff -ruN gcc-14.2.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-14.2.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-14.2.0/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:37.608069611 -0600
++++ gcc-14.2.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:42.916094494 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -149,9 +149,9 @@ diff -ruN gcc-14.1.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-14.1.0-kos/libst
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-14.1.0/libstdc++-v3/configure gcc-14.1.0-kos/libstdc++-v3/configure
---- gcc-14.1.0/libstdc++-v3/configure	2024-01-04 16:01:37.616069648 -0600
-+++ gcc-14.1.0-kos/libstdc++-v3/configure	2024-01-04 16:01:42.919094508 -0600
+diff -ruN gcc-14.2.0/libstdc++-v3/configure gcc-14.2.0-kos/libstdc++-v3/configure
+--- gcc-14.2.0/libstdc++-v3/configure	2024-01-04 16:01:37.616069648 -0600
++++ gcc-14.2.0-kos/libstdc++-v3/configure	2024-01-04 16:01:42.919094508 -0600
 @@ -15974,6 +15974,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/patches/gcc-14.2.1-kos.diff
+++ b/utils/dc-chain/patches/gcc-14.2.1-kos.diff
@@ -1,6 +1,6 @@
-diff -ruN gcc-14.1.1/gcc/config/sh/sh-c.cc gcc-14.1.1-kos/gcc/config/sh/sh-c.cc
---- gcc-14.1.1/gcc/config/sh/sh-c.cc	2024-01-04 16:01:33.790051712 -0600
-+++ gcc-14.1.1-kos/gcc/config/sh/sh-c.cc	2024-01-04 16:01:42.910094466 -0600
+diff -ruN gcc-14.2.1/gcc/config/sh/sh-c.cc gcc-14.2.1-kos/gcc/config/sh/sh-c.cc
+--- gcc-14.2.1/gcc/config/sh/sh-c.cc	2024-01-04 16:01:33.790051712 -0600
++++ gcc-14.2.1-kos/gcc/config/sh/sh-c.cc	2024-01-04 16:01:42.910094466 -0600
 @@ -141,4 +141,11 @@
  
    cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
@@ -13,9 +13,9 @@ diff -ruN gcc-14.1.1/gcc/config/sh/sh-c.cc gcc-14.1.1-kos/gcc/config/sh/sh-c.cc
 +  /* Toolchain supports setting up stack for 32MB */
 +  builtin_define ("__KOS_GCC_32MB__");
  }
-diff -ruN gcc-14.1.1/gcc/configure gcc-14.1.1-kos/gcc/configure
---- gcc-14.1.1/gcc/configure	2024-01-04 16:01:33.801051764 -0600
-+++ gcc-14.1.1-kos/gcc/configure	2024-01-04 16:01:42.913094480 -0600
+diff -ruN gcc-14.2.1/gcc/configure gcc-14.2.1-kos/gcc/configure
+--- gcc-14.2.1/gcc/configure	2024-01-04 16:01:33.801051764 -0600
++++ gcc-14.2.1-kos/gcc/configure	2024-01-04 16:01:42.913094480 -0600
 @@ -13220,7 +13220,7 @@
      target_thread_file='single'
      ;;
@@ -25,9 +25,9 @@ diff -ruN gcc-14.1.1/gcc/configure gcc-14.1.1-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff -ruN gcc-14.1.1/libgcc/config/sh/t-sh gcc-14.1.1-kos/libgcc/config/sh/t-sh
---- gcc-14.1.1/libgcc/config/sh/t-sh	2024-01-04 16:01:37.134067388 -0600
-+++ gcc-14.1.1-kos/libgcc/config/sh/t-sh	2024-01-04 16:01:42.914094485 -0600
+diff -ruN gcc-14.2.1/libgcc/config/sh/t-sh gcc-14.2.1-kos/libgcc/config/sh/t-sh
+--- gcc-14.2.1/libgcc/config/sh/t-sh	2024-01-04 16:01:37.134067388 -0600
++++ gcc-14.2.1-kos/libgcc/config/sh/t-sh	2024-01-04 16:01:42.914094485 -0600
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -37,9 +37,9 @@ diff -ruN gcc-14.1.1/libgcc/config/sh/t-sh gcc-14.1.1-kos/libgcc/config/sh/t-sh
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff -ruN gcc-14.1.1/libgcc/configure gcc-14.1.1-kos/libgcc/configure
---- gcc-14.1.1/libgcc/configure	2024-01-04 16:01:37.139067412 -0600
-+++ gcc-14.1.1-kos/libgcc/configure	2024-01-04 16:01:42.914094485 -0600
+diff -ruN gcc-14.2.1/libgcc/configure gcc-14.2.1-kos/libgcc/configure
+--- gcc-14.2.1/libgcc/configure	2024-01-04 16:01:37.139067412 -0600
++++ gcc-14.2.1-kos/libgcc/configure	2024-01-04 16:01:42.914094485 -0600
 @@ -5763,6 +5763,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -48,9 +48,9 @@ diff -ruN gcc-14.1.1/libgcc/configure gcc-14.1.1-kos/libgcc/configure
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
-diff -ruN gcc-14.1.1/libobjc/configure gcc-14.1.1-kos/libobjc/configure
---- gcc-14.1.1/libobjc/configure	2024-01-04 16:01:37.499069099 -0600
-+++ gcc-14.1.1-kos/libobjc/configure	2024-01-04 16:01:42.915094489 -0600
+diff -ruN gcc-14.2.1/libobjc/configure gcc-14.2.1-kos/libobjc/configure
+--- gcc-14.2.1/libobjc/configure	2024-01-04 16:01:37.499069099 -0600
++++ gcc-14.2.1-kos/libobjc/configure	2024-01-04 16:01:42.915094489 -0600
 @@ -2924,11 +2924,9 @@
  
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -63,9 +63,9 @@ diff -ruN gcc-14.1.1/libobjc/configure gcc-14.1.1-kos/libobjc/configure
    ;
    return 0;
  }
-diff -ruN gcc-14.1.1/libobjc/Makefile.in gcc-14.1.1-kos/libobjc/Makefile.in
---- gcc-14.1.1/libobjc/Makefile.in	2024-01-04 16:01:37.499069099 -0600
-+++ gcc-14.1.1-kos/libobjc/Makefile.in	2024-01-04 16:01:42.915094489 -0600
+diff -ruN gcc-14.2.1/libobjc/Makefile.in gcc-14.2.1-kos/libobjc/Makefile.in
+--- gcc-14.2.1/libobjc/Makefile.in	2024-01-04 16:01:37.499069099 -0600
++++ gcc-14.2.1-kos/libobjc/Makefile.in	2024-01-04 16:01:42.915094489 -0600
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -96,9 +96,9 @@ diff -ruN gcc-14.1.1/libobjc/Makefile.in gcc-14.1.1-kos/libobjc/Makefile.in
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff -ruN gcc-14.1.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-14.1.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-14.1.1/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:37.608069611 -0600
-+++ gcc-14.1.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:42.916094494 -0600
+diff -ruN gcc-14.2.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-14.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-14.2.1/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:37.608069611 -0600
++++ gcc-14.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:42.916094494 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -149,9 +149,9 @@ diff -ruN gcc-14.1.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-14.1.1-kos/libst
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-14.1.1/libstdc++-v3/configure gcc-14.1.1-kos/libstdc++-v3/configure
---- gcc-14.1.1/libstdc++-v3/configure	2024-01-04 16:01:37.616069648 -0600
-+++ gcc-14.1.1-kos/libstdc++-v3/configure	2024-01-04 16:01:42.919094508 -0600
+diff -ruN gcc-14.2.1/libstdc++-v3/configure gcc-14.2.1-kos/libstdc++-v3/configure
+--- gcc-14.2.1/libstdc++-v3/configure	2024-01-04 16:01:37.616069648 -0600
++++ gcc-14.2.1-kos/libstdc++-v3/configure	2024-01-04 16:01:42.919094508 -0600
 @@ -15974,6 +15974,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/profiles/profile.14.2.0.mk
+++ b/utils/dc-chain/profiles/profile.14.2.0.mk
@@ -1,23 +1,11 @@
 # Sega Dreamcast Toolchains Maker (dc-chain)
 # This file is part of KallistiOS.
 
-###############################################################################
-###############################################################################
-### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
-## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2024-04-26.
-###############################################################################
-###############################################################################
-
 # Toolchain versions for SH
 sh_binutils_ver=2.42
-sh_gcc_ver=14.1.1
+sh_gcc_ver=14.2.0
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
-
-# Overide SH toolchain download type
-sh_gcc_download_type=git
-sh_gcc_git_repo=git://gcc.gnu.org/git/gcc.git
-sh_gcc_git_branch=releases/gcc-14
 
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core

--- a/utils/dc-chain/profiles/profile.14.2.1-dev.mk
+++ b/utils/dc-chain/profiles/profile.14.2.1-dev.mk
@@ -1,11 +1,23 @@
 # Sega Dreamcast Toolchains Maker (dc-chain)
 # This file is part of KallistiOS.
 
+###############################################################################
+###############################################################################
+### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2024-08-01.
+###############################################################################
+###############################################################################
+
 # Toolchain versions for SH
 sh_binutils_ver=2.42
-sh_gcc_ver=14.1.0
+sh_gcc_ver=14.2.1
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
+
+# Overide SH toolchain download type
+sh_gcc_download_type=git
+sh_gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+sh_gcc_git_branch=releases/gcc-14
 
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core


### PR DESCRIPTION
* dc-chain: Update 14.1.0 profile to GCC 14.2.0
* dc-chain: Update 14.1.1-dev profile to GCC 14.2.1 (git)

KOS patches apply cleanly to both toolchains, they both build, and they build KOS, kos-ports, and examples without error. 2ndmix runs with no obvious issues.

Now that 14.2.0 is out, we should test all examples with it and if working with no regressions, mark it as `stable` toolchain for KOS master/2.2.0. Since this PR does not stabilize 14.2.0, this PR can go into 2.1.0 though, if desired.