### PR TITLE
thread: Improve priority boosting

### DIFF
--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -139,7 +139,7 @@ int mutex_lock_timed(mutex_t *m, int timeout) {
                 /* Thread list is sorted by priority, update the position
                  * of the thread holding the lock */
                 thd_remove_from_runnable(m->holder);
-                thd_add_to_runnable(m->holder, 0);
+                thd_add_to_runnable(m->holder, true);
             }
 
             rv = genwait_wait(m, timeout ? "mutex_lock_timed" : "mutex_lock",


### PR DESCRIPTION
When failing to obtain an already locked mutex owned by a thread with the same priority than us, we want the other thread to be bumped to the front of the queue, not to the end of the queue.