### PR TITLE
Fix Strided Textures

### DIFF
--- a/examples/dreamcast/kgl/basic/elements/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/elements/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/basic/gl/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/gl/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/basic/scissor/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/scissor/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/basic/txrenv/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/txrenv/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/basic/zclip_arrays/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/zclip_arrays/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/blur/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/blur/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/mipmap/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/mipmap/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/multitexture-arrays/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/multitexture-arrays/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/multitexture-elements/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/multitexture-elements/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/specular/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/specular/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/specular/texture.c
+++ b/examples/dreamcast/kgl/demos/specular/texture.c
@@ -82,7 +82,7 @@ GLuint glTextureLoadPVR(char *fname, unsigned char UseMipMap) {
             break;//RECTANGLE
 
         case 0x0B:
-            texFormat = PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;
+            texFormat = PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;
             break;//RECTANGULAR STRIDE
 
         case 0x0D:

--- a/examples/dreamcast/kgl/nehe/nehe06/pvr-texture.c
+++ b/examples/dreamcast/kgl/nehe/nehe06/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/nehe/nehe08/pvr-texture.c
+++ b/examples/dreamcast/kgl/nehe/nehe08/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/nehe/nehe09/pvr-texture.c
+++ b/examples/dreamcast/kgl/nehe/nehe09/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/nehe/nehe16/pvr-texture.c
+++ b/examples/dreamcast/kgl/nehe/nehe16/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/pvr/strided_texture/Makefile
+++ b/examples/dreamcast/pvr/strided_texture/Makefile
@@ -1,6 +1,6 @@
 #
 # strided_texture
-# Copyright (C) Andress Barajas
+# Copyright (C) 2024 Andress Barajas
 #   
 
 TARGET = strided_texture.elf

--- a/examples/dreamcast/pvr/strided_texture/Makefile
+++ b/examples/dreamcast/pvr/strided_texture/Makefile
@@ -1,0 +1,27 @@
+#
+# strided_texture
+# Copyright (C) Andress Barajas
+#   
+
+TARGET = strided_texture.elf
+OBJS = strided_texture.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist: $(TARGET)
+	-rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/pvr/strided_texture/strided_texture.c
+++ b/examples/dreamcast/pvr/strided_texture/strided_texture.c
@@ -1,0 +1,228 @@
+/* KallistiOS ##version##
+
+   strided_texture.c
+   Copyright (C) 2024 Andress Barajas
+*/
+
+/*
+    This example demonstrates rendering a black-and-white chessboard pattern 
+    using a 640x480 texture with 16bpp color depth. In this example, the texture 
+    width and stride are both set to 640. However, because 640 is not a power 
+    of two, we need to use the `PVR_TXRFMT_X32_STRIDE` flag. This flag informs the 
+    PVR that the texture's width (or "stride") is a multiple of 32 rather than 
+    a power of two.
+
+    Steps to configure and render a texture with a 32-pixel multiple 
+    width:
+
+    1. Configure the Polygon Header for Textures:
+    
+       - Use `pvr_poly_cxt_txr()` to set up the polygon context for the texture.
+       - Specify `PVR_TXRFMT_NONTWIDDLED | PVR_TXRFMT_X32_STRIDE` in the format
+         flags.
+       - Provide dimensions in powers of two, which should be larger than the
+         actual texture. For example, if your texture is 640x480, set width and
+         height to `1024` and `512`, respectively.
+
+       Example:
+           ```c
+           pvr_poly_cxt_txr(&cxt, PVR_LIST_OP_POLY,
+                            PVR_TXRFMT_RGB565 | PVR_TXRFMT_NONTWIDDLED |
+                            PVR_TXRFMT_X32_STRIDE, 1024, 512,
+                            texture_pointer, PVR_FILTER_NONE);
+           ```
+
+  2. Set the Global Texture Stride Register:
+
+       - Use `PVR_SET(PVR_TXR_STRIDE_MULT, stride_multi);` to define a custom
+         texture stride width in increments of 32 pixels.
+       - Calculate `stride_multi` by dividing the texture width by 32.
+       - The `PVR_TXR_STRIDE_MULT` register defines how the hardware interprets 
+         each row's width in VRAM. For a 640-pixel wide texture, `stride_multi` 
+         would be:
+        
+           ```c
+           PVR_SET(PVR_TXR_STRIDE_MULT, 640 / 32);
+           ```
+       Important Notes:
+       - Texture widths that are multiples of 32 (but not powers of two) require 
+         the `PVR_TXRFMT_X32_STRIDE` flag.
+       - Palette-based textures are incompatible with the `PVR_TXRFMT_X32_STRIDE` 
+         flag.
+       - `PVR_TXR_STRIDE_MULT` is a global register. All textures using the 
+         `PVR_TXRFMT_X32_STRIDE` flag in the same frame must share the same 
+         stride. Changing `PVR_TXR_STRIDE_MULT` affects all such textures 
+         rendered afterward.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <arch/arch.h>
+
+#include <dc/pvr.h>
+#include <dc/maple.h>
+#include <dc/maple/controller.h>
+
+/* The width of the texture in pixels (must be a multiple of 32) */
+#define TEXTURE_WIDTH    640
+
+/* The height of the texture in pixels */
+#define TEXTURE_HEIGHT   480
+
+/* 
+   Macro to calculate the next power of two for a given integer `x`.
+   
+   Example:
+     NEXT_POWER_OF_TWO(640) -> 1024
+*/
+#define NEXT_POWER_OF_TWO(x)    (1 << (32 - __builtin_clz((x) - 1)))
+
+/* 
+   The power-of-two width to be passed to texture setup functions. 
+   Based on TEXTURE_WIDTH, this should be equal to or greater than 
+   TEXTURE_WIDTH, and will match the hardware requirement for 
+   power-of-two texture dimensions.
+*/
+#define TEXTURE_PADDED_WIDTH    NEXT_POWER_OF_TWO(TEXTURE_WIDTH)
+
+/* 
+   The power-of-two height to be passed to texture setup functions. 
+   Based on TEXTURE_HEIGHT, this should be equal to or greater than 
+   TEXTURE_HEIGHT, following the power-of-two requirement.
+*/
+#define TEXTURE_PADDED_HEIGHT   NEXT_POWER_OF_TWO(TEXTURE_HEIGHT)
+
+/* RGB565 colors for chessboard pattern */
+#define COLOR_BLACK   0x0000
+#define COLOR_WHITE   0xFFFF
+
+static pvr_poly_hdr_t hdr;
+static pvr_vertex_t verts[4];
+
+static pvr_ptr_t board_texture;
+
+static void draw_frame(void) {
+    pvr_wait_ready();
+    pvr_scene_begin();
+
+    pvr_list_begin(PVR_LIST_OP_POLY);
+
+    pvr_prim(&hdr, sizeof(hdr));
+
+    pvr_prim(&verts[0], sizeof(pvr_vertex_t));
+    pvr_prim(&verts[1], sizeof(pvr_vertex_t));
+    pvr_prim(&verts[2], sizeof(pvr_vertex_t));
+    pvr_prim(&verts[3], sizeof(pvr_vertex_t));
+
+    pvr_list_finish();
+    pvr_scene_finish();
+}
+
+static void load_texture(void) {
+    pvr_poly_cxt_t cxt;
+    uint16_t *grid_texture;
+
+    /* Allocate memory for the texture with 32-byte alignment */
+    grid_texture = (uint16_t *)memalign(32, TEXTURE_WIDTH * TEXTURE_HEIGHT * 2);
+
+    /* Generate a chessboard pattern */
+    for(int y = 0; y < TEXTURE_HEIGHT; y++) {
+        for(int x = 0; x < TEXTURE_WIDTH; x++) {
+            /* Determine if we are in an even or odd square. */
+            int square_x = x / 32;
+            int square_y = y / 32;
+            int is_white_square = (square_x + square_y) % 2;
+
+            grid_texture[y * TEXTURE_WIDTH + x] = is_white_square
+                                    ? COLOR_WHITE : COLOR_BLACK;
+        }
+    }
+
+    /* Allocate space in VRAM for the texture */
+    board_texture = pvr_mem_malloc(TEXTURE_WIDTH * TEXTURE_HEIGHT * 2);
+
+    /* Load the chessboard pattern into VRAM */
+    pvr_txr_load(grid_texture, board_texture, 
+                 TEXTURE_WIDTH * TEXTURE_HEIGHT * 2);
+
+    /* Set texture context format for nontwiddled, strided texture */
+    pvr_poly_cxt_txr(&cxt, PVR_LIST_OP_POLY,
+                     PVR_TXRFMT_RGB565 | PVR_TXRFMT_NONTWIDDLED 
+                     | PVR_TXRFMT_X32_STRIDE, TEXTURE_PADDED_WIDTH, 
+                     TEXTURE_PADDED_HEIGHT, board_texture, PVR_FILTER_NONE);
+    pvr_poly_compile(&hdr, &cxt);
+
+    /* Set the STRIDE register to texture width / 32 */
+    PVR_SET(PVR_TXR_STRIDE_MULT, TEXTURE_WIDTH / 32);
+
+    free(grid_texture);
+}
+
+/*
+   When setting up the vertices, the texture width (stride) is divided by
+   the padded texture width (and similarly for the height) to ensure that 
+   the non-power-of-two dimensions are mapped correctly to the power-of-two 
+   padded dimensions used in VRAM. This allows textures with non-standard
+   widths (e.g., multiples of 32) to render accurately on the Dreamcast's
+   PVR hardware.
+*/
+static void setup_vertices(void) {
+    int color = PVR_PACK_COLOR(1.0f, 1.0f, 1.0f, 1.0f);
+
+    verts[0].x = 0.0f;
+    verts[0].y = 0.0f;
+    verts[0].z = 1.0f;
+    verts[0].u = 0.0f;
+    verts[0].v = 0.0f;
+    verts[0].argb = color;
+    verts[0].oargb = 0;
+    verts[0].flags = PVR_CMD_VERTEX;
+
+    verts[1].x = 640.0f;
+    verts[1].y = 0.0f;
+    verts[1].z = 1.0f;
+    verts[1].u = (float)TEXTURE_WIDTH / (float)TEXTURE_PADDED_WIDTH;
+    verts[1].v = 0.0f;
+    verts[1].argb = color;
+    verts[1].oargb = 0;
+    verts[1].flags = PVR_CMD_VERTEX;
+
+    verts[2].x = 0.0f;
+    verts[2].y = 480.0f;
+    verts[2].z = 1.0f;
+    verts[2].u = 0.0f;
+    verts[2].v = (float)TEXTURE_HEIGHT / (float)TEXTURE_PADDED_HEIGHT;
+    verts[2].argb = color;
+    verts[2].oargb = 0;
+    verts[2].flags = PVR_CMD_VERTEX;
+
+    verts[3].x = 640.0f;
+    verts[3].y = 480.0f;
+    verts[3].z = 1.0f;
+    verts[3].u = (float)TEXTURE_WIDTH / (float)TEXTURE_PADDED_WIDTH;
+    verts[3].v = (float)TEXTURE_HEIGHT / (float)TEXTURE_PADDED_HEIGHT;
+    verts[3].argb = color;
+    verts[3].oargb = 0;
+    verts[3].flags = PVR_CMD_VERTEX_EOL;
+}
+
+int main(int argc, char **argv) {
+
+    pvr_init_defaults();
+
+    /* If the user hits start, bail */
+    cont_btn_callback(0, CONT_START, (cont_btn_callback_t)arch_exit);
+
+    load_texture();
+
+    setup_vertices();
+
+    draw_frame();
+    
+    /* Wait for exit */
+    for(;;) { }
+
+    return 0;
+}
+

--- a/examples/dreamcast/pvr/strided_texture/strided_texture.c
+++ b/examples/dreamcast/pvr/strided_texture/strided_texture.c
@@ -32,26 +32,29 @@
                             texture_pointer, PVR_FILTER_NONE);
            ```
 
-  2. Set the Global Texture Stride Register:
+    2. Set the Global Texture Stride Register:
 
-       - Use `PVR_SET(PVR_TXR_STRIDE_MULT, stride_multi);` to define a custom
-         texture stride width in increments of 32 pixels.
-       - Calculate `stride_multi` by dividing the texture width by 32.
-       - The `PVR_TXR_STRIDE_MULT` register defines how the hardware interprets 
-         each row's width in VRAM. For a 640-pixel wide texture, `stride_multi` 
-         would be:
+       - Use `pvr_txr_set_stride(texture_width);` to define a custom texture 
+         stride width in increments of 32 pixels. 
+       - The `texture_width` parameter should be the full width of the texture 
+         in pixels.
+       - This setting instructs the hardware on how to interpret each row's 
+         width in VRAM for non-power-of-two textures. For a 640-pixel wide 
+         texture, you would call:
         
            ```c
-           PVR_SET(PVR_TXR_STRIDE_MULT, 640 / 32);
+           pvr_txr_set_stride(640);
            ```
-       Important Notes:
+
+    Important Notes:
+
        - Texture widths that are multiples of 32 (but not powers of two) require 
          the `PVR_TXRFMT_X32_STRIDE` flag.
        - Palette-based textures are incompatible with the `PVR_TXRFMT_X32_STRIDE` 
          flag.
-       - `PVR_TXR_STRIDE_MULT` is a global register. All textures using the 
-         `PVR_TXRFMT_X32_STRIDE` flag in the same frame must share the same 
-         stride. Changing `PVR_TXR_STRIDE_MULT` affects all such textures 
+       - `pvr_txr_set_stride()` sets a global PVR register. All textures using 
+         the `PVR_TXRFMT_X32_STRIDE` flag in the same frame must share the same 
+         stride. Changing `pvr_txr_set_stride()` affects all such textures 
          rendered afterward.
 */
 
@@ -153,8 +156,8 @@ static void load_texture(void) {
                      TEXTURE_PADDED_HEIGHT, board_texture, PVR_FILTER_NONE);
     pvr_poly_compile(&hdr, &cxt);
 
-    /* Set the STRIDE register to texture width / 32 */
-    PVR_SET(PVR_TXR_STRIDE_MULT, TEXTURE_WIDTH / 32);
+    /* Set the global non-power-of-two stride register */
+    pvr_txr_set_stride(TEXTURE_WIDTH);
 
     free(grid_texture);
 }

--- a/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
@@ -145,8 +145,6 @@ static int setup_pvr(void) {
                     PVR_FILTER_BILINEAR);
     pvr_poly_compile(&hdr, &cxt);
 
-    hdr.mode3 |= PVR_TXRFMT_STRIDE;
-
     vert[0].z     = vert[1].z     = vert[2].z     = vert[3].z     = 1.0f; 
     vert[0].argb  = vert[1].argb  = vert[2].argb  = vert[3].argb  = 
         PVR_PACK_COLOR(1.0f, 1.0f, 1.0f, 1.0f);    

--- a/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
@@ -144,8 +144,6 @@ static int setup_pvr(void) {
                     PVR_FILTER_BILINEAR);
     pvr_poly_compile(&hdr, &cxt);
 
-    hdr.mode3 |= PVR_TXRFMT_STRIDE;
-
     vert[0].z     = vert[1].z     = vert[2].z     = vert[3].z     = 1.0f; 
     vert[0].argb  = vert[1].argb  = vert[2].argb  = vert[3].argb  = 
         PVR_PACK_COLOR(1.0f, 1.0f, 1.0f, 1.0f);    

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -186,7 +186,7 @@ int pvr_init(pvr_init_params_t *params) {
     PVR_SET(PVR_UNK_0080, 0x00000007);      /* M */
     PVR_SET(PVR_CHEAP_SHADOW, 0x00000001);      /* cheap shadow */
     PVR_SET(PVR_UNK_007C, 0x0027df77);      /* M */
-    PVR_SET(PVR_TEXTURE_MODULO, 0x00000000);    /* stride width */
+    PVR_SET(PVR_TXR_STRIDE_MULT, 0x00000000);    /* stride width */
     PVR_SET(PVR_FOG_DENSITY, 0x0000ff07);       /* fog density */
     PVR_SET(PVR_UNK_0118, 0x00008040);      /* M */
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -14,6 +14,7 @@
 #include <dc/pvr.h>
 #include <dc/video.h>
 #include <kos/string.h>
+#include <kos/dbglog.h>
 
 #include "pvr_internal.h"
 
@@ -80,6 +81,27 @@ int pvr_get_stats(pvr_stats_t *stat) {
 
 int pvr_vertex_dma_enabled(void) {
     return pvr_state.dma_mode;
+}
+
+bool pvr_txr_set_stride(uint32_t texture_width) {
+    uint32_t temp;
+
+    if(texture_width % 32 != 0 || texture_width > 992) { /* 1024 - 32 = 992 */
+        dbglog(DBG_ERROR, 
+            "Texture width must be divisible by 32 and be 992 or less.");
+        return false;
+    }
+
+    temp = PVR_GET(PVR_TXR_STRIDE_MULT);
+    temp &= ~0x1F;
+    temp |= (texture_width / 32) & 0x1F;
+    PVR_SET(PVR_TXR_STRIDE_MULT, temp);
+
+    return true;
+}
+
+uint32_t pvr_txr_get_stride(void) {
+    return (PVR_GET(PVR_TXR_STRIDE_MULT) & 0x1F) * 32;
 }
 
 /******** INTERNAL STUFF ************************************************/

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -40,6 +40,7 @@
 __BEGIN_DECLS
 
 #include <stdalign.h>
+#include <stdbool.h>
 
 #include <arch/memory.h>
 #include <arch/types.h>
@@ -2269,6 +2270,52 @@ void pvr_poly_cxt_txr_mod(pvr_poly_cxt_t *dst, pvr_list_t list,
     
     Helper functions for handling texture tasks of various kinds.
 */
+
+/** \brief   Set the global stride width for non-power-of-two textures in PVR RAM.
+    \ingroup pvr_txr_mgmt 
+
+    This function configures the global texture stride register 
+    `PVR_TXR_STRIDE_MULT`, which defines the row width in VRAM for 
+    non-power-of-two textures. The setting applies to all textures 
+    rendered with the `PVR_TXRFMT_X32_STRIDE` flag in the same frame. 
+    Since `PVR_TXR_STRIDE_MULT` is a global register, all textures 
+    using this flag must share the same stride width in each frame.
+
+    The stride width configured here is **only supported for textures 
+    with widths that are multiples of 32 pixels** and up to a maximum 
+    of 992 pixels. Any texture width not meeting this requirement will 
+    not work with the `PVR_TXRFMT_X32_STRIDE` flag.
+
+    \warning
+    - Textures that are palette-based cannot use the `PVR_TXRFMT_X32_STRIDE` 
+      flag so the stride set here will not apply to them.
+
+    \param  texture_width   The width of the texture in pixels. Must be a 
+                            multiple of 32 and up to 992 pixels.
+    \retval true            On success.
+    \retval false           On failure.
+
+    \sa pvr_txr_get_stride()
+*/
+bool pvr_txr_set_stride(uint32_t texture_width);
+
+/** \brief   Get the current texture stride width in pixels as set in the PVR.
+    \ingroup pvr_txr_mgmt 
+
+    This function reads the `PVR_TXR_STRIDE_MULT` register and calculates the 
+    texture stride width in pixels. The value returned is the width in pixels 
+    that has been configured for all textures using the `PVR_TXRFMT_X32_STRIDE` 
+    flag in the same frame. 
+
+    The stride width is computed by taking the current multiplier in 
+    `PVR_TXR_STRIDE_MULT` (which stores the width divided by 32), and 
+    multiplying it back by 32 to return the full width in pixels.
+
+    \return                 The current texture stride width in pixels.
+
+    \sa pvr_txr_set_stride()
+*/
+uint32_t pvr_txr_get_stride(void);
 
 /** \brief   Load raw texture data from an SH-4 buffer into PVR RAM.
     \ingroup pvr_txr_mgmt 

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -632,8 +632,8 @@ typedef struct {
 #define PVR_TXRFMT_PAL8BPP      (6 << 27)   /**< \brief 8BPP paletted format */
 #define PVR_TXRFMT_TWIDDLED     (0 << 26)   /**< \brief Texture is twiddled */
 #define PVR_TXRFMT_NONTWIDDLED  (1 << 26)   /**< \brief Texture is not twiddled */
-#define PVR_TXRFMT_NOSTRIDE     (0 << 21)   /**< \brief Texture is not strided */
-#define PVR_TXRFMT_STRIDE       (1 << 21)   /**< \brief Texture is strided */
+#define PVR_TXRFMT_POW2_STRIDE  (0 << 25)   /**< \brief Stride is a power-of-two */
+#define PVR_TXRFMT_X32_STRIDE   (1 << 25)   /**< \brief Stride is multiple of 32 */
 
 /* OR one of these into your texture format if you need it. Note that
    these coincide with the twiddled/stride bits, so you can't have a
@@ -1219,7 +1219,7 @@ Striplength set to 2 */
 #define PVR_SCAN_CLK            0x00d8  /**< \brief Clock and scanline values */
 #define PVR_BORDER_Y            0x00dc  /**< \brief Window border Y position */
 
-#define PVR_TEXTURE_MODULO      0x00e4  /**< \brief Output texture width modulo */
+#define PVR_TXR_STRIDE_MULT     0x00e4  /**< \brief Multiplier for stride width in increments of 32 */
 #define PVR_VIDEO_CFG           0x00e8  /**< \brief Misc video config */
 #define PVR_BITMAP_X            0x00ec  /**< \brief Bitmap window X position */
 #define PVR_BITMAP_Y            0x00f0  /**< \brief Bitmap window Y position */

--- a/utils/pvrtex/file_dctex.h
+++ b/utils/pvrtex/file_dctex.h
@@ -166,7 +166,7 @@ typedef struct {
 		Bits 10-6:
 			Stride value. This is the width of the texture divided by 32.
 			Only valid on texture will stride bit set.
-			Place this value in the bottom 5 bits of the PVR register PVR_TEXTURE_MODULO (at address 0xA05F80E4).
+			Place this value in the bottom 5 bits of the PVR register PVR_TXR_STRIDE_MULT (at address 0xA05F80E4).
 			Only one stride value can be used per frame.
 	
 		Bits 5-3:
@@ -511,7 +511,7 @@ static inline pvr_ptr_t fDtAdjustPVRPointer(const fDtHeader * texheader, pvr_ptr
 */
 static inline void fDtSetPvrStride(const fDtHeader *tex) {
 	if (fDtIsStrided(tex))
-		PVR_SET(PVR_TEXTURE_MODULO, fDtGetStride(tex));
+		PVR_SET(PVR_TXR_STRIDE_MULT, fDtGetStride(tex));
 }
 
 /*


### PR DESCRIPTION
Custom strided textures never worked it seems like.  This PR should fix that.

- Corrected custom strided textures by adjusting PVR_TXRFMT_STRIDE handling. 
- Renamed PVR_TEXTURE_MODULO to PVR_TEXTURE_STRIDE for clarity. 
- Added an example to demonstrate custom strided texture usage.