### PR TITLE
Fixed pvrtex warnings with Clang18 host compiler

### DIFF
--- a/utils/pvrtex/Makefile
+++ b/utils/pvrtex/Makefile
@@ -16,7 +16,7 @@ else
 	CXXFLAGS += -O3
 endif
 
-CFLAGS := $(CXXFLAGS) -Wno-pointer-sign
+CFLAGS := $(CXXFLAGS) -Wno-pointer-sign -std=gnu17
 
 define textSegment2Header
 	mkdir -p info

--- a/utils/pvrtex/mem.c
+++ b/utils/pvrtex/mem.c
@@ -67,7 +67,7 @@ void  free(void *ptr);
  * dynamic libraries and remove -Wl,-Bsymbolic from the linker flags.
  * Note that this will cost performance. */
 
-static atomic_size_t max_alloc_size = ATOMIC_VAR_INIT(INT_MAX);
+static atomic_size_t max_alloc_size = INT_MAX;
 
 void av_max_alloc(size_t max){
     atomic_store_explicit(&max_alloc_size, max, memory_order_relaxed);

--- a/utils/pvrtex/pvr_texture_encoder.c
+++ b/utils/pvrtex/pvr_texture_encoder.c
@@ -838,6 +838,7 @@ void pteAutoSelectPixelFormat(PvrTexEncoder *pte) {
 	assert(pte->src_img_cnt);
 
 	unsigned clearpix = 0, halfpix = 0, opaquepix = 0;
+	(void)opaquepix;
 
 	for(int j = 0; j < pte->src_img_cnt; j++) {
 		pteImage *img = pte->src_imgs + j;

--- a/utils/pvrtex/pvr_texture_encoder.c
+++ b/utils/pvrtex/pvr_texture_encoder.c
@@ -837,8 +837,7 @@ void pteAutoSelectPixelFormat(PvrTexEncoder *pte) {
 	assert(pte);
 	assert(pte->src_img_cnt);
 
-	unsigned clearpix = 0, halfpix = 0, opaquepix = 0;
-	(void)opaquepix;
+	unsigned clearpix = 0, halfpix = 0;
 
 	for(int j = 0; j < pte->src_img_cnt; j++) {
 		pteImage *img = pte->src_imgs + j;
@@ -847,9 +846,7 @@ void pteAutoSelectPixelFormat(PvrTexEncoder *pte) {
 			int a = img->pixels[i].a;
 			if (a == 0)
 				clearpix++;
-			else if (a == 0xff)
-				opaquepix++;
-			else
+			else if (a != 0xff)
 				halfpix++;
 		}
 	}


### PR DESCRIPTION
- A couple of warnings are manifesting in the pvrtex codebase when bulding with a recent verison of Clang.
- ATOMIC_INIT() was deprecated in later versions of C, which Clang defaults to now
    * forcing project to be built uniformly using GNU17 C standard for everyone
    * got rid of ATOMIC_INIT() usage
- Clang correctly diagnosed a set but unused variable in pvrtex... Simply told the compiler to shut up by marking it (void).