### PR TITLE
Extended snd_sfx functionality

### DIFF
--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -122,6 +122,7 @@ snd_sfx_play_chn
 snd_sfx_play_chn_ex
 snd_sfx_volume
 snd_sfx_pan
+snd_sfx_freq
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -120,6 +120,7 @@ snd_sfx_play_ex
 snd_sfx_stop_all
 snd_sfx_play_chn
 snd_sfx_play_chn_ex
+snd_sfx_volume
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -116,8 +116,10 @@ snd_sfx_load
 snd_sfx_load_ex
 snd_sfx_load_fd
 snd_sfx_play
+snd_sfx_play_ex
 snd_sfx_stop_all
 snd_sfx_play_chn
+snd_sfx_play_chn_ex
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -121,6 +121,7 @@ snd_sfx_stop_all
 snd_sfx_play_chn
 snd_sfx_play_chn_ex
 snd_sfx_volume
+snd_sfx_pan
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -167,6 +167,7 @@ snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free
 snd_sfx_volume
+snd_sfx_pan
 snd_stream_set_callback
 snd_stream_set_callback_direct
 snd_stream_filter_add

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -159,8 +159,10 @@ snd_sfx_load
 snd_sfx_load_ex
 snd_sfx_load_fd
 snd_sfx_play
+snd_sfx_play_ex
 snd_sfx_stop_all
 snd_sfx_play_chn
+snd_sfx_play_chn_ex
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -166,6 +166,7 @@ snd_sfx_play_chn_ex
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free
+snd_sfx_volume
 snd_stream_set_callback
 snd_stream_set_callback_direct
 snd_stream_filter_add

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -168,6 +168,7 @@ snd_sfx_chn_alloc
 snd_sfx_chn_free
 snd_sfx_volume
 snd_sfx_pan
+snd_sfx_freq
 snd_stream_set_callback
 snd_stream_set_callback_direct
 snd_stream_filter_add

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -204,6 +204,19 @@ int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan);
 */
 int snd_sfx_play_chn_ex(int chn, sfxhnd_t idx, int vol, int pan, uint32_t freq, bool is_loop, uint32_t loop_start, uint32_t loop_end);
 
+/** \brief  Change the volume of a playing sound channel.
+
+    This function updates the volume of the specified channel of sound. 
+    It does no checking to make sure that a sound effect is playing on the channel
+    specified, and thus can be used even if you're using the channel for some
+    other purpose than sound effects.
+
+    \param  chn             The channel to affect.
+    \param  vol             The volume to play at (between 0 and 255).
+*/
+void snd_sfx_volume( int chn, int vol );
+
+
 /** \brief  Stop a single channel of sound.
 
     This function stops the specified channel of sound from playing. It does no
@@ -240,6 +253,7 @@ int snd_sfx_chn_alloc(void);
     \param  chn             The channel to free.
 */
 void snd_sfx_chn_free(int chn);
+
 
 /** @} */
 

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -230,6 +230,17 @@ void snd_sfx_volume( int chn, int vol );
 */
 void snd_sfx_pan( int chn, int pan );
 
+/** \brief  Change the frequency of a playing sound channel.
+
+    This function updates the playback frequency of the specified channel of sound. 
+    It does no checking to make sure that a sound effect is playing on the channel
+    specified, and thus can be used even if you're using the channel for some
+    other purpose than sound effects.
+
+    \param  chn             The channel to affect.
+    \param  freq            The new frequency of the sound.
+*/
+void snd_sfx_freq( int chn, int freq );
 
 /** \brief  Stop a single channel of sound.
 

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -216,6 +216,20 @@ int snd_sfx_play_chn_ex(int chn, sfxhnd_t idx, int vol, int pan, uint32_t freq, 
 */
 void snd_sfx_volume( int chn, int vol );
 
+/** \brief  Change the volume of a playing sound channel.
+
+    This function updates the volume of the specified channel of sound. 
+    It does no checking to make sure that a sound effect is playing on the channel
+    specified, and thus can be used even if you're using the channel for some
+    other purpose than sound effects.
+
+    \param  chn             The channel to affect.
+    \param  pan             The panning value of the sound effect. 0 is all the
+                            way to the left, 128 is center, 255 is all the way
+                            to the right.
+*/
+void snd_sfx_pan( int chn, int pan );
+
 
 /** \brief  Stop a single channel of sound.
 

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -140,6 +140,29 @@ void snd_sfx_unload_all(void);
 */
 int snd_sfx_play(sfxhnd_t idx, int vol, int pan);
 
+/** \brief  Play a sound effect.
+
+    This function plays a loaded sound effect with the specified volume (for
+    both stereo or mono) and panning values (for mono sounds only).
+
+    \param  idx             The handle to the sound effect to play.
+    \param  vol             The volume to play at (between 0 and 255).
+    \param  pan             The panning value of the sound effect. 0 is all the
+                            way to the left, 128 is center, 255 is all the way
+                            to the right.
+    \param  freq            Override playback frequency, or set to 0 to use sample default frequency
+    \param  is_loop         If set, this sound effect will continue to loop until explicitly stopped
+                            If not set, this sound effect will play once and terminate
+    \param  loop_start      Index of first sample when looping
+    \param  loop_end        Index of last sample when looping. Pass 0 to loop at the end of the effect
+
+    \return                 The channel used to play the sound effect (or the
+                            left channel in the case of a stereo sound, the
+                            right channel will be the next one) on success, or
+                            -1 on failure.
+*/
+int snd_sfx_play_ex(sfxhnd_t idx, int vol, int pan, uint32_t freq, bool is_loop, uint32_t loop_start, uint32_t loop_end );
+
 /** \brief  Play a sound effect on a specific channel.
 
     This function works similar to snd_sfx_play(), but allows you to specify the
@@ -157,6 +180,29 @@ int snd_sfx_play(sfxhnd_t idx, int vol, int pan);
     \return                 chn
 */
 int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan);
+
+/** \brief  Play a sound effect on a specific channel.
+
+    This function works similar to snd_sfx_play(), but allows you to specify the
+    channel to play on. No error checking is done with regard to the channel, so
+    be sure its safe to play on that channel before trying.
+
+    \param  chn             The channel to play on (or in the case of stereo,
+                            the left channel).
+    \param  idx             The handle to the sound effect to play.
+    \param  vol             The volume to play at (between 0 and 255).
+    \param  pan             The panning value of the sound effect. 0 is all the
+                            way to the left, 128 is center, 255 is all the way
+                            to the right.
+    \param  freq            Override playback frequency, or set to 0 to use sample default frequency
+    \param  is_loop         If set, this sound effect will continue to loop until explicitly stopped
+                            If not set, this sound effect will play once and terminate
+    \param  loop_start      Index of first sample when looping
+    \param  loop_end        Index of last sample when looping. Pass 0 to loop at the end of the effect
+
+    \return                 chn
+*/
+int snd_sfx_play_chn_ex(int chn, sfxhnd_t idx, int vol, int pan, uint32_t freq, bool is_loop, uint32_t loop_start, uint32_t loop_end);
 
 /** \brief  Stop a single channel of sound.
 

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -660,3 +660,14 @@ void snd_sfx_pan( int chn, int pan ){
     chan->pan = pan;
     snd_sh4_to_aica(tmp, cmd->size);
 }
+
+void snd_sfx_freq( int chn, int freq ){
+    AICA_CMDSTR_CHANNEL(tmp, cmd, chan);
+    cmd->cmd = AICA_CMD_CHAN;
+    cmd->timestamp = 0;
+    cmd->size = AICA_CMDSTR_CHANNEL_SIZE;
+    cmd->cmd_id = chn;
+    chan->cmd = AICA_CH_CMD_UPDATE | AICA_CH_UPDATE_SET_FREQ;
+    chan->freq = freq;
+    snd_sh4_to_aica(tmp, cmd->size);  
+}

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -21,6 +21,7 @@
 #include <kos/fs.h>
 #include <arch/irq.h>
 #include <dc/spu.h>
+#include <dc/sound/aica_comm.h>
 #include <dc/sound/sound.h>
 #include <dc/sound/sfxmgr.h>
 
@@ -502,7 +503,7 @@ err_occurred:
     return SFXHND_INVALID;
 }
 
-int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan){
+    int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan){
     return snd_sfx_play_chn_ex( chn, idx, vol, pan, 0, false, 0, 0 );
 }
 
@@ -636,4 +637,15 @@ void snd_sfx_chn_free(int chn) {
     old = irq_disable();
     sfx_inuse &= ~(1ULL << chn);
     irq_restore(old);
+}
+
+void snd_sfx_volume( int chn, int vol ){
+    AICA_CMDSTR_CHANNEL(tmp, cmd, chan);
+    cmd->cmd = AICA_CMD_CHAN;
+    cmd->timestamp = 0;
+    cmd->size = AICA_CMDSTR_CHANNEL_SIZE;
+    cmd->cmd_id = chn;
+    chan->cmd = AICA_CH_CMD_UPDATE | AICA_CH_UPDATE_SET_VOL;
+    chan->vol = vol;
+    snd_sh4_to_aica(tmp, cmd->size);
 }

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -502,8 +502,12 @@ err_occurred:
     return SFXHND_INVALID;
 }
 
-int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan) {
-    int size;
+int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan){
+    return snd_sfx_play_chn_ex( chn, idx, vol, pan, 0, false, 0, 0 );
+}
+
+int snd_sfx_play_chn_ex(int chn, sfxhnd_t idx, int vol, int pan, uint32_t freq, bool is_loop, uint32_t loop_start, uint32_t loop_end) {
+    uint32 size;
     snd_effect_t *t = (snd_effect_t *)idx;
     AICA_CMDSTR_CHANNEL(tmp, cmd, chan);
 
@@ -519,10 +523,10 @@ int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan) {
     chan->base = t->locl;
     chan->type = t->fmt;
     chan->length = size;
-    chan->loop = 0;
-    chan->loopstart = 0;
-    chan->loopend = size;
-    chan->freq = t->rate;
+    chan->loop = is_loop ? 1 : 0;
+    chan->loopstart = loop_start;
+    chan->loopend = loop_end ? loop_end : size;
+    chan->freq = freq ? freq : t->rate;
     chan->vol = vol;
 
     if(!t->stereo) {
@@ -546,6 +550,10 @@ int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan) {
 }
 
 int snd_sfx_play(sfxhnd_t idx, int vol, int pan) {
+    return snd_sfx_play_ex( idx, vol, pan, 0, false, 0, 0 );
+}
+
+int snd_sfx_play_ex(sfxhnd_t idx, int vol, int pan, uint32_t freq, bool is_loop, uint32_t loop_start, uint32_t loop_end ){
     int chn, moved, old;
 
     /* This isn't perfect.. but it should be good enough. */
@@ -569,7 +577,7 @@ int snd_sfx_play(sfxhnd_t idx, int vol, int pan) {
     }
     else {
         sfx_nextchan = (chn + 2) % 64;  /* in case of stereo */
-        return snd_sfx_play_chn(chn, idx, vol, pan);
+        return snd_sfx_play_chn_ex(chn, idx, vol, pan, freq, is_loop, loop_start, loop_end);
     }
 }
 

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -649,3 +649,14 @@ void snd_sfx_volume( int chn, int vol ){
     chan->vol = vol;
     snd_sh4_to_aica(tmp, cmd->size);
 }
+
+void snd_sfx_pan( int chn, int pan ){
+    AICA_CMDSTR_CHANNEL(tmp, cmd, chan);
+    cmd->cmd = AICA_CMD_CHAN;
+    cmd->timestamp = 0;
+    cmd->size = AICA_CMDSTR_CHANNEL_SIZE;
+    cmd->cmd_id = chn;
+    chan->cmd = AICA_CH_CMD_UPDATE | AICA_CH_UPDATE_SET_PAN;
+    chan->pan = pan;
+    snd_sh4_to_aica(tmp, cmd->size);
+}


### PR DESCRIPTION
The KOS AICA sound driver has functionality beyond what is exposed by the current simple snd_sfx functions. My use case is playing short sound effects that loop (like a short engine noise sample), where the pitch and frequency can be changed dynamically at runtime. 

My current options for accessing this functionality are:

- External library from kos-ports (i.e OpenAL) but the partial implementation does not include that functionality.
- Use the audio streaming api. This doesn't provide the convenience functions for loading and playing short sounds like the snd_sfx api does, and as far as I can tell is aimed at much larger sound buffers. It's much more complex and powerful than the current snd_sfx api, to the point where I wasn't able to understand it without examples, of which I couldn't find any that don't depend on external libraries to provide most of the interface.

So finding neither of those options suitable I've added
snd_sfx_play_ex() and snd_sfx_play_chn_ex(), an extended version of snd_sfx_play() and snd_sfx_play_chn() respectively, that expose access to some parameters that the original functions set to default values (frequency, looping, loop start and end points), which enables me to start a looping sound at a given frequency. The original functions call the extended versions with the default parameters they used previously.

I also need to be able to dynamically change the volume, pan, and frequency of playing sound effects, and so have added snd_sfx_volume() snd_sfx_pan(), snd_sfx_freq().

These are fairly simple additions that allow me to forgo the need to use a kos-ports library (if a sufficiently complete one exists) that I think might be useful to others using the simple sfx api but find it slightly lacking. 