### PR TITLE
Implement Support for C99 Floating-Point Environment

### DIFF
--- a/include/sys/fenv.h
+++ b/include/sys/fenv.h
@@ -50,6 +50,102 @@ typedef uint8_t fenv_t;
 /** Type representing all FP status flags collectively. */
 typedef uint8_t fexcept_t;
 
+/** Clears the given floating-point exception flags.
+ * 
+ *  \param  excepts     Bitwise OR'd list of FP exception flags
+ *  \retval 0           Success
+ */
+int feclearexcept(int excepts);
+
+/** Determines which of a subset of the FP exceptions are set.
+ *  
+ *  \param  excepts     Bitwise OR'd list of FP exception flags to test
+ *  \returns            Bitwise OR of the FP exception macros that are both
+ *                      in \p excepts and are currently set.
+ */
+int fetestexcept(int excepts);
+
+/** Raises the specified floating-point exceptions.
+ * 
+ *  \param   excepts     Bitwise OR'd list of FP exception flags to raise
+ *  \retval  0           Success   
+ */
+int feraiseexcept(int excepts);
+
+/** Copies the state of the given FP flags from the environment.
+ * 
+ *  \param  flagp   Structure to store the FP state status within
+ *  \param  excepts Bitwise OR'd list of FP exception flags to store
+ *  \retval 0       Success
+ * 
+ *  \sa fesetexceptflag()
+ */
+int fegetexceptflag(fexcept_t *flagp, int excepts);
+
+/** Copies the state of the given FP flags to the environment.
+ * 
+ *  \param  flagp   Structure to copy the FP state status from
+ *  \param  excepts Bitwise OR'd list of FP exception flags to set
+ *  \retval 0       Success
+ * 
+ *  \sa fegetexceptflag()
+ */
+int fesetexceptflag(const fexcept_t* flagp, int excepts);
+
+/** Sets the floating-point rounding mode.
+ * 
+ *  \param  round   New rounding mode to set
+ *  \retval 0       Success
+ *  \retval Other   Failure; returns current rounding mode
+ * 
+ *  \sa fegetround()
+ */
+int fesetround(int round);
+
+/** Gets the floating-point rounding mode.
+ * 
+ *  \returns    Value corresponding to current rounding mode 
+ *  
+ *  \sa fesetround() 
+ */
+int fegetround(void);
+
+/** Stores the status of the FP environment.
+ * 
+ *  \param  envp    Structure to store FP status within
+ *  \retval 0       Success
+ *
+ *  \sa fesetenv()
+ */
+int fegetenv(fenv_t *envp);
+
+/** Restores the status of the FP environment.
+ * 
+ *  \note
+ *  Does not raise any exceptions, only modifies the flags.
+ * 
+ *  \param  envp    Structure containing previous FP status
+ *  \retval 0       Success
+ * 
+ *  \sa fegetenv()
+ */
+int fesetenv(const fenv_t* envp);
+
+/** Saves the FP env, clears status flags, prevents exceptions from trapping.
+ * 
+ *  \param  envp    Structure where the FP environment will be stored
+ * 
+ *  \retval 0       Success  
+ */
+int feholdexcept(fenv_t *envp);
+
+/** Restores FP environment and raises previously raised exceptions.
+ * 
+ *  \param  envp    FP environment to be restored
+ *  \retval 0       Success
+ */
+int feupdateenv(const fenv_t *envp);
+
 /** \name  POSIX Extensions
  *  \brief Extended functionality for POSIX compliance.
  *  @{

--- a/include/sys/fenv.h
+++ b/include/sys/fenv.h
@@ -1,0 +1,78 @@
+/* KallistiOS ##version##
+   sys/fenv.h
+   Copyright (C) 2024 Falco Girgis
+*/
+
+/** \file
+    \brief SH4-Specific FENV definitions and extensions.
+*/
+
+#ifndef __SYS_FENV_H
+#define __SYS_FENV_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+#include <stdint.h>
+
+/** \name  Exception Types
+ *  \brief Flags for floating-point exception types
+ *  @{
+ */
+#define FE_INEXACT    0x01 /**< Rounding was necessary to store result */
+#define FE_UNDERFLOW  0x02 /**< Result was subnomral with precision loss */
+#define FE_OVERFLOW   0x04 /**< Result too large to be representable */
+#define FE_DIVBYZERO  0x08 /**< Pole error occurred */
+#define FE_INVALID    0x10 /**< Domain error occurred */
+#define FE_ALL_ACCEPT 0x1f /**< Mask which includes all exception types */
+/** @} */
+
+/** \name  Rounding Modes 
+ *  \brief Values for floating-point rounding modes
+ *  \note  
+ *  If the unrounded value is larger than the maximum expressible absolute value, 
+ *  the value will be the maximum expressible absolute value.
+ *  @{
+ */
+#define FE_TONEAREST  0x0 /**< Round to nearest value. If two, use LSB of 0. */
+#define FE_TOWARDZERO 0x1 /**< Discard digits below the round bit of value. */
+#define FE_DOWNWARD   0x2 /**< Unsupported. */
+#define FE_UPWARD     0x3 /**< Unsupported. */
+/** @} */
+
+/** Default floating-point environment at program start. */
+#define FE_DFL_ENV   _fe_dfl_env
+/** Default floating-point control modes at program start. */
+#define FE_DFL_MODE  _fe_dfl_mode
+
+/** Type representing entire FP environment. */
+typedef uint8_t fenv_t;
+/** Type representing all FP status flags collectively. */
+typedef uint8_t fexcept_t;
+
+/** \name  POSIX Extensions
+ *  \brief Extended functionality for POSIX compliance.
+ *  @{
+ */
+typedef uint8_t femode_t;
+int fegetmode(femode_t *mode);
+int fesetmode(const femode_t *mode);
+/** @} */
+
+/** \name  GNU Extensions
+ *  \brief Extended GNU functionality support.
+ *  @{
+ */
+int feenableexcept(int excepts);
+int fedisableexcept(int excepts);
+int fegetexcept(void);
+/** @} */
+
+/** \cond INTERNAL */
+extern const fenv_t *_fe_dfl_env;
+extern const femode_t *_fe_dfl_mode;
+/** \endcond */
+
+__END_DECLS
+
+#endif

--- a/kernel/libc/c11/Makefile
+++ b/kernel/libc/c11/Makefile
@@ -11,6 +11,6 @@ OBJS = call_once.o cnd_broadcast.o cnd_destroy.o cnd_init.o cnd_signal.o \
     mtx_timedlock.o mtx_trylock.o mtx_unlock.o thrd_create.o thrd_current.o \
     thrd_detach.o thrd_equal.o thrd_exit.o thrd_join.o thrd_sleep.o \
     thrd_yield.o tss_create.o tss_delete.o tss_get.o tss_set.o \
-    aligned_alloc.o timespec_get.o timegm.o atomics.o
+    aligned_alloc.o timespec_get.o timegm.o atomics.o fenv.o
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/c11/fenv.c
+++ b/kernel/libc/c11/fenv.c
@@ -118,7 +118,7 @@ int fegetround(void) {
 
 int fesetround(int round) {
     if(round & ~0x1)
-        return 1;
+        return fegetround();
 
     int fpscr = FPSCR;
     fpscr &= ~FENV_RM_MASK;

--- a/kernel/libc/c11/fenv.c
+++ b/kernel/libc/c11/fenv.c
@@ -1,0 +1,154 @@
+/* KallistiOS ##version##
+   fenv.c
+   Copyright (C) 2024 Falco Girgis
+*/
+
+#include <fenv.h>
+#include <float.h>
+
+#define FPSCR            __builtin_sh_get_fpscr()
+#define FPSCR_SET(value) __builtin_sh_set_fpscr((value))
+
+static fenv_t __fe_dfl_env = 0;
+const fenv_t *_fe_dfl_env = &__fe_dfl_env;
+
+static femode_t __fe_dfl_mode = 0;
+const femode_t *_fe_dfl_mode = &__fe_dfl_mode;
+
+#define FENV_MODE_MASK  0x3c0000
+#define FENV_MODE_SHIFT 18
+
+int fegetmode(femode_t *mode) {
+    *mode = (FPSCR & FENV_MODE_MASK) >> FENV_MODE_SHIFT;
+    return 0;
+}
+
+int fesetmode(const femode_t *mode) {
+    FPSCR_SET((*mode << FENV_MODE_SHIFT) & FENV_MODE_MASK);
+    return 0;
+}
+
+#define FENV_EXCEPT_MASK  0x1f
+#define FENV_ENABLE_SHIFT 7
+#define FENV_FLAG_SHIFT 2
+
+/* GNU Extensions */
+int feenableexcept(int excepts) {
+    FPSCR_SET(FPSCR | ((excepts & FENV_EXCEPT_MASK) << FENV_ENABLE_SHIFT));
+    return 0;
+}
+
+int fedisableexcept(int excepts) {
+    FPSCR_SET(FPSCR & ~((excepts & FENV_EXCEPT_MASK) << FENV_ENABLE_SHIFT));
+    return 0;
+}
+
+int fegetexcept(void) {
+    return (FPSCR >> FENV_FLAG_SHIFT) & FENV_EXCEPT_MASK;
+}
+
+int feclearexcept(int excepts) {
+    excepts &= FE_ALL_ACCEPT;
+
+    FPSCR_SET(FPSCR & ~((excepts & FENV_EXCEPT_MASK) << FENV_FLAG_SHIFT));
+    return 0;
+}
+
+int fetestexcept(int excepts) {
+    excepts &= FE_ALL_ACCEPT;
+
+    return (FPSCR & (excepts << FENV_FLAG_SHIFT));
+}
+
+int feraiseexcept(int excepts) {
+    if(!excepts)
+        return 0;
+
+    if(excepts & FE_INEXACT) {
+        volatile double a = 1.0;
+        volatile double b = 3.0;
+        volatile double c = a / b;
+        (void)c;
+    }
+
+    if(excepts & FE_UNDERFLOW) {
+        volatile double a = DBL_MIN;
+        volatile double b = 10.0;
+        volatile double c = a / b;
+        (void)c;
+    }
+
+    if(excepts & FE_OVERFLOW) {
+        volatile double a = DBL_MAX;
+        volatile double b = 10.0;
+        volatile double c = a * b;
+        (void)c;
+    }
+
+    if(excepts & FE_DIVBYZERO) {
+        volatile double a = 1.0;
+        volatile double b = 0.0;
+        volatile double c = a / b;
+        (void)c;
+    }
+
+    FPSCR_SET(FPSCR | ((excepts & FE_ALL_ACCEPT) << FENV_FLAG_SHIFT));
+    return 0;
+}
+
+int fegetexceptflag(fexcept_t *flagp, int excepts) {
+    excepts &= FE_ALL_ACCEPT;
+    *flagp = (FPSCR >> FENV_FLAG_SHIFT) & excepts;
+    return 0;
+}
+
+int fesetexceptflag(const fexcept_t *flagp, int excepts) {
+    int fpscr = FPSCR;
+    fpscr &= ~((excepts & FE_ALL_ACCEPT) << FENV_FLAG_SHIFT);
+    fpscr |= (*flagp & excepts & FE_ALL_ACCEPT) << FENV_FLAG_SHIFT;
+    FPSCR_SET(fpscr);
+    return 0;
+}
+
+#define FENV_RM_MASK 0x3
+
+int fegetround(void) {
+    return FPSCR & FENV_RM_MASK;
+}
+
+int fesetround(int round) {
+    if(round & ~0x1)
+        return 1;
+
+    int fpscr = FPSCR;
+    fpscr &= ~FENV_RM_MASK;
+    fpscr |= round;
+    FPSCR_SET(fpscr);
+
+    return 0;
+}
+
+int fegetenv(fenv_t *envp) {
+    *envp = (FPSCR >> FENV_ENABLE_SHIFT) & FENV_EXCEPT_MASK;
+    return 0;
+}
+
+int feholdexcept(fenv_t *envp) {
+    fegetenv(envp);
+    fedisableexcept(FE_ALL_ACCEPT);
+    return 0;
+}
+
+int fesetenv(const fenv_t *envp) {
+    int fpscr = FPSCR;
+    fpscr &= ~(FENV_EXCEPT_MASK << FENV_ENABLE_SHIFT);
+    fpscr |= ((*envp & FENV_EXCEPT_MASK) << FENV_ENABLE_SHIFT);
+    FPSCR_SET(fpscr);
+    return 0;
+}
+
+int feupdateenv(const fenv_t *envp) {
+    int excepts = fegetexcept();
+    fesetenv(envp);
+    return feraiseexcept(excepts);
+}


### PR DESCRIPTION
C99's `<fenv.h>` adds all kinds of useful things for working with the floating-point environment of a FPU, including enabling/disabling exceptions, checking status flags, swapping round modes, etc. Turns out Hitachi went to great lengths to ensure the SH4's FPU mapped extremely well to this standard C API, and it implements almost the entirety of the feature-set.... Just too bad Newlib doesn't have any implementation of this API for most of its embedded targets... and yes, several people working with several different ports have specifically mentioned they need support for this functionality... and tbh, it's just good to have.

TIME TO ROLL OUR OWN!

- Initial implementation of FENV complete
    * GNU extension implementation complete
    * POSIX extension implementation complete
- Doxygen still has work to be done
- Header file/API still needs everything exposed
- Example/Test scenario needs to be written