### PR TITLE
[RFC] pvr: Add new function pvr_send_to_ta()

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/Makefile
+++ b/kernel/arch/dreamcast/hardware/pvr/Makefile
@@ -13,6 +13,9 @@ OBJS += pvr_buffers.o pvr_irq.o
 # Init / Shutdown / Globals / Misc
 OBJS += pvr_init_shutdown.o pvr_globals.o pvr_misc.o
 
+# Fast Tile Accelerator upload function
+OBJS += pvr_send_to_ta.o
+
 # Fog
 OBJS += pvr_fog.o
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_send_to_ta.s
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_send_to_ta.s
@@ -1,0 +1,43 @@
+! KallistiOS ##version##
+!
+!   arch/dreamcast/hardware/pvr/pvr_send_to_ta.s
+!   Copyright (C) 2024 Paul Cercueil
+!
+! Fast function to upload geometry to the Tile Accelerator without SQs
+!
+
+.globl _pvr_send_to_ta
+
+_pvr_send_to_ta:
+	fschg
+	mov.l	_irq_and,r1
+	mov	#0x78,r2
+	mov.l	_ta_addr,r3
+	stc	sr,r0
+	and	r0,r1
+	fmov	@r4+,dr0
+	shll	r2
+	fmov	@r4+,dr2
+	or	r2,r1
+	fmov	@r4+,dr4
+	fmov	@r4+,dr6
+	ldc	r1,sr
+
+	movca.l	r0,@r3
+	add	#32,r3
+	fmov	dr6,@-r3
+	fmov	dr4,@-r3
+	fmov	dr2,@-r3
+	fmov	dr0,@-r3
+	fschg
+
+	ldc	r0,sr
+
+	rts
+	ocbp	@r3
+
+.align 2
+_irq_and:
+	.long	0xefffff0f
+_ta_addr:
+	.long	0x90000000

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -2006,6 +2006,17 @@ void pvr_dr_init(pvr_dr_state_t *vtx_buf_ptr);
 */
 void pvr_dr_finish(void);
 
+/** \brief  Upload a 32-byte payload to the Tile Accelerator
+
+    Upload the given payload to the Tile Accelerator. The difference with the
+    Direct Rendering approach above is that the Store Queues are not used, and
+    therefore can be used for anything else.
+
+    \param  data            A pointer to the 32-byte payload.
+                            The pointer must be aligned to 8 bytes.
+*/
+void pvr_send_to_ta(void *data);
+
 /** @} */
 
 /** \brief   Submit a primitive of the given list type.


### PR DESCRIPTION
This function can be used to upload a 32-byte payload to the Tile Accelerator.

The difference with the Direct Rendering approach is that the SQs are not used, and therefore can be used for anything else.