### PR TITLE
Remove g1ata mutex use in biosfont

### DIFF
--- a/kernel/arch/dreamcast/hardware/biosfont.c
+++ b/kernel/arch/dreamcast/hardware/biosfont.c
@@ -14,7 +14,6 @@
 #include <dc/syscalls.h>
 
 #include <kos/dbglog.h>
-#include <kos/mutex.h>
 
 /*
 
@@ -75,12 +74,7 @@ int bfont_set_32bit_mode(int on) {
     return rv;
 }
 
-/* From cdrom.c */
-extern mutex_t _g1_ata_mutex;
-
 int lock_bfont(void) {
-    if(mutex_lock(&_g1_ata_mutex) == -1) return -1;
-
     /* Just make sure no outside system took the lock */
     while(syscall_font_lock() != 0)
         thd_pass();
@@ -89,8 +83,6 @@ int lock_bfont(void) {
 }
 
 int unlock_bfont(void) {
-    if(mutex_unlock(&_g1_ata_mutex) == -1) return -1;
-
     syscall_font_unlock();
 
     return 0;


### PR DESCRIPTION
Removed mutex from biosfont because it causes an issue in DS bootloader as well as give the ability to use biofonts inside of an IRQ context.

Removing the mutex fixes this issue: https://github.com/KallistiOS/KallistiOS/issues/690