### PR TITLE
Separate out trap from irq. 

### DIFF
--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -27,6 +27,9 @@ __BEGIN_DECLS
 
 #include <arch/types.h>
 
+/* Included for legacy compatibility with these two APIs being one. */
+#include <arch/trap.h>
+
 /** \defgroup irqs  Interrupts
     \brief          IRQs and ISRs for the SH4's CPU
     \ingroup        system
@@ -316,18 +319,6 @@ int irq_set_handler(irq_t source, irq_handler hnd, void *data);
     \return                 A pointer to the procedure to handle the exception.
 */
 irq_handler irq_get_handler(irq_t source);
-
-/** \brief   Set or remove a handler for a trapa code.
-    \ingroup irqs
-    
-    \param  code            The value passed to the trapa opcode.
-    \param  hnd             A pointer to the procedure to handle the trap.
-    \param  data            A pointer that will be passed along to the callback.
-
-    \retval 0               On success.
-    \retval -1              If the code is invalid (greater than 0xFF).
-*/
-int trapa_set_handler(irq_t code, irq_handler hnd, void *data);
 
 /** \brief   Set a global exception handler.
     \ingroup irqs

--- a/kernel/arch/dreamcast/include/arch/trap.h
+++ b/kernel/arch/dreamcast/include/arch/trap.h
@@ -1,0 +1,102 @@
+/* KallistiOS ##version##
+
+   arch/dreamcast/include/arch/trap.h
+   Copyright (C) 2024 Falco Girgis
+
+*/
+
+/** \file    
+    \brief   Interrupt and exception handling.
+    \ingroup traps
+
+    This file contains various definitions and declarations related to handling
+    trap events, as are invoked through the `TRAPA` instruction.
+
+    \author Falco Girgis
+
+    \see    arch/irq.h, dc/asic.h
+
+    \todo
+        - state management, propagation
+        - TRAPA instruction inline ASM
+        - document reserved TRAP codes
+*/
+
+#ifndef __ARCH_TRAP_H
+#define __ARCH_TRAP_H
+
+#include <stdint.h>
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+/** \cond */ /* Forward declarations */
+struct irq_context;
+typedef struct irq_context irq_context_t;
+/** \endcond */
+
+/** \defgroup traps  Traps
+    \brief    API for managing TRAPA events and handlers.
+    \ingroup  system
+
+    This API provides methods for setting and getting the installed handler for
+    a particular `TRAPA` code.
+
+    `TRAPA` is an SH4 instruction which simply takes a code (0-255) and fires
+    an exception event which transfers execution to the kernel so that it can
+    then be handled in software.
+
+    @{
+*/
+
+/** Type for a code passed to the `TRAPA` instruction. */
+typedef uint8_t trapa_t;
+
+/** \defgroup irq_trapa_handler Handlers 
+    \brief                      API for managing TRAPA handlers
+
+    This API allows for the setting and retrieving of a handler associated with
+    a particular `TRAPA` value. 
+
+    @{
+*/
+
+/** The type of a TRAPA handler
+
+    \param  trap            The IRQ that caused the handler to be called.
+    \param  context         The CPU's context.
+    \param  data            Arbitrary userdata associated with the handler.
+*/
+typedef void (*trapa_handler)(trapa_t trap, irq_context_t *context, void *data);
+
+/** Set or remove a handler for a trapa code.
+    
+    \param  trap            The value passed to the trapa opcode.
+    \param  hnd             A pointer to the procedure to handle the trap.
+    \param  data            A pointer that will be passed along to the callback.
+
+    \retval 0               On success.
+
+    \sa trapa_get_handler()
+*/
+int trapa_set_handler(trapa_t trap, trapa_handler hnd, void *data);
+
+/** Get an existing TRAPA handler.
+
+    \param code             The value passed to the trapa opcode.
+    \param data             A pointer to a void* which will be filled in with
+                            the handler's userdata, or NULL if not interested.
+
+    \return                 A pointer to the procedure to handle the TRAP code.
+
+    \sa trapa_set_handler()
+*/
+trapa_handler trapa_get_handler(trapa_t trap, void **data);
+
+/** @} */
+
+/** @} */
+
+__END_DECLS
+
+#endif /* __ARCH_TRAP_H */

--- a/kernel/arch/dreamcast/kernel/gdb_stub.c
+++ b/kernel/arch/dreamcast/kernel/gdb_stub.c
@@ -910,14 +910,14 @@ static void handle_exception(irq_t code, irq_context_t *context, void *data) {
     gdb_handle_exception(code);
 }
 
-static void handle_user_trapa(irq_t code, irq_context_t *context, void *data) {
+static void handle_user_trapa(trapa_t code, irq_context_t *context, void *data) {
     (void)code;
     (void)data;
     irq_ctx = context;
     gdb_handle_exception(EXC_TRAPA);
 }
 
-static void handle_gdb_trapa(irq_t code, irq_context_t *context, void *data) {
+static void handle_gdb_trapa(trapa_t code, irq_context_t *context, void *data) {
     /*
     * trapa 0x20 indicates a software trap inserted in
     * place of code ... so back up PC by one

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -22,11 +22,17 @@ struct irq_cb {
     void *data;
 };
 
+/* TRAPA handler closure */
+struct trapa_cb {
+    trapa_handler hdl;
+    void         *data;
+};
+
 /* Exception table -- this table matches (EXPEVT>>4) to a function pointer.
    If the pointer is null, then nothing happens. Otherwise, the function will
    handle the exception. */
 static struct irq_cb irq_handlers[0x100];
-static struct irq_cb trapa_handlers[0x100];
+static struct trapa_cb trapa_handlers[0x100];
 
 /* Global exception handler -- hook this if you want to get each and every
    exception; you might get more than you bargained for, but it can be useful. */
@@ -75,12 +81,17 @@ irq_handler irq_get_global_handler(void) {
 }
 
 /* Set or remove a trapa handler */
-int trapa_set_handler(irq_t code, irq_handler hnd, void *data) {
-    if(code > 0xff) return -1;
-
-    trapa_handlers[code] = (struct irq_cb){ hnd, data };
-
+int trapa_set_handler(trapa_t code, trapa_handler hnd, void *data) {
+    trapa_handlers[code] = (struct trapa_cb){ hnd, data };
     return 0;
+}
+
+/* Get a particular trapa handler */
+trapa_handler trapa_get_handler(trapa_t code, void **data) {
+    if(data)
+        *data = trapa_handlers[code].data;
+
+    return trapa_handlers[code].hdl;
 }
 
 /* Get a string description of the exception */


### PR DESCRIPTION
This is separated out from #618 to try to reduce the scope of that PR to be more digestible. My intent is to do at least one more that will have the stylistic/type changes from the PR and some of the documentation update.

Since this is almost a review of that PR I made two changes compared to what was in the PR:
1) The \retval documentation for the setter was updated to remove the failure return, as it is no longer possible to trigger or checked at all.
2) Adding of trap.h into kos.h wasn't done. It might be that it's the right way to go by the end of it, but it seems very much to me that including trap.h would *always* require irq.h as they share irq_context. The way it's done here so far is ok, having it be a 'child' header internally to irq.h. What may be needed in the end would be something like an `irq_internal.h` to have `irq_context` (instead of the forward declaration) and perhaps things shared by exceptions then an exception.h as well.