### PR TITLE
CD Syscall Types Update

### DIFF
--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -133,7 +133,7 @@ cd_cmd_ret_t cdrom_exec_cmd_timed(cd_cmd_code_t cmd, void *param, uint32_t timeo
 /* Return the status of the drive as two integers (see constants) */
 int cdrom_get_status(int *status, int *disc_type) {
     int rv = CD_ERR_OK;
-    uint32_t params[2];
+    cd_check_drive_params_t params = {0};
 
     /* We might be called in an interrupt to check for ISO cache
        flushing, so make sure we're not interrupting something
@@ -156,10 +156,10 @@ int cdrom_get_status(int *status, int *disc_type) {
 
     if(rv >= 0) {
         if(status != NULL)
-            *status = params[0];
+            *status = params.status;
 
         if(disc_type != NULL)
-            *disc_type = params[1];
+            *disc_type = params.disc_type;
     }
     else {
         if(status != NULL)
@@ -175,6 +175,7 @@ int cdrom_get_status(int *status, int *disc_type) {
 /* Wrapper for the change datatype syscall */
 cd_cmd_ret_t cdrom_change_datatype(cd_read_sec_part_t sector_part, cd_track_type_t track_type, int sector_size) {
     uint32_t params[4];
+    cd_check_drive_params_t check_params = {0};
 
     mutex_lock_scoped(&_g1_ata_mutex);
 
@@ -190,9 +191,9 @@ cd_cmd_ret_t cdrom_change_datatype(cd_read_sec_part_t sector_part, cd_track_type
         if(track_type == CD_TRACK_TYPE_DEFAULT) {
             /* If not overriding track_type, check what the drive thinks we should 
                use */
-            syscall_gdrom_check_drive(params);
+            syscall_gdrom_check_drive(check_params);
 
-            if(params[1] == CD_CDROM_XA)
+            if(check_params.disc_type == CD_CDROM_XA)
                 track_type = CD_TRACK_TYPE_MODE2_FORM1;
             else
                 track_type = CD_TRACK_TYPE_MODE1;

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -287,11 +287,7 @@ cd_cmd_ret_t cdrom_read_sectors(void *buffer, uint32_t sector, size_t cnt) {
 /* XXX: Use some CD-Gs and other stuff to test if you get more than just the 
    Q byte */
 cd_cmd_ret_t cdrom_get_subcode(void *buffer, size_t buflen, cd_sub_type_t which) {
-    struct {
-        cd_sub_type_t   which;
-        size_t          buflen;
-        void           *buffer;
-    } params;
+    cd_cmd_getscd_params_t params;
 
     params.which = which;
     params.buflen = buflen;
@@ -318,18 +314,9 @@ uint32_t cdrom_locate_data_track(cd_toc_t *toc) {
     return 0;
 }
 
-/* Play CDDA tracks
-   start  -- track to play from
-   end    -- track to play to
-   repeat -- number of times to repeat (0-15, 15=infinite)
-   mode   -- CDDA_TRACKS or CDDA_SECTORS
- */
+/* Play CDDA tracks */
 cd_cmd_ret_t cdrom_cdda_play(uint32 start, uint32 end, uint32 repeat, cd_cdda_mode_t mode) {
-    struct {
-        uint32_t start;
-        uint32_t end;
-        uint32_t repeat;
-    } params;
+    cd_cmd_play_params_t params;
 
     /* Limit to 0-15 */
     if(repeat > 15)

--- a/kernel/arch/dreamcast/hardware/syscalls.c
+++ b/kernel/arch/dreamcast/hardware/syscalls.c
@@ -165,9 +165,9 @@ void syscall_gdrom_reset(void) {
         PARAM_NA, PARAM_NA, SUPER_FUNC_GDROM);
 }
 
-int syscall_gdrom_check_drive(uint32_t status[2]) {
+int syscall_gdrom_check_drive(cd_check_drive_params_t params) {
     MAKE_SYSCALL_INT(VEC_MISC_GDROM, FUNC_GDROM_DRIVE_STATUS, 
-        status, PARAM_NA, SUPER_FUNC_GDROM);
+        params, PARAM_NA, SUPER_FUNC_GDROM);
 }
 
 gdc_cmd_id_t syscall_gdrom_send_command(cd_cmd_code_t cmd, void *params) {

--- a/kernel/arch/dreamcast/hardware/syscalls.c
+++ b/kernel/arch/dreamcast/hardware/syscalls.c
@@ -170,7 +170,7 @@ int syscall_gdrom_check_drive(uint32_t status[2]) {
         status, PARAM_NA, SUPER_FUNC_GDROM);
 }
 
-uint32_t syscall_gdrom_send_command(uint32_t cmd, void *params) {
+gdc_cmd_id_t syscall_gdrom_send_command(cd_cmd_code_t cmd, void *params) {
     uint32_t request_id = 0;
 
     MAKE_SYSCALL_SET(VEC_MISC_GDROM, FUNC_GDROM_SEND_COMMAND, 
@@ -179,7 +179,7 @@ uint32_t syscall_gdrom_send_command(uint32_t cmd, void *params) {
     return request_id;
 }
 
-int syscall_gdrom_check_command(uint32_t id, int32_t status[4]) {
+cmd_cmd_chk_t syscall_gdrom_check_command(gdc_cmd_id_t id, int32_t status[4]) {
     MAKE_SYSCALL_INT(VEC_MISC_GDROM, FUNC_GDROM_CHECK_COMMAND, 
         id, status, SUPER_FUNC_GDROM);
 }
@@ -189,7 +189,7 @@ void syscall_gdrom_exec_server(void) {
         PARAM_NA, PARAM_NA, SUPER_FUNC_GDROM);
 }
 
-int syscall_gdrom_abort_command(uint32_t id) {
+int syscall_gdrom_abort_command(gdc_cmd_id_t id) {
     MAKE_SYSCALL_INT(VEC_MISC_GDROM, FUNC_GDROM_ABORT_COMMAND, 
         id, PARAM_NA, SUPER_FUNC_GDROM);
 }
@@ -204,12 +204,12 @@ void syscall_gdrom_dma_callback(uintptr_t callback, void *param) {
         callback, param, SUPER_FUNC_GDROM);
 }
 
-int syscall_gdrom_dma_transfer(uint32_t id, const int32_t params[2]) {
+int syscall_gdrom_dma_transfer(gdc_cmd_id_t id, const int32_t params[2]) {
     MAKE_SYSCALL_INT(VEC_MISC_GDROM, FUNC_GDROM_DMA_TRANSFER, 
         id, params, SUPER_FUNC_GDROM);
 }
 
-int syscall_gdrom_dma_check(uint32_t id, size_t *size) {
+int syscall_gdrom_dma_check(gdc_cmd_id_t id, size_t *size) {
     MAKE_SYSCALL_INT(VEC_MISC_GDROM, FUNC_GDROM_DMA_CHECK, 
         id, size, SUPER_FUNC_GDROM);
 }
@@ -219,12 +219,12 @@ void syscall_gdrom_pio_callback(uintptr_t callback, void *param) {
         callback, param, SUPER_FUNC_GDROM);
 }
 
-int syscall_gdrom_pio_transfer(uint32_t id, const int32_t params[2]) {
+int syscall_gdrom_pio_transfer(gdc_cmd_id_t id, const int32_t params[2]) {
     MAKE_SYSCALL_INT(VEC_MISC_GDROM, FUNC_GDROM_PIO_TRANSFER, 
         id, params, SUPER_FUNC_GDROM);
 }
 
-int syscall_gdrom_pio_check(uint32_t id, size_t *size) {
+int syscall_gdrom_pio_check(gdc_cmd_id_t id, size_t *size) {
      MAKE_SYSCALL_INT(VEC_MISC_GDROM, FUNC_GDROM_PIO_CHECK, 
         id, size, SUPER_FUNC_GDROM);
 }

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -13,6 +13,7 @@
 __BEGIN_DECLS
 
 #include <arch/types.h>
+#include <dc/syscalls.h>
 
 /** \file    dc/cdrom.h
     \brief   CD access to the GD-ROM drive.
@@ -27,7 +28,7 @@ __BEGIN_DECLS
     CD, it will automatically detect and react to disc changes for you.
 
     This file only facilitates reading raw sectors and doing other fairly low-
-    level things with CDs. If you're looking for higher-level stuff, like 
+    level things with CDs. If you're looking for higher-level stuff, like
     normal file reading, consult with the stuff for the fs and for fs_iso9660.
 
     \author Megan Potter
@@ -36,80 +37,10 @@ __BEGIN_DECLS
     \see    dc/fs_iso9660.h
 */
 
-/** \defgroup gdrom     GD-ROM 
+/** \defgroup gdrom     GD-ROM
     \brief              Driver for the Dreamcast's GD-ROM drive
     \ingroup            vfs
 */
-
-/** \defgroup cd_cmd_codes          Syscall Command Codes
-    \brief                          Command codes for GD-ROM syscalsl
-    \ingroup  gdrom
-
-    These are the syscall command codes used to actually do stuff with the
-    GD-ROM drive. These were originally provided by maiwe.
-
-    @{
-*/
-#define CMD_CHECK_LICENSE       2  /**< \brief Check license */
-#define CMD_REQ_SPI_CMD         4  /**< \brief Request to Sega Packet Interface */
-#define CMD_PIOREAD            16  /**< \brief Read via PIO */
-#define CMD_DMAREAD            17  /**< \brief Read via DMA */
-#define CMD_GETTOC             18  /**< \brief Read TOC */
-#define CMD_GETTOC2            19  /**< \brief Read TOC */
-#define CMD_PLAY               20  /**< \brief Play track */
-#define CMD_PLAY2              21  /**< \brief Play sectors */
-#define CMD_PAUSE              22  /**< \brief Pause playback */
-#define CMD_RELEASE            23  /**< \brief Resume from pause */
-#define CMD_INIT               24  /**< \brief Initialize the drive */
-#define CMD_DMA_ABORT          25  /**< \brief Abort DMA transfer */
-#define CMD_OPEN_TRAY          26  /**< \brief Open CD tray (on DevBox?) */
-#define CMD_SEEK               27  /**< \brief Seek to a new position */
-#define CMD_DMAREAD_STREAM     28  /**< \brief Stream DMA until end/abort */
-#define CMD_NOP                29  /**< \brief No operation */
-#define CMD_REQ_MODE           30  /**< \brief Request mode */
-#define CMD_SET_MODE           31  /**< \brief Setup mode */
-#define CMD_SCAN_CD            32  /**< \brief Scan CD */
-#define CMD_STOP               33  /**< \brief Stop the disc from spinning */
-#define CMD_GETSCD             34  /**< \brief Get subcode data */
-#define CMD_GETSES             35  /**< \brief Get session */
-#define CMD_REQ_STAT           36  /**< \brief Request stat */
-#define CMD_PIOREAD_STREAM     37  /**< \brief Stream PIO until end/abort */
-#define CMD_DMAREAD_STREAM_EX  38  /**< \brief Stream DMA transfer */
-#define CMD_PIOREAD_STREAM_EX  39  /**< \brief Stream PIO transfer */
-#define CMD_GET_VERS           40  /**< \brief Get syscall driver version */
-#define CMD_MAX                47  /**< \brief Max of GD syscall commands */
-/** @} */
-
-/** \defgroup cd_cmd_response       Command Responses
-    \brief                          Responses from GD-ROM syscalls
-    \ingroup  gdrom
-
-    These are the values that the various functions can return as error codes.
-    @{
-*/
-#define ERR_OK          0   /**< \brief No error */
-#define ERR_NO_DISC     1   /**< \brief No disc in drive */
-#define ERR_DISC_CHG    2   /**< \brief Disc changed, but not reinitted yet */
-#define ERR_SYS         3   /**< \brief System error */
-#define ERR_ABORTED     4   /**< \brief Command aborted */
-#define ERR_NO_ACTIVE   5   /**< \brief System inactive? */
-#define ERR_TIMEOUT     6   /**< \brief Aborted due to timeout */
-/** @} */
-
-/** \defgroup cd_cmd_status         Command Status Responses
-    \brief                          GD-ROM status responses
-    \ingroup  gdrom
-
-    These are the raw values the status syscall returns.
-    @{
-*/
-#define FAILED      -1  /**< \brief Command failed */
-#define NO_ACTIVE   0   /**< \brief System inactive? */
-#define PROCESSING  1   /**< \brief Processing command */
-#define COMPLETED   2   /**< \brief Command completed successfully */
-#define STREAMING   3   /**< \brief Stream type command is in progress */
-#define BUSY        4   /**< \brief GD syscalls is busy */
-/** @} */
 
 /** \defgroup cd_cmd_ata_status       ATA Statuses
     \brief                            ATA statuses for GD-ROM driver
@@ -124,125 +55,27 @@ __BEGIN_DECLS
 #define ATA_STAT_BUSY       0x04
 /** @} */
 
-/** \defgroup cdda_read_modes       CDDA Read Modes
-    \brief                          Read modes for CDDA
+/** \brief    Read modes for CDDA
     \ingroup  gdrom
 
     Valid values to pass to the cdrom_cdda_play() function for the mode
-    parameter.
-    @{
+    parameter. These set whether to use
 */
-#define CDDA_TRACKS     1   /**< \brief Play by track number */
-#define CDDA_SECTORS    2   /**< \brief Play by sector number */
-/** @} */
+typedef enum cd_cdda_mode {
+    CDDA_TRACKS,   /**< \brief Play by track number (CMD_PLAY) */
+    CDDA_SECTORS   /**< \brief Play by sector number (CMD_PLAY2) */
+} cd_cdda_mode_t;
 
-/** \defgroup cd_read_sector_part    Read Sector Part
-    \brief                           Whether to read data or whole sector
-    \ingroup  gdrom
+/** \brief      Mode to use when reading
+    \ingroup    gdrom
 
-    Parts of the a CD-ROM sector to read. These are possible values for the
-    third parameter word sent with the change data type syscall. 
-    @{
-*/
-#define CDROM_READ_WHOLE_SECTOR 0x1000    /**< \brief Read the whole sector */
-#define CDROM_READ_DATA_AREA    0x2000    /**< \brief Read the data area */
-/** @} */
-
-/** \defgroup cd_read_subcode_type    Read Subcode Type
-    \brief                            Types of data to read from sector subcode
-    \ingroup  gdrom
-
-    Types of data available to read from the sector subcode. These are 
-    possible values for the first parameter sent to the GETSCD syscall.
-    @{
-*/
-#define CD_SUB_Q_ALL            0    /**< \brief Read all Subcode Data */
-#define CD_SUB_Q_CHANNEL        1    /**< \brief Read Q Channel Subcode Data */
-#define CD_SUB_MEDIA_CATALOG    2    /**< \brief Read the Media Catalog 
-                                                 Subcode Data */
-#define CD_SUB_TRACK_ISRC       3    /**< \brief Read the ISRC Subcode Data */
-#define CD_SUB_RESERVED         4    /**< \brief Reserved */
-/** @} */
-
-/** \defgroup cd_subcode_audio    Subcode Audio Status
-    \brief                        GETSCD syscall response codes
-    \ingroup  gdrom
-
-    Information about CDDA playback from GETSCD syscall.
-    @{
-*/
-#define CD_SUB_AUDIO_STATUS_INVALID    0x00
-#define CD_SUB_AUDIO_STATUS_PLAYING    0x11
-#define CD_SUB_AUDIO_STATUS_PAUSED     0x12
-#define CD_SUB_AUDIO_STATUS_ENDED      0x13
-#define CD_SUB_AUDIO_STATUS_ERROR      0x14
-#define CD_SUB_AUDIO_STATUS_NO_INFO    0x15
-/** @} */
-
-/** \defgroup cd_read_sector_mode    Read Sector Mode
-    \brief                           Mode to use when reading sectors
-    \ingroup  gdrom
-
-    How to read the sectors of a CD, via PIO or DMA. 4th parameter of 
+    How to read the sectors of a CD, via PIO or DMA. 4th parameter of
     cdrom_read_sectors_ex.
-    @{
 */
-#define CDROM_READ_PIO 0    /**< \brief Read sector(s) in PIO mode */
-#define CDROM_READ_DMA 1    /**< \brief Read sector(s) in DMA mode */
-/** @} */
-
-/** \defgroup cd_status_values      Status Values
-    \brief                          Status values for GD-ROM drive
-    \ingroup  gdrom
-
-    These are the values that can be returned as the status parameter from the
-    cdrom_get_status() function.
-    @{
-*/
-#define CD_STATUS_READ_FAIL -1  /**< \brief Can't read status */
-#define CD_STATUS_BUSY      0   /**< \brief Drive is busy */
-#define CD_STATUS_PAUSED    1   /**< \brief Disc is paused */
-#define CD_STATUS_STANDBY   2   /**< \brief Drive is in standby */
-#define CD_STATUS_PLAYING   3   /**< \brief Drive is currently playing */
-#define CD_STATUS_SEEKING   4   /**< \brief Drive is currently seeking */
-#define CD_STATUS_SCANNING  5   /**< \brief Drive is scanning */
-#define CD_STATUS_OPEN      6   /**< \brief Disc tray is open */
-#define CD_STATUS_NO_DISC   7   /**< \brief No disc inserted */
-#define CD_STATUS_RETRY     8   /**< \brief Retry is needed */
-#define CD_STATUS_ERROR     9   /**< \brief System error */
-#define CD_STATUS_FATAL     12  /**< \brief Need reset syscalls */
-/** @} */
-
-/** \defgroup cd_disc_types         Drive Disc Types
-    \brief                          Disc types within GD-ROM drive
-    \ingroup  gdrom
-
-    These are the values that can be returned as the disc_type parameter from
-    the cdrom_get_status() function.
-    @{
-*/
-#define CD_CDDA     0x00    /**< \brief Audio CD (Red book) or no disc */
-#define CD_CDROM    0x10    /**< \brief CD-ROM or CD-R (Yellow book) */
-#define CD_CDROM_XA 0x20    /**< \brief CD-ROM XA (Yellow book extension) */
-#define CD_CDI      0x30    /**< \brief CD-i (Green book) */
-#define CD_GDROM    0x80    /**< \brief GD-ROM */
-#define CD_FAIL     0xf0    /**< \brief Need reset syscalls */
-/** @} */
-
-/** \brief  TOC structure returned by the BIOS.
-    \ingroup gdrom
-
-    This is the structure that the CMD_GETTOC2 syscall command will return for
-    the TOC. Note the data is in FAD, not LBA/LSN.
-
-    \headerfile dc/cdrom.h
-*/
-typedef struct {
-    uint32  entry[99];          /**< \brief TOC space for 99 tracks */
-    uint32  first;              /**< \brief Point A0 information (1st track) */
-    uint32  last;               /**< \brief Point A1 information (last track) */
-    uint32  leadout_sector;     /**< \brief Point A2 information (leadout) */
-} CDROM_TOC;
+typedef enum cd_read_mode {
+    CDROM_READ_PIO = 0,    /**< \brief Read sector(s) in PIO mode */
+    CDROM_READ_DMA = 1     /**< \brief Read sector(s) in DMA mode */
+} cd_read_mode_t;
 
 /** \defgroup cd_toc_access         TOC Access Macros
     \brief                          Macros used to access the TOC
@@ -285,9 +118,9 @@ typedef struct {
 
     \param  size            The size of the sector data.
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
 */
-int cdrom_set_sector_size(int size);
+cd_cmd_ret_t cdrom_set_sector_size(size_t size);
 
 /** \brief    Execute a CD-ROM command.
     \ingroup  gdrom
@@ -298,9 +131,9 @@ int cdrom_set_sector_size(int size);
     \param  cmd             The command number to execute.
     \param  param           Data to pass to the syscall.
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
 */
-int cdrom_exec_cmd(int cmd, void *param);
+cd_cmd_ret_t cdrom_exec_cmd(cd_cmd_code_t cmd, void *param);
 
 /** \brief    Execute a CD-ROM command with timeout.
     \ingroup  gdrom
@@ -312,32 +145,28 @@ int cdrom_exec_cmd(int cmd, void *param);
     \param  param           Data to pass to the syscall.
     \param  timeout         Timeout in milliseconds.
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
 */
-int cdrom_exec_cmd_timed(int cmd, void *param, int timeout);
+cd_cmd_ret_t
+cdrom_exec_cmd_timed(cd_cmd_code_t cmd, void *param, uint32_t timeout);
 
 /** \brief    Get the status of the GD-ROM drive.
     \ingroup  gdrom
+    
+    This is a wrapper around syscall_gdrom_check_drive.
+    
+    TODO: this should be updated to just return what is taken without
+    setting -1, with the return being used to determine if the params
+    are valid or not.
 
     \param  status          Space to return the drive's status.
     \param  disc_type       Space to return the type of disc in the drive.
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref syscall_gdrom_check_drive
     \see    cd_status_values
-    \see    cd_disc_types
+    \see    cd_disc_types_t
 */
 int cdrom_get_status(int *status, int *disc_type);
-
-/** \brief    Change the datatype of disc.
-    \ingroup  gdrom
-
-    \note                   This function is formally deprecated. It should not
-                            be used in any future code, and may be removed in
-                            the future. You should instead use
-                            cdrom_change_datatype.
-*/
-int cdrom_change_dataype(int sector_part, int cdxa, int sector_size)
-                        __depr("Use cdrom_change_datatype instead.");
 
 /** \brief    Change the datatype of disc.
     \ingroup  gdrom
@@ -346,15 +175,16 @@ int cdrom_change_dataype(int sector_part, int cdxa, int sector_size)
     syscall. This allows these parameters to be modified without a reinit. 
     Each parameter allows -1 as a default, which is tied to the former static 
     values provided by cdrom_reinit and cdrom_set_sector_size.
-
     \param sector_part      How much of each sector to return.
-    \param cdxa             What CDXA mode to read as (if applicable).
+    \param track_type       What track type to read as (if applicable).
     \param sector_size      What sector size to read (eg. - 2048, 2532).
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
     \see    cd_read_sector_part
 */
-int cdrom_change_datatype(int sector_part, int cdxa, int sector_size);
+cd_cmd_ret_t
+cdrom_change_datatype(cd_read_sec_part_t sector_part,
+                      cd_track_type_t track_type, int sector_size);
 
 /** \brief    Re-initialize the GD-ROM drive.
     \ingroup  gdrom
@@ -362,27 +192,29 @@ int cdrom_change_datatype(int sector_part, int cdxa, int sector_size);
     This function is for reinitializing the GD-ROM drive after a disc change to
     its default settings. Calls cdrom_reinit(-1,-1,-1)
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
     \see    cdrom_reinit_ex
 */
-int cdrom_reinit(void);
+cd_cmd_ret_t cdrom_reinit(void);
 
 /** \brief    Re-initialize the GD-ROM drive with custom parameters.
     \ingroup  gdrom
 
-    At the end of each cdrom_reinit(), cdrom_change_datatype is called. 
-    This passes in the requested values to that function after 
+    At the end of each cdrom_reinit(), cdrom_change_datatype is called.
+    This passes in the requested values to that function after
     reinitialization, as opposed to defaults.
 
     \param sector_part      How much of each sector to return.
-    \param cdxa             What CDXA mode to read as (if applicable).
+    \param track_type       What track type to read as (if applicable).
     \param sector_size      What sector size to read (eg. - 2048, 2532).
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
     \see    cd_read_sector_part
     \see    cdrom_change_datatype
 */
-int cdrom_reinit_ex(int sector_part, int cdxa, int sector_size);
+cd_cmd_ret_t
+cdrom_reinit_ex(cd_read_sec_part_t sector_part,
+                cd_track_type_t, int sector_size);
 
 /** \brief    Read the table of contents from the disc.
     \ingroup  gdrom
@@ -391,9 +223,9 @@ int cdrom_reinit_ex(int sector_part, int cdxa, int sector_size);
 
     \param  toc_buffer      Space to store the returned TOC in.
     \param  session         The session of the disc to read.
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
 */
-int cdrom_read_toc(CDROM_TOC *toc_buffer, int session);
+cd_cmd_ret_t cdrom_read_toc(cd_toc_t *toc_buffer, uint32_t session);
 
 /** \brief    Read one or more sector from a CD-ROM.
     \ingroup  gdrom
@@ -401,16 +233,18 @@ int cdrom_read_toc(CDROM_TOC *toc_buffer, int session);
     This function reads the specified number of sectors from the disc, starting
     where requested. This will respect the size of the sectors set with
     cdrom_change_datatype(). The buffer must have enough space to store the
-    specified number of sectors.
+    specified number of sectors and size must be a multiple of 32 for DMA.
 
     \param  buffer          Space to store the read sectors.
     \param  sector          The sector to start reading from.
     \param  cnt             The number of sectors to read.
-    \param  mode            DMA or PIO
-    \return                 \ref cd_cmd_response
+    \param  mode            \ref cd_read_mode_t
+    \return                 \ref cd_cmd_ret_t
     \see    cd_read_sector_mode
 */
-int cdrom_read_sectors_ex(void *buffer, int sector, int cnt, int mode);
+cd_cmd_ret_t
+cdrom_read_sectors_ex(void *buffer, uint32_t sector, size_t cnt,
+                      cd_read_mode_t mode);
 
 /** \brief    Read one or more sector from a CD-ROM in PIO mode.
     \ingroup  gdrom
@@ -420,26 +254,28 @@ int cdrom_read_sectors_ex(void *buffer, int sector, int cnt, int mode);
     \param  buffer          Space to store the read sectors.
     \param  sector          The sector to start reading from.
     \param  cnt             The number of sectors to read.
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
     \see    cdrom_read_sectors_ex
 */
-int cdrom_read_sectors(void *buffer, int sector, int cnt);
+cd_cmd_ret_t
+cdrom_read_sectors(void *buffer, uint32_t sector, size_t cnt);
 
 /** \brief    Read subcode data from the most recently read sectors.
     \ingroup  gdrom
 
-    After reading sectors, this can pull subcode data regarding the sectors 
-    read. If reading all subcode data with CD_SUB_CURRENT_POSITION, this needs 
+    After reading sectors, this can pull subcode data regarding the sectors
+    read. If reading all subcode data with CD_SUB_CURRENT_POSITION, this needs
     to be performed one sector at a time.
 
     \param  buffer          Space to store the read subcode data.
     \param  buflen          Amount of data to be read.
     \param  which           Which subcode type do you wish to get.
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
     \see    cd_read_subcode_type
 */
-int cdrom_get_subcode(void *buffer, int buflen, int which);
+cd_cmd_ret_t
+cdrom_get_subcode(void *buffer, size_t buflen, cd_sub_type_t which);
 
 /** \brief    Locate the sector of the data track.
     \ingroup  gdrom
@@ -450,7 +286,7 @@ int cdrom_get_subcode(void *buffer, int buflen, int which);
     \param  toc             The TOC to search through.
     \return                 The FAD of the track, or 0 if none is found.
 */
-uint32 cdrom_locate_data_track(CDROM_TOC *toc);
+uint32_t cdrom_locate_data_track(cd_toc_t *toc);
 
 /** \brief    Play CDDA audio tracks or sectors.
     \ingroup  gdrom
@@ -461,32 +297,33 @@ uint32 cdrom_locate_data_track(CDROM_TOC *toc);
     \param  end             The track or sector to end playback at.
     \param  loops           The number of times to repeat (max of 15).
     \param  mode            The mode to play (see \ref cdda_read_modes).
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
 */
-int cdrom_cdda_play(uint32 start, uint32 end, uint32 loops, int mode);
+cd_cmd_ret_t
+cdrom_cdda_play(uint32_t start, uint32_t end, uint32_t loops, cd_cdda_mode_t mode);
 
 /** \brief    Pause CDDA audio playback.
     \ingroup  gdrom
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
 */
-int cdrom_cdda_pause(void);
+cd_cmd_ret_t cdrom_cdda_pause(void);
 
 /** \brief    Resume CDDA audio playback after a pause.
     \ingroup  gdrom
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
 */
-int cdrom_cdda_resume(void);
+cd_cmd_ret_t cdrom_cdda_resume(void);
 
 /** \brief    Spin down the CD.
     \ingroup  gdrom
 
     This stops the disc in the drive from spinning until it is accessed again.
 
-    \return                 \ref cd_cmd_response
+    \return                 \ref cd_cmd_ret_t
 */
-int cdrom_spin_down(void);
+cd_cmd_ret_t cdrom_spin_down(void);
 
 /** \brief    Initialize the GD-ROM for reading CDs.
     \ingroup  gdrom

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -73,8 +73,8 @@ typedef enum cd_cdda_mode {
     cdrom_read_sectors_ex.
 */
 typedef enum cd_read_mode {
-    CDROM_READ_PIO = 0,    /**< \brief Read sector(s) in PIO mode */
-    CDROM_READ_DMA = 1     /**< \brief Read sector(s) in DMA mode */
+    CDROM_READ_PIO,    /**< \brief Read sector(s) in PIO mode */
+    CDROM_READ_DMA     /**< \brief Read sector(s) in DMA mode */
 } cd_read_mode_t;
 
 /** \defgroup cd_toc_access         TOC Access Macros

--- a/kernel/arch/dreamcast/include/dc/syscalls.h
+++ b/kernel/arch/dreamcast/include/dc/syscalls.h
@@ -280,26 +280,6 @@ typedef enum cd_cmd_code {
     CMD_MAX               = 47,  /**< \brief Max of GD syscall commands */
 } cd_cmd_code_t;
 
-/** \brief      TOC structure returned by the BIOS.
-    \ingroup    gdrom_syscalls
-
-    This is the structure that the CMD_GETTOC2 syscall command will return for
-    the TOC. Note the data is in FAD, not LBA/LSN.
-
-*/
-typedef struct cd_toc {
-    uint32_t  entry[99];          /**< \brief TOC space for 99 tracks */
-    uint32_t  first;              /**< \brief Point A0 information (1st track) */
-    uint32_t  last;               /**< \brief Point A1 information (last track) */
-    uint32_t  leadout_sector;     /**< \brief Point A2 information (leadout) */
-} cd_toc_t;
-
-/* Compat. Not sure if this is a good way to mark it, or if this is useful to do at 
-    all. But 'CDROM_TOC' violates our style guide which has caps reserved for defines
-    or macros.
-*/
-#define CDROM_TOC __depr("Use the type cd_toc_t rather than CDROM_TOC.") cd_toc_t
-
 /** \brief      Responses from GDROM syscalls
     \ingroup    gdrom_syscalls
 
@@ -350,6 +330,38 @@ typedef enum cd_track_type {
     CD_TRACK_TYPE_DEFAULT     = -1
 } cd_track_type_t;
 
+/** \brief      TOC structure returned by the BIOS.
+    \ingroup    gdrom_syscalls
+
+    This is the structure that the CMD_GETTOC2 syscall command will return for
+    the TOC. Note the data is in FAD, not LBA/LSN.
+
+*/
+typedef struct cd_toc {
+    uint32_t  entry[99];          /**< \brief TOC space for 99 tracks */
+    uint32_t  first;              /**< \brief Point A0 information (1st track) */
+    uint32_t  last;               /**< \brief Point A1 information (last track) */
+    uint32_t  leadout_sector;     /**< \brief Point A2 information (leadout) */
+} cd_toc_t;
+
+/* Compat. Not sure if this is a good way to mark it, or if this is useful to do at
+    all. But 'CDROM_TOC' violates our style guide which has caps reserved for defines
+    or macros.
+*/
+#define CDROM_TOC __depr("Use the type cd_toc_t rather than CDROM_TOC.") cd_toc_t
+
+/** \brief      Params for PLAY command
+    \ingroup    gdrom_syscalls
+
+    Params for CMD_PLAY and CMD_PLAY2.
+
+*/
+typedef struct cd_cmd_play_params {
+    uint32_t start;     /**< \brief Track to play from */
+    uint32_t end;       /**< \brief Track to play to */
+    uint32_t repeat;    /**< \brief Times to repeat (0-15, 15=infinite) */
+} cd_cmd_play_params_t;
+
 /** \brief      Read Sector Part
     \ingroup    gdrom_syscalls
 
@@ -378,6 +390,15 @@ typedef enum cd_sub_type {
     CD_SUB_TRACK_ISRC     = 3,    /**< \brief Read the ISRC Subcode Data */
     CD_SUB_RESERVED       = 4     /**< \brief Reserved */
 } cd_sub_type_t;
+
+/** \brief      Params for GETSCD command
+    \ingroup    gdrom_syscalls
+*/
+typedef struct cd_cmd_getscd_params {
+    cd_sub_type_t   which;
+    size_t          buflen;
+    void           *buffer;
+} cd_cmd_getscd_params_t;
 
 /** \brief      Subcode Audio Statuses
     \ingroup    gdrom_syscalls

--- a/kernel/arch/dreamcast/include/dc/syscalls.h
+++ b/kernel/arch/dreamcast/include/dc/syscalls.h
@@ -227,6 +227,14 @@ typedef enum cd_disc_types {
     CD_FAIL     = 0xf0     /**< \brief Need reset syscalls */
 } cd_disc_types_t;
 
+/** \brief      Params for Check Drive syscall
+    \ingroup    gdrom_syscalls
+*/
+typedef struct cd_check_drive_params {
+    cd_stat_t       status;
+    cd_disc_types_t disc_type;
+} cd_check_drive_params_t;
+
 /** \brief      ID of a queued command
     \ingroup    gdrom_syscalls
     
@@ -415,7 +423,7 @@ void syscall_gdrom_reset(void);
     \return                 0 on success, or non-zero on
                             failure.
 */
-int syscall_gdrom_check_drive(uint32_t status[2]);
+int syscall_gdrom_check_drive(cd_check_drive_params_t params);
 
 /** \brief      Send a command to the GDROM command queue.
     \ingroup    gdrom_syscalls

--- a/kernel/arch/dreamcast/include/dc/syscalls.h
+++ b/kernel/arch/dreamcast/include/dc/syscalls.h
@@ -303,7 +303,7 @@ typedef enum cd_cmd_ret {
     CD_ERR_DISC_CHG  = 2,   /**< \brief Disc changed, but not reinitted yet */
     CD_ERR_SYS       = 3,   /**< \brief System error */
     CD_ERR_ABORTED   = 4,   /**< \brief Command aborted */
-    CD_ERR_NO_ACTIVE = 5,   /**< \brief System inactive? */
+    CD_ERR_INACTIVE  = 5,   /**< \brief System inactive? */
     CD_ERR_TIMEOUT   = 6,   /**< \brief Aborted due to timeout */
 } cd_cmd_ret_t;
 

--- a/kernel/arch/dreamcast/include/dc/syscalls.h
+++ b/kernel/arch/dreamcast/include/dc/syscalls.h
@@ -105,7 +105,6 @@ uint8_t *syscall_font_address(void);
 int syscall_font_lock(void);
 
 /** \brief   Unlocks access to ROM font.
-    \ingroup system_calls
 
     This function releases the mutex locked with syscall_font_lock().
 
@@ -183,25 +182,232 @@ int syscall_flashrom_write(uint32_t pos, const void *src, size_t n);
 */
 int syscall_flashrom_delete(uint32_t pos);
 
-/** \brief   Initialize the GDROM drive.
+/** \defgroup   gdrom_syscalls
+    \brief      GDROM Syscalls and Data Types
+    \ingroup    system_calls
+    \ingroup    gdrom
+
+    These are the syscalls that allow operation of the GDROM drive
+    as well as data types for their returns and parameters.
+*/
+
+/** \brief      Status of GDROM drive
+    \ingroup    gdrom_syscalls
+
+    These are the values that can be returned as the first param of
+    syscall_gdrom_check_drive.
+*/
+typedef enum cd_stat {
+    CD_STATUS_READ_FAIL = -1,   /**< \brief Can't read status */
+    CD_STATUS_BUSY      =  0,   /**< \brief Drive is busy */
+    CD_STATUS_PAUSED    =  1,   /**< \brief Disc is paused */
+    CD_STATUS_STANDBY   =  2,   /**< \brief Drive is in standby */
+    CD_STATUS_PLAYING   =  3,   /**< \brief Drive is currently playing */
+    CD_STATUS_SEEKING   =  4,   /**< \brief Drive is currently seeking */
+    CD_STATUS_SCANNING  =  5,   /**< \brief Drive is scanning */
+    CD_STATUS_OPEN      =  6,   /**< \brief Disc tray is open */
+    CD_STATUS_NO_DISC   =  7,   /**< \brief No disc inserted */
+    CD_STATUS_RETRY     =  8,   /**< \brief Retry is needed */
+    CD_STATUS_ERROR     =  9,   /**< \brief System error */
+    CD_STATUS_FATAL     =  12,  /**< \brief Need reset syscalls */
+} cd_stat_t;
+
+/** \brief      Disc types the GDROM can identify
+    \ingroup    gdrom_syscalls
+
+    These are the values that can be returned as the second param of
+    syscall_gdrom_check_drive.
+*/
+typedef enum cd_disc_types {
+    CD_CDDA     = 0x00,    /**< \brief Audio CD (Red book) or no disc */
+    CD_CDROM    = 0x10,    /**< \brief CD-ROM or CD-R (Yellow book) */
+    CD_CDROM_XA = 0x20,    /**< \brief CD-ROM XA (Yellow book extension) */
+    CD_CDI      = 0x30,    /**< \brief CD-i (Green book) */
+    CD_GDROM    = 0x80,    /**< \brief GD-ROM */
+    CD_FAIL     = 0xf0     /**< \brief Need reset syscalls */
+} cd_disc_types_t;
+
+/** \brief      ID of a queued command
+    \ingroup    gdrom_syscalls
+    
+    This is the ID of a queued command. It is returned by syscall_gdrom_send_command
+    and is passed to other syscalls to specify which queued command to act on.
+*/
+typedef uint32_t gdc_cmd_id_t;
+
+/** \brief      Command codes for GDROM syscalls
+    \ingroup    gdrom_syscalls
+
+    These are the syscall command codes used to actually do stuff with the
+    GDROM drive. These were originally provided by maiwe.
+*/
+typedef enum cd_cmd_code {
+    CMD_CHECK_LICENSE     =  2,  /**< \brief Check license */
+    CMD_REQ_SPI_CMD       =  4,  /**< \brief Request to Sega Packet Interface */
+    CMD_PIOREAD           = 16,  /**< \brief Read via PIO */
+    CMD_DMAREAD           = 17,  /**< \brief Read via DMA */
+    CMD_GETTOC            = 18,  /**< \brief Read TOC */
+    CMD_GETTOC2           = 19,  /**< \brief Read TOC */
+    CMD_PLAY              = 20,  /**< \brief Play track */
+    CMD_PLAY2             = 21,  /**< \brief Play sectors */
+    CMD_PAUSE             = 22,  /**< \brief Pause playback */
+    CMD_RELEASE           = 23,  /**< \brief Resume from pause */
+    CMD_INIT              = 24,  /**< \brief Initialize the drive */
+    CMD_DMA_ABORT         = 25,  /**< \brief Abort DMA transfer */
+    CMD_OPEN_TRAY         = 26,  /**< \brief Open CD tray (on DevBox?) */
+    CMD_SEEK              = 27,  /**< \brief Seek to a new position */
+    CMD_DMAREAD_STREAM    = 28,  /**< \brief Stream DMA until end/abort */
+    CMD_NOP               = 29,  /**< \brief No operation */
+    CMD_REQ_MODE          = 30,  /**< \brief Request mode */
+    CMD_SET_MODE          = 31,  /**< \brief Setup mode */
+    CMD_SCAN_CD           = 32,  /**< \brief Scan CD */
+    CMD_STOP              = 33,  /**< \brief Stop the disc from spinning */
+    CMD_GETSCD            = 34,  /**< \brief Get subcode data */
+    CMD_GETSES            = 35,  /**< \brief Get session */
+    CMD_REQ_STAT          = 36,  /**< \brief Request stat */
+    CMD_PIOREAD_STREAM    = 37,  /**< \brief Stream PIO until end/abort */
+    CMD_DMAREAD_STREAM_EX = 38,  /**< \brief Stream DMA transfer */
+    CMD_PIOREAD_STREAM_EX = 39,  /**< \brief Stream PIO transfer */
+    CMD_GET_VERS          = 40,  /**< \brief Get syscall driver version */
+    CMD_MAX               = 47,  /**< \brief Max of GD syscall commands */
+} cd_cmd_code_t;
+
+/** \brief      TOC structure returned by the BIOS.
+    \ingroup    gdrom_syscalls
+
+    This is the structure that the CMD_GETTOC2 syscall command will return for
+    the TOC. Note the data is in FAD, not LBA/LSN.
+
+*/
+typedef struct cd_toc {
+    uint32_t  entry[99];          /**< \brief TOC space for 99 tracks */
+    uint32_t  first;              /**< \brief Point A0 information (1st track) */
+    uint32_t  last;               /**< \brief Point A1 information (last track) */
+    uint32_t  leadout_sector;     /**< \brief Point A2 information (leadout) */
+} cd_toc_t;
+
+/* Compat. Not sure if this is a good way to mark it, or if this is useful to do at 
+    all. But 'CDROM_TOC' violates our style guide which has caps reserved for defines
+    or macros.
+*/
+#define CDROM_TOC __depr("Use the type cd_toc_t rather than CDROM_TOC.") cd_toc_t
+
+/** \brief      Responses from GDROM syscalls
+    \ingroup    gdrom_syscalls
+
+    These are the values that some gdrom syscalls can return as error codes.
+*/
+typedef enum cd_cmd_ret {
+    CD_ERR_OK        = 0,   /**< \brief No error */
+    CD_ERR_NO_DISC   = 1,   /**< \brief No disc in drive */
+    CD_ERR_DISC_CHG  = 2,   /**< \brief Disc changed, but not reinitted yet */
+    CD_ERR_SYS       = 3,   /**< \brief System error */
+    CD_ERR_ABORTED   = 4,   /**< \brief Command aborted */
+    CD_ERR_NO_ACTIVE = 5,   /**< \brief System inactive? */
+    CD_ERR_TIMEOUT   = 6,   /**< \brief Aborted due to timeout */
+} cd_cmd_ret_t;
+
+/** \brief      Responses from GDROM check command syscall
+    \ingroup    gdrom_syscalls
+
+    These are return values of syscall_gdrom_check_command.
+*/
+typedef enum cd_cmd_chk {
+    CD_CMD_FAILED     = -1,   /**< \brief Command failed */
+    CD_CMD_INACTIVE   =  0,   /**< \brief System inactive? */
+    CD_CMD_PROCESSING =  1,   /**< \brief Processing command */
+    CD_CMD_COMPLETED  =  2,   /**< \brief Command completed successfully */
+    CD_CMD_STREAMING  =  3,   /**< \brief Stream type command is in progress */
+    CD_CMD_BUSY       =  4,   /**< \brief GD syscalls is busy */
+} cmd_cmd_chk_t;
+
+/** \brief      Track type to read as (if applicable).
+    \ingroup    gdrom_syscalls
+
+    Track type used to read a sector. These are possible values for the
+    second parameter word sent with syscall_gdrom_sector_mode.
+    
+    \note CD_TRACK_TYPE_DEFAULT not supported by the syscall and is provided
+    for compatibility in cdrom_reinit_ex
+*/
+typedef enum cd_track_type {
+    CD_TRACK_TYPE_UNKNOWN     = 0x0e00,
+    CD_TRACK_TYPE_MODE2_NONXA = 0x0c00,
+    CD_TRACK_TYPE_MODE2_FORM2 = 0x0a00,
+    CD_TRACK_TYPE_MODE2_FORM1 = 0x0800,
+    CD_TRACK_TYPE_MODE2       = 0x0600,
+    CD_TRACK_TYPE_MODE1       = 0x0400,
+    CD_TRACK_TYPE_CDDA        = 0x0200,
+    CD_TRACK_TYPE_ANY         = 0x0000,
+    CD_TRACK_TYPE_DEFAULT     = -1
+} cd_track_type_t;
+
+/** \brief      Read Sector Part
+    \ingroup    gdrom_syscalls
+
+    Parts of the a disc sector to read. These are possible values for the
+    third parameter word sent with syscall_gdrom_sector_mode.
+    
+    \note CD_READ_DEFAULT not supported by the syscall and is provided
+    for compatibility in cdrom_reinit_ex
+*/
+typedef enum cd_read_sec_part {
+    CD_READ_WHOLE_SECTOR = 0x1000,    /**< \brief Read the whole sector */
+    CD_READ_DATA_AREA    = 0x2000,    /**< \brief Read the data area */
+    CD_READ_DEFAULT      = -1         /**< \brief cdrom_reinit default */
+} cd_read_sec_part_t;
+
+/** \brief      Types of data to read from sector subcode
+    \ingroup    gdrom_syscalls
+
+    Types of data available to read from the sector subcode. These are
+    possible values for the first parameter sent to the GETSCD syscall.
+*/
+typedef enum cd_sub_type {
+    CD_SUB_Q_ALL          = 0,    /**< \brief Read all Subcode Data */
+    CD_SUB_Q_CHANNEL      = 1,    /**< \brief Read Q Channel Subcode Data */
+    CD_SUB_MEDIA_CATALOG  = 2,    /**< \brief Read the Media Catalog Subcode Data */
+    CD_SUB_TRACK_ISRC     = 3,    /**< \brief Read the ISRC Subcode Data */
+    CD_SUB_RESERVED       = 4     /**< \brief Reserved */
+} cd_sub_type_t;
+
+/** \brief      Subcode Audio Statuses
+    \ingroup    gdrom_syscalls
+
+    Information about CDDA playback returned by the GETSCD syscall command.
+    This is returned in the second byte of the buffer.
+*/
+typedef enum cd_sub_audio {
+    CD_SUB_AUDIO_STATUS_INVALID    = 0x00,
+    CD_SUB_AUDIO_STATUS_PLAYING    = 0x11,
+    CD_SUB_AUDIO_STATUS_PAUSED     = 0x12,
+    CD_SUB_AUDIO_STATUS_ENDED      = 0x13,
+    CD_SUB_AUDIO_STATUS_ERROR      = 0x14,
+    CD_SUB_AUDIO_STATUS_NO_INFO    = 0x15
+} cd_sub_audio_t;
+
+/** \brief      Initialize the GDROM drive.
+    \ingroup    gdrom_syscalls
 
     This function initializes the GDROM drive. Should be called before any 
     commands are sent.
 */
 void syscall_gdrom_init(void);
 
-/** \brief   Reset the GDROM drive.
+/** \brief      Reset the GDROM drive.
+    \ingroup    gdrom_syscalls
 
     This function resets the GDROM drive.
 */
 void syscall_gdrom_reset(void);
 
-/** \brief   Checks the GDROM drive status.
+/** \brief      Checks the GDROM drive status.
+    \ingroup    gdrom_syscalls
 
     This function retrieves the general condition of the GDROM drive. It 
     populates a provided array with two elements. The first element 
-    indicates the current drive status, and the second element identifies 
-    the type of disk inserted (if any).
+    indicates the current drive status (cd_stat_t), and the second
+    element identifies the type of disc inserted if any (cd_disc_types_t).
 
     \param  status          The pointer to two 32-bit unsigned integers to 
                             receive extended status information.
@@ -211,14 +417,15 @@ void syscall_gdrom_reset(void);
 */
 int syscall_gdrom_check_drive(uint32_t status[2]);
 
-/** \brief   Send a command to the GDROM command queue.
+/** \brief      Send a command to the GDROM command queue.
+    \ingroup    gdrom_syscalls
 
     This function sends a command to the GDROM queue.
 
     \note
     Call syscall_gdrom_exec_server() to run queued commands.
 
-    \param  cmd             The command code (see CMD_* in \ref dc/cdrom.h).
+    \param  cmd             The command code.
     \param  params          The pointer to parameter block for the command, 
                             can be NULL if the command does not take 
                             parameters.
@@ -227,13 +434,14 @@ int syscall_gdrom_check_drive(uint32_t status[2]);
 
     \sa syscall_gdrom_check_command(), syscall_gdrom_exec_server()
 */
-uint32_t syscall_gdrom_send_command(uint32_t cmd, void *params);
+gdc_cmd_id_t syscall_gdrom_send_command(cd_cmd_code_t cmd, void *params);
 
-/** \brief   Check status of queued command for the GDROM.
+/** \brief      Check status of queued command for the GDROM.
+    \ingroup    gdrom_syscalls
 
     This function checks if a queued command has completed.
 
-    \param  id              The request id (>=1).
+    \param  id              The request to check.
     \param  status          The pointer to four 32-bit integers to 
                             receive status information.
 
@@ -246,9 +454,10 @@ uint32_t syscall_gdrom_send_command(uint32_t cmd, void *params);
 
     \sa syscall_gdrom_send_command(), syscall_gdrom_exec_server()
 */
-int syscall_gdrom_check_command(uint32_t id, int32_t status[4]);
+cmd_cmd_chk_t syscall_gdrom_check_command(gdc_cmd_id_t id, int32_t status[4]);
 
-/** \brief   Process queued GDROM commands.
+/** \brief      Process queued GDROM commands.
+    \ingroup    gdrom_syscalls
 
     This function starts processing queued commands. This must be 
     called a few times to process all commands. An example of it in 
@@ -258,18 +467,20 @@ int syscall_gdrom_check_command(uint32_t id, int32_t status[4]);
 */
 void syscall_gdrom_exec_server(void);
 
-/** \brief   Abort a queued GDROM command.
+/** \brief      Abort a queued GDROM command.
+    \ingroup    gdrom_syscalls
 
     This function tries to abort a previously queued command.
 
-    \param  id              The request id (>=1) to abort.
+    \param  id              The request to abort.
 
     \return                 0 on success, or non-zero on
                             failure.
 */
-int syscall_gdrom_abort_command(uint32_t id);
+int syscall_gdrom_abort_command(gdc_cmd_id_t id);
 
-/** \brief   Sets/gets the sector mode for read commands.
+/** \brief      Sets/gets the sector mode for read commands.
+    \ingroup    gdrom_syscalls
 
     This function sets/gets the sector mode for read commands.
 
@@ -282,7 +493,8 @@ int syscall_gdrom_abort_command(uint32_t id);
 */
 int syscall_gdrom_sector_mode(uint32_t mode[4]);
 
-/** \brief   Setup GDROM DMA callback.
+/** \brief      Setup GDROM DMA callback.
+    \ingroup    gdrom_syscalls
 
     This function sets up DMA transfer end callback for 
     \ref CMD_DMAREAD_STREAM_EX (\ref dc/cdrom.h).
@@ -292,12 +504,13 @@ int syscall_gdrom_sector_mode(uint32_t mode[4]);
 */
 void syscall_gdrom_dma_callback(uintptr_t callback, void *param);
 
-/** \brief   Initiates a GDROM DMA transfer.
+/** \brief      Initiates a GDROM DMA transfer.
+    \ingroup    gdrom_syscalls
 
     This function initiates a DMA transfer for 
     \ref CMD_DMAREAD_STREAM_EX (\ref dc/cdrom.h).
 
-    \param  id              The request id (>=1).
+    \param  id              The request id.
     \param  params          The pointer to two 32-bit integers. The first 
                             element indicates the destination address, and 
                             the second element identifies how many bytes to 
@@ -306,23 +519,25 @@ void syscall_gdrom_dma_callback(uintptr_t callback, void *param);
     \return                 0 on success, or non-zero on
                             failure.
 */
-int syscall_gdrom_dma_transfer(uint32_t id, const int32_t params[2]);
+int syscall_gdrom_dma_transfer(gdc_cmd_id_t id, const int32_t params[2]);
 
-/** \brief   Checks a GDROM DMA transfer.
+/** \brief      Checks a GDROM DMA transfer.
+    \ingroup    gdrom_syscalls
 
     This function checks the progress of a DMA transfer for 
     \ref CMD_DMAREAD_STREAM_EX (see \ref dc/cdrom.h).
 
-    \param  id              The request id (>=1).
+    \param  id              The request id.
     \param  size            The pointer to receive the remaining amount of
                             bytes to transfer.
 
     \retval 0               On success.
     \retval -1              On failure.
 */
-int syscall_gdrom_dma_check(uint32_t id, size_t *size);
+int syscall_gdrom_dma_check(gdc_cmd_id_t id, size_t *size);
 
-/** \brief   Setup GDROM PIO callback.
+/** \brief      Setup GDROM PIO callback.
+    \ingroup    gdrom_syscalls
 
     This function sets up PIO transfer end callback for 
     \ref CMD_PIOREAD_STREAM_EX (see \ref dc/cdrom.h).
@@ -333,12 +548,13 @@ int syscall_gdrom_dma_check(uint32_t id, size_t *size);
 */
 void syscall_gdrom_pio_callback(uintptr_t callback, void *param);
 
-/** \brief   Initiates a GDROM PIO transfer.
+/** \brief      Initiates a GDROM PIO transfer.
+    \ingroup    gdrom_syscalls
 
     This function initiates a PIO transfer for 
     \ref CMD_PIOREAD_STREAM_EX (see \ref dc/cdrom.h).
 
-    \param  id              The request id (>=1).
+    \param  id              The request id.
     \param  params          The pointer to two 32-bit integers. The first 
                             element indicates the destination address, and 
                             the second element identifies how many bytes to 
@@ -347,21 +563,22 @@ void syscall_gdrom_pio_callback(uintptr_t callback, void *param);
     \return                 0 on success, or non-zero on
                             failure.
 */
-int syscall_gdrom_pio_transfer(uint32_t id, const int32_t params[2]);
+int syscall_gdrom_pio_transfer(gdc_cmd_id_t id, const int32_t params[2]);
 
-/** \brief   Checks a GDROM PIO transfer.
+/** \brief      Checks a GDROM PIO transfer.
+    \ingroup    gdrom_syscalls
 
     This function checks the progress of a PIO transfer for 
     \ref CMD_PIOREAD_STREAM_EX (see \ref dc/cdrom.h).
 
-    \param  id              The request id (>=1).
+    \param  id              The request id.
     \param  size            The pointer to receive the remaining amount of
                             bytes to transfer.
 
     \retval 0               On success.
     \retval -1              On failure.
 */
-int syscall_gdrom_pio_check(uint32_t id, size_t *size);
+int syscall_gdrom_pio_check(gdc_cmd_id_t id, size_t *size);
 
 /** \brief   Initializes all the syscall vectors.
 


### PR DESCRIPTION
This is in the works to get in the typing and cleanup suggestions from #619 and #736 with a different scope.

The key purpose is to add strongly defined types for the various returns and parameters of the functions for interacting with the GDROM drive, replacing the many sets of defines, generic types, and untyped structs.

Changes:
- [x] Redefine each group of CD defines to an enum, per #619. (The only one left out is the unused group of ATA Status defines @DC-SWAT perhaps you have more info on them since you added them? Are these returned by one of the syscalls? Maybe they're the 4th param of Check Command?)
- [x] Move syscall related define groups to syscalls.h
- [x] Rename some of the define group values to better match our general naming scheme (`CD_ERR_OK` rather than just `ERR_OK`).
- [ ] Cleanups to structure (some due to the typing, some due to the scoped mutex or syscalls updates)
- [ ] Create types for used param structs.
- [ ] Clean up the documentation, ensuring there are good cross-referencces between the data types and functions that they get used by.

Possible further work:
- [ ] Add abort command (per #736) with some refactoring of the command issuance.
- [ ] Separate out gd syscall things into a separate header from the others.
- [ ] Fully type each of the syscall's param structs.

Still need a bit more work for what I was sure to add, but wanted to make sure to make it public now to get feedback/help with the documentation, naming, and just general review for mistakes.