### PR TITLE
Fix 24-bit / 32-bit video modes

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
@@ -284,7 +284,7 @@ void pvr_allocate_buffers(pvr_init_params_t *params) {
 
         /* Output buffer */
         fbuf->frame = outaddr;
-        fbuf->frame_size = pvr_state.w * pvr_state.h * 2;
+        fbuf->frame_size = pvr_state.w * pvr_state.h * vid_pmode_bpp[vid_mode->pm];
         outaddr += fbuf->frame_size;
 
         /* N-byte align */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -174,7 +174,7 @@ int pvr_init(pvr_init_params_t *params) {
        is still unknown. */
     PVR_SET(PVR_UNK_00A8, 0x15d1c951);      /* M (Unknown magic value) */
     PVR_SET(PVR_UNK_00A0, 0x00000020);      /* M */
-    PVR_SET(PVR_FB_CFG_2, 0x00000009);      /* alpha config */
+    /* PVR_FB_CFG_2 is configured in vid_set_mode() */
     PVR_SET(PVR_UNK_0110, 0x00093f39);      /* M */
     PVR_SET(PVR_UNK_0098, 0x00800408);      /* M */
     PVR_SET(PVR_TEXTURE_CLIP, 0x00000000);      /* texture clip distance */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -240,7 +240,7 @@ void pvr_begin_queued_render(void) {
     PVR_SET(PVR_PCLIP_Y, pvr_state.pclip_y);
 
     if(!pvr_state.to_texture[bufn])
-        PVR_SET(PVR_RENDER_MODULO, (pvr_state.w * 2) / 8);
+        PVR_SET(PVR_RENDER_MODULO, (pvr_state.w * vid_pmode_bpp[vid_mode->pm]) / 8);
     else
         PVR_SET(PVR_RENDER_MODULO, pvr_state.to_txr_rp[bufn]);
 

--- a/kernel/arch/dreamcast/hardware/video.c
+++ b/kernel/arch/dreamcast/hardware/video.c
@@ -290,6 +290,24 @@ void vid_set_mode(int dm, vid_pixel_mode_t pm) {
     vid_set_mode_ex(&mode);
 }
 
+enum pvr_pm_modes {
+	PVR_PM_XRGB1555,
+	PVR_PM_RGB565,
+	PVR_PM_ARGB4444,
+	PVR_PM_ARGB1555,
+	PVR_PM_RGB888,
+	PVR_PM_XRGB8888,
+	PVR_PM_ARGB8888,
+	PVR_PM_DITHER = 8,
+};
+
+static const unsigned int vid_bpp_to_pvr_cfg2[] = {
+	[PM_RGB555] = PVR_PM_XRGB1555 | PVR_PM_DITHER,
+	[PM_RGB565] = PVR_PM_RGB565 | PVR_PM_DITHER,
+	[PM_RGB888P] = PVR_PM_RGB888,
+	[PM_RGB0888] = PVR_PM_XRGB8888,
+};
+
 /*-----------------------------------------------------------------------------*/
 void vid_set_mode_ex(vid_mode_t *mode) {
     uint16_t ct;
@@ -339,6 +357,7 @@ void vid_set_mode_ex(vid_mode_t *mode) {
     }
 
     PVR_SET(PVR_FB_CFG_1, data);
+    PVR_SET(PVR_FB_CFG_2, vid_bpp_to_pvr_cfg2[mode->pm]);
 
     /* Linestride */
     PVR_SET(PVR_RENDER_MODULO, (mode->width * vid_pmode_bpp[mode->pm]) / 8);


### PR DESCRIPTION
These video modes were only usable when writing the framebuffer directly, and not when using the PVR.

These two commits fix 24 / 32-bit support in KallistiOS so that these video modes can be used.