### PR TITLE
Fix kos doxygen warnings

### DIFF
--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -208,7 +208,7 @@ extern const struct in6_addr in6addr_loopback;
 #define IPPROTO_UDP     17
 
 /** \brief   Internet Protocol Version 6. 
-    \ingroup networking_ipv
+    \ingroup networking_ip
 */
 #define IPPROTO_IPV6    41
 

--- a/include/poll.h
+++ b/include/poll.h
@@ -6,7 +6,7 @@
 
 /** \file    poll.h
     \brief   Definitions for the poll() function.
-    \ingroup threading_posix
+    \ingroup threading_polling
 
     This file contains the definitions needed for using the poll() function, as
     directed by the POSIX 2008 standard (aka The Open Group Base Specifications
@@ -27,7 +27,9 @@
 
 __BEGIN_DECLS
 
-/** \addtogroup threading_posix
+/** \defgroup threading_polling  Polling
+    \brief                       Implementation of POSIX polling.
+    \ingroup                     threading_posix
     @{
 */
 

--- a/kernel/arch/dreamcast/include/arch/byteorder.h
+++ b/kernel/arch/dreamcast/include/arch/byteorder.h
@@ -32,7 +32,10 @@ __BEGIN_DECLS
 #undef BYTE_ORDER
 #endif
 
-/** \addtogroup arch
+/** \defgroup system_arch  Byte Order
+    \brief                 Byte-order management for the SH4 architecture
+    \ingroup               arch
+
     @{
 */
 

--- a/kernel/arch/dreamcast/include/dc/video.h
+++ b/kernel/arch/dreamcast/include/dc/video.h
@@ -318,7 +318,7 @@ uint32_t vid_border_color(uint8_t r, uint8_t g, uint8_t b);
 void vid_clear(uint8_t r, uint8_t g, uint8_t b);
 
 /** \brief   Clear VRAM.
-    \ingroup video_vram
+    \ingroup video_fb
 
     This function is essentially a memset() for the whole of VRAM that will
     clear it all to 0 bytes.


### PR DESCRIPTION
This PR fixes warnings that show up when building the docs using ```make docs``` in kos folder.