### PR TITLE
PVR Hybrid Submission Model

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -40,6 +40,16 @@ static void dma_next_list(void *data) {
             // Get the buffers for this frame.
             b = pvr_state.dma_buffers + (pvr_state.ram_target ^ 1);
 
+            /* If we are in PVR DMA mode, yet we haven't associated a
+               RAM-residing vertex buffer with the current list
+               (because we submitted it directly, for example),
+               mark it as complete, so we skip trying to DMA it. */
+            if(!b->base[i]) {
+                pvr_state.lists_dmaed       |= 1 << i;
+                pvr_state.lists_transferred |= 1 << i;
+                continue;
+            }
+
             // Flush the last 32 bytes out of dcache, just in case.
             // dcache_flush_range((ptr_t)(b->base[i] + b->ptr[i] - 32), 32);
             dcache_flush_range((ptr_t)(b->base[i]), b->ptr[i] + 32);


### PR DESCRIPTION
Very first attempt at an initial implementation of a "hybrid" vertex submission strategy using the existing PVR APIs.

To use this method:
1) Enable DMA mode when initializing the PVR
2) Set the in-RAM vertex buffers for each list type to be deferred with
   the DMA (pvr_set_vertbuf()).
3) For the list type to be immediately submitted:
    - pvr_list_begin(LIST_TYPE);
    - pvr_dr_begin(dr_state);
    - /* COMMIT POLYGONS */
    - pvr_list_end(); //!!!! NOTICE YOU DO NOT CALL PVR_DR_END()!!!

These changes have been tested and work 100% with: 1) Regular pvr_prim() (not broken)
2) PVR DMA (not broken)
3) PVR DR (not broken)
4) Hybrid
    a. OP list submitted via PVR DR
    b. TR list submitted via PVR DMA

THERE IS CURRENTLY A KNOWN ISSUE WITH:
1) Hybrid
    a. OP list submitted via PVR DMA
    b. TR list submitted via PVR DR
*** Currently causes artifacts if a piece of geometry isn't getting submitted for each list type. ***