### PR TITLE
Fix: OCRAM mode is initialized with bit 5 of CCR not bit 6

### DIFF
--- a/kernel/arch/dreamcast/kernel/startup.s
+++ b/kernel/arch/dreamcast/kernel/startup.s
@@ -236,4 +236,4 @@ ccr_addr:
 ccr_data:
 	.word	0x090d
 ccr_data_ocram:
-	.word	0x092d
+	.word	0x091d


### PR DESCRIPTION
Changed constant ccr_data_ocram in startup.s to 0x091d from 0x092d - previous code was toggling bit 6 of CCR, which is unused, instead of bit 5 which controls OCRAM mode.

See page 79 of the SH4 Manual Here:

https://www.st.com/resource/en/user_manual/cd00147165-sh-4-32-bit-cpu-core-architecture-stmicroelectronics.pdf