### PR TITLE
Introduce CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,165 @@
+name: Build
+
+# Trigger only on pull requests or pushes to the test branch
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:  # Allows manual triggering of the workflow via a button
+
+jobs:
+  build-ubuntu:
+    name: Build on Ubuntu
+    runs-on: ubuntu-latest
+
+    env:
+      TOOLCHAIN_PATH: /opt/toolchains/dc
+
+    steps:
+      # Checkout the repository code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Install dependencies on Ubuntu
+      - name: Set up dependencies on Ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt install -y gawk patch bzip2 tar make libgmp-dev libmpfr-dev libmpc-dev gettext wget \
+            libelf-dev texinfo bison flex sed git build-essential diffutils curl libjpeg-dev libpng-dev \
+            python3 pkg-config cmake libisofs-dev meson ninja-build rake
+        shell: bash
+
+      # Create the toolchain directory and copy the code
+      - name: Create toolchain directory
+        run: |
+          sudo mkdir -p $TOOLCHAIN_PATH
+          sudo chmod -R 755 $TOOLCHAIN_PATH
+          sudo chown -R $(id -u):$(id -g) $TOOLCHAIN_PATH
+          mkdir -p $TOOLCHAIN_PATH/kos
+          cp -r $GITHUB_WORKSPACE/* $TOOLCHAIN_PATH/kos
+        shell: bash
+
+      # Build the SH4 toolchain
+      - name: Build SH4 Toolchain
+        run: |
+          cd $TOOLCHAIN_PATH/kos/utils/dc-chain
+          make
+        shell: bash
+
+      # Set up KOS environment and build KOS
+      - name: Set up KOS environment and build
+        run: |
+          cd $TOOLCHAIN_PATH/kos
+          cp doc/environ.sh.sample environ.sh  # Copy environment setup script
+          source $TOOLCHAIN_PATH/kos/environ.sh  # Source the environment
+          export LIBRARY_PATH="/usr/local/lib"
+          export CPATH="/usr/local/include"
+          make
+        shell: bash
+
+  build-macos:
+    name: Build on macOS
+    runs-on: macos-latest
+
+    env:
+      TOOLCHAIN_PATH: /opt/toolchains/dc
+
+    steps:
+      # Checkout the repository code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Install dependencies on macOS
+      - name: Set up dependencies on macOS
+        run: |
+          brew install texinfo libelf meson libisofs
+        shell: bash
+
+      # Create the toolchain directory and copy the code
+      - name: Create toolchain directory
+        run: |
+          sudo mkdir -p $TOOLCHAIN_PATH
+          sudo chmod -R 755 $TOOLCHAIN_PATH
+          sudo chown -R $(id -u):$(id -g) $TOOLCHAIN_PATH
+          mkdir -p $TOOLCHAIN_PATH/kos
+          cp -r $GITHUB_WORKSPACE/* $TOOLCHAIN_PATH/kos
+        shell: bash
+
+      # Configure the toolchain on macOS
+      - name: Configure the toolchain on macOS
+        run: |
+          cd $TOOLCHAIN_PATH/kos/utils/dc-chain
+          cp Makefile.default.cfg Makefile.cfg  # Copy default configuration
+          sed -i '' 's/toolchain_profile=stable/toolchain_profile=14.2.0/' Makefile.cfg  # Set profile
+        shell: bash
+
+      # Build the SH4 toolchain
+      - name: Build SH4 Toolchain
+        run: |
+          cd $TOOLCHAIN_PATH/kos/utils/dc-chain
+          make
+        shell: bash
+
+      # Set up KOS environment and build KOS
+      - name: Set up KOS environment and build
+        run: |
+          cd $TOOLCHAIN_PATH/kos
+          cp doc/environ.sh.sample environ.sh  # Copy environment setup script
+          source $TOOLCHAIN_PATH/kos/environ.sh  # Source the environment
+          export LIBRARY_PATH="$(brew --prefix)/lib"
+          export CPATH="$(brew --prefix)/include"
+          make
+        shell: bash
+
+  build-freebsd:
+    name: Build on FreeBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 60  # Extend the timeout to 60 minutes
+
+    env:
+      TOOLCHAIN_PATH: /opt/toolchains/dc
+
+    steps:
+      # Checkout the repository code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Set up and run the FreeBSD VM for testing
+      - name: Test in FreeBSD
+        id: test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          envs: 'TOOLCHAIN_PATH'  # Pass the environment variable for the toolchain
+          usesh: true  # Use shell inside the FreeBSD VM
+          prepare: |
+            pkg install -y sudo  # Install sudo in the FreeBSD VM
+
+          run: |
+            # Create the toolchain directory and copy the code
+            sudo mkdir -p $TOOLCHAIN_PATH
+            sudo chmod -R 755 $TOOLCHAIN_PATH
+            sudo chown -R $(id -u):$(id -g) $TOOLCHAIN_PATH
+            mkdir -p $TOOLCHAIN_PATH/kos
+            cp -r $GITHUB_WORKSPACE/* $TOOLCHAIN_PATH/kos
+
+            # Install dependencies on FreeBSD
+            sudo pkg install -y gcc gmake binutils texinfo bash jpeg-turbo libjpeg-turbo png \
+              libelf git subversion python3 gmp mpfr
+
+            # Configure the toolchain on FreeBSD
+            cd $TOOLCHAIN_PATH/kos/utils/dc-chain
+            cp Makefile.default.cfg Makefile.cfg  # Copy default configuration
+            sed -i '' 's/toolchain_profile=stable/toolchain_profile=14.2.0/' Makefile.cfg  # Set profile
+
+            # Build the SH4 toolchain using gmake
+            cd $TOOLCHAIN_PATH/kos/utils/dc-chain
+            gmake
+
+            # Set up KOS environment and build KOS
+            cd $TOOLCHAIN_PATH/kos
+            cp doc/environ.sh.sample environ.sh  # Copy environment setup script
+            . $TOOLCHAIN_PATH/kos/environ.sh  # Source the environment (use '.' instead of 'source' on FreeBSD)
+            gmake

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifndef KOS_BASE
 error:
 	@echo You don\'t seem to have a working  environ.sh file. Please take a look at
 	@echo doc/README for more info.
-	@exit 0
+	@exit 1
 endif
 
 all:

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # KallistiOS Environment Settings
 #
 # This is a sample script for configuring and customizing your
@@ -91,8 +93,11 @@ export KOS_GENROMFS="${KOS_BASE}/utils/genromfs/genromfs"
 # the default can be changed to "gmake," for the GNU
 # implementation.
 #
-export KOS_MAKE="make"
-#export KOS_MAKE="gmake"
+if uname -s | grep -q "BSD"; then
+    export KOS_MAKE="gmake"
+else
+    export KOS_MAKE="make"
+fi
 
 # Loader Utility
 #
@@ -213,4 +218,8 @@ export KOS_SH4_PRECISION="-m4-single-only"
 # environment settings. If you want to configure additional compiler
 # options or see where other build flags are set, look at this file.
 #
-. ${KOS_BASE}/environ_base.sh
+if uname -s | grep -q "BSD"; then
+    . ${KOS_BASE}/environ_base.sh
+else
+    source ${KOS_BASE}/environ_base.sh
+fi

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # KallistiOS environment variable settings. These are the shared pieces
 # that are generated from the user config. Configure if you like.
 
@@ -18,13 +20,25 @@ export KOS_ARCH_DIR="${KOS_BASE}/kernel/arch/${KOS_ARCH}"
 . ${KOS_BASE}/environ_${KOS_ARCH}.sh
 
 # Add the compiler bins dir to the path if it is not already
-if [[ ":$PATH:" != *":${KOS_CC_BASE}/bin:"* ]]; then
-  export PATH="${PATH}:${KOS_CC_BASE}/bin"
+if uname -s | grep -q "BSD"; then
+  if [ ":$PATH:" != *":${KOS_CC_BASE}/bin:"* ]; then
+    export PATH="${PATH}:${KOS_CC_BASE}/bin"
+  fi
+else
+  if [[ ":$PATH:" != *":${KOS_CC_BASE}/bin:"* ]]; then
+    export PATH="${PATH}:${KOS_CC_BASE}/bin"
+  fi
 fi
 
 # Add the build wrappers dir to the path if it is not already
-if [[ ":$PATH:" != *":${KOS_BASE}/utils/build_wrappers:"* ]]; then
-  export PATH="${PATH}:${KOS_BASE}/utils/build_wrappers"
+if uname -s | grep -q "BSD"; then
+  if [ ":$PATH:" != *":${KOS_BASE}/utils/build_wrappers:"* ]; then
+    export PATH="${PATH}:${KOS_BASE}/utils/build_wrappers"
+  fi
+else
+  if [[ ":$PATH:" != *":${KOS_BASE}/utils/build_wrappers:"* ]]; then
+    export PATH="${PATH}:${KOS_BASE}/utils/build_wrappers"
+  fi
 fi
 
 # Our includes

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # KallistiOS environment variable settings. These are the shared pieces
 # for the Dreamcast(tm) platform.
 
@@ -7,8 +9,14 @@ if [ -z "${DC_TOOLS_BASE}" ] ; then
 fi
 
 # Add the external DC tools dir to the path if it is not already.
-if [[ ":$PATH:" != *":${DC_TOOLS_BASE}:"* ]]; then
+if uname -s | grep -q "BSD"; then
+	if [ ":$PATH:" != *":${DC_TOOLS_BASE}:"* ]; then
   export PATH="${PATH}:${DC_TOOLS_BASE}"
+	fi
+else
+	if [[ ":$PATH:" != *":${DC_TOOLS_BASE}:"* ]]; then
+  export PATH="${PATH}:${DC_TOOLS_BASE}"
+	fi
 fi
 
 # Default the SH4 floating point precision if it isn't already set.

--- a/kernel/arch/dreamcast/kernel/make_banner.sh
+++ b/kernel/arch/dreamcast/kernel/make_banner.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Re-creates the banner.h file for each compilation run
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -13,7 +13,7 @@ endif
 # Ok for these to fail atm...
 
 all:
-	for i in $(DIRS); do $(KOS_MAKE) -C $$i; done
+	for i in $(DIRS); do $(KOS_MAKE) -C $$i || exit 1; done
 
 clean:
 	for i in $(DIRS); do $(KOS_MAKE) -C $$i clean; done

--- a/utils/dc-chain/doc/bsd.md
+++ b/utils/dc-chain/doc/bsd.md
@@ -32,7 +32,7 @@ build the whole toolchain.
 
 The packages below need to be installed:
 ```
-pkg install gcc gmake binutils texinfo bash libjpeg-turbo png libelf git subversion python3
+pkg install gcc gmake binutils texinfo bash jpeg-turbo libjpeg-turbo png libelf git subversion python3 gmp mpfr
 ```
 On **BSD** systems, the `make` command is **NOT** the same as the **GNU Make**
 tool; instead **GNU Make** is invoked using `gmake`; you must use `gmake`
@@ -72,8 +72,11 @@ To build the toolchain, do the following:
 	```
 	cd /opt/toolchains/dc/kos/utils/dc-chain/
 	```
-3. (Optional) Copy and alter the `Makefile.cfg` file options to your liking.
-
+3. Copy and alter the `Makefile.cfg` file options to your liking and use profile 14.2.0.
+	```
+	cp Makefile.default.cfg Makefile.cfg
+	sed -i '' 's/toolchain_profile=stable/toolchain_profile=14.2.0/' Makefile.cfg
+	```
 4. Enter the following to start downloading and building toolchain:
 	```
 	gmake

--- a/utils/dc-chain/doc/macos.md
+++ b/utils/dc-chain/doc/macos.md
@@ -101,7 +101,11 @@ To build the toolchain, do the following:
 	cd /opt/toolchains/dc/kos/utils/dc-chain/
 	```
 
-2. (Optional) Copy and alter the `Makefile.cfg` file options to your liking.
+2. (Optional) Copy and alter the `Makefile.cfg` file options to your liking and use profile 14.2.0.
+	```
+	cp Makefile.default.cfg Makefile.cfg # Copy default configuration
+	sed -i  s/toolchain_profile=stable/toolchain_profile=14.2.0/ Makefile.cfg  # Set profile
+	```
 
 3. Enter the following to start downloading and building toolchain:
 	```

--- a/utils/dcbumpgen/Makefile
+++ b/utils/dcbumpgen/Makefile
@@ -1,8 +1,8 @@
 
 # Makefile stolen from the kmgenc program.
 
-CFLAGS = -O2 -Wall -DINLINE=inline -I/usr/local/include
-LDFLAGS = -s -lpng -ljpeg -lm -lz -L/usr/local/lib
+CFLAGS = -O2 -Wall -DINLINE=inline -I/usr/local/include $(foreach dir,$(CPATH),-I$(dir))
+LDFLAGS = -s -lpng -ljpeg -lm -lz -L/usr/local/lib $(foreach dir,$(LIBRARY_PATH),-L$(dir))
 
 all: dcbumpgen
 

--- a/utils/genexports/genexports.sh
+++ b/utils/genexports/genexports.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 usage() {
 	echo 'genexports.sh <inpfile> <outpfile> <symbolname>'

--- a/utils/genexports/genexportstubs.sh
+++ b/utils/genexports/genexportstubs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 usage() {
 	echo 'genexportstubs.sh <inpfile> <outpfile>'

--- a/utils/version/version.sh
+++ b/utils/version/version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Little version release util for KOS
 # Copyright (C) 2000-2002 Megan Potter


### PR DESCRIPTION
 * CI for Ubuntu, MacOS and FreeBSD
 * Running per PR, on master branch

An example of how this looks like, can be found https://github.com/drpaneas/KallistiOS/actions/runs/10901703715

There are some modification in the scripts, so they know if this is BSD or Linux system, which is important for executing shell scripts properly. Then, some modifications to the BSD installation packages were made, since there are some changes there and certain libraries were needed. Eventually, for Mac and BSD, the CI is building against gcc-14.2.0 (the previous ones do not build).