### PR TITLE
dc-chain: Fix ARM toolchain build error when JIT is enabled for SH toolchain

### DIFF
--- a/utils/dc-chain/doc/CHANGELOG.md
+++ b/utils/dc-chain/doc/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 | Date<br/>_____________ | Author(s)<br/>_____________ | Changes<br/>_____________ |
 |:-----------------------|:----------------------------|---------------------------|
+| 2024-08-11 | Eric Fradella | Fix ARM toolchain build error when JIT is enabled for SH toolchain. |
+| 2024-08-07 | Eric Fradella | Updated binutils to 2.43. Updated GCC 11 profile with support for GCC 11.5.0. |
+| 2024-08-01 | Eric Fradella | Updated GCC 14 profile with support for GCC 14.2.0. |
+| 2024-07-15 | Eric Fradella | Updated profiles for GDB 15.1. |
+| 2024-06-26 | Eric Fradella | Updated GCC 12 profile with support for GCC 12.4.0. |
+| 2024-05-24 | Eric Fradella | Added support for GCC 13.3.0. |
 | 2024-05-08 | Falco Girgis | Added configuration option for libstdc++'s timezone database. |
 | 2024-05-02 | Eric Fradella | Deprecated GCC 4.7.4 profile. Revamped configuration system into separate profiles and Makefile.cfg. Revised configuration options and documentation. |
 | 2024-05-01 | Falco Girgis | Added config option for enabling the Ada langauge. |

--- a/utils/dc-chain/scripts/gcc-pass1.mk
+++ b/utils/dc-chain/scripts/gcc-pass1.mk
@@ -2,7 +2,9 @@
 # This file is part of KallistiOS.
 
 build-sh4-gcc-pass1: build = build-gcc-$(target)-$(gcc_ver)-pass1
+build-sh4-gcc-pass1: enabled_languages = $(pass1_languages)
 build-arm-gcc-pass1: build = build-gcc-$(target)-$(gcc_ver)
+build-arm-gcc-pass1: enabled_languages = c
 $(build_gcc_pass1) $(build_gcc_pass2): src_dir = gcc-$(gcc_ver)
 $(build_gcc_pass1) $(build_gcc_pass2): log = $(logdir)/$(build).log
 $(build_gcc_pass1): logdir
@@ -17,7 +19,7 @@ $(build_gcc_pass1): logdir
 	      --with-gnu-ld \
 	      --without-headers \
 	      --with-newlib \
-	      --enable-languages=$(pass1_languages) \
+	      --enable-languages=$(enabled_languages) \
 	      --disable-libssp \
 	      --enable-checking=release \
 	      $(cpu_configure_args) \


### PR DESCRIPTION
Right now, if libgccjit is enabled in the `Makefile.cfg` and the user runs `make all` so that both SH and ARM toolchains are built, libgccjit will try to build for the ARM toolchain which was not intended and will result in a build error. This PR fixes dc-chain so that it will only build libgccjit support for SH, not ARM. 