### PR TITLE
aica: Channel masks are 64 bits, use ULL consts

### DIFF
--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -4,6 +4,7 @@
    Copyright (C) 2000, 2001, 2002, 2003, 2004 Megan Potter
    Copyright (C) 2023 Ruslan Rostovtsev
    Copyright (C) 2023 Andy Barajas
+   Copyright (C) 2024 Stefanos Kornilios Mitsis Poiitidis
 
    Sound effects management system; this thing loads and plays sound effects
    during game operation.
@@ -447,7 +448,7 @@ int snd_sfx_play(sfxhnd_t idx, int vol, int pan) {
     chn = sfx_nextchan;
     moved = 0;
 
-    while(sfx_inuse & (1 << chn)) {
+    while(sfx_inuse & (1ULL << chn)) {
         chn = (chn + 1) % 64;
 
         if(sfx_nextchan == chn)
@@ -490,7 +491,7 @@ void snd_sfx_stop_all(void) {
     int i;
 
     for(i = 0; i < 64; i++) {
-        if(sfx_inuse & (1 << i))
+        if(sfx_inuse & (1ULL << i))
             continue;
 
         snd_sfx_stop(i);
@@ -503,13 +504,13 @@ int snd_sfx_chn_alloc(void) {
     old = irq_disable();
 
     for(chn = 0; chn < 64; chn++)
-        if(!(sfx_inuse & (1 << chn)))
+        if(!(sfx_inuse & (1ULL << chn)))
             break;
 
     if(chn >= 64)
         chn = -1;
     else
-        sfx_inuse |= 1 << chn;
+        sfx_inuse |= 1ULL << chn;
 
     irq_restore(old);
 
@@ -520,6 +521,6 @@ void snd_sfx_chn_free(int chn) {
     int old;
 
     old = irq_disable();
-    sfx_inuse &= ~(1 << chn);
+    sfx_inuse &= ~(1ULL << chn);
     irq_restore(old);
 }

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -5,6 +5,7 @@
    Copyright (C) 2002 Florian Schulze
    Copyright (C) 2020 Lawrence Sebald
    Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2024 Stefanos Kornilios Mitsis Poiitidis
 
    SH-4 support routines for SPU streaming sound driver
 */
@@ -559,12 +560,12 @@ static void snd_stream_start_type(snd_stream_hnd_t hnd, uint32_t type, uint32_t 
         snd_sh4_to_aica(tmp, cmd->size);
 
         /* Start both channels simultaneously */
-        cmd->cmd_id = (1 << streams[hnd].ch[0]) |
-                      (1 << streams[hnd].ch[1]);
+        cmd->cmd_id = (1ULL << streams[hnd].ch[0]) |
+                      (1ULL << streams[hnd].ch[1]);
     }
     else {
         /* Start one channel */
-        cmd->cmd_id = (1 << streams[hnd].ch[0]);
+        cmd->cmd_id = (1ULL << streams[hnd].ch[0]);
     }
 
     chan->cmd = AICA_CH_CMD_START | AICA_CH_START_SYNC;


### PR DESCRIPTION
Fixes using channels >=32 with either `snd_sfx_chn_alloc` or streaming