### PR TITLE
Sound improvements and fixes

### DIFF
--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -114,6 +114,7 @@ snd_sfx_unload_all
 snd_sfx_unload
 snd_sfx_load
 snd_sfx_load_ex
+snd_sfx_load_fd
 snd_sfx_play
 snd_sfx_stop_all
 snd_sfx_play_chn

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -120,6 +120,7 @@ snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free
 snd_stream_set_callback
+snd_stream_set_callback_direct
 snd_stream_filter_add
 snd_stream_filter_remove
 snd_stream_init

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -134,6 +134,7 @@ snd_stream_queue_go
 snd_stream_stop
 snd_stream_poll
 snd_stream_volume
+snd_stream_pan
 snd_stream_alloc
 snd_stream_destroy
 snd_stream_reinit

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -113,6 +113,7 @@ snd_poll_resp
 snd_sfx_unload_all
 snd_sfx_unload
 snd_sfx_load
+snd_sfx_load_ex
 snd_sfx_play
 snd_sfx_stop_all
 snd_sfx_play_chn
@@ -124,6 +125,7 @@ snd_stream_set_callback_direct
 snd_stream_filter_add
 snd_stream_filter_remove
 snd_stream_init
+snd_stream_init_ex
 snd_stream_shutdown
 snd_stream_queue_enable
 snd_stream_queue_disable

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -77,6 +77,7 @@ vmu_pkg_parse
 # SPU
 spu_memload
 spu_memload_sq
+spu_memload_dma
 spu_memread
 spu_memset
 spu_memset_sq

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -120,6 +120,7 @@ flashrom_get_region
 # SPU
 spu_memload
 spu_memload_sq
+spu_memload_dma
 spu_memread
 spu_memset
 spu_memset_sq

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -156,6 +156,7 @@ snd_poll_resp
 snd_sfx_unload_all
 snd_sfx_unload
 snd_sfx_load
+snd_sfx_load_ex
 snd_sfx_play
 snd_sfx_stop_all
 snd_sfx_play_chn
@@ -167,6 +168,7 @@ snd_stream_set_callback_direct
 snd_stream_filter_add
 snd_stream_filter_remove
 snd_stream_init
+snd_stream_init_ex
 snd_stream_shutdown
 snd_stream_queue_enable
 snd_stream_queue_disable

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -157,6 +157,7 @@ snd_sfx_unload_all
 snd_sfx_unload
 snd_sfx_load
 snd_sfx_load_ex
+snd_sfx_load_fd
 snd_sfx_play
 snd_sfx_stop_all
 snd_sfx_play_chn

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -163,6 +163,7 @@ snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free
 snd_stream_set_callback
+snd_stream_set_callback_direct
 snd_stream_filter_add
 snd_stream_filter_remove
 snd_stream_init

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -177,6 +177,7 @@ snd_stream_queue_go
 snd_stream_stop
 snd_stream_poll
 snd_stream_volume
+snd_stream_pan
 snd_stream_alloc
 snd_stream_destroy
 snd_stream_reinit

--- a/kernel/arch/dreamcast/hardware/g2dma.c
+++ b/kernel/arch/dreamcast/hardware/g2dma.c
@@ -197,7 +197,14 @@ int g2_dma_transfer(void *sh4, void *g2bus, size_t length, uint32_t block,
     g2_dma->dma[g2chn].sh4_addr = ((uint32_t)sh4) & MASK_ADDRESS;
     g2_dma->dma[g2chn].size = length | RESET_ENABLED;
     g2_dma->dma[g2chn].dir = dir;
-    g2_dma->dma[g2chn].trigger_select = CPU_TRIGGER | DMA_SUSPEND_ENABLED;
+
+    if(g2chn == G2_DMA_CHAN_SPU) {
+        /* Wait until fifo is empty and start. */
+        g2_dma->dma[g2chn].trigger_select = HARDWARE_TRIGGER | DMA_SUSPEND_ENABLED;
+    }
+    else {
+        g2_dma->dma[g2chn].trigger_select = CPU_TRIGGER | DMA_SUSPEND_ENABLED;
+    }
 
     /* Start the DMA transfer */
     g2_dma->dma[g2chn].enable = 1;

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -2,13 +2,15 @@
 
    spu.c
    Copyright (C) 2000, 2001 Megan Potter
-   Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024 Ruslan Rostovtsev
  */
 
+#include <kos/thread.h>
 #include <dc/spu.h>
 #include <dc/g2bus.h>
 #include <dc/sq.h>
 #include <arch/timer.h>
+#include <errno.h>
 
 /*
 
@@ -62,7 +64,7 @@ void spu_memload(uintptr_t dst, void *src_void, size_t length) {
 
 void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
     uint8_t *src = (uint8_t *)src_void;
-    int aligned_len;
+    size_t aligned_len;
 
     /* Round up to the nearest multiple of 4 */
     if(length & 3) {
@@ -84,6 +86,41 @@ void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
     if(length > 0) {
         /* Make sure the destination is in a non-cached area */
         dst |= MEM_AREA_P2_BASE;
+        dst += aligned_len;
+        src += aligned_len;
+        g2_fifo_wait();
+        g2_write_block_32((uint32_t *)src, dst, length >> 2);
+    }
+}
+
+void spu_memload_dma(uintptr_t dst, void *src_void, size_t length) {
+
+    uint8_t *src = (uint8_t *)src_void;
+    size_t aligned_len;
+
+    /* Round up to the nearest multiple of 4 */
+    if(length & 3) {
+        length = (length + 4) & ~3;
+    }
+
+    /* Using DMA (or SQ's on fail) for all that is divisible by 32 */
+    aligned_len = length & ~31;
+    length &= 31;
+
+    do {
+        if (spu_dma_transfer(src_void, dst, aligned_len, 1, NULL, NULL) < 0) {
+            if (errno == EINPROGRESS) {
+                thd_pass();
+                continue;
+            }
+            spu_memload_sq(dst, src_void, aligned_len);
+        }
+        break;
+    } while (1);
+
+    if(length > 0) {
+        /* Make sure the destination is in a non-cached area */
+        dst |= (MEM_AREA_P2_BASE | SPU_RAM_BASE);
         dst += aligned_len;
         src += aligned_len;
         g2_fifo_wait();

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -94,7 +94,6 @@ void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
 }
 
 void spu_memload_dma(uintptr_t dst, void *src_void, size_t length) {
-
     uint8_t *src = (uint8_t *)src_void;
     size_t aligned_len;
 
@@ -108,8 +107,8 @@ void spu_memload_dma(uintptr_t dst, void *src_void, size_t length) {
     length &= 31;
 
     do {
-        if (spu_dma_transfer(src_void, dst, aligned_len, 1, NULL, NULL) < 0) {
-            if (errno == EINPROGRESS) {
+        if(spu_dma_transfer(src_void, dst, aligned_len, 1, NULL, NULL) < 0) {
+            if(errno == EINPROGRESS) {
                 thd_pass();
                 continue;
             }

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -97,6 +97,11 @@ void spu_memload_dma(uintptr_t dst, void *src_void, size_t length) {
     uint8_t *src = (uint8_t *)src_void;
     size_t aligned_len;
 
+    if(((uintptr_t)src_void) & 31) {
+        spu_memload_sq(dst, src_void, length);
+        return;
+    }
+
     /* Round up to the nearest multiple of 4 */
     if(length & 3) {
         length = (length + 4) & ~3;

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -66,6 +66,11 @@ void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
     uint8_t *src = (uint8_t *)src_void;
     size_t aligned_len;
 
+    if(length < 32) {
+        spu_memload(dst, src_void, length);
+        return;
+    }
+
     /* Round up to the nearest multiple of 4 */
     if(length & 3) {
         length = (length + 4) & ~3;
@@ -97,6 +102,10 @@ void spu_memload_dma(uintptr_t dst, void *src_void, size_t length) {
     uint8_t *src = (uint8_t *)src_void;
     size_t aligned_len;
 
+    if(length < 32) {
+        spu_memload(dst, src_void, length);
+        return;
+    }
     if(((uintptr_t)src_void) & 31) {
         spu_memload_sq(dst, src_void, length);
         return;

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -60,13 +60,31 @@ typedef uint32_t sfxhnd_t;
     or 16-bit uncompressed PCM samples, or 4-bit Yamaha ADPCM.
 
     \warning The sound effect you are loading must be at most 65534 samples 
-    in length.
+    in length
 
     \param  fn              The file to load.
     \return                 A handle to the sound effect on success. On error,
                             SFXHND_INVALID is returned.
 */
 sfxhnd_t snd_sfx_load(const char *fn);
+
+/** \brief  Load a sound effect without wav header.
+
+    This function loads a sound effect from a RAW file and returns a handle to
+    it. The sound effect can be either stereo or mono, and must either be 8-bit
+    or 16-bit uncompressed PCM samples, or 4-bit Yamaha ADPCM.
+
+    \warning The sound effect you are loading must be at most 65534 samples 
+    in length and multiple by 32 bytes for each channel.
+
+    \param  fn              The file to load.
+    \param  rate            The frequency of the sound.
+    \param  bitsize         The sample size (bits per sample).
+    \param  channels        Number of channels.
+    \return                 A handle to the sound effect on success. On error,
+                            SFXHND_INVALID is returned.
+*/
+sfxhnd_t snd_sfx_load_ex(const char *fn, uint32_t rate, uint16_t bitsize, uint16_t channels);
 
 /** \brief  Unload a sound effect.
 

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -61,7 +61,7 @@ typedef uint32_t sfxhnd_t;
     or 16-bit uncompressed PCM samples, or 4-bit Yamaha ADPCM.
 
     \warning The sound effect you are loading must be at most 65534 samples 
-    in length
+    in length.
 
     \param  fn              The file to load.
     \return                 A handle to the sound effect on success. On error,

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -86,6 +86,25 @@ sfxhnd_t snd_sfx_load(const char *fn);
 */
 sfxhnd_t snd_sfx_load_ex(const char *fn, uint32_t rate, uint16_t bitsize, uint16_t channels);
 
+/** \brief  Load a sound effect without wav header by file handler.
+
+    This function loads a sound effect from a RAW file and returns a handle to
+    it. The sound effect can be either stereo or mono, and must either be 8-bit
+    or 16-bit uncompressed PCM samples, or 4-bit Yamaha ADPCM.
+
+    \warning The sound effect you are loading must be at most 65534 samples 
+    in length and multiple by 32 bytes for each channel.
+
+    \param  fd              The file handler.
+    \param  len             The file length.
+    \param  rate            The frequency of the sound.
+    \param  bitsize         The sample size (bits per sample).
+    \param  channels        Number of channels.
+    \return                 A handle to the sound effect on success. On error,
+                            SFXHND_INVALID is returned.
+*/
+sfxhnd_t snd_sfx_load_fd(file_t fd, size_t len, uint32_t rate, uint16_t bitsize, uint16_t channels);
+
 /** \brief  Unload a sound effect.
 
     This function unloads a previously loaded sound effect, and frees the memory

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -2,7 +2,7 @@
 
    dc/sound/sfxmgr.h
    Copyright (C) 2002 Megan Potter
-   Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024 Ruslan Rostovtsev
    Copyright (C) 2023 Andy Barajas
 
 */
@@ -30,6 +30,7 @@
 __BEGIN_DECLS
 
 #include <arch/types.h>
+#include <kos/fs.h>
 #include <stdint.h>
 
 /** \defgroup audio_sfx     Sound Effects

--- a/kernel/arch/dreamcast/include/dc/sound/stream.h
+++ b/kernel/arch/dreamcast/include/dc/sound/stream.h
@@ -202,13 +202,13 @@ void snd_stream_prefill(snd_stream_hnd_t hnd);
 */
 int snd_stream_init(void);
 
-/** \brief  Initialize the stream system only for mono
+/** \brief  Initialize the stream system with limits.
 
     The same as \ref snd_stream_init but it can either reduce or not allocate
     the buffer for splitting the stereo stream at all.
 
     \param  channels        Max channels for any streams.
-    \param  buffer_size     Max buffer size for any streams.
+    \param  buffer_size     Max channel buffer size for any streams.
 
     \retval -1              On failure.
     \retval 0               On success.
@@ -227,7 +227,7 @@ void snd_stream_shutdown(void);
     This function allocates a stream and sets its parameters.
 
     \param  cb              The get data callback for the stream.
-    \param  bufsize         The size of the buffer for the stream.
+    \param  bufsize         The size of the buffer for each channel of the stream.
     \return                 A handle to the new stream on success,
                             SND_STREAM_INVALID on failure.
 */

--- a/kernel/arch/dreamcast/include/dc/sound/stream.h
+++ b/kernel/arch/dreamcast/include/dc/sound/stream.h
@@ -347,6 +347,16 @@ int snd_stream_poll(snd_stream_hnd_t hnd);
 */
 void snd_stream_volume(snd_stream_hnd_t hnd, int vol);
 
+/** \brief  Set the panning on the stream.
+
+    This function sets the panning of the specified stream.
+
+    \param  hnd             The stream to set volume on.
+    \param  left_pan        The left panning to set. Valid values are 0-255.
+    \param  right_pan       The right panning to set. Valid values are 0-255.
+*/
+void snd_stream_pan(snd_stream_hnd_t hnd, int left_pan, int right_pan);
+
 /** @} */
 
 __END_DECLS

--- a/kernel/arch/dreamcast/include/dc/sound/stream.h
+++ b/kernel/arch/dreamcast/include/dc/sound/stream.h
@@ -3,7 +3,7 @@
    dc/sound/stream.h
    Copyright (C) 2002, 2004 Megan Potter
    Copyright (C) 2020 Lawrence Sebald
-   Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024 Ruslan Rostovtsev
 
 */
 
@@ -176,6 +176,19 @@ void snd_stream_prefill(snd_stream_hnd_t hnd);
     \retval 0               On success.
 */
 int snd_stream_init(void);
+
+/** \brief  Initialize the stream system only for mono
+
+    The same as \ref snd_stream_init but it can either reduce or not allocate
+    the buffer for splitting the stereo stream at all.
+
+    \param  channels        Max channels for any streams.
+    \param  buffer_size     Max buffer size for any streams.
+
+    \retval -1              On failure.
+    \retval 0               On success.
+*/
+int snd_stream_init_ex(int channels, size_t buffer_size);
 
 /** \brief  Shut down the stream system.
 

--- a/kernel/arch/dreamcast/include/dc/sound/stream.h
+++ b/kernel/arch/dreamcast/include/dc/sound/stream.h
@@ -71,6 +71,21 @@ typedef int snd_stream_hnd_t;
 typedef void *(*snd_stream_callback_t)(snd_stream_hnd_t hnd, int smp_req,
                                        int *smp_recv);
 
+/** \brief  Direct stream data transfer callback type.
+
+    Functions for providing stream data will be of this type, and can be
+    registered with snd_stream_set_callback_direct().
+
+    \param  hnd             The stream handle being referred to.
+    \param  left            Left channel buffer address on AICA side.
+    \param  right           Right channel buffer address on AICA side.
+    \param  size_req        Requested size for each channel.
+    \retval -1              On failure.
+    \retval size_recv       On success, received size.
+*/
+typedef size_t (*snd_stream_callback_direct_t)(snd_stream_hnd_t hnd,
+    uintptr_t left,  uintptr_t right,  size_t size_req);
+
 /** \brief  Set the callback for a given stream.
 
     This function sets the get data callback function for a given stream,
@@ -80,6 +95,16 @@ typedef void *(*snd_stream_callback_t)(snd_stream_hnd_t hnd, int smp_req,
     \param  cb              A pointer to the callback function.
 */
 void snd_stream_set_callback(snd_stream_hnd_t hnd, snd_stream_callback_t cb);
+
+/** \brief  Set the callback for a given stream with direct transfer.
+
+    This function sets the get data callback function for a given stream,
+    overwriting any old callback that may have been in place.
+
+    \param  hnd             The stream handle for the callback.
+    \param  cb              A pointer to the callback function.
+*/
+void snd_stream_set_callback_direct(snd_stream_hnd_t hnd, snd_stream_callback_direct_t cb);
 
 /** \brief  Set the user data for a given stream.
 

--- a/kernel/arch/dreamcast/include/dc/spu.h
+++ b/kernel/arch/dreamcast/include/dc/spu.h
@@ -2,7 +2,7 @@
 
    dc/spu.h
    Copyright (C) 2000, 2001 Megan Potter
-   Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024 Ruslan Rostovtsev
 
 */
 
@@ -59,6 +59,18 @@ void spu_memload(uintptr_t to, void *from, size_t length);
                             up to be a multiple of 4.
 */
 void spu_memload_sq(uintptr_t to, void *from, size_t length);
+
+/** \brief  Copy a block of data to sound RAM.
+
+    This function acts much like memcpy() but copies to the sound RAM area
+    by using the DMA.
+
+    \param  to              The offset in sound RAM to copy to. Do not include
+                            the 0xA0800000 part, it is implied.
+    \param  from            A pointer to copy from.
+    \param  length          The number of bytes to copy. Must be a multiple of 32.
+*/
+void spu_memload_dma(uintptr_t to, void *from, size_t length);
 
 /** \brief  Copy a block of data from sound RAM.
 

--- a/kernel/arch/dreamcast/include/dc/spu.h
+++ b/kernel/arch/dreamcast/include/dc/spu.h
@@ -47,7 +47,7 @@ __BEGIN_DECLS
 void spu_memload(uintptr_t to, void *from, size_t length);
 
 
-/** \brief  Copy a block of data to sound RAM.
+/** \brief  Copy a block of data to sound RAM by using the Store Queues.
 
     This function acts much like memcpy() but copies to the sound RAM area
     by using the Store Queues.
@@ -60,10 +60,10 @@ void spu_memload(uintptr_t to, void *from, size_t length);
 */
 void spu_memload_sq(uintptr_t to, void *from, size_t length);
 
-/** \brief  Copy a block of data to sound RAM.
+/** \brief  Copy a block of data to sound RAM by using DMA (or SQ on fails).
 
     This function acts much like memcpy() but copies to the sound RAM area
-    by using the DMA.
+    by using the DMA. If DMA fails, then will be used the Store Queues.
 
     \param  to              The offset in sound RAM to copy to. Do not include
                             the 0xA0800000 part, it is implied.

--- a/kernel/arch/dreamcast/sound/snd_pcm_split.s
+++ b/kernel/arch/dreamcast/sound/snd_pcm_split.s
@@ -1,7 +1,7 @@
 ! KallistiOS ##version##
 !
 ! arch/dreamcast/sound/snd_pcm_split.s
-! Copyright (C) 2023 Ruslan Rostovtsev
+! Copyright (C) 2023, 2024 Ruslan Rostovtsev
 !
 ! Optimized SH4 assembler code for separating stereo 8/16-bit PCM and
 ! stereo 4-bit ADPCM into independent single channels.
@@ -67,7 +67,7 @@ _snd_pcm16_split:
 !
 ! void snd_pcm8_split(uint32_t *data, uint32_t *left, uint32_t *right, size_t size);
 !
-    .align 2
+	.align 2
 _snd_pcm8_split:
 	mov #-5, r1
 	shld r1, r7
@@ -94,44 +94,216 @@ _snd_pcm8_split:
 !
 ! void snd_adpcm_split(uint32_t *data, uint32_t *left, uint32_t *right, size_t size);
 !
-    .align 2
+	.align 2
 _snd_adpcm_split:
 	mov #-5, r1
 	shld r1, r7
+	mov.l r8, @-r15
+	mov.l r9, @-r15
 	mov.l r10, @-r15
-	mov #16, r1
+	mov.l r11, @-r15
+	mov #4, r1
+	mov #15, r11
 .adpcm_pref:
 	add #32, r4
 	pref @r4
 	add #-32, r4
 .adpcm_copy:
 	dt r1
-	mov.w @r4+, r10
-	mov r10, r0
-	and #0xf0, r0
-	mov r0, r2
-	shlr2 r2
-	mov r10, r0
-	shlr2 r2
-	and #0x0f, r0
+	!!! src = *data++;
+	mov.l @r4+, r0
+
+	!!! dst_r = src & 0xf
 	mov r0, r3
-	shlr8 r10
-	mov r10, r0
-	and #0xf0, r0
-	or r0, r2
-	mov.b r2, @r5
-	add #1, r5
-	mov r10, r0
-	and #0x0f, r0
-	shll2 r0
-	shll2 r0
-	or r0, r3
-	mov.b r3, @r6
+	and r11, r3
+
+	!!! src >>= 4
+	mov #-4, r10
+	shld r10, r0
+
+	!!! dst_l = src & 0xf
+	mov r0, r2
+	and r11, r2
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! tmp_r = src & 0xf
+	mov r0, r9
+	and r11, r9
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! tmp_l = src & 0xf
+	mov r0, r8
+	and r11, r8
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! tmp <<= 4,
+	mov #4, r10
+	shld r10, r9
+	shld r10, r8
+
+	!!! dst |= tmp
+	or r9, r3
+	or r8, r2
+
+	!!! tmp_r = src & 0xf
+	mov r0, r9
+	and r11, r9
+
+	!!! src >>= 4
+	mov #-4, r10
+	shld r10, r0
+
+	!!! tmp_l = src & 0xf
+	mov r0, r8
+	and r11, r8
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! tmp <<= 8,
+	shll8 r9
+	shll8 r8
+
+	!!! dst |= tmp
+	or r9, r3
+	or r8, r2
+
+	!!! tmp_r = src & 0xf
+	mov r0, r9
+	and r11, r9
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! tmp_l = src & 0xf
+	mov r0, r8
+	and r11, r8
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! tmp <<= 12,
+	mov #12, r10
+	shld r10, r9
+	shld r10, r8
+
+	!!! dst |= tmp
+	or r9, r3
+	or r8, r2
+
+	!!! src = *data++;
+	mov.l @r4+, r0
+
+	!!! tmp_r = src & 0xf
+	mov r0, r9
+	and r11, r9
+
+	!!! src >>= 4
+	mov #-4, r10
+	shld r10, r0
+
+	!!! tmp_l = src & 0xf
+	mov r0, r8
+	and r11, r8
+
+	!!! tmp <<= 16,
+	shll16 r9
+	shll16 r8
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! dst |= tmp
+	or r9, r3
+	or r8, r2
+
+	!!! tmp_r = src & 0xf
+	mov r0, r9
+	and r11, r9
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! tmp_l = src & 0xf
+	mov r0, r8
+	and r11, r8
+
+	!!! tmp <<= 20,
+	mov #20, r10
+	shld r10, r9
+	shld r10, r8
+
+	!!! dst |= tmp
+	or r9, r3
+	or r8, r2
+
+	!!! src >>= 4
+	mov #-4, r10
+	shld r10, r0
+
+	!!! tmp_r = src & 0xf
+	mov r0, r9
+	and r11, r9
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! tmp_l = src & 0xf
+	mov r0, r8
+	and r11, r8
+
+	!!! tmp <<= 24,
+	mov #24, r10
+	shld r10, r9
+	shld r10, r8
+
+	!!! dst |= tmp
+	or r9, r3
+	or r8, r2
+
+	!!! src >>= 4
+	mov #-4, r10
+	shld r10, r0
+
+	!!! tmp_r = src & 0xf
+	mov r0, r9
+	and r11, r9
+
+	!!! src >>= 4
+	shld r10, r0
+
+	!!! tmp_l = src & 0xf
+	mov r0, r8
+	and r11, r8
+
+	!!! tmp <<= 28,
+	mov #28, r10
+	shld r10, r9
+	shld r10, r8
+
+	!!! dst |= tmp
+	or r9, r3
+	or r8, r2
+
+	!!! *chan++ = dst;
+	mov.l r2, @r5
+	mov.l r3, @r6
+.adpcm_loops:
+	add #4, r5
 	bf/s .adpcm_copy
-	add #1, r6
+	add #4, r6
 	dt r7
 	bf/s .adpcm_pref
-	mov #16, r1
+	mov #4, r1
+.adpcm_exit:
+	mov.l @r15+, r11
 	mov.l @r15+, r10
+	mov.l @r15+, r9
 	rts
-	nop
+	mov.l @r15+, r8

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -2,7 +2,7 @@
 
    snd_sfxmgr.c
    Copyright (C) 2000, 2001, 2002, 2003, 2004 Megan Potter
-   Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024 Ruslan Rostovtsev
    Copyright (C) 2023 Andy Barajas
    Copyright (C) 2024 Stefanos Kornilios Mitsis Poiitidis
 
@@ -329,7 +329,7 @@ sfxhnd_t snd_sfx_load(const char *fn) {
     /* Open the sound effect file */
     fd = fs_open(fn, O_RDONLY);
     if(fd <= FILEHND_INVALID) {
-        dbglog(DBG_ERROR, "snd_sfx_load: can't open sfx %s\n", fn);
+        dbglog(DBG_ERROR, "snd_sfx_load: can't open %s\n", fn);
         return SFXHND_INVALID;
     }
 
@@ -435,14 +435,14 @@ sfxhnd_t snd_sfx_load_fd(file_t fd, size_t len, uint32_t rate, uint16_t bitsize,
         goto err_occurred;
     }
     /* Uncomment when implementation is merged.
-    if(fs_ioctl(fd, IOCTL_FS_ROOTBUS_DMA_LENGTH, &fs_dma_len) == 0) {
+    if(fs_ioctl(fd, IOCTL_FS_ROOTBUS_DMA_READY, &fs_dma_len) == 0) {
         if(chan_len >= fs_dma_len && (chan_len & (fs_dma_len - 1)) == 0) {
             fs_rootbus_dma_ready = 1;
         }
     }
     */
     if(fs_rootbus_dma_ready) {
-        if(fs_read(fd, (void *)(effect->locl | SPU_RAM_BASE), chan_len) <= 0) {
+        if(fs_read(fd, (void *)(effect->locl | SPU_RAM_UNCACHED_BASE), chan_len) <= 0) {
             goto err_occurred;
         }
     }
@@ -462,7 +462,7 @@ sfxhnd_t snd_sfx_load_fd(file_t fd, size_t len, uint32_t rate, uint16_t bitsize,
             goto err_occurred;
         }
         if(fs_rootbus_dma_ready) {
-            if(fs_read(fd, (void *)(effect->locr | SPU_RAM_BASE), chan_len) <= 0) {
+            if(fs_read(fd, (void *)(effect->locr | SPU_RAM_UNCACHED_BASE), chan_len) <= 0) {
                 goto err_occurred;
             }
         }

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -205,40 +205,42 @@ static snd_effect_t *create_snd_effect(wavhdr_t *wavhdr, uint8_t *wav_data) {
 
     effect->rate = rate;
     effect->stereo = channels > 1;
+    effect->locl = snd_mem_malloc(len / channels);
+
+    if(!effect->locl) {
+        goto err_occurred;
+    }
+    if(channels > 1) {
+        effect->locr = snd_mem_malloc(len / channels);
+        if(!effect->locr) {
+            snd_mem_free(effect->locl);
+            goto err_occurred;
+        }
+    }
+
+    if(fmt == WAVE_FMT_YAMAHA_ADPCM_ITU_G723 || fmt == WAVE_FMT_YAMAHA_ADPCM) {
+        effect->fmt = AICA_SM_ADPCM;
+        effect->len = (len * 2) / channels; /* 4-bit packed samples */
+    }
+    else if(fmt == WAVE_FMT_PCM && bitsize == 8) {
+        effect->fmt = AICA_SM_8BIT;
+        effect->len = len / channels;
+    }
+    else if(fmt == WAVE_FMT_PCM && bitsize == 16) {
+        effect->fmt = AICA_SM_16BIT;
+        effect->len = (len / 2) / channels;
+    }
+    else {
+        goto err_occurred;
+    }
 
     if(channels == 1) {
         /* Mono PCM/ADPCM */
-        if(fmt == WAVE_FMT_YAMAHA_ADPCM_ITU_G723 || fmt == WAVE_FMT_YAMAHA_ADPCM) {
-            effect->fmt = AICA_SM_ADPCM;
-            effect->len = len * 2; /* 4-bit packed samples */
-        }
-        else if(fmt == WAVE_FMT_PCM && bitsize == 8) {
-            effect->fmt = AICA_SM_8BIT;
-            effect->len = len;
-        }
-        else if(fmt == WAVE_FMT_PCM && bitsize == 16) {
-            effect->fmt = AICA_SM_16BIT;
-            effect->len = len / 2;
-        }
-        else {
-            goto err_occurred;
-        }
-
-        effect->locl = snd_mem_malloc(len);
-        if(effect->locl)
-            spu_memload_sq(effect->locl, wav_data, len);
-
-        effect->locr = 0;
+        spu_memload_sq(effect->locl, wav_data, len);
     }
     else if(channels == 2 && fmt == WAVE_FMT_PCM && bitsize == 16) {
         /* Stereo 16-bit PCM */
-        effect->len = len / 4; /* Two stereo, 16-bit samples */
-        effect->fmt = AICA_SM_16BIT;
-        effect->locl = snd_mem_malloc(len / 2);
-        effect->locr = snd_mem_malloc(len / 2);
-
-        if(effect->locl && effect->locr)
-            snd_pcm16_split_sq((uint32_t *)wav_data, effect->locl, effect->locr, len);
+        snd_pcm16_split_sq((uint32_t *)wav_data, effect->locl, effect->locr, len);
     }
     else if(channels == 2 && fmt == WAVE_FMT_PCM && bitsize == 8) {
         /* Stereo 8-bit PCM */
@@ -254,17 +256,8 @@ static snd_effect_t *create_snd_effect(wavhdr_t *wavhdr, uint8_t *wav_data) {
         }
 
         snd_pcm8_split((uint32_t *)wav_data, left_buf, right_buf, len);
-
-        effect->fmt = AICA_SM_8BIT;
-        effect->len = len / 2;
-        effect->locl = snd_mem_malloc(len / 2);
-        effect->locr = snd_mem_malloc(len / 2);
-
-        if(effect->locl)
-            spu_memload_sq(effect->locl, left_buf, len / 2);
-
-        if(effect->locr)
-            spu_memload_sq(effect->locr, right_buf, len / 2);
+        spu_memload_sq(effect->locl, left_buf, len / 2);
+        spu_memload_sq(effect->locr, right_buf, len / 2);
 
         free(left_buf);
         free(right_buf);
@@ -284,16 +277,8 @@ static snd_effect_t *create_snd_effect(wavhdr_t *wavhdr, uint8_t *wav_data) {
             memcpy(right_buf, wav_data + (len / 2), len / 2);
         }
 
-        effect->len = len;   /* Two stereo, 4-bit samples */
-        effect->fmt = AICA_SM_ADPCM;
-        effect->locl = snd_mem_malloc(len / 2);
-        effect->locr = snd_mem_malloc(len / 2);
-
-        if(effect->locl)
-            spu_memload_sq(effect->locl, wav_data, len / 2);
-
-        if(effect->locr)
-            spu_memload_sq(effect->locr, right_buf, len / 2);
+        spu_memload_sq(effect->locl, wav_data, len / 2);
+        spu_memload_sq(effect->locr, right_buf, len / 2);
 
         if(ownmem)
             free(right_buf);
@@ -305,7 +290,6 @@ static snd_effect_t *create_snd_effect(wavhdr_t *wavhdr, uint8_t *wav_data) {
         if(left_buf == NULL)
             goto err_occurred;
 
-
         right_buf = (uint32_t *)memalign(32, len / 2);
 
         if(right_buf == NULL) {
@@ -314,23 +298,18 @@ static snd_effect_t *create_snd_effect(wavhdr_t *wavhdr, uint8_t *wav_data) {
         }
 
         snd_adpcm_split((uint32_t *)wav_data, left_buf, right_buf, len);
-
-        effect->len = len; /* Two stereo, 4-bit samples */
-        effect->fmt = AICA_SM_ADPCM;
-        effect->locl = snd_mem_malloc(len / 2);
-        effect->locr = snd_mem_malloc(len / 2);
-
-        if(effect->locl)
-            spu_memload_sq(effect->locl, left_buf, len / 2);
-
-        if(effect->locr)
-            spu_memload_sq(effect->locr, right_buf, len / 2);
+        spu_memload_sq(effect->locl, left_buf, len / 2);
+        spu_memload_sq(effect->locr, right_buf, len / 2);
 
         free(left_buf);
         free(right_buf);
     }
     else {
 err_occurred:
+        if(effect->locl)
+            snd_mem_free(effect->locl);
+        if(effect->locr)
+            snd_mem_free(effect->locr);
         free(effect);
         effect = SFXHND_INVALID;
     }
@@ -346,21 +325,20 @@ sfxhnd_t snd_sfx_load(const char *fn) {
     uint8_t *wav_data;
     uint32_t sample_count;
 
-    dbglog(DBG_DEBUG, "snd_sfx: loading effect %s\n", fn);
-
     /* Open the sound effect file */
     fd = fs_open(fn, O_RDONLY);
     if(fd <= FILEHND_INVALID) {
-        dbglog(DBG_WARNING, "snd_sfx: can't open sfx %s\n", fn);
+        dbglog(DBG_ERROR, "snd_sfx_load: can't open sfx %s\n", fn);
         return SFXHND_INVALID;
     }
 
     /* Read WAV header */
     if(read_wav_header(fd, &wavhdr) < 0) {
         fs_close(fd);
+        dbglog(DBG_ERROR, "snd_sfx_load: can't read wav header %s\n", fn);
         return SFXHND_INVALID;
     }
-
+    /*
     dbglog(DBG_DEBUG, "WAVE file is %s, %luHZ, %d bits/sample, "
         "%u bytes total, format %d\n", 
            wavhdr.fmt.channels == 1 ? "mono" : "stereo", 
@@ -368,13 +346,13 @@ sfxhnd_t snd_sfx_load(const char *fn) {
            wavhdr.fmt.sample_size, 
            wavhdr.chunk.size, 
            wavhdr.fmt.format);
-
+    */
     sample_count = wavhdr.fmt.sample_size >= 8 
         ? wavhdr.chunk.size / ((wavhdr.fmt.sample_size / 8) * wavhdr.fmt.channels) 
-        : wavhdr.chunk.size / (0.5 * wavhdr.fmt.channels);
+        : (wavhdr.chunk.size * 2) / wavhdr.fmt.channels;
 
     if(sample_count > 65534) {
-        dbglog(DBG_WARNING, "WAVE file is over 65534 samples\n");
+        dbglog(DBG_WARNING, "snd_sfx_load: WAVE file is over 65534 samples\n");
     }
 
     /* Read WAV data */

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -394,7 +394,7 @@ int snd_stream_init(void) {
 int snd_stream_init_ex(int channels, size_t buffer_size) {
     max_channels = channels;
 
-    if(channels == 2) {
+    if(channels == 2 && buffer_size > 0) {
         /* Create stereo separation buffers */
         sep_buffer[0] = memalign(32, buffer_size);
         sep_buffer[1] = sep_buffer[0] + (buffer_size / 8);
@@ -852,6 +852,27 @@ void snd_stream_volume(snd_stream_hnd_t hnd, int vol) {
 
     if(streams[hnd].channels == 2) {
         cmd->cmd_id = streams[hnd].ch[1];
+        snd_sh4_to_aica(tmp, cmd->size);
+    }
+}
+
+/* Set the panning on the streaming channels */
+void snd_stream_pan(snd_stream_hnd_t hnd, int left_pan, int right_pan) {
+    AICA_CMDSTR_CHANNEL(tmp, cmd, chan);
+
+    CHECK_HND(hnd);
+
+    cmd->cmd = AICA_CMD_CHAN;
+    cmd->timestamp = 0;
+    cmd->size = AICA_CMDSTR_CHANNEL_SIZE;
+    cmd->cmd_id = streams[hnd].ch[0];
+    chan->cmd = AICA_CH_CMD_UPDATE | AICA_CH_UPDATE_SET_PAN;
+    chan->pan = left_pan;
+    snd_sh4_to_aica(tmp, cmd->size);
+
+    if(streams[hnd].channels == 2) {
+        cmd->cmd_id = streams[hnd].ch[1];
+        chan->pan = right_pan;
         snd_sh4_to_aica(tmp, cmd->size);
     }
 }

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -375,7 +375,7 @@ int snd_stream_init(void) {
 int snd_stream_init_ex(int channels, size_t buffer_size) {
     max_channels = channels;
 
-    if (channels == 2) {
+    if(channels == 2) {
         /* Create stereo separation buffers */
         sep_buffer[0] = memalign(32, buffer_size);
         sep_buffer[1] = sep_buffer[0] + (buffer_size / 8);
@@ -462,7 +462,7 @@ void snd_stream_destroy(snd_stream_hnd_t hnd) {
     snd_stream_stop(hnd);
     snd_sfx_chn_free(streams[hnd].ch[0]);
 
-    if (max_channels == 2) {
+    if(max_channels == 2) {
         snd_sfx_chn_free(streams[hnd].ch[1]);
     }
 
@@ -708,7 +708,7 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
         needed_bytes = (int)stream->buffer_size / stream->channels;
     }
 
-    if (!stream->initted || !stream->get_data) {
+    if(!stream->initted || !stream->get_data) {
         return -2;
     }
     data = stream->get_data(hnd, needed_bytes * stream->channels, &got_bytes);

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -437,6 +437,7 @@ snd_stream_hnd_t snd_stream_alloc(snd_stream_callback_t cb, int bufsize) {
 
     /* Setup the callback */
     snd_stream_set_callback(hnd, cb);
+    snd_stream_set_callback_direct(hnd, NULL);
 
     /* Initialize our filter chain list */
     TAILQ_INIT(&streams[hnd].filters);
@@ -464,6 +465,7 @@ snd_stream_hnd_t snd_stream_reinit(snd_stream_hnd_t hnd, snd_stream_callback_t c
 
     /* Setup the callback */
     snd_stream_set_callback(hnd, cb);
+    snd_stream_set_callback_direct(hnd, NULL);
 
     return hnd;
 }
@@ -721,7 +723,7 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
         needed_samples &= ~(bytes_to_samples(hnd, 2048 / stream->channels) - 1);
         needed_bytes = samples_to_bytes(hnd, needed_samples);
         /* Reduce data requests */
-        if((uint32_t)needed_bytes < stream->buffer_size / 2) {
+        if((uint32_t)needed_bytes < (stream->buffer_size / 2)) {
             return 0;
         }
     }
@@ -735,8 +737,8 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
         return 0;
     }
 
-    if((uint32_t)needed_bytes > stream->buffer_size) {
-        needed_bytes = (int)stream->buffer_size;
+    if((uint32_t)needed_bytes > stream->buffer_size / 2) {
+        needed_bytes = (int)stream->buffer_size / 2;
     }
 
     if(!stream->initted) {

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -371,8 +371,10 @@ void snd_stream_prefill(snd_stream_hnd_t hnd) {
     mutex_lock(&stream_mutex);
 
     if(stream->req_data) {
-        filled = stream->req_data(hnd, stream->spu_ram_sch[0],
-            stream->spu_ram_sch[1], stream->buffer_size);
+        filled = stream->req_data(hnd,
+            stream->spu_ram_sch[0] | SPU_RAM_BASE,
+            stream->spu_ram_sch[1] | SPU_RAM_BASE,
+            stream->buffer_size);
     }
     if(filled <= 0 && stream->get_data) {
         snd_stream_prefill_part(hnd, 0);
@@ -735,8 +737,9 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
 
     if(stream->req_data) {
         got_bytes = stream->req_data(hnd,
-            stream->spu_ram_sch[0] + write_pos,
-            stream->channels == 2 ? (stream->spu_ram_sch[1] + write_pos) : 0,
+            (stream->spu_ram_sch[0] | SPU_RAM_BASE) + write_pos,
+            (stream->channels == 2 ?
+                ((stream->spu_ram_sch[1] | SPU_RAM_BASE) + write_pos) : 0),
             needed_bytes);
 
         if(got_bytes) {

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -452,13 +452,12 @@ void snd_stream_destroy(snd_stream_hnd_t hnd) {
     filter_t *c, *n;
 
     assert(hnd >= 0 && hnd < SND_STREAM_MAX);
-    mutex_lock_timed(&stream_mutex, LOCK_TIMEOUT_MS);
 
     if(!streams[hnd].initted) {
-        mutex_unlock(&stream_mutex);
         return;
     }
 
+    mutex_lock_timed(&stream_mutex, LOCK_TIMEOUT_MS);
     snd_stream_stop(hnd);
     snd_sfx_chn_free(streams[hnd].ch[0]);
 

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -111,8 +111,6 @@ static mutex_t stream_mutex = MUTEX_INITIALIZER;
 
 static int max_channels = 2;
 
-#define LOCK_TIMEOUT_MS 500
-
 /* Check an incoming handle */
 #define CHECK_HND(x) do { \
         assert( (x) >= 0 && (x) < SND_STREAM_MAX ); \
@@ -370,7 +368,7 @@ void snd_stream_prefill(snd_stream_hnd_t hnd) {
     if(!stream->get_data && !stream->req_data) {
         return;
     }
-    mutex_lock_timed(&stream_mutex, LOCK_TIMEOUT_MS);
+    mutex_lock(&stream_mutex);
 
     if(stream->req_data) {
         filled = stream->req_data(hnd, stream->spu_ram_sch[0],
@@ -476,7 +474,7 @@ void snd_stream_destroy(snd_stream_hnd_t hnd) {
         return;
     }
 
-    mutex_lock_timed(&stream_mutex, LOCK_TIMEOUT_MS);
+    mutex_lock(&stream_mutex);
     snd_stream_stop(hnd);
     snd_sfx_chn_free(streams[hnd].ch[0]);
 
@@ -778,7 +776,7 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
     }
 
     if(stream->channels == 2) {
-        mutex_lock_timed(&stream_mutex, LOCK_TIMEOUT_MS);
+        mutex_lock(&stream_mutex);
 
         if(streams[hnd].bitsize == 16) {
             if((uintptr_t)data & 31) {
@@ -817,7 +815,7 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
         }
         dcache_purge_range((uintptr_t)first_dma_buf, needed_bytes);
 
-        mutex_lock_timed(&stream_mutex, LOCK_TIMEOUT_MS);
+        mutex_lock(&stream_mutex);
         stream->poll_thd = thd_current;
 
         spu_dma_transfer(first_dma_buf,


### PR DESCRIPTION
Ready for review.

- Added `snd_stream_init_ex()` with the ability to reduce consumption of memory for separation interleaved stereo buffer and channels usage.
- Added direct DMA streaming capability for G1Bus-based storage devices.
- Improved sound streams data transfer to the SPU.
- Reduced the number of data requests for sound streams.
- Improved ADPCM channel separation by 56%.
- Added `spu_memload_dma()` as an alternative for `spu_memload_sq()`.
- Added `snd_stream_pan()` to use 2 separate mono streams as one stereo or something.
- Added `snd_sfx_load_ex()` for optimized loading of RAW files with ability to direct transfer from G1Bus-based devices.
- Handling out of SPU memory in `snd_sfx_load()`.
- Added `snd_sfx_load_fd()` the same as  `snd_sfx_load_ex()` but for working with sets.
- Changed SPU DMA trigger to avoid extra stalls since SH4 can frequently accesses AICA registers.
- Reduced the impact and number of mutex triggers on streams. The mutex is there only to protect the DMA and the channel split buffer. I initially placed it poorly.
- Some minor fixes and optimizations.

Sound streams (not direct) tested in DreamShell applications and GTA3. Two streams simultaneously in both cases.
We can save up to 64KB memory for this game (currently 48 KB, because stereo radio are used).
`spu_memload_dma()` works buggy in GTA3 with SFX, I don't know why. Looks like G2 DMA issue, but I've tried use CH3 for this function and get the same behavior, so it is not a conflict of using one DMA channel. That's why I don't use it anywhere yet. Although for libwav from kos-ports it works fine if I use it for streams prefill.