### PR TITLE
thread: Add priority boosting system

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ Platform-specific changes are prefixed with the platform name, otherwise the cha
 - Added . & .. directories to filesystems that lack it [AB]
 - Replaced previous implementation of realpath() to remove license from AUTHORS [AB]
 - Enabled hybrid PVR DR/DMA vertex submission in driver + sped up pvr_prim() [FG]
+- Add thread priority boosting system [Paul Cercueil = PC]
 
 ## KallistiOS version 2.1.0
 - Cleaned up generated stubs files on a make clean [Lawrence Sebald == LS]

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -182,8 +182,11 @@ typedef __attribute__((aligned(32))) struct kthread {
     /** \brief  Kernel thread id. */
     tid_t tid;
 
-    /** \brief  Static priority: 0..PRIO_MAX (higher means lower priority). */
+    /** \brief  Dynamic priority */
     prio_t prio;
+
+    /** \brief  Static priority: 0..PRIO_MAX (higher means lower priority). */
+    prio_t real_prio;
 
     /** \brief  Thread flags. */
     kthread_flags_t flags;

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -516,6 +516,7 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
             /* Set Thread Pointer */
             nt->context.gbr = (uint32_t)nt->tcbhead;
             nt->tid = tid;
+            nt->real_prio = real_attr.prio;
             nt->prio = real_attr.prio;
             nt->state = STATE_READY;
 
@@ -627,6 +628,7 @@ int thd_set_prio(kthread_t *thd, prio_t prio) {
 
     /* Set the new priority */
     thd->prio = prio;
+    thd->real_prio = prio;
     return 0;
 }
 


### PR DESCRIPTION
Introduce a new 'real_prio' field into the thread structure, which contains the static priority set during the thread creation or with thd_set_prio().

The 'prio' field now represents the dynamic priority. When a low-priority thread A holds a lock, and a high-priority thread B requests it, the dynamic priority of A will be temporarily raised to the dynamic priority of B, until A releases the lock, in which case it falls back to its static priority.

The point of this setup is to avoid starvation, where a low-priority thread holds a resource that is needed by a high-priority thread, and won't release it because it rarely gets preempted.

This is not yet perfect, as we can imagine a setup where a low-priority thread A holds two locks, each one requested by different high-priority tasts B and C; A would get boosted to B's dynamic priority, and when releasing the lock, reset to its original low priority, causing thread C to starve.

An example program is available here: https://gist.github.com/pcercuei/591edca1727aa092ee8aa03b3d35906a
Which shows the starvation problem in the current KOS, and shows it resolved after this change.