### PR TITLE
Make FD_SETSIZE configurable

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -144,6 +144,21 @@ export KOS_CFLAGS="${KOS_CFLAGS} -O2"
 #
 #export KOS_CFLAGS="${KOS_CFLAGS} -freorder-blocks-algorithm=simple -flto=auto"
 
+# RAM-Saving Optimization
+#
+# Uncomment the line below to reduce the default size of FD_SETSIZE from the
+# default value of 1024 to 64. FD_SETSIZE defines the maximum number of files
+# that can be opened simultaneously, including files on the ramdisk, romdisk, 
+# CD, VMU, network sockets, etc. The default setting allows 1024 files to be
+# opened at once, which is typically more than most use cases require.
+#
+# By reducing this value, you can save approximately ~11.25 KB of RAM, which 
+# can be particularly useful when porting large games to the Dreamcast that 
+# are strapped for memory. However, be cautious not to set it too low, as this 
+# may limit the number of files and sockets that can be opened simultaneously.
+#
+# export KOS_CFLAGS="${KOS_CFLAGS} -DFD_SETSIZE=64"
+
 # Frame Pointers
 #
 # Controls whether frame pointers are emitted or not. Disabled by

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -29,6 +29,7 @@ __BEGIN_DECLS
 
 #include <sys/types.h>
 #include <kos/limits.h>
+#include <kos/opts.h>
 #include <time.h>
 #include <sys/queue.h>
 #include <stdarg.h>
@@ -204,11 +205,6 @@ typedef struct vfs_handler {
     /** \brief Get status information on an already opened file. */
     int (*fstat)(void *hnd, struct stat *st);
 } vfs_handler_t;
-
-/** \brief  The number of distinct file descriptors that can be in use at a
-            time.
-*/
-#define FD_SETSIZE  64
 
 /** \cond */
 /* This is the private struct that will be used as raw file handles

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -208,7 +208,7 @@ typedef struct vfs_handler {
 /** \brief  The number of distinct file descriptors that can be in use at a
             time.
 */
-#define FD_SETSIZE  1024
+#define FD_SETSIZE  64
 
 /** \cond */
 /* This is the private struct that will be used as raw file handles

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -130,7 +130,7 @@ __BEGIN_DECLS
 #endif
 
 /** \brief  The number of distinct file descriptors that can be in use at a
-            time. */
+            time. This value can be overwritten in environ.sh */
 #ifndef FD_SETSIZE
 #define FD_SETSIZE 1024
 #endif

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -129,6 +129,12 @@ __BEGIN_DECLS
 #define FS_RAMDISK_MAX_FILES 8
 #endif
 
+/** \brief  The number of distinct file descriptors that can be in use at a
+            time. */
+#ifndef FD_SETSIZE
+#define FD_SETSIZE 1024
+#endif
+
 /** @} */
 
 __END_DECLS

--- a/include/sys/_types.h
+++ b/include/sys/_types.h
@@ -161,7 +161,7 @@ typedef _CLOCK_T_   __clock_t;
 
 // This part inserted to fix newlib brokenness.
 /** \brief  Size of an fd_set. */
-#define FD_SETSIZE      1024
+#define FD_SETSIZE      64
 
 /* The architecture should define the macro BYTE_ORDER in <arch/types.h> to
    equal one of these macros for code that looks for these BSD-style macros. */

--- a/include/sys/_types.h
+++ b/include/sys/_types.h
@@ -159,10 +159,6 @@ typedef _TIMER_T_   __timer_t;
 
 typedef _CLOCK_T_   __clock_t;
 
-// This part inserted to fix newlib brokenness.
-/** \brief  Size of an fd_set. */
-#define FD_SETSIZE      64
-
 /* The architecture should define the macro BYTE_ORDER in <arch/types.h> to
    equal one of these macros for code that looks for these BSD-style macros. */
 /** \brief  Little Endian test macro */

--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -43,7 +43,7 @@ __BEGIN_DECLS
 
 #ifndef FD_SETSIZE
 /* This matches fs.h. */
-#define FD_SETSIZE 1024
+#define FD_SETSIZE 64
 #endif
 
 #define NFDBITS 32

--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -26,6 +26,7 @@
 __BEGIN_DECLS
 
 #include <newlib.h>
+#include <kos/opts.h>
 
 #if __NEWLIB__ > 2 || (__NEWLIB__ == 2 && __NEWLIB_MINOR__ > 2)
 #include <sys/_timeval.h>
@@ -40,11 +41,6 @@ __BEGIN_DECLS
 #ifndef _SYS_TYPES_FD_SET
 
 #define _SYS_TYPES_FD_SET
-
-#ifndef FD_SETSIZE
-/* This matches fs.h. */
-#define FD_SETSIZE 64
-#endif
 
 #define NFDBITS 32
 

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -186,7 +186,7 @@ static int fs_hnd_unref(fs_hnd_t *ref) {
 
 /* Assigns a file descriptor (index) to a file handle (pointer). Will auto-
    reference the handle, and unrefs on error. */
-static int fs_hnd_assign(fs_hnd_t * hnd) {
+static int fs_hnd_assign(fs_hnd_t *hnd) {
     int i;
 
     fs_hnd_ref(hnd);
@@ -197,6 +197,11 @@ static int fs_hnd_assign(fs_hnd_t * hnd) {
             break;
 
     if(i >= FD_SETSIZE) {
+        if(FD_SETSIZE != 1024)
+            dbglog(DBG_ERROR, "fs_hnd_assign: Update -DFD_SETSIZE flag in \
+                  environ.sh to support additional files being opened. Current \
+                  limit is %d\n", FD_SETSIZE);
+
         fs_hnd_unref(hnd);
         errno = EMFILE;
         return -1;


### PR DESCRIPTION
1. Moves the three existing #define FD_SETSIZE 1024 to kos/opts.h
2. Allows the value to be configurable in environ.sh
3. Add some dbglog message if the value is set too low and the user gets a runtime error when trying to open a file.