### PR TITLE
Blessing GCC14.2.0 as the new "stable" toolchain.

### DIFF
--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -13,9 +13,9 @@
 # - 11.5.0:       Last release in the GCC 11 series, released 2024-07-19.
 # Supported upstream:
 # - 12.4.0:       Latest release in the GCC 12 series, released 2024-06-20.
-# - stable:       Tested stable; based on GCC 13.2.0, released 2023-07-27.
+# - 13.2.0:       Formerly stable; based on GCC 13.2.0, released 2023-07-27.
 # - 13.3.0:       Latest release in the GCC 13 series, released 2024-05-21.
-# - 14.2.0:       Latest release in the GCC 14 series, released 2024-08-01.
+# - stable:       Stable, based on GCC 14.2.0, released 2024-08-01.
 # Development versions:
 # - 13.3.1-dev    Bleeding edge GCC 13 series from git.
 # - 14.2.1-dev    Bleeding edge GCC 14 series from git.

--- a/utils/dc-chain/doc/CHANGELOG.md
+++ b/utils/dc-chain/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Date<br/>_____________ | Author(s)<br/>_____________ | Changes<br/>_____________ |
 |:-----------------------|:----------------------------|---------------------------|
+| 2024-09-30 | Falco Girgis | Blessed GCC 14.2.0 as the new stable toolchain profile.
 | 2024-08-11 | Eric Fradella | Fix ARM toolchain build error when JIT is enabled for SH toolchain. |
 | 2024-08-07 | Eric Fradella | Updated binutils to 2.43. Updated GCC 11 profile with support for GCC 11.5.0. |
 | 2024-08-01 | Eric Fradella | Updated GCC 14 profile with support for GCC 14.2.0. |

--- a/utils/dc-chain/profiles/profile.13.2.0.mk
+++ b/utils/dc-chain/profiles/profile.13.2.0.mk
@@ -3,8 +3,8 @@
 
 # Toolchain versions for SH
 sh_binutils_ver=2.43
-sh_gcc_ver=14.2.0
-newlib_ver=4.4.0.20231231
+sh_gcc_ver=13.2.0
+newlib_ver=4.3.0.20230120
 gdb_ver=15.1
 
 # Toolchain for ARM

--- a/utils/dc-chain/profiles/profile.stable.mk
+++ b/utils/dc-chain/profiles/profile.stable.mk
@@ -3,8 +3,8 @@
 
 # Toolchain versions for SH
 sh_binutils_ver=2.43
-sh_gcc_ver=13.2.0
-newlib_ver=4.3.0.20230120
+sh_gcc_ver=14.2.0
+newlib_ver=4.4.0.20231231
 gdb_ver=15.1
 
 # Toolchain for ARM


### PR DESCRIPTION
GCC14.2.0 has been previewed by at least half of us KOS devs, plus a substantial proportion of our users ever since it has released. I've only ever seen *fewer* ICEs and issues than with the current "stable" toolchain, plus it has nice new C++ language features. I think the time has come to mark it as stable, as many users are already having to rebuild toolchains manually to get this version anyway...

- Updated "stable" and "13.2.0" toolchain descriptions in Makefile.default.cfg
- Added profile.13.2.0.mk.
- Renamed profile.14.2.0 -> profile.stable.mk
- Updated CHANGELOG.md.