### PR TITLE
Ensure maple devices are reset back to standard on shutdown

### DIFF
--- a/examples/dreamcast/rumble/rumble.c
+++ b/examples/dreamcast/rumble/rumble.c
@@ -346,10 +346,6 @@ int main(int argc, char *argv[]) {
         pvr_scene_finish();
     }
 
-    /* Stop rumbling before exiting, if it still exists. */
-    if((purudev != NULL) && (purudev->valid != 0))
-        purupuru_rumble_raw(purudev, 0x00000000);
-
     plx_font_destroy(fnt);
     plx_fcxt_destroy(cxt);
 

--- a/examples/dreamcast/vmu/vmu_beep/beep.c
+++ b/examples/dreamcast/vmu/vmu_beep/beep.c
@@ -70,8 +70,8 @@ int main(int argc, char *argv[]) {
     };
     char s[8][2] = { "", "", "", "", "", "", "", "" };
 
-    /* If the face buttons are all pressed, exit the app */
-    cont_btn_callback(0, CONT_RESET_BUTTONS, on_reset);
+    /* If start is pressed, exit the app */
+    cont_btn_callback(0, CONT_START, on_reset);
 
     pvr_init_defaults();
 
@@ -171,7 +171,7 @@ int main(int argc, char *argv[]) {
         w.y += 25.0f;
 
         plx_fcxt_setpos_pnt(cxt, &w);
-        plx_fcxt_draw(cxt, "Press A+B+X+Y+START to quit.");
+        plx_fcxt_draw(cxt, "Press START to quit.");
 
         plx_fcxt_end(cxt);
         pvr_scene_finish();
@@ -211,9 +211,6 @@ int main(int argc, char *argv[]) {
 
         old_buttons = state->buttons;
     }
-
-    if(vmudev)
-        vmu_beep_raw(vmudev, VMU_STOP_EFFECT);
 
     plx_font_destroy(fnt);
     plx_fcxt_destroy(cxt);

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -14,6 +14,7 @@
 #include <dc/vblank.h>
 #include <kos/thread.h>
 #include <kos/init.h>
+#include <kos/genwait.h>
 
 #include <dc/maple/controller.h>
 #include <dc/maple/keyboard.h>
@@ -33,6 +34,55 @@
   Thanks to the LinuxDC guys for some ideas on how to better implement this.
 
 */
+
+static void maple_dev_reset_cb(maple_state_t *st, maple_frame_t *frame) {
+    (void)st;
+
+    /* Unlock the frame */
+    maple_frame_unlock(frame);
+
+    /* Wake up! */
+    genwait_wake_all(frame);
+}
+
+void maple_dev_reset(maple_device_t *dev) {
+
+    assert(dev != NULL);
+
+    /* Lock the frame */
+    while(maple_frame_lock(&dev->frame) < 0)
+        thd_pass();
+
+    /* Reset the frame */
+    maple_frame_init(&dev->frame);
+    dev->frame.cmd = MAPLE_COMMAND_RESET;
+    dev->frame.dst_port = dev->port;
+    dev->frame.dst_unit = dev->unit;
+    dev->frame.length = 0;
+    dev->frame.callback = maple_dev_reset_cb;
+    maple_queue_frame(&dev->frame);
+
+    /* Wait for the device to accept it */
+    if(genwait_wait(&dev->frame, "dev_reset", 500, NULL) < 0) {
+        if(dev->frame.state != MAPLE_FRAME_VACANT) {
+            /* Something went wrong.... */
+            dev->frame.state = MAPLE_FRAME_VACANT;
+            dbglog(DBG_ERROR, "dev_reset: timeout to unit %c%c\n",
+                   dev->port + 'A', dev->unit + '0');
+        }
+    }
+
+    dbglog(DBG_INFO, "dev_reset: reset sent to unit %c%c\n",
+                   dev->port + 'A', dev->unit + '0');
+
+    return;
+}
+
+void maple_dev_reset_all(void) {
+    MAPLE_FOREACH_BEGIN(MAPLE_FUNC_ANY, void, st)
+        maple_dev_reset(__dev);
+    MAPLE_FOREACH_END()
+}
 
 /* Initialize Hardware (call after driver inits) */
 static void maple_hw_init(void) {
@@ -105,6 +155,9 @@ static void maple_hw_init(void) {
 void maple_hw_shutdown(void) {
     int p, u, cnt;
     uint32  ptr;
+
+    /* Reset all devices to leave them as we found them */
+    maple_dev_reset_all();
 
     /* Unhook interrupts */
     vblank_handler_remove(maple_state.vbl_handle);
@@ -202,10 +255,8 @@ KOS_INIT_FLAG_WEAK(purupuru_shutdown, true);
 KOS_INIT_FLAG_WEAK(sip_shutdown, true);
 KOS_INIT_FLAG_WEAK(dreameye_shutdown, true);
 
-/* Full shutdown: shutdown maple operations and known drivers */
+/* Full shutdown: shutdown each driver, then all hardware operations. */
 void maple_shutdown(void) {
-    maple_hw_shutdown();
-
     KOS_INIT_FLAG_CALL(dreameye_shutdown);
     KOS_INIT_FLAG_CALL(sip_shutdown);
     KOS_INIT_FLAG_CALL(purupuru_shutdown);
@@ -214,4 +265,6 @@ void maple_shutdown(void) {
     KOS_INIT_FLAG_CALL(kbd_shutdown);
     KOS_INIT_FLAG_CALL(cont_shutdown);
     KOS_INIT_FLAG_CALL(lightgun_shutdown);
+
+    maple_hw_shutdown();
 }

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -166,6 +166,7 @@ __BEGIN_DECLS
 #define MAPLE_FUNC_ARGUN        0x20000000  /**< \brief AR gun? */
 #define MAPLE_FUNC_KEYBOARD     0x40000000  /**< \brief Keyboard */
 #define MAPLE_FUNC_LIGHTGUN     0x80000000  /**< \brief Lightgun */
+#define MAPLE_FUNC_ANY          0xffffffff  /**< \brief Match/request any */
 /** @} */
 
 /* \cond */


### PR DESCRIPTION
In looking for the best way to address #229 , I hit upon the fact that there's a maple device reset command. My understanding is that this should work to stop any ongoing operations and to reset any settings back to default.

It seems to work right with `rumble` and `vmu_lcd` just fine, but `vmu_beep` just keeps beeping. Most likely I'm doing something wrong in enumerating and sending the command as it might need to be one for the LCD and one for the Timer (where the beeping lives).

In the end the cleanups should likely be readded to the examples with notes that it's the polite thing to do. Additionally, it may make sense to have the reset called on startup to clear anything from previous software.