### PR TITLE
Added functionality to biosfont

### DIFF
--- a/examples/dreamcast/video/screenshot/screenshot.c
+++ b/examples/dreamcast/video/screenshot/screenshot.c
@@ -30,7 +30,7 @@
 
 #include <kos/thread.h>
 
-#define SHOW_BLACK_BG 1
+#define SHOW_BLACK_BG  true
 
 /* Keeps track of the amount of screenshots you have taken */
 static int counter = 0;
@@ -38,7 +38,6 @@ static int counter = 0;
 int main(int argc, char **argv) {
     uint8_t r, g, b;
     uint32_t t = 0;
-    int font_height_offset = 0;
     char filename[256];
 
     /* Adjust frequency for faster or slower transitions */
@@ -48,7 +47,7 @@ int main(int argc, char **argv) {
     cont_state_t *state;
 
     /* Set the video mode */
-    vid_set_mode(DM_640x480, PM_RGB565);   
+    vid_set_mode(DM_640x480, PM_RGB565);
 
     while(1) {
         if((cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER)) != NULL) {
@@ -82,13 +81,8 @@ int main(int argc, char **argv) {
         vid_clear(r, g, b);
 
         /* Draw Foreground */
-        font_height_offset = (640 * (480 - (BFONT_HEIGHT * 6))) + (BFONT_THIN_WIDTH * 2);
-        bfont_draw_str(vram_s + font_height_offset, 640, SHOW_BLACK_BG, 
-            "Press Start to exit");
-            
-        font_height_offset += 640 * BFONT_HEIGHT * 2;
-        bfont_draw_str(vram_s + font_height_offset, 640, SHOW_BLACK_BG, 
-            "Press A to take a screen shot");
+        bfont_draw_str_vram_fmt(24, 336, SHOW_BLACK_BG, 
+            "Press Start to exit\n\nPress A to take a screen shot");
 
         vid_flip(-1);
     }

--- a/examples/dreamcast/vmu/vmu_game/vmu_game.c
+++ b/examples/dreamcast/vmu/vmu_game/vmu_game.c
@@ -12,15 +12,14 @@
 
 void draw_findings(void) {
     file_t      d;
-    int     y = 88;
 
     d = fs_open("/vmu/a1", O_RDONLY | O_DIR);
 
     if(!d) {
-        bfont_draw_str(vram_s + y * 640 + 10, 640, 0, "Can't read VMU");
+        bfont_draw_str_vram_fmt(10, 88, false, "Can't read VMU");
     }
     else {
-        bfont_draw_str(vram_s + y * 640 + 10, 640, 0, "VMU found. Press Start.");
+        bfont_draw_str_vram_fmt(10, 88, false, "VMU found. Press Start.");
     }
 }
 
@@ -33,7 +32,7 @@ void new_vmu(void) {
     if(dev == NULL) {
         if(dev_checked) {
             memset4(vram_s + 88 * 640, 0, 640 * (480 - 64) * 2);
-            bfont_draw_str(vram_s + 88 * 640 + 10, 640, 0, "No VMU");
+            bfont_draw_str_vram_fmt(10, 88, false, "No VMU");
             dev_checked = 0;
         }
     }
@@ -88,18 +87,13 @@ void write_game_entry(void) {
 
     dev = maple_enum_type(0, MAPLE_FUNC_MEMCARD);
     
-    if (dev)
-    {
+    if(dev)
         vmufs_write(dev, "Tetris", data, data_size, VMUFS_VMUGAME);
-    }
 }
 
 int main(int argc, char **argv) {
-    bfont_draw_str(vram_s + 20 * 640 + 20, 640, 0,
-                   "Put a VMU you don't care too much about");
-    bfont_draw_str(vram_s + 42 * 640 + 20, 640, 0,
-                   "in slot A1 and press START");
-    bfont_draw_str(vram_s + 88 * 640 + 10, 640, 0, "No VMU");
+    bfont_draw_str_vram_fmt(20, 20, false,
+        "Put a VMU you don't care too much about\nin slot A1 and press START\n\nNo VMU");
 
     if(wait_start() < 0) return 0;
 

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -93,11 +93,24 @@ vmu_pkg_build
 vmu_pkg_parse
 
 # Bios Font
+bfont_set_foreground_color
+bfont_set_background_color
 bfont_set_encoding
+bfont_find_char
+bfont_find_char_jp
+bfont_find_char_jp_half
+bfont_find_icon
+bfont_draw_ex
+bfont_draw
 bfont_draw_thin
 bfont_draw_wide
-bfont_draw
+bfont_draw_str_ex
+bfont_draw_str_ex_fmt
+bfont_draw_str_ex_vfmt
 bfont_draw_str
+bfont_draw_str_fmt
+bfont_draw_str_vram_vfmt
+bfont_draw_str_vram_fmt
 
 # CD-Rom
 cdrom_reinit

--- a/kernel/arch/dreamcast/include/dc/biosfont.h
+++ b/kernel/arch/dreamcast/include/dc/biosfont.h
@@ -5,6 +5,7 @@
    Japanese Functions Copyright (C) 2002 Kazuaki Matsumoto
    Copyright (C) 2017 Donald Haase
    Copyright (C) 2024 Falco Girgis
+   Copyright (C) 2024 Andress Barajas
 
 */
 
@@ -286,18 +287,6 @@ uint32_t bfont_set_foreground_color(uint32_t c);
 */
 uint32_t bfont_set_background_color(uint32_t c);
 
-/** \brief      Set the font to draw 32-bit color.
-    \deprecated Use the bpp parameter of the bfont_draw_ex() functions.
-
-    This function changes whether the font draws colors as 32-bit or 16-bit. The
-    default is to use 16-bit.
-
-    \param  on              Set to 0 to use 16-bit color, 32-bit otherwise.
-    \return                 The old state (1 = 32-bit, 0 = 16-bit).
-*/
-bool bfont_set_32bit_mode(bool on)
-    __depr("Please use the bpp function of the the bfont_draw_ex functions");
-
 /** @} */
 
 /* Constants for the function below */
@@ -391,7 +380,7 @@ uint8_t *bfont_find_icon(bfont_vmu_icon_t icon);
     \param fg           The foreground color to use.
     \param bg           The background color to use.
     \param bpp          The number of bits per pixel in the buffer.
-    \param opaque       If non-zero, overwrite background areas with black,
+    \param opaque       If true, overwrite background areas with black,
                             otherwise do not change them from what they are.
     \param c            The character to draw.
     \param wide         Draw a wide character.
@@ -410,7 +399,7 @@ size_t bfont_draw_ex(void *buffer, uint32_t bufwidth, uint32_t fg,
 
     \param  buffer          The buffer to draw to (at least 12 x 24 pixels)
     \param  bufwidth        The width of the buffer in pixels
-    \param  opaque          If non-zero, overwrite blank areas with black,
+    \param  opaque          If true, overwrite blank areas with black,
                             otherwise do not change them from what they are
     \param  c               The character to draw
     \return                 Amount of width covered in bytes.
@@ -424,7 +413,7 @@ size_t bfont_draw(void *buffer, uint32_t bufwidth, bool opaque, uint32_t c);
 
     \param  buffer          The buffer to draw to (at least 12 x 24 pixels)
     \param  bufwidth        The width of the buffer in pixels
-    \param  opaque          If non-zero, overwrite blank areas with black,
+    \param  opaque          If true, overwrite blank areas with black,
                             otherwise do not change them from what they are
     \param  c               The character to draw
     \param  iskana          Set to 1 if the character is a kana, 0 if ISO-8859-1
@@ -440,7 +429,7 @@ size_t bfont_draw_thin(void *buffer, uint32_t bufwidth, bool opaque,
 
     \param  buffer          The buffer to draw to (at least 24 x 24 pixels)
     \param  bufwidth        The width of the buffer in pixels
-    \param  opaque          If non-zero, overwrite blank areas with black,
+    \param  opaque          If true, overwrite blank areas with black,
                             otherwise do not change them from what they are
     \param  c               The character to draw
     \return                 Amount of width covered in bytes.
@@ -463,12 +452,12 @@ size_t bfont_draw_wide(void *buffer, uint32_t bufwidth, bool opaque,
     if the encoding is set to one of the Japanese encodings. Colors and bitdepth
     can be set.
 
-    \param b                The buffer to draw to.
-    \param width            The width of the buffer in pixels.
-    \param fg               The foreground color to use.
-    \param bg               The background color to use.
-    \param bpp              The number of bits per pixel in the buffer.
-    \param opaque           If non-zero, overwrite background areas with black,
+    \param  b               The buffer to draw to.
+    \param  width           The width of the buffer in pixels.
+    \param  fg              The foreground color to use.
+    \param  bg              The background color to use.
+    \param  bpp             The number of bits per pixel in the buffer.
+    \param  opaque          If true, overwrite background areas with black,
                             otherwise do not change them from what they are.
     \param str              The string to draw.
 
@@ -482,15 +471,15 @@ void bfont_draw_str_ex(void *b, uint32_t width, uint32_t fg, uint32_t bg,
     This function is equivalent to bfont_draw_str_ex(), except that the string
     is formatted as with the `printf()` function.
 
-    \param b                The buffer to draw to.
-    \param width            The width of the buffer in pixels.
-    \param fg               The foreground color to use.
-    \param bg               The background color to use.
-    \param bpp              The number of bits per pixel in the buffer.
-    \param opaque           If non-zero, overwrite background areas with black,
+    \param  b               The buffer to draw to.
+    \param  width           The width of the buffer in pixels.
+    \param  fg              The foreground color to use.
+    \param  bg              The background color to use.
+    \param  bpp             The number of bits per pixel in the buffer.
+    \param  opaque          If true, overwrite background areas with black,
                             otherwise do not change them from what they are.
-    \param fmt              The printf-style format string to draw.
-    \param ...              Additional printf-style variadic arguments
+    \param  fmt             The printf-style format string to draw.
+    \param  ...             Additional printf-style variadic arguments
 
     \sa bfont_draw_str_ex_vfmt()
 */
@@ -503,15 +492,15 @@ void bfont_draw_str_ex_fmt(void *b, uint32_t width, uint32_t fg, uint32_t bg,
     This function is equivalent to bfont_draw_str_ex_fmt(), except that the
     variadic argument list is passed via a pointer to a va_list.
 
-    \param b                The buffer to draw to.
-    \param width            The width of the buffer in pixels.
-    \param fg               The foreground color to use.
-    \param bg               The background color to use.
-    \param bpp              The number of bits per pixel in the buffer.
-    \param opaque           If non-zero, overwrite background areas with black,
+    \param  b               The buffer to draw to.
+    \param  width           The width of the buffer in pixels.
+    \param  fg              The foreground color to use.
+    \param  bg              The background color to use.
+    \param  bpp             The number of bits per pixel in the buffer.
+    \param  opaque          If true, overwrite background areas with black,
                             otherwise do not change them from what they are.
-    \param fmt              The printf-style format string to draw.
-    \param var_args         Additional printf-style variadic arguments
+    \param  fmt             The printf-style format string to draw.
+    \param  var_args        Additional printf-style variadic arguments
 
     \sa bfont_draw_str_ex_fmt()
 */
@@ -528,7 +517,7 @@ void bfont_draw_str_ex_vfmt(void *b, uint32_t width, uint32_t fg, uint32_t bg,
 
     \param  b               The buffer to draw to.
     \param  width           The width of the buffer in pixels.
-    \param  opaque          If one, overwrite blank areas with bfont_bgcolor,
+    \param  opaque          If true, overwrite blank areas with bfont_bgcolor,
                             otherwise do not change them from what they are.
     \param  str             The string to draw.
 */
@@ -541,15 +530,50 @@ void bfont_draw_str(void *b, uint32_t width, bool opaque, const char *str);
 
     \param  b               The buffer to draw to.
     \param  width           The width of the buffer in pixels.
-    \param  opaque          If one, overwrite blank areas with bfont_bgcolor,
+    \param  opaque          If true, overwrite blank areas with bfont_bgcolor,
                             otherwise do not change them from what they are.
     \param  fmt             The printf-style format string to draw.
     \param  ...             Additional printf-style variadic arguments.
 */
 void bfont_draw_str_fmt(void *b, uint32_t width, bool opaque, const char *fmt,
                         ...) __printflike(4, 5);
+                        
+/** \brief   Draw a full formatted string to video ram (with va_args).
+ 
+    This function is equivalent to bfont_draw_str_ex_vfmt(), except that 
+    the variadic argument list is passed via a pointer to a va_list.
 
-/** @} */
+    \param  x               The x position to start drawing at.
+    \param  y               The y position to start drawing at.
+    \param  fg              The foreground color to use.
+    \param  bg              The background color to use.
+    \param  opaque          If true, overwrite background areas with black,
+                            otherwise do not change them from what they are.
+    \param  fmt             The printf-style format string to draw.
+    \param  var_args        Additional printf-style variadic arguments
+
+    \sa bfont_draw_str_ex()
+*/
+void bfont_draw_str_vram_vfmt(uint32_t x, uint32_t y, uint32_t fg, uint32_t bg, 
+                              bool opaque, const char *fmt, 
+                              va_list *var_args);
+
+/** \brief   Draw a full string to video ram.
+
+    This function draws a NUL-terminated string in the set encoding to video
+    ram. This will automatically handle mixed half and full-width characters
+    if the encoding is set to one of the Japanese encodings. Draws pre-set
+    16-bit colors.
+
+    \param  x               The x position to start drawing at.
+    \param  y               The y position to start drawing at.
+    \param  opaque          If true, overwrite blank areas with bfont_bgcolor,
+                            otherwise do not change them from what they are.
+    \param  fmt             The printf-style format string to draw.
+    \param  ...             Additional printf-style variadic arguments.
+*/
+void bfont_draw_str_vram_fmt(uint32_t x, uint32_t y, bool opaque, const char *fmt, 
+                             ...) __printflike(4, 5);
 
 /** @} */
 


### PR DESCRIPTION
 - Added two new functions (bfont_draw_str_vram_vfmt & bfont_draw_str_vram_fmt) that draw to the frame buffer start at a x,y location. 
 - Added support to handle \n and \t. 
 - Fix documentation spacing
 - Update two examples to demo the new API