### PR TITLE
Made builtin font used by vmu_printf() public.

### DIFF
--- a/kernel/arch/dreamcast/include/dc/vmu_fb.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_fb.h
@@ -146,8 +146,9 @@ void vmufb_print_string_into(vmufb_t *fb,
                             painting the text (or NULL to use the default)
     \param  str             The text to render
  */
-inline void vmufb_print_string(vmufb_t *fb, const vmufb_font_t *fnt,
-                               const char *str) {
+static __inline__
+void vmufb_print_string(vmufb_t *fb, const vmufb_font_t *fnt,
+                        const char *str) {
     vmufb_print_string_into(fb, fnt, 0, 0,
                             VMU_SCREEN_WIDTH, VMU_SCREEN_HEIGHT, 0, str);
 }

--- a/kernel/arch/dreamcast/include/dc/vmu_fb.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_fb.h
@@ -10,35 +10,50 @@
 
 /** \file    dc/vmu_fb.h
     \brief   VMU framebuffer.
-    \ingroup vmu
+    \ingroup vmu_fb
 
     This file provides an API that can be used to compose a 48x32 image that can
     then be displayed on the VMUs connected to the system.
+
+    \author Paul Cercueil
 */
 
-#include <dc/maple.h>
-#include <stdint.h>
+#include <sys/cdefs.h>
+__BEGIN_DECLS
 
-/** \brief  VMU framebuffer.
+#include <dc/maple.h>
+#include <dc/maple/vmu.h>
+#include <stdint.h>
+#include <stdarg.h>
+
+/** \defgroup vmu_fb Framebuffer
+ *  \ingroup  vmu
+ *
+ *  This API provides a virtual framebuffer abstraction for the VMU with a
+ *  series of convenient methods for drawing complex and dynamic content.
+ *
+ *  @{
+*/
+
+/** \brief Virtual framebuffer for the VMU
 
     This object contains a 48x32 monochrome framebuffer. It can be painted to,
-    or displayed one the VMUs connected to the system, using the API below.
-
-    \headerfile dc/vmu_fb.h
+    or displayed on one the VMUs connected to the system, using the API below.
  */
-typedef struct {
-    uint32_t data[48];
+typedef struct vmufb {
+    uint32_t data[VMU_SCREEN_WIDTH]; /**< Private framebuffer pixel data */
 } vmufb_t;
 
 /** \brief  VMU framebuffer font meta-data.
 
-    \headerfile dc/vmu_fb.h
+    This structure describes a font, including character sizes,
+    layout, and a pointer to the raw font data.
  */
-typedef struct {
-    unsigned int w;         /**< \brief Character width in pixels */
-    unsigned int h;         /**< \brief Character height in pixels */
-    unsigned int stride;    /**< \brief Size of one character in bytes */
-    const char *fontdata;   /**< \brief Pointer to the font data */
+typedef struct vmufb_font {
+    unsigned int w;         /**< Character width in pixels */
+    unsigned int h;         /**< Character height in pixels */
+    size_t       stride;    /**< Size of one character in bytes */
+    const char  *fontdata;  /**< Pointer to the font data */
 } vmufb_font_t;
 
 /** \brief  Render into the VMU framebuffer
@@ -103,7 +118,7 @@ void vmufb_present(const vmufb_t *fb, maple_device_t *dev);
 
     \param  fb              A pointer to the vmufb_t to paint to.
     \param  font            A pointer to the vmufb_font_t that will be used for
-                            painting the text
+                            painting the text (or NULL to use the default)
     \param  x               The horizontal position of the top-left corner of
                             the drawing area, in pixels
     \param  y               The vertical position of the top-left corner of the
@@ -115,11 +130,11 @@ void vmufb_present(const vmufb_t *fb, maple_device_t *dev);
     \param  str             The text to render
  */
 void vmufb_print_string_into(vmufb_t *fb,
-			     const vmufb_font_t *font,
-			     unsigned int x, unsigned int y,
-			     unsigned int w, unsigned int h,
-			     unsigned int line_spacing,
-			     const char *str);
+                             const vmufb_font_t *font,
+                             unsigned int x, unsigned int y,
+                             unsigned int w, unsigned int h,
+                             unsigned int line_spacing,
+                             const char *str);
 
 /** \brief  Render a string into the VMU framebuffer
 
@@ -128,15 +143,56 @@ void vmufb_print_string_into(vmufb_t *fb,
 
     \param  fb              A pointer to the vmufb_t to paint to.
     \param  font            A pointer to the vmufb_font_t that will be used for
-                            painting the text
+                            painting the text (or NULL to use the default)
     \param  str             The text to render
  */
-static __inline__ void
-vmufb_print_string(vmufb_t *fb, const vmufb_font_t *font, const char *str) {
-    vmufb_print_string_into(fb, font, 0, 0, 48, 32, 0, str);
+inline void vmufb_print_string(vmufb_t *fb, const vmufb_font_t *fnt,
+                               const char *str) {
+    vmufb_print_string_into(fb, fnt, 0, 0,
+                            VMU_SCREEN_WIDTH, VMU_SCREEN_HEIGHT, 0, str);
 }
 
+/** \brief  Render a string to attached VMUs using the built-in font
+
+    Uses the built-in VMU font to render a string to all VMUs connected to the
+    system.
+
+    \note
+    The font currently set as the default font will be used.
+
+    \param  fmt             The format string, optionally followed by extra
+                            arguments.
+
+    \sa vmu_set_font()
+ */
+void vmu_printf(const char *fmt, ...) __printflike(1, 2);
+
+/** \brief Sets the default font for drawing text to the VMU.
+ *
+ *  \warning
+ *  The API does not take ownership of or copy \p font, so
+ *  the given pointer must remain valid as long as it is set
+ *  as the default!
+ *
+ *  \param  font    Pointer to the font to set as default
+ *  \returns        Pointer to the previous default font
+ *
+ *  \sa vmu_get_font()
+ */
+const vmufb_font_t *vmu_set_font(const vmufb_font_t *font);
+
+/** \brief Returns the default font used to draw text to the VMU.
+ *
+ *  \returns    Pointer to the font currently set as the default
+ *
+ *  \sa vmu_set_font()
+ */
+const vmufb_font_t *vmu_get_font(void);
+
 /** \brief Built-in VMU framebuffer font.
+ *
+ *  \note
+ *  This is the font that is currently used as the default.
  *
  *  Linux 4x6 font: lib/fonts/font_mino_4x6.c
  *
@@ -144,15 +200,8 @@ vmufb_print_string(vmufb_t *fb, const vmufb_font_t *font, const char *str) {
  */
 extern const vmufb_font_t vmufb_font4x6;
 
-/** \brief  Render a string to attached VMUs using the built-in font
+/** @} */
 
-    Uses the built-in VMU font to render a string to all VMUs connected to the
-    system.
-
-    \param  fmt             The format string, optionally followed by extra
-                            arguments.
- */
-__attribute__ ((format (printf, 1, 2)))
-void vmu_printf(const char *fmt, ...);
+__END_DECLS
 
 #endif /* __DC_VMU_FB_H */

--- a/kernel/arch/dreamcast/include/dc/vmu_fb.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_fb.h
@@ -136,6 +136,14 @@ vmufb_print_string(vmufb_t *fb, const vmufb_font_t *font, const char *str) {
     vmufb_print_string_into(fb, font, 0, 0, 48, 32, 0, str);
 }
 
+/** \brief Built-in VMU framebuffer font.
+ *
+ *  Linux 4x6 font: lib/fonts/font_mino_4x6.c
+ *
+ *  \author Kenneth Albanowski
+ */
+extern const vmufb_font_t vmufb_font4x6;
+
 /** \brief  Render a string to attached VMUs using the built-in font
 
     Uses the built-in VMU font to render a string to all VMUs connected to the

--- a/kernel/arch/dreamcast/util/vmu_fb.c
+++ b/kernel/arch/dreamcast/util/vmu_fb.c
@@ -2,6 +2,7 @@
 
    util/vmu_fb.c
    Copyright (C) 2023 Paul Cercueil
+   Copyright (C) 2024 Falco Girgis
 
 */
 
@@ -13,6 +14,8 @@
 
 #define GENMASK(h, l) \
     (((unsigned int)-1 << (l)) & ((unsigned int)-1 >> (31 - (h))))
+
+static const vmufb_font_t *default_font = &vmufb_font4x6;
 
 static uint64_t extract_bits(const uint8_t *data,
                              unsigned int offt, unsigned int w) {
@@ -81,7 +84,7 @@ void vmufb_paint_area(vmufb_t *fb,
 
     for (i = 0; i < h; i++) {
         bits = extract_bits((const uint8_t *)data, i * w, w);
-        insert_bits((uint8_t *)fb->data, (y + i) * 48 + x, w, bits);
+        insert_bits((uint8_t *)fb->data, (y + i) * VMU_SCREEN_WIDTH + x, w, bits);
     }
 }
 
@@ -92,7 +95,7 @@ void vmufb_clear(vmufb_t *fb) {
 void vmufb_clear_area(vmufb_t *fb,
                       unsigned int x, unsigned int y,
                       unsigned int w, unsigned int h) {
-    uint32_t tmp[48] = {};
+    uint32_t tmp[VMU_SCREEN_WIDTH] = {};
 
     vmufb_paint_area(fb, x, y, w, h, (const char *) tmp);
 }
@@ -120,6 +123,7 @@ void vmufb_print_string_into(vmufb_t *fb,
                              unsigned int line_spacing,
                              const char *str) {
     unsigned int xorig = x, yorig = y;
+    font = font? font : default_font;
 
     for (; *str; str++) {
         switch (*str) {
@@ -147,4 +151,14 @@ void vmufb_print_string_into(vmufb_t *fb,
 
         x += font->w;
     }
+}
+
+const vmufb_font_t *vmu_set_font(const vmufb_font_t *font) {
+    const vmufb_font_t *temp = default_font;
+    default_font = font;
+    return temp;
+}
+
+const vmufb_font_t *vmu_get_font(void) {
+    return default_font;
 }

--- a/kernel/arch/dreamcast/util/vmu_printf.c
+++ b/kernel/arch/dreamcast/util/vmu_printf.c
@@ -122,8 +122,7 @@ const vmufb_font_t vmufb_font4x6 = {
 	.fontdata = fontdata_4x6,
 };
 
-void vmu_printf(const char *fmt, ...)
-{
+void vmu_printf(const char *fmt, ...) {
 	maple_device_t *dev;
 	unsigned int vmu;
 	char buf[256];
@@ -135,7 +134,8 @@ void vmu_printf(const char *fmt, ...)
 	vsnprintf(buf, sizeof(buf), fmt, va);
 	va_end(va);
 
-	vmufb_print_string(&vmufb, &vmufb_font4x6, buf);
+	vmufb_clear(&vmufb);
+	vmufb_print_string(&vmufb, vmu_get_font(), buf);
 
 	for (vmu = 0; ; vmu++) {
 		dev = maple_enum_type(vmu, MAPLE_FUNC_LCD);

--- a/kernel/arch/dreamcast/util/vmu_printf.c
+++ b/kernel/arch/dreamcast/util/vmu_printf.c
@@ -115,7 +115,7 @@ static const char fontdata_4x6[] = {
 	0xee, 0xe0, 0x00, 0x66, 0x00, 0xee, 0xee, 0xe0,
 };
 
-static const vmufb_font_t vmufb_font4x6 = {
+const vmufb_font_t vmufb_font4x6 = {
 	.w = 4,
 	.h = 6,
 	.stride = 3,


### PR DESCRIPTION
- Need a quick font without external dependencies to use with the extended font-drawing methods in the vmufb API? Sweet. We already have one used by vmu_printf()
- Simply remove the static keyword from the font definition and then declare it extern in the vmu_fb.h header file for others to use and profit from.