### PR TITLE
Fix license link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A beginner's guide to development for the Sega Dreamcast along with detailed ins
 
 # Licensing
 KallistiOS itself is licensed under the BSD-like **KOS License**. **Attribution is not optional**. Additionally, this distribution contains code licensed under various free software licenses.
-See [LICENSE.md](doc/LICENSE.md) for more information on licensing, as well as [LICENSE.KOS](doc/LICENSE.KOS) for the actual **KOS License** text.
+See [LICENSE.md](doc/LICENSE.md) for more information on licensing, as well as [LICENSE.KOS](doc/license/LICENSE.KOS) for the actual **KOS License** text.
 
 # Examples 
 Once you've set up the environment and are ready to begin developing, a good place to start learning is the examples directory, which provides demos for the various KOS APIs and for interacting with the Dreamcast's hardware. Examples include:


### PR DESCRIPTION
Currently, the LICENSE.KOS hyperlink links to the wrong file in the README..
A small oversite, this just points the LICENSE.KOS hyperlink to the correct path.

Seems the issue only appeared 5 days ago: https://github.com/KallistiOS/KallistiOS/commit/80cb6f09e553f70efd184b40ad46fabde4bccd07#diff-96556ca5ff73520e34131c74bbf03376659c7f0b5db25adca2193348decf4fdc
Looks like i got lucky when looking through licenses :p