### PR TITLE
Made macros for HZ and THD stack sizes overridable

### DIFF
--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -52,7 +52,7 @@ extern uint32 _arch_mem_top;
 /** \brief  Base address of available physical pages. */
 #define page_phys_base  0x8c010000
 
-#ifndef HZ
+#ifndef THD_SCHED_HZ
 /** \brief Scheduler interrupt frequency
 
     Timer interrupt frequency for the KOS thread scheduler.
@@ -63,8 +63,14 @@ extern uint32 _arch_mem_top;
 
     \sa thd_get_hz(), thd_set_hz()
 */
-#define HZ              100
+#define THD_SCHED_HZ    100
 #endif
+
+/** Legacy symbol for scheduler frequency.
+ *  \deprecated
+ *  \sa THD_SCHED_HZ
+ */
+const unsigned HZ __depr("Please use the new THD_SCHED_HZ macro.") = THD_SCHED_HZ;
 
 #ifndef THD_STACK_SIZE
 /** \brief  Default thread stack size. */

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -52,6 +52,7 @@ extern uint32 _arch_mem_top;
 /** \brief  Base address of available physical pages. */
 #define page_phys_base  0x8c010000
 
+#ifndef HZ
 /** \brief Scheduler interrupt frequency
 
     Timer interrupt frequency for the KOS thread scheduler.
@@ -63,12 +64,17 @@ extern uint32 _arch_mem_top;
     \sa thd_get_hz(), thd_set_hz()
 */
 #define HZ              100
+#endif
 
+#ifndef THD_STACK_SIZE
 /** \brief  Default thread stack size. */
 #define THD_STACK_SIZE  32768
+#endif
 
+#ifndef THD_KERNEL_STACK_SIZE
 /** \brief Main/kernel thread's stack size. */
 #define THD_KERNEL_STACK_SIZE (64 * 1024)
+#endif
 
 /** \brief  Default video mode. */
 #define DEFAULT_VID_MODE    DM_640x480

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -70,7 +70,8 @@ extern uint32 _arch_mem_top;
  *  \deprecated
  *  \sa THD_SCHED_HZ
  */
-const unsigned HZ __depr("Please use the new THD_SCHED_HZ macro.") = THD_SCHED_HZ;
+static const
+unsigned HZ __depr("Please use the new THD_SCHED_HZ macro.") = THD_SCHED_HZ;
 
 #ifndef THD_STACK_SIZE
 /** \brief  Default thread stack size. */

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -60,7 +60,7 @@ static alignas(8) uint8_t thd_idle_stack[64];
 /* Thread scheduler data */
 
 /* Scheduler timer interrupt frequency (Hertz) */
-static unsigned int thd_sched_ms = 1000 / HZ;
+static unsigned int thd_sched_ms = 1000 / THD_SCHED_HZ;
 
 /* Thread list. This includes all threads except dead ones. */
 static struct ktlist thd_list;


### PR DESCRIPTION
- Many people are starting to overrun the main kernel thread stack
- We may want to eventually arrive at a better solution for providing a thread size for the kernel stack eventually, but until we get there, I think this will suffice, as it's in-line with our other overridable macros.
- Added `#ifdef`s around `HZ`, `THD_STACK_SIZE`, and `THD_KERNEL_STACK_SIZE` in `arch.h` to only define them if they weren't already provided by the build system or externally.

Here's an example of someone needing such behavior ASAP:
https://github.com/azihassan/devilutionX/issues/3