### PR TITLE
Ensure the name manager selects the best match on lookup.

### DIFF
--- a/kernel/exports/nmmgr.c
+++ b/kernel/exports/nmmgr.c
@@ -34,12 +34,18 @@ static nmmgr_list_t nmmgr_handlers;
 
 /* Locate a name handler for a given path name */
 nmmgr_handler_t * nmmgr_lookup(const char *fn) {
-    nmmgr_handler_t *cur;
+    nmmgr_handler_t *cur = NULL, *tmp;
+    size_t          cur_len = 0, tmp_len;
 
-    /* Scan the handler table and look for a path match */
-    LIST_FOREACH(cur, &nmmgr_handlers, list_ent) {
-        if(!strncasecmp(cur->pathname, fn, strlen(cur->pathname)))
-            break;
+    /* Scan the handler table and look for the best path match */
+    LIST_FOREACH(tmp, &nmmgr_handlers, list_ent) {
+        tmp_len = strlen(tmp->pathname);
+        if(!strncasecmp(tmp->pathname, fn, tmp_len)) {
+            if(cur_len < tmp_len) {
+                cur_len = tmp_len;
+                cur = tmp;
+            }
+        }
     }
 
     if(cur == NULL) {


### PR DESCRIPTION
Before this it would always simply pick the first. This change allows registered names to overlap and still be found. So now you can mount something to `/c` without breaking `/cd`.

To test the difference, take any program with a builtin romdisk and mount it to `/c` as well (or `/vm` or any partial name of something already mounted) as so: `fs_romdisk_mount("/c", (void *)romdisk_data, 0);` (making sure you have a global ref for the romdisk_data: `extern const unsigned char romdisk_data[];`). Then try opening `/cd`.

This changes some very low level behavior in the name manager, so if anyone has any thoughts please share. I tried to think through different ways this might cause worse mismatches, but couldn't think of any.

This is a first step change toward #649 , which would necessarily mean differentiating nested names.