### PR TITLE
Remove FD_SETSIZE setting from environ.sh

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -144,21 +144,6 @@ export KOS_CFLAGS="${KOS_CFLAGS} -O2"
 #
 #export KOS_CFLAGS="${KOS_CFLAGS} -freorder-blocks-algorithm=simple -flto=auto"
 
-# RAM-Saving Optimization
-#
-# Uncomment the line below to reduce the default size of FD_SETSIZE from the
-# default value of 1024 to 64. FD_SETSIZE defines the maximum number of files
-# that can be opened simultaneously, including files on the ramdisk, romdisk, 
-# CD, VMU, network sockets, etc. The default setting allows 1024 files to be
-# opened at once, which is typically more than most use cases require.
-#
-# By reducing this value, you can save approximately ~11.25 KB of RAM, which 
-# can be particularly useful when porting large games to the Dreamcast that 
-# are strapped for memory. However, be cautious not to set it too low, as this 
-# may limit the number of files and sockets that can be opened simultaneously.
-#
-# export KOS_CFLAGS="${KOS_CFLAGS} -DFD_SETSIZE=64"
-
 # Frame Pointers
 #
 # Controls whether frame pointers are emitted or not. Disabled by

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -129,8 +129,9 @@ __BEGIN_DECLS
 #define FS_RAMDISK_MAX_FILES 8
 #endif
 
-/** \brief  The number of distinct file descriptors that can be in use at a
-            time. This value can be overwritten in environ.sh */
+/** \brief  The number of distinct file descriptors, including files and
+            network sockets, that can be in use at a time. Decreasing this
+            value can reduce memory usage.  */
 #ifndef FD_SETSIZE
 #define FD_SETSIZE 1024
 #endif

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -197,10 +197,9 @@ static int fs_hnd_assign(fs_hnd_t *hnd) {
             break;
 
     if(i >= FD_SETSIZE) {
-        if(FD_SETSIZE != 1024)
-            dbglog(DBG_ERROR, "fs_hnd_assign: Update -DFD_SETSIZE flag in \
-                  environ.sh to support additional files being opened. Current \
-                  limit is %d\n", FD_SETSIZE);
+        dbglog(DBG_ERROR, "fs_hnd_assign: Update FD_SETSIZE definition in \
+              opts.h to support additional files being opened. Current \
+              limit is %d\n", FD_SETSIZE);
 
         fs_hnd_unref(hnd);
         errno = EMFILE;


### PR DESCRIPTION
Both BlueCrab and I pointed out that this setting belongs in opts.h and does not belong in environ.sh, yet PR#703 was merged anyway. This PR reverts the change to environ.sh.