### PR TITLE
bin2c's Makefile bug

### DIFF
--- a/utils/bin2c/Makefile
+++ b/utils/bin2c/Makefile
@@ -3,9 +3,8 @@
 
 all: bin2c
 
-bin2c:
-	gcc -o bin2c bin2c.c
+bin2c: bin2c.c
+	gcc -o $@ $^
 
 clean:
 	-rm -f bin2c
-


### PR DESCRIPTION
 The bin2c target does not depend on bin2c.c so it wont get rebuilt if bin2c.c source changes.
 
 If there is going to be a 2.1.1 release, this should be included.