### PR TITLE
Prevent thd_shutdown() from destroying kernel thread

### DIFF
--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -1131,7 +1131,8 @@ void thd_shutdown(void) {
 
     /* Kill remaining live threads */
     LIST_FOREACH_SAFE(cur, &thd_list, t_list, tmp) {
-        thd_destroy(cur);
+        if(cur->tid != 1)
+            thd_destroy(cur);
     }
 
     sem_destroy(&thd_reap_sem);


### PR DESCRIPTION
In certain circumstances (e.g. at shutdown time in Rust `std` applications using the experimental `libpthread` branch), `thd_shutdown()` will destroy the kernel thread early, resulting in an `arch: aborting the system` error. This prevents `thd_shutdown()` from destroying the kernel thread.