### PR TITLE
gitignore: add .vscode folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *~
 .*.swp
 .DS_Store
+.vscode/
 doc/reference/
 environ.sh
 romdisk.img


### PR DESCRIPTION
Add .vscode folders, that could be added in the examples by the users when using Visual Studio Code, to gitignore