### PR TITLE
Fix KOS warning when compiling SDL2 using m4-single

### DIFF
--- a/kernel/arch/dreamcast/include/arch/args.h
+++ b/kernel/arch/dreamcast/include/arch/args.h
@@ -14,7 +14,7 @@
     \author Paul Cercueil
 */
 
-#if defined(__SH4_SINGLE_ONLY__) && __SH4_SINGLE_ONLY__
+#ifdef __SH4_SINGLE_ONLY__
 #define KOS_SH4_SINGLE_ONLY 1
 #else
 #define KOS_SH4_SINGLE_ONLY 0

--- a/kernel/arch/dreamcast/include/arch/args.h
+++ b/kernel/arch/dreamcast/include/arch/args.h
@@ -14,7 +14,7 @@
     \author Paul Cercueil
 */
 
-#if __SH4_SINGLE_ONLY__
+#if defined(__SH4_SINGLE_ONLY__) && __SH4_SINGLE_ONLY__
 #define KOS_SH4_SINGLE_ONLY 1
 #else
 #define KOS_SH4_SINGLE_ONLY 0


### PR DESCRIPTION
While compiling SDL2 library I came across this warning when using m4-single instead of m4-single-only:

/opt/toolchains/dc/kos/kernel/arch/dreamcast/include/arch/args.h:17:5: warning:"__SH4_SINGLE_ONLY__" is not defined, evaluates to 0 [-Wundef]
   17 | #if __SH4_SINGLE_ONLY__
      |     ^~~~~~~~~~~~~~~~~~~
    
This PR should fix the warning.