### PR TITLE
Scoped IRQ disable

### DIFF
--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -434,6 +434,25 @@ int irq_init(void);
 */
 void irq_shutdown(void);
 
+/** \cond */
+static inline void __irq_scoped_cleanup(int *state) {
+    irq_restore(*state);
+}
+
+#define ___irq_disable_scoped(l) \
+    int __scoped_irq_##l __attribute__((cleanup(__irq_scoped_cleanup))) = irq_disable()
+
+#define __irq_disable_scoped(l) ___irq_disable_scoped(l)
+/** \endcond */
+
+/** \brief  Disable interrupts with scope management.
+
+    This macro will disable interrupts, similarly to irq_disable(), with the
+    difference that the interrupt state will automatically be restored once the
+    execution exits the functional block in which the macro was called.
+*/
+#define irq_disable_scoped() __irq_disable_scoped(__LINE__)
+
 __END_DECLS
 
 #endif  /* __ARCH_IRQ_H */

--- a/kernel/exports/library.c
+++ b/kernel/exports/library.c
@@ -107,11 +107,10 @@ klibrary_t *library_by_libid(libid_t libid) {
 /* Library shell creation and deletion */
 
 klibrary_t * library_create(int flags) {
-    int     oldirq = 0;
     klibrary_t  * np;
     libid_t     libid;
 
-    oldirq = irq_disable();
+    irq_disable_scoped();
     np = NULL;
 
     /* Get a new library id */
@@ -135,7 +134,6 @@ klibrary_t * library_create(int flags) {
         }
     }
 
-    irq_restore(oldirq);
     return np;
 }
 
@@ -200,17 +198,14 @@ uint32 library_get_version(klibrary_t * lib) {
 
 /*****************************************************************************/
 klibrary_t * library_lookup(const char * name) {
-    int     old;
     klibrary_t  * lib;
 
-    old = irq_disable();
+    irq_disable_scoped();
 
     LIST_FOREACH(lib, &library_list, list) {
         if(!strcasecmp(lib->lib_get_name(), name))
             break;
     }
-
-    irq_restore(old);
 
     if(!lib)
         errno = ENOENT;

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -392,7 +392,8 @@ static void net_dhcp_renew(void) {
 
 static void net_dhcp_bind(dhcp_pkt_t *pkt, int len) {
     uint32 tmp = ntohl(pkt->yiaddr);
-    uint32 old = irq_disable();
+
+    irq_disable_scoped();
 
     /* Bind the IP address first */
     net_default_dev->ip_addr[0] = (tmp >> 24) & 0xFF;
@@ -476,8 +477,6 @@ static void net_dhcp_bind(dhcp_pkt_t *pkt, int len) {
     }
 
     state = DHCP_STATE_BOUND;
-
-    irq_restore(old);
 }
 
 static void net_dhcp_thd(void *obj) {

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -2971,14 +2971,13 @@ int net_tcp_init(void) {
 
 void net_tcp_shutdown(void) {
     struct tcp_sock *i, *tmp;
-    int old;
 
     /* Kill the thread and make sure we can grab the lock */
     if(thd_cb_id >= 0)
         net_thd_del_callback(thd_cb_id);
 
     /* Disable IRQs so we can kill the sockets in peace... */
-    old = irq_disable();
+    irq_disable_scoped();
 
     /* Clean up existing sockets */
     i = LIST_FIRST(&tcp_socks);
@@ -3006,6 +3005,4 @@ void net_tcp_shutdown(void) {
 
     /* Remove us from fs_socket and clean up the semaphore */
     fs_socket_proto_remove(&proto);
-
-    irq_restore(old);
 }

--- a/kernel/thread/rwsem.c
+++ b/kernel/thread/rwsem.c
@@ -44,9 +44,9 @@ int rwsem_init(rw_semaphore_t *s) {
 
 /* Destroy a reader/writer semaphore */
 int rwsem_destroy(rw_semaphore_t *s) {
-    int rv = 0, old;
+    int rv = 0;
 
-    old = irq_disable();
+    irq_disable_scoped();
 
     if(s->read_count || s->write_lock) {
         errno = EBUSY;
@@ -56,13 +56,12 @@ int rwsem_destroy(rw_semaphore_t *s) {
         free(s);
     }
 
-    irq_restore(old);
     return rv;
 }
 
 /* Lock a reader/writer semaphore for reading */
 int rwsem_read_lock_timed(rw_semaphore_t *s, int timeout) {
-    int old, rv = 0;
+    int rv = 0;
 
     if((rv = irq_inside_int())) {
         dbglog(DBG_WARNING, "%s: called inside an interrupt with code: "
@@ -78,7 +77,7 @@ int rwsem_read_lock_timed(rw_semaphore_t *s, int timeout) {
         return -1;
     }
 
-    old = irq_disable();
+    irq_disable_scoped();
 
     /* If the write lock is not held, let the thread proceed */
     if(!s->write_lock) {
@@ -99,7 +98,6 @@ int rwsem_read_lock_timed(rw_semaphore_t *s, int timeout) {
         }
     }
 
-    irq_restore(old);
     return rv;
 }
 
@@ -116,7 +114,7 @@ int rwsem_read_lock_irqsafe(rw_semaphore_t *s) {
 
 /* Lock a reader/writer semaphore for writing */
 int rwsem_write_lock_timed(rw_semaphore_t *s, int timeout) {
-    int old, rv = 0;
+    int rv = 0;
 
     if(irq_inside_int()) {
         dbglog(DBG_WARNING, "rwsem_write_lock_timed: called inside "
@@ -130,7 +128,7 @@ int rwsem_write_lock_timed(rw_semaphore_t *s, int timeout) {
         return -1;
     }
 
-    old = irq_disable();
+    irq_disable_scoped();
 
     /* If the write lock is not held and there are no readers in their critical
        sections, let the thread proceed. */
@@ -153,7 +151,6 @@ int rwsem_write_lock_timed(rw_semaphore_t *s, int timeout) {
         }
     }
 
-    irq_restore(old);
     return rv;
 }
 
@@ -170,12 +167,9 @@ int rwsem_write_lock_irqsafe(rw_semaphore_t *s) {
 
 /* Unlock a reader/writer semaphore from a read lock. */
 int rwsem_read_unlock(rw_semaphore_t *s) {
-    int old;
-
-    old = irq_disable();
+    irq_disable_scoped();
 
     if(!s->read_count) {
-        irq_restore(old);
         errno = EPERM;
         return -1;
     }
@@ -193,19 +187,16 @@ int rwsem_read_unlock(rw_semaphore_t *s) {
         }
     }
 
-    irq_restore(old);
-
     return 0;
 }
 
 /* Unlock a reader/writer semaphore from a write lock. */
 int rwsem_write_unlock(rw_semaphore_t *s) {
-    int old, woken;
+    int woken;
 
-    old = irq_disable();
+    irq_disable_scoped();
 
     if(s->write_lock != thd_current) {
-        irq_restore(old);
         errno = EPERM;
         return -1;
     }
@@ -220,77 +211,57 @@ int rwsem_write_unlock(rw_semaphore_t *s) {
         genwait_wake_all(s);
     }
 
-    irq_restore(old);
-
     return 0;
 }
 
 int rwsem_unlock(rw_semaphore_t *s) {
-    int old, rv;
-
-    old = irq_disable();
+    irq_disable_scoped();
 
     if(!s->write_lock && !s->read_count) {
         errno = EPERM;
-        rv = -1;
-    }
-    /* Is this thread holding the write lock? */
-    else if(s->write_lock == thd_current) {
-        rv = rwsem_write_unlock(s);
-    }
-    /* Not holding the write lock, assume its holding the read lock... */
-    else {
-        rv = rwsem_read_unlock(s);
+        return -1;
     }
 
-    irq_restore(old);
-    return rv;
+    /* Is this thread holding the write lock? */
+    if(s->write_lock == thd_current)
+        return rwsem_write_unlock(s);
+
+    /* Not holding the write lock, assume its holding the read lock... */
+    return rwsem_read_unlock(s);
 }
 
 /* Attempt to lock a reader/writer semaphore for reading, but do not block. */
 int rwsem_read_trylock(rw_semaphore_t *s) {
-    int old, rv;
-
-    old = irq_disable();
+    irq_disable_scoped();
 
     /* Is the write lock held? */
     if(s->write_lock) {
-        rv = -1;
         errno = EWOULDBLOCK;
-    }
-    else {
-        rv = 0;
-        ++s->read_count;
+        return -1;
     }
 
-    irq_restore(old);
-    return rv;
+    ++s->read_count;
+    return 0;
 }
 
 /* Attempt to lock a reader/writer semaphore for writing, but do not block. */
 int rwsem_write_trylock(rw_semaphore_t *s) {
-    int old, rv;
-
-    old = irq_disable();
+    irq_disable_scoped();
 
     /* Are there any readers in their critical sections, or is the write lock
        already held, if so we can't do anything about that now. */
     if(s->read_count || s->write_lock) {
-        rv = -1;
         errno = EWOULDBLOCK;
-    }
-    else {
-        rv = 0;
-        s->write_lock = thd_current;
+        return -1;
     }
 
-    irq_restore(old);
-    return rv;
+    s->write_lock = thd_current;
+    return 0;
 }
 
 /* "Upgrade" a read lock to a write lock. */
 int rwsem_read_upgrade_timed(rw_semaphore_t *s, int timeout) {
-    int old, rv = 0;
+    int rv;
 
     if(irq_inside_int()) {
         dbglog(DBG_WARNING, "rwsem_read_upgrade_timed: called inside "
@@ -304,7 +275,7 @@ int rwsem_read_upgrade_timed(rw_semaphore_t *s, int timeout) {
         return -1;
     }
 
-    old = irq_disable();
+    irq_disable_scoped();
 
     /* If there are still other readers, see if any other readers have tried to
        upgrade or not... */
@@ -312,37 +283,35 @@ int rwsem_read_upgrade_timed(rw_semaphore_t *s, int timeout) {
         if(s->reader_waiting) {
             /* We've got someone ahead of us, so there's really not anything
                that can be done at this point... */
-            rv = -1;
             errno = EBUSY;
+            return -1;
         }
-        else {
-            --s->read_count;
-            s->reader_waiting = thd_current;
-            rv = genwait_wait(&s->write_lock, timeout ?
-                              "rwsem_read_upgrade_timed" : "rwsem_read_upgrade",
-                              timeout, NULL);
 
-            if(rv < 0) {
-                /* The only way we can error out is if there are still readers
-                   with the lock, so we can safely re-grab the lock here. */
-                ++s->read_count;
-                rv = -1;
+        --s->read_count;
+        s->reader_waiting = thd_current;
+        rv = genwait_wait(&s->write_lock, timeout ?
+                          "rwsem_read_upgrade_timed" : "rwsem_read_upgrade",
+                          timeout, NULL);
 
-                if(errno == EAGAIN)
-                    errno = ETIMEDOUT;
-            }
-            else {
-                s->write_lock = thd_current;
-            }
+        if(rv < 0) {
+            /* The only way we can error out is if there are still readers
+               with the lock, so we can safely re-grab the lock here. */
+            ++s->read_count;
+
+            if(errno == EAGAIN)
+                errno = ETIMEDOUT;
+
+            return -1;
         }
+
+        s->write_lock = thd_current;
     }
     else {
         s->read_count = 0;
         s->write_lock = thd_current;
     }
 
-    irq_restore(old);
-    return rv;
+    return 0;
 }
 
 int rwsem_read_upgrade(rw_semaphore_t *s) {
@@ -351,26 +320,22 @@ int rwsem_read_upgrade(rw_semaphore_t *s) {
 
 /* Attempt to upgrade a read lock to a write lock, but do not block. */
 int rwsem_read_tryupgrade(rw_semaphore_t *s) {
-    int old, rv;
-
-    old = irq_disable();
+    irq_disable_scoped();
 
     if(s->reader_waiting) {
-        rv = -1;
         errno = EBUSY;
-    }
-    else if(s->read_count != 1) {
-        rv = -1;
-        errno = EWOULDBLOCK;
-    }
-    else {
-        rv = 0;
-        s->read_count = 0;
-        s->write_lock = thd_current;
+        return -1;
     }
 
-    irq_restore(old);
-    return rv;
+    if(s->read_count != 1) {
+        errno = EWOULDBLOCK;
+        return -1;
+    }
+
+    s->read_count = 0;
+    s->write_lock = thd_current;
+
+    return 0;
 }
 
 /* Return the current reader count */

--- a/kernel/thread/worker.c
+++ b/kernel/thread/worker.c
@@ -77,16 +77,12 @@ kthread_worker_t *thd_worker_create_ex(const kthread_attr_t *attr,
 }
 
 void thd_worker_wakeup(kthread_worker_t *worker) {
-    uint32_t flags;
-
     assert(worker != NULL);
 
-    flags = irq_disable();
+    irq_disable_scoped();
 
     worker->pending = true;
     genwait_wake_one(worker);
-
-    irq_restore(flags);
 }
 
 void thd_worker_destroy(kthread_worker_t *worker) {
@@ -111,21 +107,18 @@ kthread_t *thd_worker_get_thread(kthread_worker_t *worker) {
 }
 
 void thd_worker_add_job(kthread_worker_t *worker, kthread_job_t *job) {
-    int flags = irq_disable();
+    irq_disable_scoped();
 
     STAILQ_INSERT_TAIL(&worker->jobs, job, entry);
-
-    irq_restore(flags);
 }
 
 kthread_job_t *thd_worker_dequeue_job(kthread_worker_t *worker) {
     kthread_job_t *job;
-    int flags = irq_disable();
+
+    irq_disable_scoped();
 
     job = STAILQ_FIRST(&worker->jobs);
     STAILQ_REMOVE_HEAD(&worker->jobs, entry);
-
-    irq_restore(flags);
 
     return job;
 }


### PR DESCRIPTION
This PR adds `irq_disable_scoped()`, following the work that has been done with `mutex_lock_scoped()`.

This macro will disable interrupts, similarly to irq_disable(), with the difference that the interrupt state will automatically be restored once the execution exits the functional block in which the macro was called.