### PR TITLE
Gracefully return 0 for ARM/PVR available memory when called before initialization

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -179,7 +179,8 @@ static uint32 pvr_mem_available_int(void) {
 }
 
 uint32 pvr_mem_available(void) {
-    CHECK_MEM_BASE;
+    if(!pvr_mem_base)
+        return 0;
 
     return pvr_mem_available_int() + 
         (PVR_RAM_INT_TOP - (uint32)pvr_mem_base);

--- a/kernel/arch/dreamcast/sound/snd_mem.c
+++ b/kernel/arch/dreamcast/sound/snd_mem.c
@@ -294,7 +294,8 @@ uint32 snd_mem_available(void) {
     snd_block_t *e;
     size_t largest = 0;
 
-    assert_msg(initted, "Use of snd_mem_available before snd_mem_init");
+    if(!initted)
+        return 0;
 
     if(irq_inside_int()) {
         if(!spinlock_trylock(&snd_mem_mutex)) {


### PR DESCRIPTION
- Rather than asserting and crashing, which isn't really warranted, modified pvr_mem_available() and snd_mem_available() to gracefully return 0 when called before PVR/Sound RAM has been initialized.
- This way profilers and monitors in other threads can still boot up and show proper stats while things are being initialized, rather than simply crashing in debug builds and returning garbage in release builds.