### PR TITLE
Revert "Support chained LBA28 DMA transfers in IDE and DMA transfers in FAT"

### DIFF
--- a/addons/libkosfat/bpb.c
+++ b/addons/libkosfat/bpb.c
@@ -4,7 +4,6 @@
    Copyright (C) 2012, 2019 Lawrence Sebald
 */
 
-#include <malloc.h>
 #include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -19,7 +18,7 @@ static int fat_read_raw_boot(fat_bootblock_t *sb, kos_blockdev_t *bd) {
     if(bd->l_block_size > 9) {
         uint8_t *buf;
 
-        if(!(buf = (uint8_t *)memalign(32, 1 << bd->l_block_size)))
+        if(!(buf = (uint8_t *)malloc(1 << bd->l_block_size)))
             return -ENOMEM;
 
         if(bd->read_blocks(bd, 0, 1, buf))
@@ -28,6 +27,9 @@ static int fat_read_raw_boot(fat_bootblock_t *sb, kos_blockdev_t *bd) {
         memcpy(sb, buf, 512);
         free(buf);
         return 0;
+    }
+    else if(bd->l_block_size == 9) {
+        return bd->read_blocks(bd, 0, 1, sb);
     }
     else {
         return bd->read_blocks(bd, 0, 512 >> bd->l_block_size, sb);

--- a/addons/libkosfat/bpb.h
+++ b/addons/libkosfat/bpb.h
@@ -64,7 +64,7 @@ typedef struct fat_bootblock {
         fat16_ebpb_t fat16;
         fat32_ebpb_t fat32;
     } ebpb;
-} __attribute__((packed,aligned(32))) fat_bootblock_t;
+} __attribute__((packed)) fat_bootblock_t;
 
 typedef struct fat32_fsinfo {
     uint32_t fsinfo_sig1;
@@ -74,7 +74,7 @@ typedef struct fat32_fsinfo {
     uint32_t last_alloc_cluster;
     uint8_t reserved2[12];
     uint32_t fsinfo_sig3;
-} __attribute__((packed,aligned(32))) fat32_fsinfo_t;
+} __attribute__((packed)) fat32_fsinfo_t;
 
 #define FAT32_FSINFO_SIG1 0x41615252
 #define FAT32_FSINFO_SIG2 0x61417272

--- a/addons/libkosfat/fatfs.c
+++ b/addons/libkosfat/fatfs.c
@@ -4,7 +4,6 @@
    Copyright (C) 2012, 2013, 2019 Lawrence Sebald
 */
 
-#include <malloc.h>
 #include <stdio.h>
 #include <errno.h>
 #include <stdint.h>
@@ -316,7 +315,7 @@ fat_fs_t *fat_fs_init_ex(kos_blockdev_t *bd, uint32_t flags, int cache_sz,
     }
 
     for(j = 0; j < cache_sz; ++j) {
-        if(!(rv->bcache[j]->data = (uint8_t *)memalign(32, cluster_size))) {
+        if(!(rv->bcache[j]->data = (uint8_t *)malloc(cluster_size))) {
             goto out_bcache;
         }
 
@@ -338,7 +337,7 @@ fat_fs_t *fat_fs_init_ex(kos_blockdev_t *bd, uint32_t flags, int cache_sz,
     }
 
     for(j = 0; j < fcache_sz; ++j) {
-        if(!(rv->fcache[j]->data = (uint8_t *)memalign(32, block_size))) {
+        if(!(rv->fcache[j]->data = (uint8_t *)malloc(block_size))) {
             goto out_fcache2;
         }
 

--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -170,9 +170,6 @@ static uint8_t orig_dev = 0x00;
 /* Variables related to DMA. */
 static int dma_in_progress = 0;
 static int dma_blocking = 0;
-static uint8_t dma_cmd = 0;
-static size_t dma_nb_sectors = 0;
-static uint64_t dma_sector = 0;
 static semaphore_t dma_done = SEM_INITIALIZER(0);
 static kthread_t *dma_thd = NULL;
 
@@ -214,47 +211,12 @@ inline int g1_ata_mutex_unlock(void) {
     return mutex_unlock(&_g1_ata_mutex);
 }
 
-static void g1_ata_set_sector_and_count(uint64_t sector, uint32_t count, int lba28) {
-    if(!lba28) {
-        OUT8(G1_ATA_SECTOR_COUNT, (uint8_t)(count >> 8));
-        OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 24) & 0xFF));
-        OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 32) & 0xFF));
-        OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 40) & 0xFF));
-    }
-
-    /* Write out the number of sectors we want and the lower 24-bits of
-       the LBA we're looking for. Note that putting 0 into the sector count
-       register returns 256 sectors. */
-    OUT8(G1_ATA_SECTOR_COUNT, (uint8_t)count);
-    OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 0) & 0xFF));
-    OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 8) & 0xFF));
-    OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 16) & 0xFF));
-}
-
 static void g1_dma_irq_hnd(uint32 code, void *data) {
-    unsigned int nb_sectors;
-
     /* XXXX: Probably should look at the code to make sure it isn't an error. */
     (void)code;
     (void)data;
 
-    if(dma_in_progress && dma_nb_sectors > 256) {
-        dma_sector += 256;
-        dma_nb_sectors -= 256;
-        nb_sectors = dma_nb_sectors <= 256 ? dma_nb_sectors : 256;
-
-        /* Set the DMA parameters for the next transfer. */
-        g1_ata_set_sector_and_count(dma_sector, nb_sectors, 1);
-        OUT32(G1_ATA_DMA_ADDRESS, IN32(G1_ATA_DMA_ADDRESS) + 256 * 512);
-        OUT32(G1_ATA_DMA_LENGTH, nb_sectors * 512);
-
-        /* Write out the command to the device. */
-        OUT8(G1_ATA_COMMAND_REG, dma_cmd);
-
-        /* Re-start the DMA transfer. */
-        OUT32(G1_ATA_DMA_STATUS, 1);
-    }
-    else if(dma_in_progress) {
+    if(dma_in_progress) {
         /* Signal the calling thread to continue, if it is blocking. */
         if(dma_blocking) {
             sem_signal(&dma_done);
@@ -320,8 +282,6 @@ static inline int g1_ata_wait_drq(void) {
 static int dma_common(uint8_t cmd, size_t nsects, uint32_t addr, int dir,
                       int block) {
     uint8_t status;
-
-    dma_cmd = cmd;
 
     /* Set the thread ID that initiated this DMA. */
     dma_thd = thd_current;
@@ -529,7 +489,6 @@ int g1_ata_read_lba(uint64_t sector, size_t count, void *buf) {
     uint8_t nsects = (uint8_t)count;
     uint16_t word;
     uint8_t *ptr = (uint8_t *)buf;
-    int lba28, cmd;
 
     /* Make sure that we've been initialized and there's a disk attached. */
     if(!devices) {
@@ -561,26 +520,44 @@ int g1_ata_read_lba(uint64_t sector, size_t count, void *buf) {
         count -= nsects;
 
         /* Which mode are we using: LBA28 or LBA48? */
-        lba28 = (sector + nsects) <= 0x0FFFFFFF;
-        if(lba28) {
+        if((sector + nsects) <= 0x0FFFFFFF) {
             g1_ata_select_device(G1_ATA_SLAVE | G1_ATA_LBA_MODE |
                                  ((sector >> 24) & 0x0F));
-            cmd = ATA_CMD_READ_SECTORS;
+
+            /* Write out the number of sectors we want and the lower 24-bits of
+               the LBA we're looking for. */
+            OUT8(G1_ATA_SECTOR_COUNT, nsects);
+            OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 0) & 0xFF));
+            OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 8) & 0xFF));
+            OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 16) & 0xFF));
+
+            /* Wait until the drive is ready to accept the command. */
+            g1_ata_wait_nbsy();
+            g1_ata_wait_drdy();
+
+            /* Write out the command to the device. */
+            OUT8(G1_ATA_COMMAND_REG, ATA_CMD_READ_SECTORS);
         }
         else {
             g1_ata_select_device(G1_ATA_SLAVE | G1_ATA_LBA_MODE);
-            cmd = ATA_CMD_READ_SECTORS_EXT;
+
+            /* Write out the number of sectors we want and the LBA. */
+            OUT8(G1_ATA_SECTOR_COUNT, 0);
+            OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 24) & 0xFF));
+            OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 32) & 0xFF));
+            OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 40) & 0xFF));
+            OUT8(G1_ATA_SECTOR_COUNT, nsects);
+            OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 0) & 0xFF));
+            OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 8) & 0xFF));
+            OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 16) & 0xFF));
+
+            /* Wait until the drive is ready to accept the command. */
+            g1_ata_wait_nbsy();
+            g1_ata_wait_drdy();
+
+            /* Write out the command to the device. */
+            OUT8(G1_ATA_COMMAND_REG, ATA_CMD_READ_SECTORS_EXT);
         }
-
-        /* Write out the number of sectors we want and the LBA. */
-        g1_ata_set_sector_and_count(sector, nsects, lba28);
-
-        /* Wait until the drive is ready to accept the command. */
-        g1_ata_wait_nbsy();
-        g1_ata_wait_drdy();
-
-        /* Write out the command to the device. */
-        OUT8(G1_ATA_COMMAND_REG, cmd);
 
         /* Now, wait for the drive to give us back each sector. */
         for(i = 0; i < nsects; ++i, ++sector) {
@@ -612,9 +589,9 @@ out:
 
 int g1_ata_read_lba_dma(uint64_t sector, size_t count, void *buf,
                         int block) {
-    int lba28, old, can_lba48 = CAN_USE_LBA48();
+    int rv = 0;
     uint32_t addr;
-    uint8_t cmd;
+    int old, can_lba48 = CAN_USE_LBA48();
 
     /* Make sure we're actually being asked to do work... */
     if(!count)
@@ -644,7 +621,7 @@ int g1_ata_read_lba_dma(uint64_t sector, size_t count, void *buf,
     }
 
     /* Chaining isn't done yet, so make sure we don't need to. */
-    if(count > 65536) {
+    if(count > 65536 || (!can_lba48 && count > 256)) {
         errno = EOVERFLOW;
         return -1;
     }
@@ -686,41 +663,56 @@ int g1_ata_read_lba_dma(uint64_t sector, size_t count, void *buf,
     /* Set the settings for this transfer and re-enable IRQs. */
     dma_blocking = block;
     dma_in_progress = 1;
-    dma_nb_sectors = count;
-    dma_sector = sector;
     irq_restore(old);
-
-    if(!can_lba48 && count > 256)
-        count = 256;
 
     /* Wait for the device to signal it is ready. */
     g1_ata_wait_bsydrq();
 
     /* Which mode are we using: LBA28 or LBA48? */
-    lba28 = !can_lba48 || use_lba28(sector, count);
-    if(lba28) {
+    if(!can_lba48 || use_lba28(sector, count)) {
         g1_ata_select_device(G1_ATA_SLAVE | G1_ATA_LBA_MODE |
                              ((sector >> 24) & 0x0F));
-        cmd = ATA_CMD_READ_DMA;
+
+        /* Write out the number of sectors we want and the lower 24-bits of
+           the LBA we're looking for. Note that putting 0 into the sector count
+           register returns 256 sectors. */
+        OUT8(G1_ATA_SECTOR_COUNT, (uint8_t)count);
+        OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 0) & 0xFF));
+        OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 8) & 0xFF));
+        OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 16) & 0xFF));
+
+        /* Do the rest of the work... */
+        rv = dma_common(ATA_CMD_READ_DMA, count, addr, G1_DMA_TO_MEMORY, block);
     }
     else {
         g1_ata_select_device(G1_ATA_SLAVE | G1_ATA_LBA_MODE);
-        cmd = ATA_CMD_READ_DMA_EXT;
+
+        /* Write out the number of sectors we want and the LBA. Note that in
+           LBA48 mode, putting 0 into the sector count register returns 65536
+           sectors (not that we have that much RAM on the Dreamcast). */
+        OUT8(G1_ATA_SECTOR_COUNT, (uint8_t)(count >> 8));
+        OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 24) & 0xFF));
+        OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 32) & 0xFF));
+        OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 40) & 0xFF));
+        OUT8(G1_ATA_SECTOR_COUNT, (uint8_t)count);
+        OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 0) & 0xFF));
+        OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 8) & 0xFF));
+        OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 16) & 0xFF));
+
+        /* Do the rest of the work... */
+        rv = dma_common(ATA_CMD_READ_DMA_EXT, count, addr, G1_DMA_TO_MEMORY,
+                        block);
     }
 
-    /* Write out the number of sectors we want and the LBA. */
-    g1_ata_set_sector_and_count(sector, count, lba28);
-
-    /* Do the rest of the work... */
-    return dma_common(cmd, count, addr, G1_DMA_TO_MEMORY, block);
+    return rv;
 }
 
 int g1_ata_write_lba(uint64_t sector, size_t count, const void *buf) {
+    int rv = 0;
     unsigned int i, j;
     uint8_t nsects = (uint8_t)count;
     uint16_t word;
     uint8_t *ptr = (uint8_t *)buf;
-    int cmd, lba28;
 
     /* Make sure that we've been initialized and there's a disk attached. */
     if(!devices) {
@@ -752,22 +744,36 @@ int g1_ata_write_lba(uint64_t sector, size_t count, const void *buf) {
         count -= nsects;
 
         /* Which mode are we using: LBA28 or LBA48? */
-        lba28 = (sector + nsects) <= 0x0FFFFFFF;
-        if(lba28) {
+        if((sector + nsects) <= 0x0FFFFFFF) {
             g1_ata_select_device(G1_ATA_SLAVE | G1_ATA_LBA_MODE |
                                  ((sector >> 24) & 0x0F));
-            cmd = ATA_CMD_WRITE_SECTORS;
+
+            /* Write out the number of sectors we want and the lower 24-bits of
+               the LBA we're looking for. */
+            OUT8(G1_ATA_SECTOR_COUNT, nsects);
+            OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 0) & 0xFF));
+            OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 8) & 0xFF));
+            OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 16) & 0xFF));
+
+            /* Write out the command to the device. */
+            OUT8(G1_ATA_COMMAND_REG, ATA_CMD_WRITE_SECTORS);
         }
         else {
             g1_ata_select_device(G1_ATA_SLAVE | G1_ATA_LBA_MODE);
-            cmd = ATA_CMD_WRITE_SECTORS_EXT;
+
+            /* Write out the number of sectors we want and the LBA. */
+            OUT8(G1_ATA_SECTOR_COUNT, 0);
+            OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 24) & 0xFF));
+            OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 32) & 0xFF));
+            OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 40) & 0xFF));
+            OUT8(G1_ATA_SECTOR_COUNT, nsects);
+            OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 0) & 0xFF));
+            OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 8) & 0xFF));
+            OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 16) & 0xFF));
+
+            /* Write out the command to the device. */
+            OUT8(G1_ATA_COMMAND_REG, ATA_CMD_WRITE_SECTORS_EXT);
         }
-
-        /* Write out the number of sectors we want and the LBA. */
-        g1_ata_set_sector_and_count(sector, nsects, lba28);
-
-        /* Write out the command to the device. */
-        OUT8(G1_ATA_COMMAND_REG, cmd);
 
         /* Now, send the drive each sector. */
         for(i = 0; i < nsects; ++i, ++sector) {
@@ -786,15 +792,18 @@ int g1_ata_write_lba(uint64_t sector, size_t count, const void *buf) {
     /* Wait for the device to signal that it has finished writing the data. */
     g1_ata_wait_bsydrq();
 
+    rv = 0;
+
     g1_ata_mutex_unlock();
 
-    return 0;
+    return rv;
 }
 
 int g1_ata_write_lba_dma(uint64_t sector, size_t count, const void *buf,
                          int block) {
-    int cmd, lba28, old, can_lba48 = CAN_USE_LBA48();
+    int rv = 0;
     uint32_t addr;
+    int old, can_lba48 = CAN_USE_LBA48();
 
     /* Make sure we're actually being asked to do work... */
     if(!count)
@@ -866,30 +875,49 @@ int g1_ata_write_lba_dma(uint64_t sector, size_t count, const void *buf,
     /* Set the settings for this transfer and re-enable IRQs. */
     dma_blocking = block;
     dma_in_progress = 1;
-    dma_nb_sectors = count;
-    dma_sector = sector;
     irq_restore(old);
 
     /* Wait for the device to signal it is ready. */
     g1_ata_wait_bsydrq();
 
     /* Which mode are we using: LBA28 or LBA48? */
-    lba28 = !can_lba48 || use_lba28(sector, count);
-    if(lba28) {
+    if(!can_lba48 || use_lba28(sector, count)) {
         g1_ata_select_device(G1_ATA_SLAVE | G1_ATA_LBA_MODE |
                              ((sector >> 24) & 0x0F));
-        cmd = ATA_CMD_WRITE_DMA;
+
+        /* Write out the number of sectors we have and the lower 24-bits of
+           the LBA we're looking for. Note that putting 0 into the sector count
+           register writes 256 sectors. */
+        OUT8(G1_ATA_SECTOR_COUNT, (uint8_t)count);
+        OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 0) & 0xFF));
+        OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 8) & 0xFF));
+        OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 16) & 0xFF));
+
+        /* Do the rest of the work... */
+        rv = dma_common(ATA_CMD_WRITE_DMA, count, addr, G1_DMA_TO_DEVICE,
+                        block);
     }
     else {
         g1_ata_select_device(G1_ATA_SLAVE | G1_ATA_LBA_MODE);
-        cmd = ATA_CMD_WRITE_DMA_EXT;
+
+        /* Write out the number of sectors we have and the LBA. Note that in
+           LBA48 mode, putting 0 into the sector count register writes 65536
+           sectors (not that we have that much RAM on the Dreamcast). */
+        OUT8(G1_ATA_SECTOR_COUNT, (uint8_t)(count >> 8));
+        OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 24) & 0xFF));
+        OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 32) & 0xFF));
+        OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 40) & 0xFF));
+        OUT8(G1_ATA_SECTOR_COUNT, (uint8_t)count);
+        OUT8(G1_ATA_LBA_LOW, (uint8_t)((sector >> 0) & 0xFF));
+        OUT8(G1_ATA_LBA_MID, (uint8_t)((sector >> 8) & 0xFF));
+        OUT8(G1_ATA_LBA_HIGH, (uint8_t)((sector >> 16) & 0xFF));
+
+        /* Do the rest of the work... */
+        rv = dma_common(ATA_CMD_WRITE_DMA_EXT, count, addr, G1_DMA_TO_DEVICE,
+                        block);
     }
 
-    /* Write out the number of sectors we want and the LBA. */
-    g1_ata_set_sector_and_count(sector, count, lba28);
-
-    /* Do the rest of the work... */
-    return dma_common(cmd, count, addr, G1_DMA_TO_DEVICE, block);
+    return rv;
 }
 
 int g1_ata_flush(void) {


### PR DESCRIPTION
Reverts KallistiOS/KallistiOS#662

Breaks the much more common LBA48 and possibly general paths. Failures reported both in dreamboot and dreamshell related to this. Needs to be well tested before being merged again. Simply running with it integrated and not having failures in daily usage is not sufficient.