### PR TITLE
Remove sd from the list of examples folders

### DIFF
--- a/examples/dreamcast/Makefile
+++ b/examples/dreamcast/Makefile
@@ -6,7 +6,7 @@
 #
 
 DIRS = 2ndmix basic libdream kgl hello sound png vmu conio pvr video \
-	   lua parallax dreameye filesystem sd lightgun keyboard sdl dev rumble \
+	   lua parallax dreameye filesystem lightgun keyboard sdl dev rumble \
 	   micropython
 
 ifneq ($(KOS_SUBARCH), naomi)


### PR DESCRIPTION
I overlooked this in #634 . The sd folder was left in the list of example folders to build. Since it no longer had a Makefile in it or it's subdirs, `make` would just silently pass over it by using `check-dir` . Unfortunately neither `clean` nor `dist` do the same test when trying to run their directives on the subfolders and so they would throw an error on the sd folder until it was manually removed.

This was only a problem if you had not run a clean on examples prior to pulling #634 which moved the folder, as that would result in the sd folder staying with objects and elfs and such.