### PR TITLE
Make m4-single the default floating-point precision ABI

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -13,6 +13,7 @@ Platform-specific changes are prefixed with the platform name, otherwise the cha
 - **Dreamcast**: Cleaned up, documented, and enhanced BIOS font API [FG]
 - Rework PVR hybrid mode + IRQ handling [PC]
 - **Dreamcast**: Add support and update toolchain profiles for Newlib 4.5.0, Binutils 2.43.1, and GDB 15.2 [EF]
+- **Dreamcast**: Make m4-single the default floating-point ABI [EF]
 
 ## KallistiOS version 2.1.1
 - Added pvrtex utility by TapamN to utils [Daniel Fairchild == DF]

--- a/doc/RELNOTES.md
+++ b/doc/RELNOTES.md
@@ -2,6 +2,44 @@ KallistiOS ##version##
 Copyright (C) 2002, 2003 Megan Potter
 Copyright (C) 2012-2019 Lawrence Sebald
 Copyright (C) 2024 Donald Haase
+Copyright (C) 2025 Eric Fradella
+
+RELEASE NOTES for 2.2.0
+-----------------------
+A significant change has been made regarding the default floating-point ABI used
+by KallistiOS. In previous KOS releases, and even in commercial games released
+during the Dreamcast's lifetime, the `m4-single-only` floating-point ABI was
+used. With the `m4-single-only` ABI, the SH4 CPU is always in single-precision
+mode and all uses of 64-bit `double` values are truncated to 32-bit `float`
+values by the compiler, allowing the compiler to use twice the number of
+floating-point registers at the expense of precision. Going forward, KOS now
+uses the `m4-single` floating-point ABI by default. With the `m4-single` ABI,
+the SH4 CPU is in single-precision mode upon function entry, but the compiler
+can change the mode and use true 64-bit `double` values within functions. For
+most projects, there are no implications from this change other than gaining
+the ability to use 64-bit `double` values. There are, however, two possibilities
+for negative effects:
+
+- In older projects using `double` values (which were actually being truncated
+  to 32-bit `float` values upon compilation anyway), the code should be changed
+  to explicitly use `float` values instead. If not changed, fewer floating-point
+  registers may be available to the compiler, in exchange for a needless bonus
+  doubling of floating-point precision.
+
+- The order of floating-point register names is changed. When using
+  `m4-single-only`, register names are ordered fr4, fr5, fr6, fr7, etc., but in
+  `m4-single`, register names are ordered fr5, fr4, fr7, fr6, etc. In order to
+  account for this difference and still have inline assembly functions using
+  floating-point registers work properly regardless of the ABI used, the
+  KOS_FPARG(n) macro has been provided in `arch/args.h`.
+
+Despite the change to `m4-single` by default, KOS is still committed to full
+support for `m4-single-only` in addition to offering new support for
+`m4-single`. This is selectable using the `KOS_SH4_PRECISION` environment
+variable within environ.sh. It is highly recommended to compile KOS, all
+kos-ports, and all libraries with the same uniform setting as your projects.
+Other ABIs, such as `m4` or `m4-nofpu`, are not supported at this time.
+
 
 RELEASE NOTES for 2.1.1
 -----------------------
@@ -23,9 +61,9 @@ RELEASE NOTES for 2.1.0
 
 # What's New in Version 2.1.0
 
-KOS v2.1.0 has been a long time in the making. As such, it seemed prudent to 
-provide an overview of the new functionality since v2.0.0 in 2013. We intend 
-to have more frequent versioned releases moving forward, so this kind of 
+KOS v2.1.0 has been a long time in the making. As such, it seemed prudent to
+provide an overview of the new functionality since v2.0.0 in 2013. We intend
+to have more frequent versioned releases moving forward, so this kind of
 information should be easily seen in the changelog.
 
 # Core Functionality

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -183,19 +183,22 @@ export KOS_CFLAGS="${KOS_CFLAGS} -fno-builtin"
 #
 #export KOS_CFLAGS="${KOS_CFLAGS} -fbuiltin -ffast-math -ffp-contract=fast -mfsrra -mfsca"
 
-# SH4 Floating Point Arithmetic Precision
+# SH4 Floating-Point Arithmetic Precision
 #
-# KallistiOS only officially supports the single-precision-only floating-point
-# arithmetic mode (-m4-single-only), but double precision, single default
-# (-m4-single) or double precision default (-m4) modes can be enabled here by
-# adjusting KOS_SH4_PRECISION.
-# WARNING: Adjusting this setting has a high likelihood of breaking KallistiOS,
-#          kos-ports, and existing codebases which assume -m4-single-only.
-#          Do not touch this setting unless you know what you are doing!
-# NOTE: Altering this setting also requires your toolchain to have been built
-#       with support for these modes, which is not the case by default!
+# KallistiOS supports both the single-precision-default ABI (m4-single) and the
+# single-precision-only ABI (m4-single-only). When using m4-single, the SH4 will
+# be in single-precision mode upon function entry but will switch to double-
+# precision mode if 64-bit doubles are used. When using m4-single-only, the SH4
+# will always be in single-precision mode and 64-bit doubles will be truncated to
+# 32-bit floats. Historically, m4-single-only was used in both official and
+# homebrew Dreamcast software, but m4-single is the default as of KOS 2.2.0 to
+# increase compatibility with newer libraries which require 64-bit doubles.
 #
-export KOS_SH4_PRECISION="-m4-single-only"
+# WARNING: When adjusting this setting, make sure all software, including
+#          kos-ports and linked external libraries, are rebuilt using the same
+#          floating-point precision ABI setting!
+#
+export KOS_SH4_PRECISION="-m4-single"
 
 # Use LRA (Local Register Allocator) Pass
 #

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -12,8 +12,14 @@ if ! expr ":$PATH:" : ".*:${DC_TOOLS_BASE}:.*" > /dev/null ; then
 fi
 
 # Default the SH4 floating-point precision if it isn't already set.
+# m4-single is used if supported by the current toolchain, otherwise
+# m4-single-only is used as a fallback option.
 if [ -z "${KOS_SH4_PRECISION}" ] ; then
-    export KOS_SH4_PRECISION="-m4-single"
+    if echo 'int main(){}' | ${KOS_CC} -x c -c -o /dev/null - -m4-single 2>/dev/null; then
+        export KOS_SH4_PRECISION="-m4-single"
+    else
+        export KOS_SH4_PRECISION="-m4-single-only"
+    fi
 fi
 
 export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_SH4_PRECISION} -ml -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec"

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -11,9 +11,9 @@ if ! expr ":$PATH:" : ".*:${DC_TOOLS_BASE}:.*" > /dev/null ; then
   export PATH="${PATH}:${DC_TOOLS_BASE}"
 fi
 
-# Default the SH4 floating point precision if it isn't already set.
+# Default the SH4 floating-point precision if it isn't already set.
 if [ -z "${KOS_SH4_PRECISION}" ] ; then
-    export KOS_SH4_PRECISION="-m4-single-only"
+    export KOS_SH4_PRECISION="-m4-single"
 fi
 
 export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_SH4_PRECISION} -ml -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec"

--- a/loadable/Makefile.prefab
+++ b/loadable/Makefile.prefab
@@ -22,8 +22,8 @@ endif
 # First one checks for missing symbols (and fully links with an offset
 # of zero so we can do tracebacks later), second one makes the real file.
 $(TARGET): $(OBJS)
-	$(KOS_CC) -g -ml -m4-single-only -O2 -g -Wl,-Ttext=0x00000000 -e _start -nostartfiles -nodefaultlibs -o dbg-$(TARGET) $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) $(DBG_LIBS) -lgcc -Wl,--end-group
-	$(KOS_CC) -g -ml -m4-single-only -O2 -Wl,-d -Wl,-r -Wl,-S -Wl,-x -nostartfiles -nodefaultlibs -o $(TARGET) -Wl,-T $(KOS_BASE)/loadable/shlelf_dc.xr $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) -lgcc -Wl,--end-group
+	$(KOS_CC) -g -ml $(KOS_SH4_PRECISION) -O2 -g -Wl,-Ttext=0x00000000 -e _start -nostartfiles -nodefaultlibs -o dbg-$(TARGET) $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) $(DBG_LIBS) -lgcc -Wl,--end-group
+	$(KOS_CC) -g -ml $(KOS_SH4_PRECISION) -O2 -Wl,-d -Wl,-r -Wl,-S -Wl,-x -nostartfiles -nodefaultlibs -o $(TARGET) -Wl,-T $(KOS_BASE)/loadable/shlelf_dc.xr $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) -lgcc -Wl,--end-group
 	$(KOS_SIZE) $(TARGET)
 
 clean:

--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -136,20 +136,24 @@ enable_objcpp=1
 ### GCC OPTIONS ###
 ###################
 
-### Floating point precision support (m4-single-only|m4-single|m4)
-# Build support for various SH4 floating-point operation ABIs. KallistiOS only
-# officially supports single-precision-only mode (m4-single-only); however,
-# experimental support for single-precision-default mode (m4-single) has been
-# added to allow for the use of full 64-bit doubles. You may also include
-# double-precision-default (m4) which is untested and unsupported, or you may
-# choose to specify only m4-single-only to save disk space.
-precision_modes=m4-single-only,m4-single
+### Floating-point precision support (m4-single|m4-single-only|m4)
+# Build support for various SH4 floating-point operation ABIs. KallistiOS
+# supports both the single-precision-default ABI (m4-single) and the
+# single-precision-only ABI (m4-single-only). When using m4-single, the SH4 will
+# be in single-precision mode upon function entry but will switch to double-
+# precision mode if 64-bit doubles are used. When using m4-single-only, the SH4
+# will always be in single-precision mode and 64-bit doubles will be truncated to
+# 32-bit floats. In double-precision mode (m4), which is unsupported by
+# KallistiOS, the SH4 will be in double precision mode upon function entry.
+# Historically, m4-single-only was used in both official and homebrew Dreamcast
+# software, but m4-single is the default as of KOS 2.2.0 to increase
+# compatibility with newer libraries which require 64-bit doubles.
+precision_modes=m4-single,m4-single-only
 
-### Default floating point mode (m4|m4-single|m4-single-only)
-# Choose the default floating point precision ABI used when GCC is invoked. This
-# may be overridden by passing -m4-single-only, -m4-single, or -m4 to GCC.
-# KOS currently only officially supports m4-single-only, so it is the default.
-default_precision=m4-single-only
+### Default floating-point mode (m4-single|m4-single-only|m4)
+# Choose the default floating-point precision ABI used when GCC is invoked. This
+# may be overridden by passing -m4-single, -m4-single-only, or -m4 to GCC.
+default_precision=m4-single
 
 ### GCC threading model (single|kos)
 # KallistiOS patches to GCC provide a 'kos' thread model, which should be used.


### PR DESCRIPTION
Let's finally make `m4-single` the default. This was discussed with @QuzarDC and @ljsebald, and these were the points made:

- `m4-single` being the default in KOS/GCC is fine.
  - While it's nice that `m4-single` is a currently enabled option now, `m4-single` as a _default_ for GCC is desirable since `libgccjit`, which can be used to interface with the `rustc` compiler frontend when built with `m4-single`, does not support multilib, and is only built for the default.
  - GCC can be built with one setting as default, and KOS can use another setting as its default, though.
- More testing within KOS is needed to move to `m4-single` as default. 
  - A handful of people using it as their primary setting does not suffice for testing.
- Full compatibility in KOS with `m4-single-only` needs to remain.
- Any kos-ports incompatible with `m4-single` or `m4-single-only` is fine but this must be explicitly stated in associated documentation/readme. 
  - kos-ports checking this for you when building would be nice.
  - I've submitted a PR with such functionality: [kos-ports #90](https://github.com/KallistiOS/kos-ports/pull/90)

Some clarification around sufficient testing would be nice. As far as I know, all examples build and function just fine on `m4-single` right now. This doesn't test all code paths though. And further testing of ports would certainly be nice, since some of them aren't used very often anymore, etc.