### PR TITLE
Set ramdisk's `stat` to return 0 on successful completion.

### DIFF
--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -624,7 +624,7 @@ static int ramdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     if(f->datasize & 0x3ff)
         ++st->st_blocks;
 
-    return -1;
+    return 0;
 }
 
 static int ramdisk_fcntl(void *h, int cmd, va_list ap) {


### PR DESCRIPTION
Was returning -1, which indicates an error (ref https://pubs.opengroup.org/onlinepubs/9799919799/ ). Not sure if this was impacting upstream use.