### PR TITLE
dc-chain: Updates to profiles and patches

### DIFF
--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -10,9 +10,9 @@
 # - 9.3.0-legacy: Former 'stable' option, based on GCC 9.3.0 and Newlib 3.3.0.
 # - 9.5.0-winxp:  Most recent versions of tools which run on Windows XP.
 # - 10.5.0:       Last release in the GCC 10 series, released 2023-07-07.
+# - 11.5.0:       Last release in the GCC 11 series, released 2024-07-19.
 # Supported upstream:
-# - 11.4.0:       Latest release in the GCC 11 series, released 2023-05-15.
-# - 12.4.0:       Latest release in the GCC 12 series, released 2023-06-20.
+# - 12.4.0:       Latest release in the GCC 12 series, released 2024-06-20.
 # - stable:       Tested stable; based on GCC 13.2.0, released 2023-07-27.
 # - 13.3.0:       Latest release in the GCC 13 series, released 2024-05-21.
 # - 14.2.0:       Latest release in the GCC 14 series, released 2024-08-01.

--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -100,17 +100,17 @@ The following toolchain profiles are available for users to select in
 |---------:|:-------:|:----------:|:------------:|:-------:|:----------------:|:------|
 | 9.3.0-legacy | 9.3.0 | 3.3.0 | 2.34 | 8.4.0 | 2.34 | Former 'stable' option, based on GCC 9<br />GCC 9 series support ended upstream |
 | 9.5.0-winxp | 9.5.0 | 4.3.0 | 2.34 | 8.5.0 | 2.34 | Most recent versions of tools which run on Windows XP<br />GCC 9 series support ended upstream |
-| 10.5.0 | 10.5.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | Latest release in the GCC 10 series, released 2023-07-07<br />GCC 10 series support ended upstream |
-| 11.4.0 | 11.4.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | Latest release in the GCC 11 series, released 2023-05-15 |
-| 12.3.0 | 12.3.0 | 4.3.0 | 2.41 | 8.5.0 | 2.41 | Latest release in the GCC 12 series, released 2023-05-08 |
-| **stable** | **13.2.0** | **4.3.0** | **2.41** | **8.5.0** | **2.41** | **Tested stable; based on GCC 13.2.0, released 2023-07-27** |
-| 13.3.0 | 13.3.0 | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Latest release in the GCC 13 series, released 2024-05-21 |
-| 14.2.0 | 14.2.0 | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Latest release in the GCC 14 series, released 2024-08-01 |
-| 13.3.1-dev | 13.3.1 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 13 series from git |
-| 14.2.1-dev | 14.2.1 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 14 series from git |
-| 15.0.0-dev | 15.0.0 (git) | 4.4.0 | 2.42 | 8.5.0 | 2.42 | Bleeding edge GCC 15 series from git |
-| gccrs-dev | 14.x | 4.4.0 | 2.42 | 8.5.0 | 2.42 | GCC fork for development of the GCCRS Rust compiler |
-| rustc-dev | 14.x | 4.4.0 | 2.42 | 8.5.0 | 2.42 | GCC fork for development of the libgccjit rustc GCC codegen |
+| 10.5.0 | 10.5.0 | 4.3.0 | 2.43 | 8.5.0 | 2.43 | Latest release in the GCC 10 series, released 2023-07-07<br />GCC 10 series support ended upstream |
+| 11.5.0 | 11.5.0 | 4.3.0 | 2.43 | 8.5.0 | 2.43 | Latest release in the GCC 11 series, released 2024-07-19<br />GCC 11 series support ended upstream |
+| 12.3.0 | 12.3.0 | 4.3.0 | 2.43 | 8.5.0 | 2.43 | Latest release in the GCC 12 series, released 2023-05-08 |
+| **stable** | **13.2.0** | **4.3.0** | **2.43** | **8.5.0** | **2.43** | **Tested stable; based on GCC 13.2.0, released 2023-07-27** |
+| 13.3.0 | 13.3.0 | 4.4.0 | 2.43 | 8.5.0 | 2.43 | Latest release in the GCC 13 series, released 2024-05-21 |
+| 14.2.0 | 14.2.0 | 4.4.0 | 2.43 | 8.5.0 | 2.43 | Latest release in the GCC 14 series, released 2024-08-01 |
+| 13.3.1-dev | 13.3.1 (git) | 4.4.0 | 2.43 | 8.5.0 | 2.43 | Bleeding edge GCC 13 series from git |
+| 14.2.1-dev | 14.2.1 (git) | 4.4.0 | 2.43 | 8.5.0 | 2.43 | Bleeding edge GCC 14 series from git |
+| 15.0.0-dev | 15.0.0 (git) | 4.4.0 | 2.43 | 8.5.0 | 2.43 | Bleeding edge GCC 15 series from git |
+| gccrs-dev | 14.x | 4.4.0 | 2.43 | 8.5.0 | 2.43 | GCC fork for development of the GCCRS Rust compiler |
+| rustc-dev | 14.x | 4.4.0 | 2.43 | 8.5.0 | 2.43 | GCC fork for development of the libgccjit rustc GCC codegen |
 
 The **stable** profile is the primary, widely tested target for KallistiOS, and
 is the most recent toolchain profile known to work with all example programs.

--- a/utils/dc-chain/patches/gcc-11.5.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-11.5.0-kos.diff
@@ -1,6 +1,6 @@
-diff --color -ruN gcc-11.4.0/gcc/config/sh/sh-c.c gcc-11.4.0-kos/gcc/config/sh/sh-c.c
---- gcc-11.4.0/gcc/config/sh/sh-c.c	2023-06-05 16:36:14.199287582 -0500
-+++ gcc-11.4.0-kos/gcc/config/sh/sh-c.c	2023-06-05 16:36:16.723296050 -0500
+diff --color -ruN gcc-11.5.0/gcc/config/sh/sh-c.c gcc-11.5.0-kos/gcc/config/sh/sh-c.c
+--- gcc-11.5.0/gcc/config/sh/sh-c.c	2023-06-05 16:36:14.199287582 -0500
++++ gcc-11.5.0-kos/gcc/config/sh/sh-c.c	2023-06-05 16:36:16.723296050 -0500
 @@ -141,4 +141,11 @@
  
    cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
@@ -13,9 +13,9 @@ diff --color -ruN gcc-11.4.0/gcc/config/sh/sh-c.c gcc-11.4.0-kos/gcc/config/sh/s
 +  /* Toolchain supports setting up stack for 32MB */
 +  builtin_define ("__KOS_GCC_32MB__");
  }
-diff --color -ruN gcc-11.4.0/gcc/config/sh/sh_treg_combine.cc gcc-11.4.0-kos/gcc/config/sh/sh_treg_combine.cc
---- gcc-11.4.0/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:36:14.199287582 -0500
-+++ gcc-11.4.0-kos/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:36:16.724296054 -0500
+diff --color -ruN gcc-11.5.0/gcc/config/sh/sh_treg_combine.cc gcc-11.5.0-kos/gcc/config/sh/sh_treg_combine.cc
+--- gcc-11.5.0/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:36:14.199287582 -0500
++++ gcc-11.5.0-kos/gcc/config/sh/sh_treg_combine.cc	2023-06-05 16:36:16.724296054 -0500
 @@ -37,6 +37,7 @@
  #include "cfgrtl.h"
  #include "tree-pass.h"
@@ -35,10 +35,10 @@ diff --color -ruN gcc-11.4.0/gcc/config/sh/sh_treg_combine.cc gcc-11.4.0-kos/gcc
  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  // RTL pass class
  
-diff --color -ruN gcc-11.4.0/gcc/configure gcc-11.4.0-kos/gcc/configure
---- gcc-11.4.0/gcc/configure	2023-06-05 16:36:16.428295060 -0500
-+++ gcc-11.4.0-kos/gcc/configure	2023-06-05 16:36:16.726296060 -0500
-@@ -12635,7 +12635,7 @@
+diff --color -ruN gcc-11.5.0/gcc/configure gcc-11.5.0-kos/gcc/configure
+--- gcc-11.5.0/gcc/configure	2023-06-05 16:36:16.428295060 -0500
++++ gcc-11.5.0-kos/gcc/configure	2023-06-05 16:36:16.726296060 -0500
+@@ -12658,7 +12658,7 @@
      target_thread_file='single'
      ;;
    aix | dce | lynx | mipssde | posix | rtems | \
@@ -47,9 +47,9 @@ diff --color -ruN gcc-11.4.0/gcc/configure gcc-11.4.0-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff --color -ruN gcc-11.4.0/libgcc/config/sh/t-sh gcc-11.4.0-kos/libgcc/config/sh/t-sh
---- gcc-11.4.0/libgcc/config/sh/t-sh	2023-06-05 16:36:13.515285288 -0500
-+++ gcc-11.4.0-kos/libgcc/config/sh/t-sh	2023-06-05 16:36:16.726296060 -0500
+diff --color -ruN gcc-11.5.0/libgcc/config/sh/t-sh gcc-11.5.0-kos/libgcc/config/sh/t-sh
+--- gcc-11.5.0/libgcc/config/sh/t-sh	2023-06-05 16:36:13.515285288 -0500
++++ gcc-11.5.0-kos/libgcc/config/sh/t-sh	2023-06-05 16:36:16.726296060 -0500
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -59,9 +59,9 @@ diff --color -ruN gcc-11.4.0/libgcc/config/sh/t-sh gcc-11.4.0-kos/libgcc/config/
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff --color -ruN gcc-11.4.0/libgcc/configure gcc-11.4.0-kos/libgcc/configure
---- gcc-11.4.0/libgcc/configure	2023-06-05 16:36:13.547285395 -0500
-+++ gcc-11.4.0-kos/libgcc/configure	2023-06-05 16:36:16.727296064 -0500
+diff --color -ruN gcc-11.5.0/libgcc/configure gcc-11.5.0-kos/libgcc/configure
+--- gcc-11.5.0/libgcc/configure	2023-06-05 16:36:13.547285395 -0500
++++ gcc-11.5.0-kos/libgcc/configure	2023-06-05 16:36:16.727296064 -0500
 @@ -5688,6 +5688,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -70,9 +70,9 @@ diff --color -ruN gcc-11.4.0/libgcc/configure gcc-11.4.0-kos/libgcc/configure
  esac
  
  
-diff --color -ruN gcc-11.4.0/libobjc/configure gcc-11.4.0-kos/libobjc/configure
---- gcc-11.4.0/libobjc/configure	2023-06-05 16:36:13.230284332 -0500
-+++ gcc-11.4.0-kos/libobjc/configure	2023-06-05 16:36:16.728296067 -0500
+diff --color -ruN gcc-11.5.0/libobjc/configure gcc-11.5.0-kos/libobjc/configure
+--- gcc-11.5.0/libobjc/configure	2023-06-05 16:36:13.230284332 -0500
++++ gcc-11.5.0-kos/libobjc/configure	2023-06-05 16:36:16.728296067 -0500
 @@ -2917,11 +2917,9 @@
  
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -85,9 +85,9 @@ diff --color -ruN gcc-11.4.0/libobjc/configure gcc-11.4.0-kos/libobjc/configure
    ;
    return 0;
  }
-diff --color -ruN gcc-11.4.0/libobjc/Makefile.in gcc-11.4.0-kos/libobjc/Makefile.in
---- gcc-11.4.0/libobjc/Makefile.in	2023-06-05 16:36:13.229284328 -0500
-+++ gcc-11.4.0-kos/libobjc/Makefile.in	2023-06-05 16:36:16.728296067 -0500
+diff --color -ruN gcc-11.5.0/libobjc/Makefile.in gcc-11.5.0-kos/libobjc/Makefile.in
+--- gcc-11.5.0/libobjc/Makefile.in	2023-06-05 16:36:13.229284328 -0500
++++ gcc-11.5.0-kos/libobjc/Makefile.in	2023-06-05 16:36:16.728296067 -0500
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -118,9 +118,9 @@ diff --color -ruN gcc-11.4.0/libobjc/Makefile.in gcc-11.4.0-kos/libobjc/Makefile
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff --color -ruN gcc-11.4.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-11.4.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-11.4.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:36:13.754286089 -0500
-+++ gcc-11.4.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:36:16.728296067 -0500
+diff --color -ruN gcc-11.5.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-11.5.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-11.5.0/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:36:13.754286089 -0500
++++ gcc-11.5.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2023-06-05 16:36:16.728296067 -0500
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -171,10 +171,10 @@ diff --color -ruN gcc-11.4.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-11.4.0-k
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff --color -ruN gcc-11.4.0/libstdc++-v3/configure gcc-11.4.0-kos/libstdc++-v3/configure
---- gcc-11.4.0/libstdc++-v3/configure	2023-06-05 16:36:14.088287210 -0500
-+++ gcc-11.4.0-kos/libstdc++-v3/configure	2023-06-05 16:36:16.733296084 -0500
-@@ -15753,6 +15753,7 @@
+diff --color -ruN gcc-11.5.0/libstdc++-v3/configure gcc-11.5.0-kos/libstdc++-v3/configure
+--- gcc-11.5.0/libstdc++-v3/configure	2023-06-05 16:36:14.088287210 -0500
++++ gcc-11.5.0-kos/libstdc++-v3/configure	2023-06-05 16:36:16.733296084 -0500
+@@ -15769,6 +15769,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
      win32)	thread_header=config/i386/gthr-win32.h ;;

--- a/utils/dc-chain/patches/gcc-15.0.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-15.0.0-kos.diff
@@ -16,7 +16,7 @@ diff -ruN gcc-15.0.0/gcc/config/sh/sh-c.cc gcc-15.0.0-kos/gcc/config/sh/sh-c.cc
 diff -ruN gcc-15.0.0/gcc/configure gcc-15.0.0-kos/gcc/configure
 --- gcc-15.0.0/gcc/configure	2024-01-04 16:01:33.801051764 -0600
 +++ gcc-15.0.0-kos/gcc/configure	2024-01-04 16:01:42.913094480 -0600
-@@ -13220,7 +13220,7 @@
+@@ -13051,7 +13051,7 @@
      target_thread_file='single'
      ;;
    aix | dce | lynx | mipssde | posix | rtems | \
@@ -40,7 +40,7 @@ diff -ruN gcc-15.0.0/libgcc/config/sh/t-sh gcc-15.0.0-kos/libgcc/config/sh/t-sh
 diff -ruN gcc-15.0.0/libgcc/configure gcc-15.0.0-kos/libgcc/configure
 --- gcc-15.0.0/libgcc/configure	2024-01-04 16:01:37.139067412 -0600
 +++ gcc-15.0.0-kos/libgcc/configure	2024-01-04 16:01:42.914094485 -0600
-@@ -5763,6 +5763,7 @@
+@@ -5731,6 +5731,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
      win32)	thread_header=config/i386/gthr-win32.h ;;

--- a/utils/dc-chain/profiles/profile.10.5.0.mk
+++ b/utils/dc-chain/profiles/profile.10.5.0.mk
@@ -2,7 +2,7 @@
 # This file is part of KallistiOS.
 
 # Toolchain versions for SH
-sh_binutils_ver=2.41
+sh_binutils_ver=2.43
 sh_gcc_ver=10.5.0
 newlib_ver=4.3.0.20230120
 gdb_ver=15.1
@@ -10,7 +10,7 @@ gdb_ver=15.1
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.41
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.11.5.0.mk
+++ b/utils/dc-chain/profiles/profile.11.5.0.mk
@@ -2,15 +2,15 @@
 # This file is part of KallistiOS.
 
 # Toolchain versions for SH
-sh_binutils_ver=2.41
-sh_gcc_ver=11.4.0
+sh_binutils_ver=2.43
+sh_gcc_ver=11.5.0
 newlib_ver=4.3.0.20230120
 gdb_ver=15.1
 
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.41
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.12.4.0.mk
+++ b/utils/dc-chain/profiles/profile.12.4.0.mk
@@ -2,7 +2,7 @@
 # This file is part of KallistiOS.
 
 # Toolchain versions for SH
-sh_binutils_ver=2.41
+sh_binutils_ver=2.43
 sh_gcc_ver=12.4.0
 newlib_ver=4.3.0.20230120
 gdb_ver=15.1
@@ -10,7 +10,7 @@ gdb_ver=15.1
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.41
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.13.3.0.mk
+++ b/utils/dc-chain/profiles/profile.13.3.0.mk
@@ -2,7 +2,7 @@
 # This file is part of KallistiOS.
 
 # Toolchain versions for SH
-sh_binutils_ver=2.42
+sh_binutils_ver=2.43
 sh_gcc_ver=13.3.0
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
@@ -10,7 +10,7 @@ gdb_ver=15.1
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.42
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.13.3.1-dev.mk
+++ b/utils/dc-chain/profiles/profile.13.3.1-dev.mk
@@ -9,7 +9,7 @@
 ###############################################################################
 
 # Toolchain versions for SH
-sh_binutils_ver=2.42
+sh_binutils_ver=2.43
 sh_gcc_ver=13.3.1
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
@@ -22,7 +22,7 @@ sh_gcc_git_branch=releases/gcc-13
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.42
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.14.2.0.mk
+++ b/utils/dc-chain/profiles/profile.14.2.0.mk
@@ -2,7 +2,7 @@
 # This file is part of KallistiOS.
 
 # Toolchain versions for SH
-sh_binutils_ver=2.42
+sh_binutils_ver=2.43
 sh_gcc_ver=14.2.0
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
@@ -10,7 +10,7 @@ gdb_ver=15.1
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.42
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.14.2.1-dev.mk
+++ b/utils/dc-chain/profiles/profile.14.2.1-dev.mk
@@ -9,7 +9,7 @@
 ###############################################################################
 
 # Toolchain versions for SH
-sh_binutils_ver=2.42
+sh_binutils_ver=2.43
 sh_gcc_ver=14.2.1
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
@@ -22,7 +22,7 @@ sh_gcc_git_branch=releases/gcc-14
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.42
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.15.0.0-dev.mk
+++ b/utils/dc-chain/profiles/profile.15.0.0-dev.mk
@@ -9,7 +9,7 @@
 ###############################################################################
 
 # Toolchain versions for SH
-sh_binutils_ver=2.42
+sh_binutils_ver=2.43
 sh_gcc_ver=15.0.0
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
@@ -22,7 +22,7 @@ sh_gcc_git_branch=master
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.42
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.gccrs-dev.mk
+++ b/utils/dc-chain/profiles/profile.gccrs-dev.mk
@@ -9,7 +9,7 @@
 ###############################################################################
 
 # Toolchain versions for SH
-sh_binutils_ver=2.42
+sh_binutils_ver=2.43
 sh_gcc_ver=rs
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
@@ -22,7 +22,7 @@ sh_gcc_git_branch=master
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.42
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.rustc-dev.mk
+++ b/utils/dc-chain/profiles/profile.rustc-dev.mk
@@ -9,7 +9,7 @@
 ###############################################################################
 
 # Toolchain versions for SH
-sh_binutils_ver=2.42
+sh_binutils_ver=2.43
 sh_gcc_ver=rustc
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
@@ -22,7 +22,7 @@ sh_gcc_git_branch=master
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.42
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies

--- a/utils/dc-chain/profiles/profile.stable.mk
+++ b/utils/dc-chain/profiles/profile.stable.mk
@@ -2,7 +2,7 @@
 # This file is part of KallistiOS.
 
 # Toolchain versions for SH
-sh_binutils_ver=2.41
+sh_binutils_ver=2.43
 sh_gcc_ver=13.2.0
 newlib_ver=4.3.0.20230120
 gdb_ver=15.1
@@ -10,7 +10,7 @@ gdb_ver=15.1
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core
 # used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
-arm_binutils_ver=2.41
+arm_binutils_ver=2.43
 arm_gcc_ver=8.5.0
 
 # GCC custom dependencies


### PR DESCRIPTION
- GCC 11.x profile updated to 11.5.0
- Binutils updated to 2.43 for all non-legacy toolchains
- Patch offsets updated to cleanly patch GCC 15.0.0-dev toolchain

All toolchains successfully built on Linux, other platforms not tested.

I would not have updated `stable` to binutils 2.43 (I prefer not to mess with this profile) except that pcercuei mentioned binutils 2.43 should fix LTO build issues so I updated it as it would be a bug fix. Since this is a bug fix, I'm marking this towards 2.1.0.