### PR TITLE
CMake: Use kos-cc as the assembler

### DIFF
--- a/utils/cmake/dreamcast.toolchain.cmake
+++ b/utils/cmake/dreamcast.toolchain.cmake
@@ -51,7 +51,7 @@ set(PLATFORM_DREAMCAST TRUE)
 ##### Configure Cross-Compiler #####
 set(CMAKE_CROSSCOMPILING TRUE)
 
-set(CMAKE_ASM_COMPILER    ${KOS_BASE}/utils/build_wrappers/kos-as)
+set(CMAKE_ASM_COMPILER    ${KOS_BASE}/utils/build_wrappers/kos-cc)
 set(CMAKE_C_COMPILER      ${KOS_BASE}/utils/build_wrappers/kos-cc)
 set(CMAKE_CXX_COMPILER    ${KOS_BASE}/utils/build_wrappers/kos-c++)
 set(CMAKE_OBJC_COMPILER   ${KOS_BASE}/utils/build_wrappers/kos-cc)


### PR DESCRIPTION
CMake does detect the GNU assembler correctly, but does not seem to know how to use it properly; it passes flags it shouldn't (e.g. -with-sysroot or -isystem), or flags with the incorrect arguments.

This is because on most (all?) GNU platforms, CMake is configured to use GCC itself as the assembler. In that case, it passes the correct (and different) flags which makes it able to compile assembler files.

Fix compilation of assembler files in CMake by using kos-cc as the assembler.