### PR TITLE
PVR API cleanups

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
@@ -95,7 +95,7 @@ static uintptr_t pvr_dest_addr(uintptr_t dest, int type) {
     return dest_addr;
 }
 
-int pvr_dma_transfer(void *src, uintptr_t dest, size_t count, int type,
+int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count, int type,
                      int block, pvr_dma_callback_t callback, void *cbdata) {
     uintptr_t src_addr = ((uintptr_t)src);
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
@@ -66,7 +66,7 @@ static void pvr_dma_irq_hnd(uint32_t code, void *data) {
     }
 }
 
-static uintptr_t pvr_dest_addr(uintptr_t dest, int type) {
+static uintptr_t pvr_dest_addr(uintptr_t dest, pvr_dma_type_t type) {
     uintptr_t dest_addr;
 
     /* Send the data to the right place */
@@ -95,8 +95,9 @@ static uintptr_t pvr_dest_addr(uintptr_t dest, int type) {
     return dest_addr;
 }
 
-int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count, int type,
-                     int block, pvr_dma_callback_t callback, void *cbdata) {
+int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count,
+                     pvr_dma_type_t type, int block,
+                     pvr_dma_callback_t callback, void *cbdata) {
     uintptr_t src_addr = ((uintptr_t)src);
 
     /* Check for 32-byte alignment */
@@ -196,7 +197,7 @@ void pvr_dma_shutdown(void) {
 }
 
 /* Copies n bytes from src to PVR dest, dest must be 32-byte aligned */
-void *pvr_sq_load(void *dest, const void *src, size_t n, int type) {
+void *pvr_sq_load(void *dest, const void *src, size_t n, pvr_dma_type_t type) {
     void *dma_area_ptr;
 
     if(pvr_dma[PVR_DST] != 0) {
@@ -212,7 +213,7 @@ void *pvr_sq_load(void *dest, const void *src, size_t n, int type) {
 }
 
 /* Fills n bytes at PVR dest with 16-bit c, dest must be 32-byte aligned */
-void *pvr_sq_set16(void *dest, uint32_t c, size_t n, int type) {
+void *pvr_sq_set16(void *dest, uint32_t c, size_t n, pvr_dma_type_t type) {
     void *dma_area_ptr;
 
     if(pvr_dma[PVR_DST] != 0) {
@@ -228,7 +229,7 @@ void *pvr_sq_set16(void *dest, uint32_t c, size_t n, int type) {
 }
 
 /* Fills n bytes at PVR dest with 32-bit c, dest must be 32-byte aligned */
-void *pvr_sq_set32(void *dest, uint32_t c, size_t n, int type) {
+void *pvr_sq_set32(void *dest, uint32_t c, size_t n, pvr_dma_type_t type) {
     void *dma_area_ptr;
 
     if(pvr_dma[PVR_DST] != 0) {

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_palette.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_palette.c
@@ -17,7 +17,7 @@
 */
 
 /* Set the palette format */
-void pvr_set_pal_format(int fmt) {
+void pvr_set_pal_format(pvr_palfmt_t fmt) {
     PVR_SET(PVR_PALETTE_CFG, fmt);
 }
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
@@ -20,7 +20,7 @@
 */
 
 /* Compile a polygon context into a polygon header */
-void pvr_poly_compile(pvr_poly_hdr_t *dst, pvr_poly_cxt_t *src) {
+void pvr_poly_compile(pvr_poly_hdr_t *dst, const pvr_poly_cxt_t *src) {
     int u, v;
     uint32  txr_base;
 
@@ -321,7 +321,7 @@ void pvr_sprite_cxt_txr(pvr_sprite_cxt_t *dst, pvr_list_t list,
     dst->txr.format = textureformat;
 }
 
-void pvr_sprite_compile(pvr_sprite_hdr_t *dst, pvr_sprite_cxt_t *src) {
+void pvr_sprite_compile(pvr_sprite_hdr_t *dst, const pvr_sprite_cxt_t *src) {
     int u, v;
     uint32 txr_base;
 
@@ -457,7 +457,7 @@ void pvr_mod_compile(pvr_mod_hdr_t *dst, pvr_list_t list, uint32 mode,
 
 /* Compile a polygon context into a polygon header that is affected by
    modifier volumes */
-void pvr_poly_mod_compile(pvr_poly_mod_hdr_t *dst, pvr_poly_cxt_t *src) {
+void pvr_poly_mod_compile(pvr_poly_mod_hdr_t *dst, const pvr_poly_cxt_t *src) {
     int u, v;
     uint32  txr_base;
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_texture.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_texture.c
@@ -20,12 +20,12 @@
 */
 
 /* Load raw texture data from an SH-4 buffer into PVR RAM */
-void pvr_txr_load(void * src, pvr_ptr_t dst, uint32 count) {
+void pvr_txr_load(const void *src, pvr_ptr_t dst, uint32 count) {
     if(count & 3) {
         count = (count + 4) & ~3;
     }
 
-    pvr_sq_load((uint32 *)dst, (uint32 *)src, count, PVR_DMA_VRAM64);
+    pvr_sq_load((uint32 *)dst, (const uint32 *)src, count, PVR_DMA_VRAM64);
 }
 
 /* Linear/iterative twiddling algorithm from Marcus' tatest */
@@ -52,7 +52,7 @@ void pvr_txr_load(void * src, pvr_ptr_t dst, uint32 count) {
        PVR_TXRLOAD_INVERT
 
 */
-void pvr_txr_load_ex(void * src, pvr_ptr_t dst, uint32 w, uint32 h,
+void pvr_txr_load_ex(const void *src, pvr_ptr_t dst, uint32 w, uint32 h,
                      uint32 flags) {
     uint32 x, y, yout, min, mask, bpp, invert;
 
@@ -143,7 +143,7 @@ void pvr_txr_load_ex(void * src, pvr_ptr_t dst, uint32 w, uint32 h,
 }
 
 /* Load a KOS Platform Independent Image (subject to restraint checking) */
-void pvr_txr_load_kimg(kos_img_t *img, pvr_ptr_t dst, uint32 flags) {
+void pvr_txr_load_kimg(const kos_img_t *img, pvr_ptr_t dst, uint32 flags) {
     uint32 fmt, w, h;
 
     /* First check and make sure it's a format we can use */

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1537,7 +1537,7 @@ int pvr_get_stats(pvr_stats_t *stat);
     like the old cheap "worm hole". 
 */
 
-/** \defgroup pvr_palfmts           Formats
+/** \defgroup pvr_palfmt            Formats
     \brief                          Color palette formats of the PowerVR
     \ingroup                        pvr_pal_mgmt
 
@@ -1546,10 +1546,12 @@ int pvr_get_stats(pvr_stats_t *stat);
 
     @{
 */
-#define PVR_PAL_ARGB1555    0   /**< \brief 16-bit ARGB1555 palette format */
-#define PVR_PAL_RGB565      1   /**< \brief 16-bit RGB565 palette format */
-#define PVR_PAL_ARGB4444    2   /**< \brief 16-bit ARGB4444 palette format */
-#define PVR_PAL_ARGB8888    3   /**< \brief 32-bit ARGB8888 palette format */
+typedef enum pvr_palfmt {
+    PVR_PAL_ARGB1555,        /**< \brief 16-bit ARGB1555 palette format */
+    PVR_PAL_RGB565,          /**< \brief 16-bit RGB565 palette format */
+    PVR_PAL_ARGB4444,        /**< \brief 16-bit ARGB4444 palette format */
+    PVR_PAL_ARGB8888,        /**< \brief 32-bit ARGB8888 palette format */
+} pvr_palfmt_t;
 /** @} */
 
 /** \brief   Set the palette format.
@@ -1564,9 +1566,9 @@ int pvr_get_stats(pvr_stats_t *stat);
     paletted textures with ARGB8888 entries in the palette.
 
     \param  fmt             The format to use
-    \see    pvr_palfmts
+    \see    pvr_palfmt_t
 */
-void pvr_set_pal_format(int fmt);
+void pvr_set_pal_format(pvr_palfmt_t fmt);
 
 /** \brief   Set a palette value.
     \ingroup pvr_pal_mgmt

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -2368,6 +2368,22 @@ void pvr_txr_load_kimg(const kos_img_t *img, pvr_ptr_t dst, uint32_t flags);
 */
 typedef void (*pvr_dma_callback_t)(void *data);
 
+/** \defgroup pvr_dma_type          Transfer Modes
+    \brief                          Transfer modes with TA/PVR DMA and Store Queues
+    \ingroup  pvr_dma
+
+    @{
+*/
+typedef enum pvr_dma_type {
+    PVR_DMA_VRAM64,       /**< \brief Transfer to VRAM using TA bus */
+    PVR_DMA_VRAM32,       /**< \brief Transfer to VRAM using TA bus */
+    PVR_DMA_TA,           /**< \brief Transfer to the tile accelerator */
+    PVR_DMA_YUV,          /**< \brief Transfer to the YUV converter (TA) */
+    PVR_DMA_VRAM32_SB,    /**< \brief Transfer to/from VRAM using PVR i/f */
+    PVR_DMA_VRAM64_SB,    /**< \brief Transfer to/from VRAM using PVR i/f */
+} pvr_dma_type_t;
+/** @} */
+
 /** \brief   Perform a DMA transfer to the PVR RAM over 64-bit TA bus.
     \ingroup pvr_dma
 
@@ -2395,24 +2411,11 @@ typedef void (*pvr_dma_callback_t)(void *data);
     \em     EFAULT - dest is not 32-byte aligned \n
     \em     EIO - I/O error
 
-    \see    pvr_dma_modes
+    \see    pvr_dma_type_t
 */
-int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count, int type,
-                     int block, pvr_dma_callback_t callback, void *cbdata);
-
-/** \defgroup pvr_dma_modes         Transfer Modes
-    \brief                          Transfer modes with TA/PVR DMA and Store Queues
-    \ingroup  pvr_dma
-
-    @{
-*/
-#define PVR_DMA_VRAM64    0   /**< \brief Transfer to VRAM using TA bus */
-#define PVR_DMA_VRAM32    1   /**< \brief Transfer to VRAM using TA bus */
-#define PVR_DMA_TA        2   /**< \brief Transfer to the tile accelerator */
-#define PVR_DMA_YUV       3   /**< \brief Transfer to the YUV converter (TA) */
-#define PVR_DMA_VRAM32_SB 4   /**< \brief Transfer to/from VRAM using PVR i/f */
-#define PVR_DMA_VRAM64_SB 5   /**< \brief Transfer to/from VRAM using PVR i/f */
-/** @} */
+int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count,
+                     pvr_dma_type_t type, int block,
+                     pvr_dma_callback_t callback, void *cbdata);
 
 /** \brief   Load a texture using TA DMA.
     \ingroup pvr_dma
@@ -2525,7 +2528,8 @@ void pvr_dma_shutdown(void);
 
     \sa pvr_sq_set32()
 */
-void *pvr_sq_load(void *dest, const void *src, size_t n, int type);
+void *pvr_sq_load(void *dest, const void *src,
+                  size_t n, pvr_dma_type_t type);
 
 /** \brief   Set a block of PVR memory to a 16-bit value.
     \ingroup store_queues
@@ -2548,7 +2552,7 @@ void *pvr_sq_load(void *dest, const void *src, size_t n, int type);
 
     \sa pvr_sq_set32()
 */
-void *pvr_sq_set16(void *dest, uint32_t c, size_t n, int type);
+void *pvr_sq_set16(void *dest, uint32_t c, size_t n, pvr_dma_type_t type);
 
 /** \brief   Set a block of PVR memory to a 32-bit value.
     \ingroup store_queues
@@ -2570,7 +2574,7 @@ void *pvr_sq_set16(void *dest, uint32_t c, size_t n, int type);
 
     \sa pvr_sq_set16
 */
-void *pvr_sq_set32(void *dest, uint32_t c, size_t n, int type);
+void *pvr_sq_set32(void *dest, uint32_t c, size_t n, pvr_dma_type_t type);
 
 /*********************************************************************/
 

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -2088,7 +2088,7 @@ int pvr_check_ready(void);
     \param  dst             Where to store the compiled header.
     \param  src             The context to compile.
 */
-void pvr_poly_compile(pvr_poly_hdr_t *dst, pvr_poly_cxt_t *src);
+void pvr_poly_compile(pvr_poly_hdr_t *dst, const pvr_poly_cxt_t *src);
 
 /** \defgroup pvr_ctx_init     Initialization
     \brief                     Functions for initializing PVR polygon contexts
@@ -2137,7 +2137,7 @@ void pvr_poly_cxt_txr(pvr_poly_cxt_t *dst, pvr_list_t list,
     \param  src             The context to compile.
 */
 void pvr_sprite_compile(pvr_sprite_hdr_t *dst,
-                        pvr_sprite_cxt_t *src);
+                        const pvr_sprite_cxt_t *src);
 
 /** \brief   Fill in a sprite context for non-textured sprites.
     \ingroup pvr_ctx_init
@@ -2201,7 +2201,7 @@ void pvr_mod_compile(pvr_mod_hdr_t *dst, pvr_list_t list, uint32_t mode,
     \param  dst             Where to store the compiled header.
     \param  src             The context to compile.
 */
-void pvr_poly_mod_compile(pvr_poly_mod_hdr_t *dst, pvr_poly_cxt_t *src);
+void pvr_poly_mod_compile(pvr_poly_mod_hdr_t *dst, const pvr_poly_cxt_t *src);
 
 /** \brief   Fill in a polygon context for non-textured polygons affected by a
              modifier volume.
@@ -2265,7 +2265,7 @@ void pvr_poly_cxt_txr_mod(pvr_poly_cxt_t *dst, pvr_list_t list,
     \param  count           The size of the texture in bytes (must be a multiple
                             of 32).
 */
-void pvr_txr_load(void *src, pvr_ptr_t dst, uint32_t count);
+void pvr_txr_load(const void *src, pvr_ptr_t dst, uint32_t count);
 
 /** \defgroup pvr_txrload_constants     Flags
     \brief                              Texture loading constants
@@ -2313,7 +2313,8 @@ void pvr_txr_load(void *src, pvr_ptr_t dst, uint32_t count);
 
     \see    pvr_txrload_constants
 */
-void pvr_txr_load_ex(void *src, pvr_ptr_t dst, uint32_t w, uint32_t h, uint32_t flags);
+void pvr_txr_load_ex(const void *src, pvr_ptr_t dst,
+		     uint32_t w, uint32_t h, uint32_t flags);
 
 /** \brief   Load a KOS Platform Independent Image (subject to constraint
              checking).
@@ -2344,7 +2345,7 @@ void pvr_txr_load_ex(void *src, pvr_ptr_t dst, uint32_t w, uint32_t h, uint32_t 
                             from this function if it twiddles the texture while
                             loading.
 */
-void pvr_txr_load_kimg(kos_img_t *img, pvr_ptr_t dst, uint32_t flags);
+void pvr_txr_load_kimg(const kos_img_t *img, pvr_ptr_t dst, uint32_t flags);
 
 
 /* PVR DMA ***********************************************************/
@@ -2394,7 +2395,7 @@ typedef void (*pvr_dma_callback_t)(void *data);
 
     \see    pvr_dma_modes
 */
-int pvr_dma_transfer(void *src, uintptr_t dest, size_t count, int type,
+int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count, int type,
                      int block, pvr_dma_callback_t callback, void *cbdata);
 
 /** \defgroup pvr_dma_modes         Transfer Modes


### PR DESCRIPTION
A small cleanup of the PVR API, with changes that should not break the API nor the ABI:
- Constify data source pointers for the DMA functions;
- use an enum for the palette format;
- use an enum for the DMA transfer type.