### PR TITLE
Persist allocated `maple_device_t`s

### DIFF
--- a/examples/dreamcast/rumble/rumble.c
+++ b/examples/dreamcast/rumble/rumble.c
@@ -157,9 +157,10 @@ void wait_for_dev_attach(maple_device_t **dev_ptr, unsigned int func) {
     point_t w = {40.0f, 200.0f, 10.0f, 0.0f};
 
     /* If we already have it, and it's still valid, leave */
-    /* dev->valid is set to 0 by the driver if the device
+    /* dev->valid is set to false by the driver if the device
        is detached, but dev will stay not-null */
-    if((dev != NULL) && (maple_dev_valid(dev->port, dev->unit) != 0)) return;
+    if((dev != NULL) && dev->valid)
+        return;
 
     /* Draw up a screen */
     pvr_wait_ready();
@@ -178,7 +179,7 @@ void wait_for_dev_attach(maple_device_t **dev_ptr, unsigned int func) {
     pvr_scene_finish();
 
     /* Repeatedly check until we find one and it's valid */
-    while((dev == NULL) || (maple_dev_valid(dev->port, dev->unit) == 0)) {
+    while((dev == NULL) || !dev->valid) {
         *dev_ptr = maple_enum_type(0, func);
         dev = *dev_ptr;
         usleep(50);
@@ -269,6 +270,11 @@ int main(int argc, char *argv[]) {
 
         /* Store current button states + buttons which have been released. */
         state = (cont_state_t *)maple_dev_status(contdev);
+
+        /* Make sure we can rely on the state, otherwise loop. */
+        if(state == NULL)
+            continue;
+
         rel_buttons = (old_buttons ^ state->buttons);
 
         if((state->buttons & CONT_DPAD_LEFT) && (rel_buttons & CONT_DPAD_LEFT)) {
@@ -347,7 +353,7 @@ int main(int argc, char *argv[]) {
     }
 
     /* Stop rumbling before exiting, if it still exists. */
-    if((purudev != NULL) && (maple_dev_valid(purudev->port, purudev->unit) != 0))
+    if((purudev != NULL) && purudev->valid)
         purupuru_rumble_raw(purudev, 0x00000000);
 
     plx_font_destroy(fnt);

--- a/kernel/arch/dreamcast/hardware/maple/maple_enum.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_enum.c
@@ -14,7 +14,7 @@ int maple_enum_count(void) {
 
     for(cnt = 0, p = 0; p < MAPLE_PORT_COUNT; p++)
         for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-            if(maple_state.ports[p].units[u])
+            if(maple_dev_valid(p,u))
                 cnt++;
         }
 
@@ -23,7 +23,10 @@ int maple_enum_count(void) {
 
 /* Return a raw device info struct for the given device */
 maple_device_t * maple_enum_dev(int p, int u) {
-    return maple_state.ports[p].units[u];
+    maple_device_t *rv = maple_state.ports[p].units[u];
+    if(rv && rv->valid)
+        return rv;
+    return NULL;
 }
 
 /* Return the Nth device of the requested type (where N is zero-indexed) */
@@ -100,7 +103,7 @@ maple_device_t * maple_enum_type_ex(int n, uint32 func, uint32 cap) {
    valid before returning. Cast to the appropriate type you're expecting. */
 void * maple_dev_status(maple_device_t *dev) {
     /* The device must be valid, and must get periodic updates. */
-    if(!dev || !dev->drv || !dev->drv->periodic)
+    if(!dev || !dev->valid || !dev->drv || !dev->drv->periodic)
         return NULL;
 
     /* Waits until the first DMA happens: crude but effective (replace me later) */
@@ -108,6 +111,6 @@ void * maple_dev_status(maple_device_t *dev) {
         thd_pass();
 
     /* Cast and return the status buffer */
-    return (void *)(dev->status);
+    return dev->status;
 }
 

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -39,6 +39,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
+#include <stdbool.h>
 #include <arch/types.h>
 #include <sys/queue.h>
 
@@ -269,6 +270,7 @@ typedef struct maple_response {
 */
 typedef struct maple_device {
     /* Public */
+    bool            valid;  /**< \brief Is this a valid device? */
     int             port;   /**< \brief Maple bus port connected to */
     int             unit;   /**< \brief Unit number, off of the port */
     maple_devinfo_t info;   /**< \brief Device info struct */
@@ -282,7 +284,7 @@ typedef struct maple_device {
 
     volatile uint8          status_valid;   /**< \brief Have we got our first status update? */
 
-    uint32                  status[];       /**< \brief Status buffer (for pollable devices) */
+    void                    *status;        /**< \brief Status buffer (for pollable devices) */
 } maple_device_t;
 
 #define MAPLE_PORT_COUNT    4   /**< \brief Number of ports on the bus */
@@ -685,6 +687,7 @@ int maple_driver_unreg(maple_driver_t *driver);
     \ingroup maple
 
     \param  det             The detection frame.
+    \retval 1               Couldn't allocate buffers.
     \retval 0               On success.
     \retval -1              If no driver is available.
 */


### PR DESCRIPTION
#552 had the unintended negative impact of breaking the understanding of a `maple_device_t` pointer being able to be cached by the user and tested for its validity. Additionally, it created a condition where any operation using a `maple_device_t` pointer would be racing against the device possibly being unplugged and deallocated.

Now, the dynamically allocated device structures persist in the global table once unplugged so that the expected behaviors are restored, there are no longer race conditions against use-after-free, and the memory usage should be the same (barring plugging/unplugging devices to different ports repeatedly). 

A few extra notes:
* The autodetection has been set to use the device's frame, if one already exists, rather than the shared one.
* If no driver can be assigned to the device, the device stays allocated. Otherwise a device that fails to attach would cause allocations and frees on every autodetect.
