### PR TITLE
Add mkdcdisc tool to utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ utils/dc-chain/gcc-*
 utils/dc-chain/newlib-*
 utils/dc-chain/gdb-*
 utils/dc-chain/insight-*
+utils/mkdcdisc/mkdcdisc

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -84,6 +84,13 @@ export KOS_CMAKE_TOOLCHAIN="${KOS_BASE}/utils/cmake/dreamcast.toolchain.cmake"
 #
 export KOS_GENROMFS="${KOS_BASE}/utils/genromfs/genromfs"
 
+# Mkdcdisc Utility Path
+#
+# Specifies the path to the utility which is used by KOS
+# to create cdi images.
+#
+export KOS_MKDCDISC="${DC_TOOLS_BASE}/mkdcdisc"
+
 # Make Utility
 #
 # Configures the tool to be used as the main "make" utility

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -4,7 +4,8 @@
 # Copyright (C) 2001 Megan Potter
 #
 
-DIRS = bin2c bincnv dcbumpgen genromfs kmgenc makeip scramble vqenc wav2adpcm pvrtex
+DIRS = bin2c bincnv dcbumpgen genromfs kmgenc makeip scramble vqenc wav2adpcm pvrtex \
+		mkdcdisc
 
 ifeq ($(KOS_SUBARCH), naomi)
 	DIRS += naomibintool naominetboot

--- a/utils/mkdcdisc/Makefile
+++ b/utils/mkdcdisc/Makefile
@@ -1,0 +1,19 @@
+# KallistiOS ##version##
+#
+# utils/mkdcdisc/Makefile
+# Copyright (C) 2024 Andress Barajas
+#
+
+SCRIPT_NAME = install_mkdcdisc.sh
+
+all: run-script
+
+clean:
+	rm -rf ./mkdcdisc
+
+run-script:
+	@chmod +x $(SCRIPT_NAME)
+	@./$(SCRIPT_NAME)
+	@if [ -f ./mkdcdisc/builddir/mkdcdisc ]; then \
+		install -m 755 ./mkdcdisc/builddir/mkdcdisc $(DC_TOOLS_BASE)/; \
+	fi

--- a/utils/mkdcdisc/install_mkdcdisc.sh
+++ b/utils/mkdcdisc/install_mkdcdisc.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Clone mkdcdisc repository and build the utility
+REPO_URL="https://gitlab.com/simulant/mkdcdisc"
+CLONE_DIR="mkdcdisc"
+
+if ! command -v meson &> /dev/null
+then
+  echo "Meson is not installed. Please install it before running this script."
+  exit 0
+fi
+
+# Check if the repository already exists
+if [ -d "$CLONE_DIR" ]; then
+  echo "Repository already exists. Pulling latest changes..."
+  cd $CLONE_DIR && git pull
+else
+  echo "Cloning repository..."
+  git clone $REPO_URL
+  cd $CLONE_DIR
+fi
+
+# Build the utility
+echo "Setting up build directory..."
+meson setup builddir
+
+echo "Compiling the utility..."
+meson compile -C builddir
+
+echo "Build completed. mkdcdisc is ready to use."
+


### PR DESCRIPTION
Users often ask about how to create .CDIs. This PR addresses that by adding mkdcdisc installer to utils and exporting a PATH, KOS_MKDCDISC, to make it easy to use in their makefiles like so:

```
cdi: $(TARGET)
	$(KOS_MKDCDISC) -e $(TARGET) -o test.cdi
```

One thing to know though is that mkdcdisc depends on `meson` to build. If we move forward with this PR we may need to think about including `meson` as a dependency. Its fine if we dont.  It should fail gracefully.