### PR TITLE
Refactor sysinfo_icon/id

### DIFF
--- a/kernel/arch/dreamcast/hardware/syscalls.c
+++ b/kernel/arch/dreamcast/hardware/syscalls.c
@@ -116,18 +116,12 @@
     syscall((r4), (r5), (r6), (func)); \
 } while(0)
 
-/* 
-    Prepares FUNC_SYSINFO_ICON and FUNC_SYSINFO_ID calls for use by 
-    copying the relevant data from the system flashrom into 
-    8C000068-8C00007F.  No point in making this public.
-*/
-static void syscall_sysinfo_init(void) {
+void syscall_sysinfo_init(void) {
     MAKE_SYSCALL_VOID(VEC_SYSINFO, FUNC_SYSINFO_INIT, 
         PARAM_NA, PARAM_NA, PARAM_NA);
 }
 
 int syscall_sysinfo_icon(uint32_t icon, uint8_t *dest) {
-    syscall_sysinfo_init();
     MAKE_SYSCALL_INT(VEC_SYSINFO, FUNC_SYSINFO_ICON, 
         icon, dest, PARAM_NA);
 }
@@ -135,7 +129,6 @@ int syscall_sysinfo_icon(uint32_t icon, uint8_t *dest) {
 uint64_t syscall_sysinfo_id(void) {
     uint64_t *id = NULL;
 
-    syscall_sysinfo_init();
     MAKE_SYSCALL_SET(VEC_SYSINFO, FUNC_SYSINFO_ID, 
         PARAM_NA, PARAM_NA, PARAM_NA, id, uint64_t *);
 

--- a/kernel/arch/dreamcast/include/dc/syscalls.h
+++ b/kernel/arch/dreamcast/include/dc/syscalls.h
@@ -38,6 +38,14 @@ __BEGIN_DECLS
 #include <stdint.h>
 #include <sys/types.h>
 
+/** \brief   Inits data needed by sysinfo id/icon
+
+    This function prepares syscall_sysinfo_icon and syscall_sysinfo_id 
+    calls for use by copying the relevant data from the system flashrom 
+    into 8C000068-8C00007F.
+*/
+void syscall_sysinfo_init(void);
+
 /** \brief   Reads an icon from the flashrom.
 
     This function reads an icon from the flashrom into a destination 

--- a/kernel/arch/dreamcast/include/dc/syscalls.h
+++ b/kernel/arch/dreamcast/include/dc/syscalls.h
@@ -39,7 +39,7 @@ __BEGIN_DECLS
 #include <sys/types.h>
 
 /** \brief   Inits data needed by sysinfo id/icon
-
+    \note This is called automatically by KOS during initialization.
     This function prepares syscall_sysinfo_icon and syscall_sysinfo_id 
     calls for use by copying the relevant data from the system flashrom 
     into 8C000068-8C00007F.

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -172,6 +172,8 @@ int  __weak arch_auto_init(void) {
     timer_init();           /* Timers */
     hardware_sys_init();        /* DC low-level hardware init */
 
+    syscall_sysinfo_init();
+
     /* Initialize our timer */
     perf_cntr_timer_enable();
     timer_ms_enable();


### PR DESCRIPTION
Made syscall_sysinfo_init() public and call it in arch_auto_init() to prepare for future calls to syscalls for info_icon and info_id. This should be done to reduce redundant calls to syscall_sysinfo_init() which only needs to be called once.