### PR TITLE
Fixed Overflow with Writing PVR BG Plane

### DIFF
--- a/include/kos/time.h
+++ b/include/kos/time.h
@@ -113,11 +113,13 @@ extern __time_t timegm(struct tm *timeptr);
 #endif
 
 /* Explicitly provided function declarations for POSIX clock API, since
-getting them from Newlib requires supporting the rest of the _POSIX_TIMERS
-API, which is not implemented yet. */
+   getting them from Newlib requires supporting the rest of the _POSIX_TIMERS
+   API, which is not implemented yet. */
 extern int clock_settime(__clockid_t clock_id, const struct timespec *ts);
 extern int clock_gettime(__clockid_t clock_id, struct timespec *ts);
 extern int clock_getres(__clockid_t clock_id, struct timespec *res);
+
+extern int nanosleep(const struct timespec *req, struct timespec *rem);
 
 #endif
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -8,10 +8,13 @@
 
 #include <assert.h>
 #include <string.h>
+#include <float.h>
+
 #include <arch/timer.h>
 #include <dc/pvr.h>
 #include <dc/video.h>
 #include <kos/string.h>
+
 #include "pvr_internal.h"
 
 /*
@@ -175,7 +178,7 @@ void pvr_begin_queued_render(void) {
     volatile pvr_ta_buffers_t   * tbuf;
     volatile pvr_frame_buffers_t    * rbuf;
     pvr_bkg_poly_t  bkg;
-    uint8_t      *vrl;
+    uint32_t      *vrl;
     uint32      vert_end;
     int bufn = pvr_state.view_target;
     union {
@@ -197,20 +200,20 @@ void pvr_begin_queued_render(void) {
     /* Throw the background data on the end of the TA's list */
     bkg.flags1 = 0x90800000;    /* These are from libdream.. ought to figure out */
     bkg.flags2 = 0x20800440;    /*   what they mean for sure... heh =) */
-    bkg.dummy = 0;
-    bkg.x1 =   0.0f;
-    bkg.y1 = 480.0f;
-    bkg.z1 = 0.2f;
-    bkg.argb1 = pvr_state.bg_color;
-    bkg.x2 =   0.0f;
-    bkg.y2 =   0.0f;
-    bkg.z2 = 0.2f;
-    bkg.argb2 = pvr_state.bg_color;
-    bkg.x3 = 640.0f;
-    bkg.y3 = 480.0f;
-    bkg.z3 = 0.2f;
-    bkg.argb3 = pvr_state.bg_color;
-    vrl = (uint8_t*)(PVR_RAM_BASE | PVR_GET(PVR_TA_VERTBUF_POS));
+    bkg.dummy  = 0;
+    bkg.x1     = 0.0f;
+    bkg.y1     = pvr_state.h;
+    bkg.z1     = FLT_EPSILON;
+    bkg.argb1  = pvr_state.bg_color;
+    bkg.x2     = 0.0f;
+    bkg.y2     = 0.0f;
+    bkg.z2     = FLT_EPSILON;
+    bkg.argb2  = pvr_state.bg_color;
+    bkg.x3     = pvr_state.w;
+    bkg.y3     = pvr_state.h;
+    bkg.z3     = FLT_EPSILON;
+    bkg.argb3  = pvr_state.bg_color;
+    vrl = (uint32_t *)(PVR_RAM_BASE | PVR_GET(PVR_TA_VERTBUF_POS));
 
     memcpy4(vrl, &bkg, sizeof(bkg));
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -174,9 +174,8 @@ void pvr_begin_queued_render(void) {
     volatile pvr_ta_buffers_t   * tbuf;
     volatile pvr_frame_buffers_t    * rbuf;
     pvr_bkg_poly_t  bkg;
-    uint32      *vrl, *bkgdata;
+    uint8_t      *vrl;
     uint32      vert_end;
-    int     i;
     int bufn = pvr_state.view_target;
     union {
         float f;
@@ -210,13 +209,9 @@ void pvr_begin_queued_render(void) {
     bkg.y3 = 480.0f;
     bkg.z3 = 0.2f;
     bkg.argb3 = pvr_state.bg_color;
-    bkgdata = (uint32 *)&bkg;
-    vrl = (uint32*)(PVR_RAM_BASE | PVR_GET(PVR_TA_VERTBUF_POS));
+    vrl = (uint8_t*)(PVR_RAM_BASE | PVR_GET(PVR_TA_VERTBUF_POS));
 
-    for(i = 0; i < 0x10; i++)
-        vrl[i] = bkgdata[i];
-
-    vrl[0x11] = 0;
+    memcpy(vrl, &bkg, sizeof(bkg));
 
     /* Reset the ISP/TSP, just in case */
     //PVR_SET(PVR_RESET, PVR_RESET_ISPTSP);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -11,6 +11,7 @@
 #include <arch/timer.h>
 #include <dc/pvr.h>
 #include <dc/video.h>
+#include <kos/string.h>
 #include "pvr_internal.h"
 
 /*
@@ -211,7 +212,7 @@ void pvr_begin_queued_render(void) {
     bkg.argb3 = pvr_state.bg_color;
     vrl = (uint8_t*)(PVR_RAM_BASE | PVR_GET(PVR_TA_VERTBUF_POS));
 
-    memcpy(vrl, &bkg, sizeof(bkg));
+    memcpy4(vrl, &bkg, sizeof(bkg));
 
     /* Reset the ISP/TSP, just in case */
     //PVR_SET(PVR_RESET, PVR_RESET_ISPTSP);


### PR DESCRIPTION
- skmp (correctly) reported that our little loop to copy the internally populated `pvr_bkg_poly_t` polygon (which gets color info from `pvr_set_bg_color()`) was looping too far.
    * structure is only 60 bytes, we looped for 64 and then wrote
      another word even beyond that.
- swapped implementation to use `memcp4y()` based on `sizeof(pvr_bkg_poly_t)` which is safer.
- removed final `vrl[0x11] = 0` assignment, as it clearly wasn't necessary and doesn't appear to even be doing anything useful at-all. The BG polygon types are special and don't need end-of-list flags, and interpolate the 4th vertex, more like PVR sprites.
- Adjusted size of GB plane to not be hardcoded to 640x480 and to instead be the size of the framebuffer resolution
- Changed BG plane's Z coords from `0.2f`, which seems sketchy to `FLT_EPSILON` to push it further back.