### PR TITLE
Add an example of how to render lines with the PVR.

### DIFF
--- a/examples/dreamcast/pvr/Makefile
+++ b/examples/dreamcast/pvr/Makefile
@@ -6,6 +6,7 @@
 
 all:
 	$(KOS_MAKE) -C plasma
+	$(KOS_MAKE) -C pvrline
 	$(KOS_MAKE) -C pvrmark
 	$(KOS_MAKE) -C pvrmark_strips
 	$(KOS_MAKE) -C pvrmark_strips_direct
@@ -18,6 +19,7 @@ all:
 
 clean:
 	$(KOS_MAKE) -C plasma clean
+	$(KOS_MAKE) -C pvrline clean
 	$(KOS_MAKE) -C pvrmark clean
 	$(KOS_MAKE) -C pvrmark_strips clean
 	$(KOS_MAKE) -C pvrmark_strips_direct clean
@@ -30,6 +32,7 @@ clean:
 
 dist:
 	$(KOS_MAKE) -C plasma dist
+	$(KOS_MAKE) -C pvrline dist
 	$(KOS_MAKE) -C pvrmark dist
 	$(KOS_MAKE) -C pvrmark_strips dist
 	$(KOS_MAKE) -C pvrmark_strips_direct dist

--- a/examples/dreamcast/pvr/pvrline/Makefile
+++ b/examples/dreamcast/pvr/pvrline/Makefile
@@ -1,8 +1,3 @@
-#
-# Basic KallistiOS skeleton / test program
-# (c)2024 Jason Martin
-#
-
 # Put the filename of the output binary here
 TARGET = pvrline.elf
 

--- a/examples/dreamcast/pvr/pvrline/Makefile
+++ b/examples/dreamcast/pvr/pvrline/Makefile
@@ -1,0 +1,31 @@
+#
+# Basic KallistiOS skeleton / test program
+# (c)2024 Jason Martin
+#
+
+# Put the filename of the output binary here
+TARGET = pvrline.elf
+
+# List all of your C files here, but change the extension to ".o"
+OBJS = pvrline.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist: $(TARGET)
+	-rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)
+

--- a/examples/dreamcast/pvr/pvrline/pvrline.c
+++ b/examples/dreamcast/pvr/pvrline/pvrline.c
@@ -36,7 +36,7 @@ uint8_t __attribute__((aligned(32))) tr_buf[VERTBUF_SIZE];
  * uses the PVR to draw a line with a triangle strip consisting of 4 vertices
  * representing a quad
 */
-void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, float width, int color, 
+void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, float width, int color,
 	int which_list, pvr_poly_hdr_t *which_hdr);
 
 int main(int argc, char **argv)
@@ -90,10 +90,13 @@ int main(int argc, char **argv)
 		if (controller) {
 			cont = maple_dev_status(controller);
 			if (cont->buttons & CONT_DPAD_UP) {
-				if (linecount < 1536)
+				if (linecount < 1536) {
 					linecount += 1;
+				}
 			} else if (cont->buttons & CONT_DPAD_DOWN) {
-				if (linecount > 1) linecount -= 1;
+				if (linecount > 1) {
+					linecount -= 1;
+				}
 			} else if (cont->buttons & CONT_A) {
 				linecount = 1;
 			} else if (cont->buttons & CONT_START) {
@@ -110,8 +113,9 @@ int main(int argc, char **argv)
 
 		/*
 		 * incrementing offset added to endpoints
-		 * make endpoints get closer to the screen edges
-		 * force occasional endpoint swaps in the line drawing routine
+		 * make endpoints occasionally move to other side of screen
+		 * from where they start
+		 * force swaps in the line drawing routine
 		 */
 		offset = (offset + 5) % 360;
 
@@ -132,7 +136,7 @@ int main(int argc, char **argv)
 			v1.x += offset;
 			v1.y += offset;
 
-			/* 
+			/*
 			 * subtract an offset in the range [0,359] from v2 x and y
 			 * x stays within [141,595]
 			 * y stays within [40,447]
@@ -152,18 +156,28 @@ int main(int argc, char **argv)
 			b = rand() % 256;
 			a = rand() % 256;
 
-			color = PVR_PACK_COLOR((float)a / 255.0f, (float)r / 255.0f, 
-						(float)g / 255.0f, (float)b / 255.0f);
+			color = PVR_PACK_COLOR((float)a / 255.0f,
+				(float)r / 255.0f,
+				(float)g / 255.0f,
+				(float)b / 255.0f);
 
 			width = (rand() % 5) + 1;
 
 			/* interleaved use of PVR polygon list types */
 			if (a == 255) {
-				/* when alpha is fully opaque, use the OP list */
-				draw_pvr_line(&v1, &v2, width, color, PVR_LIST_OP_POLY, &op_hdr);
+				/*
+				 * when alpha is fully opaque
+				 * use the OP list
+				 */
+				draw_pvr_line(&v1, &v2, width, color,
+					PVR_LIST_OP_POLY, &op_hdr);
 			} else {
-				/* when alpha is transparent at all, use the TR list */
-				draw_pvr_line(&v1, &v2, width, color, PVR_LIST_TR_POLY, &tr_hdr);
+				/*
+				 * when alpha is transparent at all
+				 * use the TR list
+				 */
+				draw_pvr_line(&v1, &v2, width, color,
+					PVR_LIST_TR_POLY, &tr_hdr);
 			}
 		}
 
@@ -216,7 +230,8 @@ void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, float width, int color,
 	 * multiply by half of the line width
 	 * this scales the normal, making a quad with the requested line width
 	 */
-	float inverse_magnitude = frsqrt((dx*dx) + (dy*dy)) * ((float)width*0.5f);
+	float inverse_magnitude = frsqrt((dx*dx) + (dy*dy)) *
+		((float)width*0.5f);
 	float nx = -dy * inverse_magnitude;
 	float ny = dx * inverse_magnitude;
 
@@ -243,7 +258,7 @@ void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, float width, int color,
 	vert->y = ov2->y - ny;
 	vert->z = ov2->z;
 
-	/* submit the poly header and triangle strip vertices to requested list */
+	/* submit the poly header and vertices to requested list */
 	pvr_list_prim(which_list, which_hdr, sizeof(pvr_poly_hdr_t));
 	pvr_list_prim(which_list, &line_verts, 4 * sizeof(pvr_vertex_t));
 }

--- a/examples/dreamcast/pvr/pvrline/pvrline.c
+++ b/examples/dreamcast/pvr/pvrline/pvrline.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
 void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, int width, int color, int which_list, pvr_poly_hdr_t *which_hdr) {
 	pvr_vertex_t __attribute__((aligned(32))) line_verts[4];
 	pvr_vertex_t *vert = line_verts;
-	float lx1,lx2,ly1,ly2,lz1,lz2;
+
 	float x1,y1,x2,y2,z1,z2;
 
 	for (int i=0;i<4;i++) {
@@ -84,28 +84,20 @@ void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, int width, int color, int which_lis
 	}
 	line_verts[3].flags = PVR_CMD_VERTEX_EOL;
 
-	lx1 = v1->x;
-	ly1 = v1->y;
-	lz1 = v1->z;
-
-	lx2 = v2->x;
-	ly2 = v2->y;
-	lz2 = v2->z;
-
-	if(lx1 <= lx2) {
-		x1 = lx1;
-		y1 = ly1;
-		z1 = lz1;
-		x2 = lx2;
-		y2 = ly2;
-		z2 = lz2;
+	if(v1->x <= v2->x) {
+		x1 = v1->x;
+		y1 = v1->y;
+		z1 = v1->z;
+		x2 = v2->x;
+		y2 = v2->y;
+		z2 = v2->z;
 	} else {
-		x1 = lx2;
-		y1 = ly2;
-		z1 = lz2;
-		x2 = lx1;
-		y2 = ly1;
-		z2 = lz1;
+		x1 = v2->x;
+		y1 = v2->y;
+		z1 = v2->z;
+		x2 = v1->x;
+		y2 = v1->y;
+		z2 = v1->z;
 	}
 
 	// https://devcry.heiho.net/html/2017/20170820-opengl-line-drawing.html

--- a/examples/dreamcast/pvr/pvrline/pvrline.c
+++ b/examples/dreamcast/pvr/pvrline/pvrline.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
 	maple_device_t *controller;
 	cont_state_t *cont;
 
-    printf("---KallistiOS PVR Line-drawing Example---\n");
+	printf("---KallistiOS PVR Line-drawing Example---\n");
 	printf("Press DPAD UP to increase line count\n\t(up to a maximum of 1536"
 		" lines).\n");
 	printf("Press DPAD DOWN to decrease line count\n\t(down to a minimum of 1"

--- a/examples/dreamcast/pvr/pvrline/pvrline.c
+++ b/examples/dreamcast/pvr/pvrline/pvrline.c
@@ -1,0 +1,172 @@
+#include <kos.h>
+#include <stdlib.h>
+
+// 512 kb OP VERT BUF
+#define OP_VERTBUF_SIZE (512*1024)
+
+KOS_INIT_FLAGS(INIT_DEFAULT);
+
+pvr_init_params_t pvr_params = {
+{ PVR_BINSIZE_16, 0, 0, 0, 0 }, OP_VERTBUF_SIZE, 1, 0, 0, 3
+};
+
+uint8_t __attribute__((aligned(32))) op_buf[OP_VERTBUF_SIZE];
+
+void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, int width, int color, int which_list, pvr_poly_hdr_t *which_hdr);
+
+int main(int argc, char **argv) {
+	pvr_poly_hdr_t hdr;
+	pvr_poly_cxt_t cxt;
+
+	vec3f_t v1, v2;
+	int r, g, b;
+	int color;
+	int width;
+	int offset;
+
+	vid_set_enabled(0);
+	vid_set_mode(DM_640x480, PM_RGB565);
+	pvr_init(&pvr_params);
+	vid_set_enabled(1);
+
+	pvr_poly_cxt_col(&cxt, PVR_LIST_OP_POLY);
+	pvr_poly_compile(&hdr, &cxt);
+
+	offset = 0;
+
+	while (true) {
+		pvr_wait_ready();
+		pvr_scene_begin();
+		pvr_set_vertbuf(PVR_LIST_OP_POLY, op_buf, OP_VERTBUF_SIZE);
+
+		offset = (offset + 5) % 360;
+
+		for (int i=0;i<32;i++) {
+			v1.x = rand() % 128;
+			v1.y = rand() % 64;
+			v1.z = 5;
+
+			v2.x = 500 + (rand() % 96);
+			v2.y = 400 + (rand() % 48);
+			v2.z = 5;
+
+			v1.x += offset;
+			v1.y += offset;
+
+			v2.x -= offset;
+			v2.y -= offset;
+
+			r = rand() % 255;
+			g = rand() % 255;
+			b = rand() % 255;
+
+			color = PVR_PACK_COLOR(1.0, (float)r / 255.0f, (float)g / 255.0f, (float)b / 255.0f);
+
+			width = (rand() % 5) + 1;
+
+			draw_pvr_line(&v1, &v2, width, color, PVR_LIST_OP_POLY, &hdr);
+		}
+
+		pvr_scene_finish();
+	}
+}
+
+void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, int width, int color, int which_list, pvr_poly_hdr_t *which_hdr) {
+	pvr_vertex_t __attribute__((aligned(32))) line_verts[4];
+	pvr_vertex_t *vert = line_verts;
+	float lx1,lx2,ly1,ly2,lz1,lz2;
+	float x1,y1,x2,y2,z1,z2;
+
+	for (int i=0;i<4;i++) {
+		line_verts[i].flags = PVR_CMD_VERTEX;
+		line_verts[i].argb = color;
+		line_verts[i].oargb = 0;
+	}
+	line_verts[3].flags = PVR_CMD_VERTEX_EOL;
+
+	lx1 = v1->x;
+	ly1 = v1->y;
+	lz1 = v1->z;
+
+	lx2 = v2->x;
+	ly2 = v2->y;
+	lz2 = v2->z;
+
+	if (lx1 == lx2) {
+		if(ly1 > ly2) {
+			x1 = lx2;
+			y1 = ly2;
+			z1 = lz2;
+			x2 = lx1;
+			y2 = ly1;
+			z2 = lz1;
+		} else {
+			x1 = lx1;
+			y1 = ly1;
+			z1 = lz1;
+			x2 = lx2;
+			y2 = ly2;
+			z2 = lz2;
+		}
+	} else if (ly1 == ly2) {
+		if(lx1 < lx2) {
+			x1 = lx1;
+			y1 = ly1;
+			z1 = lz1;
+			x2 = lx2;
+			y2 = ly2;
+			z2 = lz2;
+		} else {
+			x1 = lx2;
+			y1 = ly2;
+			z1 = lz2;
+			x2 = lx1;
+			y2 = ly1;
+			z2 = lz1;
+		}
+	} else if(lx1 < lx2) {
+		x1 = lx1;
+		y1 = ly1;
+		z1 = lz1;
+		x2 = lx2;
+		y2 = ly2;
+		z2 = lz2;
+	} else { // if(lx1 > lx2)
+		x1 = lx2;
+		y1 = ly2;
+		z1 = lz2;
+		x2 = lx1;
+		y2 = ly1;
+		z2 = lz1;
+	}
+
+	// https://devcry.heiho.net/html/2017/20170820-opengl-line-drawing.html
+	float dx = x2 - x1;
+	float dy = y2 - y1;
+
+	float hlw_invmag = frsqrt((dx*dx) + (dy*dy)) * ((float)width*0.5f);
+	float nx = -dy * hlw_invmag;
+	float ny = dx * hlw_invmag;
+
+	vert->x = x1 + nx;
+	vert->y = y1 + ny;
+	vert->z = z1;
+	vert++;
+
+	vert->x = x1 - nx;
+	vert->y = y1 - ny;
+	vert->z = z2;
+	vert++;
+
+	vert->x = x2 + nx;
+	vert->y = y2 + ny;
+	vert->z = z1;
+	vert++;
+
+	vert->x = x2 - nx;
+	vert->y = y2 - ny;
+	vert->z = z2;
+
+	pvr_list_prim(which_list, which_hdr, sizeof(pvr_poly_hdr_t));
+	pvr_list_prim(which_list, &line_verts, 4 * sizeof(pvr_vertex_t));
+}

--- a/examples/dreamcast/pvr/pvrline/pvrline.c
+++ b/examples/dreamcast/pvr/pvrline/pvrline.c
@@ -92,46 +92,14 @@ void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, int width, int color, int which_lis
 	ly2 = v2->y;
 	lz2 = v2->z;
 
-	if (lx1 == lx2) {
-		if(ly1 > ly2) {
-			x1 = lx2;
-			y1 = ly2;
-			z1 = lz2;
-			x2 = lx1;
-			y2 = ly1;
-			z2 = lz1;
-		} else {
-			x1 = lx1;
-			y1 = ly1;
-			z1 = lz1;
-			x2 = lx2;
-			y2 = ly2;
-			z2 = lz2;
-		}
-	} else if (ly1 == ly2) {
-		if(lx1 < lx2) {
-			x1 = lx1;
-			y1 = ly1;
-			z1 = lz1;
-			x2 = lx2;
-			y2 = ly2;
-			z2 = lz2;
-		} else {
-			x1 = lx2;
-			y1 = ly2;
-			z1 = lz2;
-			x2 = lx1;
-			y2 = ly1;
-			z2 = lz1;
-		}
-	} else if(lx1 < lx2) {
+	if(lx1 <= lx2) {
 		x1 = lx1;
 		y1 = ly1;
 		z1 = lz1;
 		x2 = lx2;
 		y2 = ly2;
 		z2 = lz2;
-	} else { // if(lx1 > lx2)
+	} else {
 		x1 = lx2;
 		y1 = ly2;
 		z1 = lz2;

--- a/examples/dreamcast/pvr/pvrline/pvrline.c
+++ b/examples/dreamcast/pvr/pvrline/pvrline.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
 		 * incrementing offset added to endpoints
 		 * make endpoints get closer to the screen edges
 		 * force occasional endpoint swaps in the line drawing routine
-         */
+		 */
 		offset = (offset + 5) % 360;
 
 		for (int i = 0; i < linecount; i++) {
@@ -203,10 +203,10 @@ void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, float width, int color,
 
 	/*
 	 * https://devcry.heiho.net/html/2017/20170820-opengl-line-drawing.html
-     *
+	 *
 	 * get the normal to the line segment running from v1 to v2
 	 * use normal to draw a quad covering the actual line segment
-     */
+	 */
 	float dx = ov2->x - ov1->x;
 	float dy = ov2->y - ov1->y;
 

--- a/examples/dreamcast/pvr/pvrline/pvrline.c
+++ b/examples/dreamcast/pvr/pvrline/pvrline.c
@@ -1,47 +1,121 @@
-#include <kos.h>
-#include <stdlib.h>
+/*
+ * KallistiOS ##version##
+ *
+ * examples/dreamcast/pvr/pvrline/pvrline.c
+ * Copyright (C) 2024 Jason Martin
+ *
+ * This example demonstrates the use of the PVR to draw lines with quads
+ * (as triangle strips).
+ * It also demonstrates the use of pvr_list_prim, interleaving the drawing of
+ * OPAQUE and TRANSPARENT polygons.
+ */
 
-// 512 kb OP VERT BUF
-#define OP_VERTBUF_SIZE (512*1024)
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <kos.h>
+
+/* 512 kb vertex buffer size */
+#define VERTBUF_SIZE (512*1024)
 
 KOS_INIT_FLAGS(INIT_DEFAULT);
 
+/* enable OP and TR lists */
 pvr_init_params_t pvr_params = {
-{ PVR_BINSIZE_16, 0, 0, 0, 0 }, OP_VERTBUF_SIZE, 1, 0, 0, 3
+{ PVR_BINSIZE_16, 0, PVR_BINSIZE_16, 0, 0 }, VERTBUF_SIZE, 1, 0, 0, 3
 };
 
-uint8_t __attribute__((aligned(32))) op_buf[OP_VERTBUF_SIZE];
+uint8_t __attribute__((aligned(32))) op_buf[VERTBUF_SIZE];
+uint8_t __attribute__((aligned(32))) tr_buf[VERTBUF_SIZE];
 
-void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, int width, int color, int which_list, pvr_poly_hdr_t *which_hdr);
+/*
+ * given a vec3f_t representing the screen-space start of a line (x,y,z),
+ * a vec3f_t representing the screen-space end of a line (x,y,z),
+ * a color, a width, a pvr polygon list type and a pvr polygon header
+ * uses the PVR to draw a line with a triangle strip consisting of 4 vertices
+ * representing a quad
+*/
+void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, float width, int color, 
+	int which_list, pvr_poly_hdr_t *which_hdr);
 
-int main(int argc, char **argv) {
-	pvr_poly_hdr_t hdr;
-	pvr_poly_cxt_t cxt;
+int main(int argc, char **argv)
+{
+	pvr_poly_hdr_t op_hdr, tr_hdr;
+	pvr_poly_cxt_t op_cxt, tr_cxt;
 
+	/* start and end points of a line in screen-space */
 	vec3f_t v1, v2;
-	int r, g, b;
+	/* red, green, blue and alpha color components */
+	int r, g, b, a;
+	/* packed color */
 	int color;
+	/* line width */
 	int width;
+	/* moving offset added or subtracted to x and y components of endpoints */
 	int offset;
+	/* number of lines to draw per frame */
+	int linecount = 1;
+
+	maple_device_t *controller;
+	cont_state_t *cont;
+
+    printf("---KallistiOS PVR Line-drawing Example---\n");
+	printf("Press DPAD UP to increase line count\n\t(up to a maximum of 1536"
+		" lines).\n");
+	printf("Press DPAD DOWN to decrease line count\n\t(down to a minimum of 1"
+		" line).\n");
+	printf("Press A to reset line count to 1.\n");
+	printf("Press Start to exit.\n");
+
+	srand(time(NULL));
 
 	vid_set_enabled(0);
 	vid_set_mode(DM_640x480, PM_RGB565);
 	pvr_init(&pvr_params);
 	vid_set_enabled(1);
 
-	pvr_poly_cxt_col(&cxt, PVR_LIST_OP_POLY);
-	pvr_poly_compile(&hdr, &cxt);
+	/* polygon header setup, OP lines */
+	pvr_poly_cxt_col(&op_cxt, PVR_LIST_OP_POLY);
+	pvr_poly_compile(&op_hdr, &op_cxt);
+
+	/* polygon header setup, TR lines */
+	pvr_poly_cxt_col(&tr_cxt, PVR_LIST_TR_POLY);
+	pvr_poly_compile(&tr_hdr, &tr_cxt);
 
 	offset = 0;
 
 	while (true) {
+		controller = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
+		if (controller) {
+			cont = maple_dev_status(controller);
+			if (cont->buttons & CONT_DPAD_UP) {
+				if (linecount < 1536)
+					linecount += 1;
+			} else if (cont->buttons & CONT_DPAD_DOWN) {
+				if (linecount > 1) linecount -= 1;
+			} else if (cont->buttons & CONT_A) {
+				linecount = 1;
+			} else if (cont->buttons & CONT_START) {
+				break;
+			}
+		}
+
 		pvr_wait_ready();
 		pvr_scene_begin();
-		pvr_set_vertbuf(PVR_LIST_OP_POLY, op_buf, OP_VERTBUF_SIZE);
 
+		/* set vertex buffers for pvr_list_prim use */
+		pvr_set_vertbuf(PVR_LIST_OP_POLY, op_buf, VERTBUF_SIZE);
+		pvr_set_vertbuf(PVR_LIST_TR_POLY, tr_buf, VERTBUF_SIZE);
+
+		/*
+		 * incrementing offset added to endpoints
+		 * make endpoints get closer to the screen edges
+		 * force occasional endpoint swaps in the line drawing routine
+         */
 		offset = (offset + 5) % 360;
 
-		for (int i=0;i<32;i++) {
+		for (int i = 0; i < linecount; i++) {
 			v1.x = rand() % 128;
 			v1.y = rand() % 64;
 			v1.z = 5;
@@ -50,32 +124,61 @@ int main(int argc, char **argv) {
 			v2.y = 400 + (rand() % 48);
 			v2.z = 5;
 
+			/*
+			 * add an offset in the range [0,359] to v1 x and y
+			 * x stays within [0,487]
+			 * y stays within [0,422]
+			 */
 			v1.x += offset;
 			v1.y += offset;
 
+			/* 
+			 * subtract an offset in the range [0,359] from v2 x and y
+			 * x stays within [141,595]
+			 * y stays within [40,447]
+			 */
 			v2.x -= offset;
 			v2.y -= offset;
 
-			r = rand() % 255;
-			g = rand() % 255;
-			b = rand() % 255;
+			/*
+			 * the above offset can move v2 to the left of v1
+			 * this demonstrates that lines will always render correctly
+			 * regardless of vertex order
+			 */
 
-			color = PVR_PACK_COLOR(1.0, (float)r / 255.0f, (float)g / 255.0f, (float)b / 255.0f);
+			/* generate a random RGBA color */
+			r = rand() % 256;
+			g = rand() % 256;
+			b = rand() % 256;
+			a = rand() % 256;
+
+			color = PVR_PACK_COLOR((float)a / 255.0f, (float)r / 255.0f, 
+						(float)g / 255.0f, (float)b / 255.0f);
 
 			width = (rand() % 5) + 1;
 
-			draw_pvr_line(&v1, &v2, width, color, PVR_LIST_OP_POLY, &hdr);
+			/* interleaved use of PVR polygon list types */
+			if (a == 255) {
+				/* when alpha is fully opaque, use the OP list */
+				draw_pvr_line(&v1, &v2, width, color, PVR_LIST_OP_POLY, &op_hdr);
+			} else {
+				/* when alpha is transparent at all, use the TR list */
+				draw_pvr_line(&v1, &v2, width, color, PVR_LIST_TR_POLY, &tr_hdr);
+			}
 		}
 
 		pvr_scene_finish();
 	}
 }
 
-void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, int width, int color, int which_list, pvr_poly_hdr_t *which_hdr) {
+void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, float width, int color,
+	int which_list, pvr_poly_hdr_t *which_hdr)
+{
 	pvr_vertex_t __attribute__((aligned(32))) line_verts[4];
 	pvr_vertex_t *vert = line_verts;
 
-	float x1,y1,x2,y2,z1,z2;
+	vec3f_t *ov1;
+	vec3f_t *ov2;
 
 	for (int i=0;i<4;i++) {
 		line_verts[i].flags = PVR_CMD_VERTEX;
@@ -84,49 +187,63 @@ void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, int width, int color, int which_lis
 	}
 	line_verts[3].flags = PVR_CMD_VERTEX_EOL;
 
+	/*
+	 * when first vertex is to the left of or vertical with second vertex
+	 *  they are already ordered
+	 * otherwise
+	 *  swap endpoints
+	 */
 	if(v1->x <= v2->x) {
-		x1 = v1->x;
-		y1 = v1->y;
-		z1 = v1->z;
-		x2 = v2->x;
-		y2 = v2->y;
-		z2 = v2->z;
+		ov1 = v1;
+		ov2 = v2;
 	} else {
-		x1 = v2->x;
-		y1 = v2->y;
-		z1 = v2->z;
-		x2 = v1->x;
-		y2 = v1->y;
-		z2 = v1->z;
+		ov1 = v2;
+		ov2 = v1;
 	}
 
-	// https://devcry.heiho.net/html/2017/20170820-opengl-line-drawing.html
-	float dx = x2 - x1;
-	float dy = y2 - y1;
+	/*
+	 * https://devcry.heiho.net/html/2017/20170820-opengl-line-drawing.html
+     *
+	 * get the normal to the line segment running from v1 to v2
+	 * use normal to draw a quad covering the actual line segment
+     */
+	float dx = ov2->x - ov1->x;
+	float dy = ov2->y - ov1->y;
 
-	float hlw_invmag = frsqrt((dx*dx) + (dy*dy)) * ((float)width*0.5f);
-	float nx = -dy * hlw_invmag;
-	float ny = dx * hlw_invmag;
+	/*
+	 * use the fast reciprocal square root function provided by KOS
+	 * to get inverse of the magnitude of the normal
+	 * multiply by half of the line width
+	 * this scales the normal, making a quad with the requested line width
+	 */
+	float inverse_magnitude = frsqrt((dx*dx) + (dy*dy)) * ((float)width*0.5f);
+	float nx = -dy * inverse_magnitude;
+	float ny = dx * inverse_magnitude;
 
-	vert->x = x1 + nx;
-	vert->y = y1 + ny;
-	vert->z = z1;
+	/* normal offset "down" from the first endpoint */
+	vert->x = ov1->x + nx;
+	vert->y = ov1->y + ny;
+	vert->z = ov1->z;
 	vert++;
 
-	vert->x = x1 - nx;
-	vert->y = y1 - ny;
-	vert->z = z2;
+	/* normal offset "up" from the first endpoint */
+	vert->x = ov1->x - nx;
+	vert->y = ov1->y - ny;
+	vert->z = ov2->z;
 	vert++;
 
-	vert->x = x2 + nx;
-	vert->y = y2 + ny;
-	vert->z = z1;
+	/* normal offset "down" from the second endpoint */
+	vert->x = ov2->x + nx;
+	vert->y = ov2->y + ny;
+	vert->z = ov1->z;
 	vert++;
 
-	vert->x = x2 - nx;
-	vert->y = y2 - ny;
-	vert->z = z2;
+	/* normal offset "up" from the second endpoint */
+	vert->x = ov2->x - nx;
+	vert->y = ov2->y - ny;
+	vert->z = ov2->z;
 
+	/* submit the poly header and triangle strip vertices to requested list */
 	pvr_list_prim(which_list, which_hdr, sizeof(pvr_poly_hdr_t));
 	pvr_list_prim(which_list, &line_verts, 4 * sizeof(pvr_vertex_t));
 }


### PR DESCRIPTION
One of the things I needed for my port of Doom 64 to the Dreamcast was a way to draw lines with hardware acceleration.

I adapted a method of taking the normal to a line segment and drawing a quad along the line as a triangle strip.

I would have loved to have had this available as an example when I needed it.

Provided is a function for rendering lines with the PVR and an example of rendering opaque and transparent lines in an interleaved fashion using `pvr_list_prim` .

Hoping this proves useful to others and might be accepted to the KOS project.