### PR TITLE
Adjust example for removal of maple_device_t element 'valid'

### DIFF
--- a/examples/dreamcast/rumble/rumble.c
+++ b/examples/dreamcast/rumble/rumble.c
@@ -159,7 +159,7 @@ void wait_for_dev_attach(maple_device_t **dev_ptr, unsigned int func) {
     /* If we already have it, and it's still valid, leave */
     /* dev->valid is set to 0 by the driver if the device
        is detached, but dev will stay not-null */
-    if((dev != NULL) && (dev->valid != 0)) return;
+    if((dev != NULL) && (maple_dev_valid(dev->port, dev->unit) != 0)) return;
 
     /* Draw up a screen */
     pvr_wait_ready();
@@ -178,7 +178,7 @@ void wait_for_dev_attach(maple_device_t **dev_ptr, unsigned int func) {
     pvr_scene_finish();
 
     /* Repeatedly check until we find one and it's valid */
-    while((dev == NULL) || (dev->valid == 0)) {
+    while((dev == NULL) || (maple_dev_valid(dev->port, dev->unit) == 0)) {
         *dev_ptr = maple_enum_type(0, func);
         dev = *dev_ptr;
         usleep(50);
@@ -347,7 +347,7 @@ int main(int argc, char *argv[]) {
     }
 
     /* Stop rumbling before exiting, if it still exists. */
-    if((purudev != NULL) && (purudev->valid != 0))
+    if((purudev != NULL) && (maple_dev_valid(purudev->port, purudev->unit) != 0))
         purupuru_rumble_raw(purudev, 0x00000000);
 
     plx_font_destroy(fnt);


### PR DESCRIPTION
#552  Removed the member 'valid' from the `maple_device_t` struct. As a patch, updating to use `maple_dev_valid`.

May need to patch the use of this back in and have it just auto-updated. Either that or provide less clunky methods to determine if a dev object is valid or not. It's difficult to tell if it's in common use, but it should be as it's the only way to recover from a device being unplugged other than continuously renewing the dev pointer.