### PR TITLE
Naomi: examples Makefile: exclude network, modem & g1ata

### DIFF
--- a/examples/dreamcast/Makefile
+++ b/examples/dreamcast/Makefile
@@ -5,12 +5,12 @@
 # Copyright (C) 2024 Andy Barajas
 #
 
-DIRS = 2ndmix basic libdream kgl hello sound png network vmu conio pvr video \
+DIRS = 2ndmix basic libdream kgl hello sound png vmu conio pvr video \
 	   lua parallax dreameye filesystem sd lightgun keyboard sdl dev rumble \
 	   micropython
 
 ifneq ($(KOS_SUBARCH), naomi)
-	DIRS += modem g1ata
+	DIRS += network modem g1ata
 endif
 
 ifdef KOS_CCPLUS

--- a/examples/dreamcast/Makefile
+++ b/examples/dreamcast/Makefile
@@ -6,8 +6,12 @@
 #
 
 DIRS = 2ndmix basic libdream kgl hello sound png network vmu conio pvr video \
-	   lua parallax modem dreameye filesystem sd g1ata lightgun keyboard sdl dev rumble \
+	   lua parallax dreameye filesystem sd lightgun keyboard sdl dev rumble \
 	   micropython
+
+ifneq ($(KOS_SUBARCH), naomi)
+	DIRS += modem g1ata
+endif
 
 ifdef KOS_CCPLUS
 	DIRS += cpp tsunami


### PR DESCRIPTION
Exclude examples
- /network
-  /modem
- /g1ata

when building for Naomi, as the corresponding functions do not exist for Naomi