### PR TITLE
Speedup and fix AICA cmd iface. Protect SQs on G2 bus.

### DIFF
--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -146,6 +146,8 @@ snd_pcm16_split
 snd_pcm16_split_sq
 snd_pcm8_split
 snd_adpcm_split
+snd_get_pos
+snd_is_playing
 
 # Video
 vid_mode

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -202,6 +202,8 @@ snd_pcm16_split
 snd_pcm16_split_sq
 snd_pcm8_split
 snd_adpcm_split
+snd_get_pos
+snd_is_playing
 
 # Video
 vid_mode

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -87,12 +87,12 @@ void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
     /* Lock the SQs before disabling the interrupts. */
     sq_lock(NULL);
 
-    /* Make sure the FIFOs are empty */
-    g2_fifo_wait();
-
     /* Lock G2 bus because we can't suspend SQs from
      * another thread with PIO access to G2 bus. */
     ctx = g2_lock();
+
+    /* Make sure the FIFOs are empty */
+    g2_fifo_wait();
 
     sq_cpy((void *)dst, src, aligned_len);
 
@@ -229,12 +229,12 @@ void spu_memset_sq(uintptr_t dst, uint32_t what, size_t length) {
     /* Lock the SQs before disabling the interrupts. */
     sq_lock(NULL);
 
-    /* Make sure the FIFOs are empty */
-    g2_fifo_wait();
-
     /* Lock G2 bus because we can't suspend SQs from
      * another thread with PIO access to G2 bus. */
     ctx = g2_lock();
+
+    /* Make sure the FIFOs are empty */
+    g2_fifo_wait();
 
     sq_set32((void *)dst, what, aligned_len);
 
@@ -257,8 +257,9 @@ void spu_reset_chans(void) {
     int i;
     g2_ctx_t ctx;
 
-    g2_fifo_wait();
     ctx = g2_lock();
+    g2_fifo_wait();
+
     g2_write_32_raw(SNDREGADDR(0x2800), 0);
 
     for(i = 0; i < 64; i++) {

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -84,7 +84,7 @@ void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
     /* Add in the SPU RAM base (cached area) */
     dst |= SPU_RAM_BASE;
 
-    /* First lock SQs because there is a mutex there. */
+    /* Lock the SQs before disabling the interrupts. */
     sq_lock(NULL);
 
     /* Make sure the FIFOs are empty */
@@ -226,7 +226,7 @@ void spu_memset_sq(uintptr_t dst, uint32_t what, size_t length) {
     /* Add in the SPU RAM base (cached area) */
     dst |= SPU_RAM_BASE;
 
-    /* First lock SQs because there is a mutex there. */
+    /* Lock the SQs before disabling the interrupts. */
     sq_lock(NULL);
 
     /* Make sure the FIFOs are empty */

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -255,8 +255,10 @@ void spu_memset_sq(uintptr_t dst, uint32_t what, size_t length) {
 /* Reset the AICA channel registers */
 void spu_reset_chans(void) {
     int i;
+    g2_ctx_t ctx;
+
     g2_fifo_wait();
-    g2_ctx_t ctx = g2_lock();
+    ctx = g2_lock();
     g2_write_32_raw(SNDREGADDR(0x2800), 0);
 
     for(i = 0; i < 64; i++) {

--- a/kernel/arch/dreamcast/include/dc/g2bus.h
+++ b/kernel/arch/dreamcast/include/dc/g2bus.h
@@ -3,6 +3,7 @@
    g2bus.h
    Copyright (C) 2002 Megan Potter
    Copyright (C) 2023 Andy Barajas
+   Copyright (C) 2024 Ruslan Rostovtsev
 
 */
 
@@ -245,6 +246,18 @@ void g2_write_16(uintptr_t address, uint16_t value);
 */
 uint32_t g2_read_32(uintptr_t address);
 
+/** \brief  Non-blocked read one 32-bit dword from G2.
+
+    This function reads a single dword from the specified address, without all
+    necessary precautions that are required for accessing G2.
+
+    \param  address         The address in memory to read.
+    \return                 The dword read from the address specified.
+*/
+static inline uint32_t g2_read_32_raw(uintptr_t address) {
+    return *((volatile uint32_t *)address);
+}
+
 /** \brief  Write a 32-bit dword to G2.
 
     This function writes one dword to the specified address, taking all the
@@ -254,6 +267,18 @@ uint32_t g2_read_32(uintptr_t address);
     \param  value           The value to write to that address.
 */
 void g2_write_32(uintptr_t address, uint32_t value);
+
+/** \brief  Non-blocked write a 32-bit dword to G2.
+
+    This function writes one dword to the specified address, without all the
+    necessary precautions to ensure your write actually succeeds.
+
+    \param  address         The address in memory to write to.
+    \param  value           The value to write to that address.
+*/
+static inline void g2_write_32_raw(uintptr_t address, uint32_t value) {
+    *((volatile uint32_t *)address) = value;
+}
 
 /** \brief  Read a block of bytes from G2.
 

--- a/kernel/arch/dreamcast/include/dc/sound/aica_comm.h
+++ b/kernel/arch/dreamcast/include/dc/sound/aica_comm.h
@@ -90,7 +90,7 @@ typedef struct aica_channel {
     \param CHANR    aica_channel_t pointer name
 */
 #define AICA_CMDSTR_CHANNEL(T, CMDR, CHANR) \
-    uint8   T[sizeof(aica_cmd_t) + sizeof(aica_channel_t)]; \
+    uint32   T[(sizeof(aica_cmd_t) + sizeof(aica_channel_t)) / 4]; \
     aica_cmd_t  * CMDR = (aica_cmd_t *)T; \
     aica_channel_t  * CHANR = (aica_channel_t *)(CMDR->cmd_data);
 

--- a/kernel/arch/dreamcast/include/dc/sound/sound.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sound.h
@@ -2,7 +2,7 @@
 
    dc/sound/sound.h
    Copyright (C) 2002 Megan Potter
-   Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024 Ruslan Rostovtsev
 
 */
 
@@ -27,6 +27,7 @@ __BEGIN_DECLS
 
 #include <arch/types.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 /** \defgroup audio_driver  Driver
     \brief                  Low-level driver for SPU and audio management
@@ -216,7 +217,28 @@ void snd_adpcm_split(uint32_t *data, uint32_t *left, uint32_t *right, size_t siz
 
 /** @} */
 
+/** \brief  Get AICA channel position.
+
+    This function returns actual the channel position
+    that stores in SPU memory and updated by the SPU firmware.
+
+    \param  chn             The channel to retrieve position.
+
+    \return                 Last channel position in samples.
+*/
+uint16_t snd_get_pos(uint32_t ch);
+
+/** \brief  Get AICA channel playback state.
+
+    This function returns actual the channel playback state
+    that stores in AICA registers directly.
+
+    \param  chn             The channel to check.
+
+    \return                 True if the channel is playing.
+*/
+bool snd_is_playing(uint32_t ch);
+
 __END_DECLS
 
 #endif  /* __DC_SOUND_SOUND_H */
-

--- a/kernel/arch/dreamcast/include/dc/sound/sound.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sound.h
@@ -226,7 +226,7 @@ void snd_adpcm_split(uint32_t *data, uint32_t *left, uint32_t *right, size_t siz
 
     \return                 Last channel position in samples.
 */
-uint16_t snd_get_pos(uint32_t ch);
+uint16_t snd_get_pos(unsigned int ch);
 
 /** \brief  Get AICA channel playback state.
 
@@ -237,7 +237,7 @@ uint16_t snd_get_pos(uint32_t ch);
 
     \return                 True if the channel is playing.
 */
-bool snd_is_playing(uint32_t ch);
+bool snd_is_playing(unsigned int ch);
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/sound/arm/aica_cmd_iface.h
+++ b/kernel/arch/dreamcast/sound/arm/aica_cmd_iface.h
@@ -40,4 +40,8 @@
 /* Quick access to the AICA channels */
 #define AICA_CHANNEL(x)     (AICA_MEM_CHANNELS + (x) * sizeof(aica_channel_t))
 
+/* Channels status register bits */
+#define AICA_CHANNEL_KEYONEX   0x8000
+#define AICA_CHANNEL_KEYONB    0x4000
+
 #endif  /* __ARM_AICA_CMD_IFACE_H */

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -212,10 +212,10 @@ void snd_poll_resp(void) {
         dbglog(DBG_ERROR, "snd_poll_resp(): snd_aica_to_sh4 failed, giving up\n");
 }
 
-uint16_t snd_get_pos(uint32_t ch) {
+uint16_t snd_get_pos(unsigned int ch) {
     return g2_read_32(SPU_RAM_UNCACHED_BASE + AICA_CHANNEL(ch) + offsetof(aica_channel_t, pos)) & 0xffff;
 }
 
-bool snd_is_playing(uint32_t ch) {
-    return g2_read_32(MEM_AREA_P2_BASE + 0x00700000 + 0x80 * ch) & 0x4000;
+bool snd_is_playing(unsigned int ch) {
+    return g2_read_32(MEM_AREA_P2_BASE + 0x00700000 + 0x80 * ch) & AICA_CHANNEL_KEYONB;
 }

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -211,3 +211,11 @@ void snd_poll_resp(void) {
     if(rv < 0)
         dbglog(DBG_ERROR, "snd_poll_resp(): snd_aica_to_sh4 failed, giving up\n");
 }
+
+uint16_t snd_get_pos(uint32_t ch) {
+    return (g2_read_32(SPU_RAM_UNCACHED_BASE + AICA_CHANNEL(ch) + offsetof(aica_channel_t, pos)) & 0xffff);
+}
+
+bool snd_is_playing(uint32_t ch) {
+    return g2_read_32(MEM_AREA_P2_BASE + 0x00700000 + 0x80 * ch) & 0x4000;
+}


### PR DESCRIPTION
- Speedup AICA command interface by introducing non-blocking functions for working with the G2 bus (lock it once), getting rid of the semaphore and minor loop/condition optimizations.
- Fixed AICA command interface by alignment for buffer, packet size check and thread-safe for start/stop.
- Speedup AICA channel resetting by using non-blocking functions for working with the G2 bus.
- Added functions to retrieve the channels states `snd_get_pos()` and `snd_is_playing()`.
- Protect the SQs on G2 bus because they cannot be suspended from another thread at PIO access to G2 bus.

Tested on GTA3. Sound controls much stable now.