### PR TITLE
audio: Fix makefile race condition and arm clean

### DIFF
--- a/kernel/arch/dreamcast/sound/Makefile
+++ b/kernel/arch/dreamcast/sound/Makefile
@@ -18,5 +18,7 @@ SUBDIRS = arm
 
 include $(KOS_BASE)/Makefile.prefab
 
-snd_stream_drv.o: subdirs arm/stream.drv
+arm/stream.drv: subdirs
+
+snd_stream_drv.o: arm/stream.drv
 	$(KOS_BASE)/utils/bin2o/bin2o arm/stream.drv snd_stream_drv snd_stream_drv.o

--- a/kernel/arch/dreamcast/sound/arm/Makefile
+++ b/kernel/arch/dreamcast/sound/arm/Makefile
@@ -34,4 +34,4 @@ prog.elf: crt0.o main.o aica.o
 	$(DC_ARM_AS) $(DC_ARM_AFLAGS) $< -o $@
 
 clean:
-	-rm -f *.o *.srec *.elf 1ST_READ.BIN prog.bin *.bck prog.map
+	-rm -f *.o *.srec *.elf 1ST_READ.BIN prog.bin *.bck prog.map stream.drv


### PR DESCRIPTION
- arm/stream.drv depends on subdirs to generate it, so it can't be a parallel dependency.
- arm/Makefile forgot to delete stream.drv on clean

Fixes make -j 24 for me