### PR TITLE
Clean up usage of `INLINE` in utils

### DIFF
--- a/utils/dcbumpgen/Makefile
+++ b/utils/dcbumpgen/Makefile
@@ -1,7 +1,7 @@
 
 # Makefile stolen from the kmgenc program.
 
-CFLAGS = -O2 -Wall -DINLINE=inline -I/usr/local/include
+CFLAGS = -O2 -Wall -I/usr/local/include
 LDFLAGS = -s -lpng -ljpeg -lm -lz -L/usr/local/lib
 
 all: dcbumpgen

--- a/utils/kmgenc/Makefile
+++ b/utils/kmgenc/Makefile
@@ -1,8 +1,8 @@
 
 # Makefile for the kmgenc program.
 
-CFLAGS = -O2 -Wall -DINLINE=inline -I/usr/local/include #-g#
-LDFLAGS = -s -lpng -ljpeg -lz -L/usr/local/lib #-g
+CFLAGS = -O2 -Wall -I/usr/local/include
+LDFLAGS = -s -lpng -ljpeg -lz -L/usr/local/lib
 
 all: kmgenc
 

--- a/utils/vqenc/Makefile
+++ b/utils/vqenc/Makefile
@@ -1,13 +1,8 @@
 
-# Makefile for the genromfs program.
+# Makefile for the vqenc program.
 
-# Use for OSX w/Fink
-#CFLAGS = -O2 -Wall -DINLINE=inline -I/sw/include #-g#
-#LDFLAGS = -s -L/sw/lib -lpng -ljpeg -lz #-g
-
-# Use for other systems
-CFLAGS = -O2 -Wall -DINLINE=inline -I/usr/local/include #-g#
-LDFLAGS = -lpng -ljpeg -lz -lm -L/usr/local/lib #-s -g
+CFLAGS = -O2 -Wall -I/usr/local/include
+LDFLAGS = -lpng -ljpeg -lz -lm -L/usr/local/lib
 
 all: vqenc
 

--- a/utils/vqenc/vq_internal.h
+++ b/utils/vqenc/vq_internal.h
@@ -4,43 +4,39 @@
 
 #include "vq_types.h"
 
-#ifndef INLINE
-#define INLINE
-#endif
-
-static void INLINE get_color(fcolor_t *c, uint8 *pixels) {
+static void inline get_color(fcolor_t *c, uint8 *pixels) {
     c->a = pixels[0];
     c->r = pixels[1];
     c->g = pixels[2];
     c->b = pixels[3];
 }
 
-static void INLINE sum_colors(fcolor_t *out, fcolor_t *in) {
+static void inline sum_colors(fcolor_t *out, fcolor_t *in) {
     out->a += in->a;
     out->r += in->r;
     out->g += in->g;
     out->b += in->b;
 }
 
-static void INLINE div_colors(fcolor_t *out, float v) {
+static void inline div_colors(fcolor_t *out, float v) {
     out->a /= v;
     out->r /= v;
     out->g /= v;
     out->b /= v;
 }
 
-static void INLINE clear_quad(fquad_t *q) {
+static void inline clear_quad(fquad_t *q) {
     memset(q, '\0', sizeof(*q));
 }
 
-static void INLINE add_quad(fquad_t *out, fquad_t *in) {
+static void inline add_quad(fquad_t *out, fquad_t *in) {
     sum_colors(&out->p[0], &in->p[0]);
     sum_colors(&out->p[1], &in->p[1]);
     sum_colors(&out->p[2], &in->p[2]);
     sum_colors(&out->p[3], &in->p[3]);
 }
 
-static void INLINE sub_quad(fquad_t *out, fquad_t *a, fquad_t *b) {
+static void inline sub_quad(fquad_t *out, fquad_t *a, fquad_t *b) {
     int i;
 
     for(i = 0; i < 4; i++) {
@@ -51,7 +47,7 @@ static void INLINE sub_quad(fquad_t *out, fquad_t *a, fquad_t *b) {
     }
 }
 
-static void INLINE div_quad(fquad_t *q, float v) {
+static void inline div_quad(fquad_t *q, float v) {
     if(v < 1.0f) {
         clear_quad(q);
     }
@@ -63,8 +59,8 @@ static void INLINE div_quad(fquad_t *q, float v) {
     }
 }
 
-static void INLINE copy_quad(fquad_t *out, fquad_t *in) {
+static void inline copy_quad(fquad_t *out, fquad_t *in) {
     *out = *in;
 }
 
-#endif
+#endif  /* __VQ_INTERNAL_H */

--- a/utils/vqenc/vqenc.c
+++ b/utils/vqenc/vqenc.c
@@ -265,7 +265,7 @@ static uint16 pack(fcolor_t *c) {
         return PACK565(r, g, b);
 }
 
-static int INLINE le16(int x) {
+static int inline le16(int x) {
     /* Endian test added by Megan. This is probably not too efficient
        but it's portable and will get the job done. */
     unsigned long test = 0x12345678;


### PR DESCRIPTION
Something I noticed when working at #768 . vqenc is old enough that c99 support wouldn't have been universal at the time. Now we presuppose it, so removing the `INLINE` define. At the same time some others that were copy+pasted from vqenc seem to have added it without ever using it.

While I was at each, made some minor cleanup.