### PR TITLE
Add workaround for inlining to support c89 user code

### DIFF
--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -181,6 +181,10 @@
 #define __extension__
 #endif
 
+#ifndef __GNUC_STDC_INLINE__
+#define inline __inline__
+#endif
+
 /** @} */
 
 #endif  /* __KOS_CDEFS_H */


### PR DESCRIPTION
This should allow opus to build again in some toolchains after the changes in #637 . The issue is that the `inline` keyword was added in c99, so a workaround is needed for it to work with c89 code. Normally we wouldn't force special behavior to drag us back to the stone age of C, but due to the nature of how inlining works the issue is forced.

If this causes further issues then we could consider overriding the language standard the opus libs are using.