### PR TITLE
Add new regfield.h header, and clean up PVR code

### DIFF
--- a/include/kos.h
+++ b/include/kos.h
@@ -59,6 +59,7 @@ __BEGIN_DECLS
 #include <kos/string.h>
 #include <kos/init.h>
 #include <kos/oneshot_timer.h>
+#include <kos/regfield.h>
 
 #include <arch/arch.h>
 #include <arch/cache.h>

--- a/include/kos/regfield.h
+++ b/include/kos/regfield.h
@@ -1,0 +1,55 @@
+/* KallistiOS ##version##
+
+   kos/compiler.h
+   Copyright (C) 2024 Paul Cercueil
+
+   Macros to extract / insert bit fields
+*/
+
+/** \file    kos/regfield.h
+    \brief   Macros to help dealing with register fields.
+    \ingroup kernel
+
+    \author Paul Cercueil
+*/
+
+#ifndef __KOS_REGFIELD_H
+#define __KOS_REGFIELD_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+/** \brief  Create a mask with a bit set
+
+    \param  bit             The bit to set (from 0 to 31)
+    \return                 A 32-bit mask with the corresponding bit set
+ */
+#define BIT(bit)	(1u << (bit))
+
+/** \brief  Create a mask with a range of bits set
+
+    \param  h               The high bit of the range to set, included
+    \param  l               The low bit of the range to set, included
+    \return                 A 32-bit mask with the corresponding bits set
+ */
+#define GENMASK(h, l)	((0xffffffff << (l)) & (0xffffffff >> (31 - (h))))
+
+/** \brief  Extract a field value from a variable
+
+    \param  var             The 32-bit variable containing the field
+    \param  field           A 32-bit mask that corresponds to the field
+    \return                 The value of the field (shifted)
+ */
+#define FIELD_GET(var, field) \
+	(((var) & (field)) >> __builtin_ctz(field))
+
+/** \brief  Prepare a field with a given value
+
+    \param  field           A 32-bit mask that corresponds to the field
+    \param  value           The value to be put in the field
+ */
+#define FIELD_PREP(field, value) \
+	(((value) << __builtin_ctz(field)) & (field))
+
+__END_DECLS
+#endif /* __KOS_REGFIELD_H */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -263,7 +263,7 @@ void pvr_blank_polyhdr_buf(int type, pvr_poly_hdr_t * poly) {
     memset(poly, 0, sizeof(pvr_poly_hdr_t));
 
     /* Put in the list type */
-    poly->cmd = (type << PVR_TA_CMD_TYPE_SHIFT) | 0x80840012;
+    poly->cmd = FIELD_PREP(PVR_TA_CMD_TYPE, type) | 0x80840012;
 
     /* Fill in dummy values */
     poly->d1 = poly->d2 = poly->d3 = poly->d4 = 0xffffffff;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
@@ -21,148 +21,78 @@
 
 /* Compile a polygon context into a polygon header */
 void pvr_poly_compile(pvr_poly_hdr_t *dst, const pvr_poly_cxt_t *src) {
-    int u, v;
     uint32_t txr_base;
     /* Temporary variables we can read-write-modify, since we cannot do so from
        within the SQs, and we want to be able to compile this header from a PVR
        DR API submission target. */
-    uint32_t cmd, mode[3];
+    uint32_t mode2, mode3;
 
     /* Basically we just take each parameter, clip it, shift it
        into place, and OR it into the final result. */
 
     /* The base values for CMD */
-    cmd = PVR_CMD_POLYHDR;
-
-    if(src->txr.enable == PVR_TEXTURE_ENABLE)
-        cmd |= 8;
-
-    /* Or in the list type, shading type, color and UV formats */
-    cmd |= (src->list_type << PVR_TA_CMD_TYPE_SHIFT) & PVR_TA_CMD_TYPE_MASK;
-    cmd |= (src->fmt.color << PVR_TA_CMD_CLRFMT_SHIFT) & PVR_TA_CMD_CLRFMT_MASK;
-    cmd |= (src->gen.shading << PVR_TA_CMD_SHADE_SHIFT) & PVR_TA_CMD_SHADE_MASK;
-    cmd |= (src->fmt.uv << PVR_TA_CMD_UVFMT_SHIFT) & PVR_TA_CMD_UVFMT_MASK;
-    cmd |= (src->gen.clip_mode << PVR_TA_CMD_USERCLIP_SHIFT) & PVR_TA_CMD_USERCLIP_MASK;
-    cmd |= (src->fmt.modifier << PVR_TA_CMD_MODIFIER_SHIFT) & PVR_TA_CMD_MODIFIER_MASK;
-    cmd |= (src->gen.modifier_mode << PVR_TA_CMD_MODIFIERMODE_SHIFT) & PVR_TA_CMD_MODIFIERMODE_MASK;
-    cmd |= (src->gen.specular << PVR_TA_CMD_SPECULAR_SHIFT) & PVR_TA_CMD_SPECULAR_MASK;
-
-    dst->cmd = cmd;
+    dst->cmd = PVR_CMD_POLYHDR
+        | FIELD_PREP(PVR_TA_CMD_TXRENABLE, src->txr.enable)
+        | FIELD_PREP(PVR_TA_CMD_TYPE, src->list_type)
+        | FIELD_PREP(PVR_TA_CMD_CLRFMT, src->fmt.color)
+        | FIELD_PREP(PVR_TA_CMD_SHADE, src->gen.shading)
+        | FIELD_PREP(PVR_TA_CMD_UVFMT, src->fmt.uv)
+        | FIELD_PREP(PVR_TA_CMD_USERCLIP, src->gen.clip_mode)
+        | FIELD_PREP(PVR_TA_CMD_MODIFIER, src->fmt.modifier)
+        | FIELD_PREP(PVR_TA_CMD_MODIFIERMODE, src->gen.modifier_mode)
+        | FIELD_PREP(PVR_TA_CMD_SPECULAR, src->gen.specular);
 
     /* Polygon mode 1 */
-    mode[0]  = (src->depth.comparison << PVR_TA_PM1_DEPTHCMP_SHIFT) & PVR_TA_PM1_DEPTHCMP_MASK;
-    mode[0] |= (src->gen.culling << PVR_TA_PM1_CULLING_SHIFT) & PVR_TA_PM1_CULLING_MASK;
-    mode[0] |= (src->depth.write << PVR_TA_PM1_DEPTHWRITE_SHIFT) & PVR_TA_PM1_DEPTHWRITE_MASK;
-    mode[0] |= (src->txr.enable << PVR_TA_PM1_TXRENABLE_SHIFT) & PVR_TA_PM1_TXRENABLE_MASK;
-
-    dst->mode1 = mode[0];
+    dst->mode1 = FIELD_PREP(PVR_TA_PM1_DEPTHCMP, src->depth.comparison)
+        | FIELD_PREP(PVR_TA_PM1_CULLING, src->gen.culling)
+        | FIELD_PREP(PVR_TA_PM1_DEPTHWRITE, src->depth.write)
+        | FIELD_PREP(PVR_TA_PM1_TXRENABLE, src->txr.enable);
 
     /* Polygon mode 2 */
-    mode[1]  = (src->blend.src << PVR_TA_PM2_SRCBLEND_SHIFT) & PVR_TA_PM2_SRCBLEND_MASK;
-    mode[1] |= (src->blend.dst << PVR_TA_PM2_DSTBLEND_SHIFT) & PVR_TA_PM2_DSTBLEND_MASK;
-    mode[1] |= (src->blend.src_enable << PVR_TA_PM2_SRCENABLE_SHIFT) & PVR_TA_PM2_SRCENABLE_MASK;
-    mode[1] |= (src->blend.dst_enable << PVR_TA_PM2_DSTENABLE_SHIFT) & PVR_TA_PM2_DSTENABLE_MASK;
-    mode[1] |= (src->gen.fog_type << PVR_TA_PM2_FOG_SHIFT) & PVR_TA_PM2_FOG_MASK;
-    mode[1] |= (src->gen.color_clamp << PVR_TA_PM2_CLAMP_SHIFT) & PVR_TA_PM2_CLAMP_MASK;
-    mode[1] |= (src->gen.alpha << PVR_TA_PM2_ALPHA_SHIFT) & PVR_TA_PM2_ALPHA_MASK;
+    mode2 = FIELD_PREP(PVR_TA_PM2_SRCBLEND, src->blend.src)
+        | FIELD_PREP(PVR_TA_PM2_DSTBLEND, src->blend.dst)
+        | FIELD_PREP(PVR_TA_PM2_SRCENABLE, src->blend.src_enable)
+        | FIELD_PREP(PVR_TA_PM2_DSTENABLE, src->blend.dst_enable)
+        | FIELD_PREP(PVR_TA_PM2_FOG, src->gen.fog_type)
+        | FIELD_PREP(PVR_TA_PM2_CLAMP, src->gen.color_clamp)
+        | FIELD_PREP(PVR_TA_PM2_ALPHA, src->gen.alpha);
 
     if(src->txr.enable == PVR_TEXTURE_DISABLE) {
-        dst->mode2 = mode[1];
-        mode[2] = 0;
-        dst->mode3 = mode[2];
+        mode3 = 0;
     }
     else {
-        mode[1] |= (src->txr.alpha << PVR_TA_PM2_TXRALPHA_SHIFT) & PVR_TA_PM2_TXRALPHA_MASK;
-        mode[1] |= (src->txr.uv_flip << PVR_TA_PM2_UVFLIP_SHIFT) & PVR_TA_PM2_UVFLIP_MASK;
-        mode[1] |= (src->txr.uv_clamp << PVR_TA_PM2_UVCLAMP_SHIFT) & PVR_TA_PM2_UVCLAMP_MASK;
-        mode[1] |= (src->txr.filter << PVR_TA_PM2_FILTER_SHIFT) & PVR_TA_PM2_FILTER_MASK;
-        mode[1] |= (src->txr.mipmap_bias << PVR_TA_PM2_MIPBIAS_SHIFT) & PVR_TA_PM2_MIPBIAS_MASK;
-        mode[1] |= (src->txr.env << PVR_TA_PM2_TXRENV_SHIFT) & PVR_TA_PM2_TXRENV_MASK;
+        assert_msg(__builtin_popcount(src->txr.width) == 1
+		   && src->txr.width <= 1024, "Invalid texture U size");
+        assert_msg(__builtin_popcount(src->txr.height) == 1
+		   && src->txr.height <= 1024, "Invalid texture V size");
 
-        switch(src->txr.width) {
-            case 8:
-                u = 0;
-                break;
-            case 16:
-                u = 1;
-                break;
-            case 32:
-                u = 2;
-                break;
-            case 64:
-                u = 3;
-                break;
-            case 128:
-                u = 4;
-                break;
-            case 256:
-                u = 5;
-                break;
-            case 512:
-                u = 6;
-                break;
-            case 1024:
-                u = 7;
-                break;
-            default:
-                assert_msg(0, "Invalid texture U size");
-                u = 0;
-                break;
-        }
-
-        switch(src->txr.height) {
-            case 8:
-                v = 0;
-                break;
-            case 16:
-                v = 1;
-                break;
-            case 32:
-                v = 2;
-                break;
-            case 64:
-                v = 3;
-                break;
-            case 128:
-                v = 4;
-                break;
-            case 256:
-                v = 5;
-                break;
-            case 512:
-                v = 6;
-                break;
-            case 1024:
-                v = 7;
-                break;
-            default:
-                assert_msg(0, "Invalid texture V size");
-                v = 0;
-                break;
-        }
-
-        mode[1] |= (u << PVR_TA_PM2_USIZE_SHIFT) & PVR_TA_PM2_USIZE_MASK;
-        mode[1] |= (v << PVR_TA_PM2_VSIZE_SHIFT) & PVR_TA_PM2_VSIZE_MASK;
-
-        dst->mode2 = mode[1];
-
-        /* Polygon mode 3 */
-        mode[2]  = (src->txr.mipmap << PVR_TA_PM3_MIPMAP_SHIFT) & PVR_TA_PM3_MIPMAP_MASK;
-        mode[2] |= (src->txr.format << PVR_TA_PM3_TXRFMT_SHIFT) & PVR_TA_PM3_TXRFMT_MASK;
+        mode2 |= FIELD_PREP(PVR_TA_PM2_TXRALPHA, src->txr.alpha)
+            | FIELD_PREP(PVR_TA_PM2_UVFLIP, src->txr.uv_flip)
+            | FIELD_PREP(PVR_TA_PM2_UVCLAMP, src->txr.uv_clamp)
+            | FIELD_PREP(PVR_TA_PM2_FILTER, src->txr.filter)
+            | FIELD_PREP(PVR_TA_PM2_MIPBIAS, src->txr.mipmap_bias)
+            | FIELD_PREP(PVR_TA_PM2_TXRENV, src->txr.env)
+            | FIELD_PREP(PVR_TA_PM2_USIZE, __builtin_ctz(src->txr.width) - 3)
+            | FIELD_PREP(PVR_TA_PM2_VSIZE, __builtin_ctz(src->txr.height) - 3);
 
         /* Convert the texture address */
         txr_base = (uint32_t)src->txr.base;
         txr_base = (txr_base & 0x00fffff8) >> 3;
-        mode[2] |= txr_base;
 
-        dst->mode3 = mode[2];
+        /* Polygon mode 3 */
+        mode3 = FIELD_PREP(PVR_TA_PM3_MIPMAP, src->txr.mipmap)
+            | src->txr.format
+            | txr_base;
     }
+
+    dst->mode2 = mode2;
+    dst->mode3 = mode3;
 
     if(src->fmt.modifier && src->gen.modifier_mode) {
         /* If we're affected by a modifier volume, silently promote the header
            to the one that is affected by a modifier volume. */
-        dst->d1 = mode[1];
-        dst->d2 = mode[2];
+        dst->d1 = mode2;
+        dst->d2 = mode3;
     }
     else {
         dst->d1 = 0xffffffff;
@@ -338,133 +268,64 @@ void pvr_sprite_cxt_txr(pvr_sprite_cxt_t *dst, pvr_list_t list,
 }
 
 void pvr_sprite_compile(pvr_sprite_hdr_t *dst, const pvr_sprite_cxt_t *src) {
-    int u, v;
-    uint32_t txr_base;
-    uint32_t cmd, mode[3];
+    uint32_t txr_base, mode2, mode3;
 
     /* Basically we just take each parameter, clip it, shift it
        into place, and OR it into the final result. */
 
     /* The base values for CMD */
-    cmd = PVR_CMD_SPRITE;
-
-    if(src->txr.enable == PVR_TEXTURE_ENABLE)
-        cmd |= 8;
-
-    /* Or in the list type, clipping mode, and UV formats */
-    cmd |= (src->list_type << PVR_TA_CMD_TYPE_SHIFT) & PVR_TA_CMD_TYPE_MASK;
-    cmd |= (PVR_UVFMT_16BIT << PVR_TA_CMD_UVFMT_SHIFT) & PVR_TA_CMD_UVFMT_MASK;
-    cmd |= (src->gen.clip_mode << PVR_TA_CMD_USERCLIP_SHIFT) & PVR_TA_CMD_USERCLIP_MASK;
-    cmd |= (src->gen.specular << PVR_TA_CMD_SPECULAR_SHIFT) & PVR_TA_CMD_SPECULAR_MASK;
-
-    dst->cmd = cmd;
+    dst->cmd = PVR_CMD_SPRITE
+        | FIELD_PREP(PVR_TA_CMD_TXRENABLE, src->txr.enable)
+        | FIELD_PREP(PVR_TA_CMD_TYPE, src->list_type)
+        | FIELD_PREP(PVR_TA_CMD_UVFMT, PVR_UVFMT_16BIT)
+        | FIELD_PREP(PVR_TA_CMD_USERCLIP, src->gen.clip_mode)
+        | FIELD_PREP(PVR_TA_CMD_SPECULAR, src->gen.specular);
 
     /* Polygon mode 1 */
-    mode[0]  = (src->depth.comparison << PVR_TA_PM1_DEPTHCMP_SHIFT) & PVR_TA_PM1_DEPTHCMP_MASK;
-    mode[0] |= (src->gen.culling << PVR_TA_PM1_CULLING_SHIFT) & PVR_TA_PM1_CULLING_MASK;
-    mode[0] |= (src->depth.write << PVR_TA_PM1_DEPTHWRITE_SHIFT) & PVR_TA_PM1_DEPTHWRITE_MASK;
-    mode[0] |= (src->txr.enable << PVR_TA_PM1_TXRENABLE_SHIFT) & PVR_TA_PM1_TXRENABLE_MASK;
-
-    dst->mode1 = mode[0];
+    dst->mode1 = FIELD_PREP(PVR_TA_PM1_DEPTHCMP, src->depth.comparison)
+        | FIELD_PREP(PVR_TA_PM1_CULLING, src->gen.culling)
+        | FIELD_PREP(PVR_TA_PM1_DEPTHWRITE, src->depth.write)
+        | FIELD_PREP(PVR_TA_PM1_TXRENABLE, src->txr.enable);
 
     /* Polygon mode 2 */
-    mode[1]  = (src->blend.src << PVR_TA_PM2_SRCBLEND_SHIFT) & PVR_TA_PM2_SRCBLEND_MASK;
-    mode[1] |= (src->blend.dst << PVR_TA_PM2_DSTBLEND_SHIFT) & PVR_TA_PM2_DSTBLEND_MASK;
-    mode[1] |= (src->blend.src_enable << PVR_TA_PM2_SRCENABLE_SHIFT) & PVR_TA_PM2_SRCENABLE_MASK;
-    mode[1] |= (src->blend.dst_enable << PVR_TA_PM2_DSTENABLE_SHIFT) & PVR_TA_PM2_DSTENABLE_MASK;
-    mode[1] |= (src->gen.fog_type << PVR_TA_PM2_FOG_SHIFT) & PVR_TA_PM2_FOG_MASK;
-    mode[1] |= (src->gen.color_clamp << PVR_TA_PM2_CLAMP_SHIFT) & PVR_TA_PM2_CLAMP_MASK;
-    mode[1] |= (src->gen.alpha << PVR_TA_PM2_ALPHA_SHIFT) & PVR_TA_PM2_ALPHA_MASK;
+    mode2 = FIELD_PREP(PVR_TA_PM2_SRCBLEND, src->blend.src)
+        | FIELD_PREP(PVR_TA_PM2_DSTBLEND, src->blend.dst)
+        | FIELD_PREP(PVR_TA_PM2_SRCENABLE, src->blend.src_enable)
+        | FIELD_PREP(PVR_TA_PM2_DSTENABLE, src->blend.dst_enable)
+        | FIELD_PREP(PVR_TA_PM2_FOG, src->gen.fog_type)
+        | FIELD_PREP(PVR_TA_PM2_CLAMP, src->gen.color_clamp)
+        | FIELD_PREP(PVR_TA_PM2_ALPHA, src->gen.alpha);
 
     if(src->txr.enable == PVR_TEXTURE_DISABLE) {
-        dst->mode2 = mode[1];
-        dst->mode3 = 0;
+        mode3 = 0;
     }
     else {
-        mode[1] |= (src->txr.alpha << PVR_TA_PM2_TXRALPHA_SHIFT) & PVR_TA_PM2_TXRALPHA_MASK;
-        mode[1] |= (src->txr.uv_flip << PVR_TA_PM2_UVFLIP_SHIFT) & PVR_TA_PM2_UVFLIP_MASK;
-        mode[1] |= (src->txr.uv_clamp << PVR_TA_PM2_UVCLAMP_SHIFT) & PVR_TA_PM2_UVCLAMP_MASK;
-        mode[1] |= (src->txr.filter << PVR_TA_PM2_FILTER_SHIFT) & PVR_TA_PM2_FILTER_MASK;
-        mode[1] |= (src->txr.mipmap_bias << PVR_TA_PM2_MIPBIAS_SHIFT) & PVR_TA_PM2_MIPBIAS_MASK;
-        mode[1] |= (src->txr.env << PVR_TA_PM2_TXRENV_SHIFT) & PVR_TA_PM2_TXRENV_MASK;
+        assert_msg(__builtin_popcount(src->txr.width) == 1
+		   && src->txr.width <= 1024, "Invalid texture U size");
+        assert_msg(__builtin_popcount(src->txr.height) == 1
+		   && src->txr.height <= 1024, "Invalid texture V size");
 
-        switch(src->txr.width) {
-            case 8:
-                u = 0;
-                break;
-            case 16:
-                u = 1;
-                break;
-            case 32:
-                u = 2;
-                break;
-            case 64:
-                u = 3;
-                break;
-            case 128:
-                u = 4;
-                break;
-            case 256:
-                u = 5;
-                break;
-            case 512:
-                u = 6;
-                break;
-            case 1024:
-                u = 7;
-                break;
-            default:
-                assert_msg(0, "Invalid texture U size");
-                u = 0;
-                break;
-        }
+        mode2 |= FIELD_PREP(PVR_TA_PM2_TXRALPHA, src->txr.alpha)
+            | FIELD_PREP(PVR_TA_PM2_UVFLIP, src->txr.uv_flip)
+            | FIELD_PREP(PVR_TA_PM2_UVCLAMP, src->txr.uv_clamp)
+            | FIELD_PREP(PVR_TA_PM2_FILTER, src->txr.filter)
+            | FIELD_PREP(PVR_TA_PM2_MIPBIAS, src->txr.mipmap_bias)
+            | FIELD_PREP(PVR_TA_PM2_TXRENV, src->txr.env)
+            | FIELD_PREP(PVR_TA_PM2_USIZE, __builtin_ctz(src->txr.width) - 3)
+            | FIELD_PREP(PVR_TA_PM2_VSIZE, __builtin_ctz(src->txr.height) - 3);
 
-        switch(src->txr.height) {
-            case 8:
-                v = 0;
-                break;
-            case 16:
-                v = 1;
-                break;
-            case 32:
-                v = 2;
-                break;
-            case 64:
-                v = 3;
-                break;
-            case 128:
-                v = 4;
-                break;
-            case 256:
-                v = 5;
-                break;
-            case 512:
-                v = 6;
-                break;
-            case 1024:
-                v = 7;
-                break;
-            default:
-                assert_msg(0, "Invalid texture V size");
-                v = 0;
-                break;
-        }
-
-        mode[1] |= (u << PVR_TA_PM2_USIZE_SHIFT) & PVR_TA_PM2_USIZE_MASK;
-        mode[1] |= (v << PVR_TA_PM2_VSIZE_SHIFT) & PVR_TA_PM2_VSIZE_MASK;
-
-        dst->mode2 = mode[1];
-
-        /* Polygon mode 3 */
-        mode[2]  = (src->txr.mipmap << PVR_TA_PM3_MIPMAP_SHIFT) & PVR_TA_PM3_MIPMAP_MASK;
-        mode[2] |= (src->txr.format << PVR_TA_PM3_TXRFMT_SHIFT) & PVR_TA_PM3_TXRFMT_MASK;
-
+        /* Convert the texture address */
         txr_base = (uint32_t)src->txr.base;
         txr_base = (txr_base & 0x00fffff8) >> 3;
-        mode[2] |= txr_base;
 
-        dst->mode3 = mode[2];
+        /* Polygon mode 3 */
+        mode3 = FIELD_PREP(PVR_TA_PM3_MIPMAP, src->txr.mipmap)
+            | src->txr.format
+            | txr_base;
     }
+
+    dst->mode2 = mode2;
+    dst->mode3 = mode3;
 
     dst->argb = 0xFFFFFFFF;
     dst->oargb = 0x00000000;
@@ -472,11 +333,10 @@ void pvr_sprite_compile(pvr_sprite_hdr_t *dst, const pvr_sprite_cxt_t *src) {
 
 void pvr_mod_compile(pvr_mod_hdr_t *dst, pvr_list_t list, uint32 mode,
                      uint32 cull) {
-    dst->cmd = PVR_CMD_MODIFIER;
-    dst->cmd |= (list << PVR_TA_CMD_TYPE_SHIFT) & PVR_TA_CMD_TYPE_MASK;
-
-    dst->mode1 = (mode << PVR_TA_PM1_MODIFIERINST_SHIFT) & PVR_TA_PM1_MODIFIERINST_MASK;
-    dst->mode1 |= (cull << PVR_TA_PM1_CULLING_SHIFT) & PVR_TA_PM1_CULLING_MASK;
+    dst->cmd = PVR_CMD_MODIFIER
+        | FIELD_PREP(PVR_TA_CMD_TYPE, list);
+    dst->mode1 = FIELD_PREP(PVR_TA_PM1_MODIFIERINST, mode)
+        | FIELD_PREP(PVR_TA_PM1_CULLING, cull);
 
     dst->d1 = dst->d2 = dst->d3 = dst->d4 = dst->d5 = dst->d6 = 0;
 }
@@ -484,238 +344,109 @@ void pvr_mod_compile(pvr_mod_hdr_t *dst, pvr_list_t list, uint32 mode,
 /* Compile a polygon context into a polygon header that is affected by
    modifier volumes */
 void pvr_poly_mod_compile(pvr_poly_mod_hdr_t *dst, const pvr_poly_cxt_t *src) {
-    int u, v;
     uint32_t txr_base;
-    uint32_t cmd, mode1, mode2[2], mode3[2];
+    uint32_t mode2, mode3;
 
     /* Basically we just take each parameter, clip it, shift it
        into place, and OR it into the final result. */
 
     /* The base values for CMD */
-    cmd = PVR_CMD_POLYHDR;
-
-    if(src->txr.enable == PVR_TEXTURE_ENABLE)
-        cmd |= 8;
-
-    /* Or in the list type, shading type, color and UV formats */
-    cmd |= (src->list_type << PVR_TA_CMD_TYPE_SHIFT) & PVR_TA_CMD_TYPE_MASK;
-    cmd |= (src->fmt.color << PVR_TA_CMD_CLRFMT_SHIFT) & PVR_TA_CMD_CLRFMT_MASK;
-    cmd |= (src->gen.shading << PVR_TA_CMD_SHADE_SHIFT) & PVR_TA_CMD_SHADE_MASK;
-    cmd |= (src->fmt.uv << PVR_TA_CMD_UVFMT_SHIFT) & PVR_TA_CMD_UVFMT_MASK;
-    cmd |= (src->gen.clip_mode << PVR_TA_CMD_USERCLIP_SHIFT) & PVR_TA_CMD_USERCLIP_MASK;
-    cmd |= (src->fmt.modifier << PVR_TA_CMD_MODIFIER_SHIFT) & PVR_TA_CMD_MODIFIER_MASK;
-    cmd |= (src->gen.modifier_mode << PVR_TA_CMD_MODIFIERMODE_SHIFT) & PVR_TA_CMD_MODIFIERMODE_MASK;
-    cmd |= (src->gen.specular << PVR_TA_CMD_SPECULAR_SHIFT) & PVR_TA_CMD_SPECULAR_MASK;
-
-    dst->cmd = cmd;
+    dst->cmd = PVR_CMD_POLYHDR
+        | FIELD_PREP(PVR_TA_CMD_TXRENABLE, src->txr.enable)
+        | FIELD_PREP(PVR_TA_CMD_TYPE, src->list_type)
+        | FIELD_PREP(PVR_TA_CMD_CLRFMT, src->fmt.color)
+        | FIELD_PREP(PVR_TA_CMD_SHADE, src->gen.shading)
+        | FIELD_PREP(PVR_TA_CMD_UVFMT, src->fmt.uv)
+        | FIELD_PREP(PVR_TA_CMD_USERCLIP, src->gen.clip_mode)
+        | FIELD_PREP(PVR_TA_CMD_MODIFIER, src->fmt.modifier)
+        | FIELD_PREP(PVR_TA_CMD_MODIFIERMODE, src->gen.modifier_mode)
+        | FIELD_PREP(PVR_TA_CMD_SPECULAR, src->gen.specular);
 
     /* Polygon mode 1 */
-    mode1  = (src->depth.comparison << PVR_TA_PM1_DEPTHCMP_SHIFT) & PVR_TA_PM1_DEPTHCMP_MASK;
-    mode1 |= (src->gen.culling << PVR_TA_PM1_CULLING_SHIFT) & PVR_TA_PM1_CULLING_MASK;
-    mode1 |= (src->depth.write << PVR_TA_PM1_DEPTHWRITE_SHIFT) & PVR_TA_PM1_DEPTHWRITE_MASK;
-    mode1 |= (src->txr.enable << PVR_TA_PM1_TXRENABLE_SHIFT) & PVR_TA_PM1_TXRENABLE_MASK;
-
-    dst->mode1 = mode1;
+    dst->mode1 = FIELD_PREP(PVR_TA_PM1_DEPTHCMP, src->depth.comparison)
+        | FIELD_PREP(PVR_TA_PM1_CULLING, src->gen.culling)
+        | FIELD_PREP(PVR_TA_PM1_DEPTHWRITE, src->depth.write)
+        | FIELD_PREP(PVR_TA_PM1_TXRENABLE, src->txr.enable);
 
     /* Polygon mode 2 (outside volume) */
-    mode2[0]  = (src->blend.src << PVR_TA_PM2_SRCBLEND_SHIFT) & PVR_TA_PM2_SRCBLEND_MASK;
-    mode2[0] |= (src->blend.dst << PVR_TA_PM2_DSTBLEND_SHIFT) & PVR_TA_PM2_DSTBLEND_MASK;
-    mode2[0] |= (src->blend.src_enable << PVR_TA_PM2_SRCENABLE_SHIFT) & PVR_TA_PM2_SRCENABLE_MASK;
-    mode2[0] |= (src->blend.dst_enable << PVR_TA_PM2_DSTENABLE_SHIFT) & PVR_TA_PM2_DSTENABLE_MASK;
-    mode2[0] |= (src->gen.fog_type << PVR_TA_PM2_FOG_SHIFT) & PVR_TA_PM2_FOG_MASK;
-    mode2[0] |= (src->gen.color_clamp << PVR_TA_PM2_CLAMP_SHIFT) & PVR_TA_PM2_CLAMP_MASK;
-    mode2[0] |= (src->gen.alpha << PVR_TA_PM2_ALPHA_SHIFT) & PVR_TA_PM2_ALPHA_MASK;
+    mode2 = FIELD_PREP(PVR_TA_PM2_SRCBLEND, src->blend.src)
+        | FIELD_PREP(PVR_TA_PM2_DSTBLEND, src->blend.dst)
+        | FIELD_PREP(PVR_TA_PM2_SRCENABLE, src->blend.src_enable)
+        | FIELD_PREP(PVR_TA_PM2_DSTENABLE, src->blend.dst_enable)
+        | FIELD_PREP(PVR_TA_PM2_FOG, src->gen.fog_type)
+        | FIELD_PREP(PVR_TA_PM2_CLAMP, src->gen.color_clamp)
+        | FIELD_PREP(PVR_TA_PM2_ALPHA, src->gen.alpha);
 
     if(src->txr.enable == PVR_TEXTURE_DISABLE) {
-        dst->mode2_0 = mode2[0];
-        dst->mode3_0 = 0;
+        mode3 = 0;
     }
     else {
-        mode2[0] |= (src->txr.alpha << PVR_TA_PM2_TXRALPHA_SHIFT) & PVR_TA_PM2_TXRALPHA_MASK;
-        mode2[0] |= (src->txr.uv_flip << PVR_TA_PM2_UVFLIP_SHIFT) & PVR_TA_PM2_UVFLIP_MASK;
-        mode2[0] |= (src->txr.uv_clamp << PVR_TA_PM2_UVCLAMP_SHIFT) & PVR_TA_PM2_UVCLAMP_MASK;
-        mode2[0] |= (src->txr.filter << PVR_TA_PM2_FILTER_SHIFT) & PVR_TA_PM2_FILTER_MASK;
-        mode2[0] |= (src->txr.mipmap_bias << PVR_TA_PM2_MIPBIAS_SHIFT) & PVR_TA_PM2_MIPBIAS_MASK;
-        mode2[0] |= (src->txr.env << PVR_TA_PM2_TXRENV_SHIFT) & PVR_TA_PM2_TXRENV_MASK;
+        assert_msg(__builtin_popcount(src->txr.width) == 1
+		   && src->txr.width <= 1024, "Invalid texture U size");
+        assert_msg(__builtin_popcount(src->txr.height) == 1
+		   && src->txr.height <= 1024, "Invalid texture V size");
 
-        switch(src->txr.width) {
-            case 8:
-                u = 0;
-                break;
-            case 16:
-                u = 1;
-                break;
-            case 32:
-                u = 2;
-                break;
-            case 64:
-                u = 3;
-                break;
-            case 128:
-                u = 4;
-                break;
-            case 256:
-                u = 5;
-                break;
-            case 512:
-                u = 6;
-                break;
-            case 1024:
-                u = 7;
-                break;
-            default:
-                assert_msg(0, "Invalid texture U size");
-                u = 0;
-                break;
-        }
-
-        switch(src->txr.height) {
-            case 8:
-                v = 0;
-                break;
-            case 16:
-                v = 1;
-                break;
-            case 32:
-                v = 2;
-                break;
-            case 64:
-                v = 3;
-                break;
-            case 128:
-                v = 4;
-                break;
-            case 256:
-                v = 5;
-                break;
-            case 512:
-                v = 6;
-                break;
-            case 1024:
-                v = 7;
-                break;
-            default:
-                assert_msg(0, "Invalid texture V size");
-                v = 0;
-                break;
-        }
-
-        mode2[0] |= (u << PVR_TA_PM2_USIZE_SHIFT) & PVR_TA_PM2_USIZE_MASK;
-        mode2[0] |= (v << PVR_TA_PM2_VSIZE_SHIFT) & PVR_TA_PM2_VSIZE_MASK;
-
-        dst->mode2_0 = mode2[0];
-
-        /* Polygon mode 3 (outside volume) */
-        mode3[0]  = (src->txr.mipmap << PVR_TA_PM3_MIPMAP_SHIFT) & PVR_TA_PM3_MIPMAP_MASK;
-        mode3[0] |= (src->txr.format << PVR_TA_PM3_TXRFMT_SHIFT) & PVR_TA_PM3_TXRFMT_MASK;
+        mode2 |= FIELD_PREP(PVR_TA_PM2_TXRALPHA, src->txr.alpha)
+            | FIELD_PREP(PVR_TA_PM2_UVFLIP, src->txr.uv_flip)
+            | FIELD_PREP(PVR_TA_PM2_UVCLAMP, src->txr.uv_clamp)
+            | FIELD_PREP(PVR_TA_PM2_FILTER, src->txr.filter)
+            | FIELD_PREP(PVR_TA_PM2_MIPBIAS, src->txr.mipmap_bias)
+            | FIELD_PREP(PVR_TA_PM2_TXRENV, src->txr.env)
+            | FIELD_PREP(PVR_TA_PM2_USIZE, __builtin_ctz(src->txr.width) - 3)
+            | FIELD_PREP(PVR_TA_PM2_VSIZE, __builtin_ctz(src->txr.height) - 3);
 
         /* Convert the texture address */
-        txr_base = (uint32)src->txr.base;
+        txr_base = (uint32_t)src->txr.base;
         txr_base = (txr_base & 0x00fffff8) >> 3;
-        mode3[0] |= txr_base;
 
-        dst->mode3_0 = mode3[0];
+        /* Polygon mode 3 */
+        mode3 = FIELD_PREP(PVR_TA_PM3_MIPMAP, src->txr.mipmap)
+            | src->txr.format
+            | txr_base;
     }
+
+    dst->mode2_0 = mode2;
+    dst->mode3_0 = mode3;
 
     /* Polygon mode 2 (within volume) */
-    mode2[1]  = (src->blend.src2 << PVR_TA_PM2_SRCBLEND_SHIFT) & PVR_TA_PM2_SRCBLEND_MASK;
-    mode2[1] |= (src->blend.dst2 << PVR_TA_PM2_DSTBLEND_SHIFT) & PVR_TA_PM2_DSTBLEND_MASK;
-    mode2[1] |= (src->blend.src_enable2 << PVR_TA_PM2_SRCENABLE_SHIFT) & PVR_TA_PM2_SRCENABLE_MASK;
-    mode2[1] |= (src->blend.dst_enable2 << PVR_TA_PM2_DSTENABLE_SHIFT) & PVR_TA_PM2_DSTENABLE_MASK;
-    mode2[1] |= (src->gen.fog_type2 << PVR_TA_PM2_FOG_SHIFT) & PVR_TA_PM2_FOG_MASK;
-    mode2[1] |= (src->gen.color_clamp2 << PVR_TA_PM2_CLAMP_SHIFT) & PVR_TA_PM2_CLAMP_MASK;
-    mode2[1] |= (src->gen.alpha2 << PVR_TA_PM2_ALPHA_SHIFT) & PVR_TA_PM2_ALPHA_MASK;
+    mode2 = FIELD_PREP(PVR_TA_PM2_SRCBLEND, src->blend.src2)
+        | FIELD_PREP(PVR_TA_PM2_DSTBLEND, src->blend.dst2)
+        | FIELD_PREP(PVR_TA_PM2_SRCENABLE, src->blend.src_enable2)
+        | FIELD_PREP(PVR_TA_PM2_DSTENABLE, src->blend.dst_enable2)
+        | FIELD_PREP(PVR_TA_PM2_FOG, src->gen.fog_type2)
+        | FIELD_PREP(PVR_TA_PM2_CLAMP, src->gen.color_clamp2)
+        | FIELD_PREP(PVR_TA_PM2_ALPHA, src->gen.alpha2);
 
     if(src->txr2.enable == PVR_TEXTURE_DISABLE) {
-        dst->mode2_1 = mode2[1];
-        dst->mode3_1 = 0;
+        mode3 = 0;
     }
     else {
-        mode2[1] |= (src->txr2.alpha << PVR_TA_PM2_TXRALPHA_SHIFT) & PVR_TA_PM2_TXRALPHA_MASK;
-        mode2[1] |= (src->txr2.uv_flip << PVR_TA_PM2_UVFLIP_SHIFT) & PVR_TA_PM2_UVFLIP_MASK;
-        mode2[1] |= (src->txr2.uv_clamp << PVR_TA_PM2_UVCLAMP_SHIFT) & PVR_TA_PM2_UVCLAMP_MASK;
-        mode2[1] |= (src->txr2.filter << PVR_TA_PM2_FILTER_SHIFT) & PVR_TA_PM2_FILTER_MASK;
-        mode2[1] |= (src->txr2.mipmap_bias << PVR_TA_PM2_MIPBIAS_SHIFT) & PVR_TA_PM2_MIPBIAS_MASK;
-        mode2[1] |= (src->txr2.env << PVR_TA_PM2_TXRENV_SHIFT) & PVR_TA_PM2_TXRENV_MASK;
+        assert_msg(__builtin_popcount(src->txr2.width) == 1
+		   && src->txr2.width <= 1024, "Invalid texture U size");
+        assert_msg(__builtin_popcount(src->txr2.height) == 1
+		   && src->txr2.height <= 1024, "Invalid texture V size");
 
-        switch(src->txr2.width) {
-            case 8:
-                u = 0;
-                break;
-            case 16:
-                u = 1;
-                break;
-            case 32:
-                u = 2;
-                break;
-            case 64:
-                u = 3;
-                break;
-            case 128:
-                u = 4;
-                break;
-            case 256:
-                u = 5;
-                break;
-            case 512:
-                u = 6;
-                break;
-            case 1024:
-                u = 7;
-                break;
-            default:
-                assert_msg(0, "Invalid texture U size");
-                u = 0;
-                break;
-        }
-
-        switch(src->txr2.height) {
-            case 8:
-                v = 0;
-                break;
-            case 16:
-                v = 1;
-                break;
-            case 32:
-                v = 2;
-                break;
-            case 64:
-                v = 3;
-                break;
-            case 128:
-                v = 4;
-                break;
-            case 256:
-                v = 5;
-                break;
-            case 512:
-                v = 6;
-                break;
-            case 1024:
-                v = 7;
-                break;
-            default:
-                assert_msg(0, "Invalid texture V size");
-                v = 0;
-                break;
-        }
-
-        mode2[1] |= (u << PVR_TA_PM2_USIZE_SHIFT) & PVR_TA_PM2_USIZE_MASK;
-        mode2[1] |= (v << PVR_TA_PM2_VSIZE_SHIFT) & PVR_TA_PM2_VSIZE_MASK;
-
-        dst->mode2_1 = mode2[1];
-
-        /* Polygon mode 3 (within volume) */
-        mode3[1]  = (src->txr2.mipmap << PVR_TA_PM3_MIPMAP_SHIFT) & PVR_TA_PM3_MIPMAP_MASK;
-        mode3[1] |= (src->txr2.format << PVR_TA_PM3_TXRFMT_SHIFT) & PVR_TA_PM3_TXRFMT_MASK;
+        mode2 |= FIELD_PREP(PVR_TA_PM2_TXRALPHA, src->txr2.alpha)
+            | FIELD_PREP(PVR_TA_PM2_UVFLIP, src->txr2.uv_flip)
+            | FIELD_PREP(PVR_TA_PM2_UVCLAMP, src->txr2.uv_clamp)
+            | FIELD_PREP(PVR_TA_PM2_FILTER, src->txr2.filter)
+            | FIELD_PREP(PVR_TA_PM2_MIPBIAS, src->txr2.mipmap_bias)
+            | FIELD_PREP(PVR_TA_PM2_TXRENV, src->txr2.env)
+            | FIELD_PREP(PVR_TA_PM2_USIZE, __builtin_ctz(src->txr2.width) - 3)
+            | FIELD_PREP(PVR_TA_PM2_VSIZE, __builtin_ctz(src->txr2.height) - 3);
 
         /* Convert the texture address */
         txr_base = (uint32_t)src->txr2.base;
         txr_base = (txr_base & 0x00fffff8) >> 3;
-        mode3[1] |= txr_base;
 
-        dst->mode3_1 = mode3[1];
+        /* Polygon mode 3 */
+        mode3 = FIELD_PREP(PVR_TA_PM3_MIPMAP, src->txr2.mipmap)
+            | src->txr2.format
+            | txr_base;
     }
+
+    dst->mode2_1 = mode2;
+    dst->mode3_1 = mode3;
 
     dst->d1 = 0xffffffff;
     dst->d2 = 0xffffffff;

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -46,6 +46,7 @@ __BEGIN_DECLS
 #include <arch/cache.h>
 #include <dc/sq.h>
 #include <kos/img.h>
+#include <kos/regfield.h>
 
 /** \defgroup pvr   PowerVR API
     \brief          Low-level PowerVR GPU Driver.
@@ -1026,15 +1027,9 @@ Striplength set to 2 */
 #define PVR_CMD_SPRITE      0xA0000000  /**< \brief PVR sprite header */
 /** @} */
 
-/** \defgroup pvr_bitmasks          Constants and Masks
-    \brief                          Polygon header constants and masks
-    \ingroup                        pvr_primitives_headers
-
-    Note that thanks to the arrangement of constants, this is mainly a matter of
-    bit shifting to compile headers...
-
-    @{
-*/
+/** \cond
+    Deprecated macros, replaced by the pvr_bitmasks macros below.
+ */
 #define PVR_TA_CMD_TYPE_SHIFT       24
 #define PVR_TA_CMD_TYPE_MASK        (7 << PVR_TA_CMD_TYPE_SHIFT)
 
@@ -1124,6 +1119,48 @@ Striplength set to 2 */
 
 #define PVR_TA_PM3_TXRFMT_SHIFT     0
 #define PVR_TA_PM3_TXRFMT_MASK      0xffffffff
+/** \endcond */
+
+/** \defgroup pvr_bitmasks          Constants and Masks
+    \brief                          Polygon header constants and masks
+    \ingroup                        pvr_primitives_headers
+
+    Note that thanks to the arrangement of constants, this is mainly a matter of
+    bit shifting to compile headers...
+
+    @{
+*/
+#define PVR_TA_CMD_TYPE            GENMASK(26, 24)
+#define PVR_TA_CMD_USERCLIP        GENMASK(17, 16)
+#define PVR_TA_CMD_MODIFIER        BIT(7)
+#define PVR_TA_CMD_MODIFIERMODE    BIT(6)
+#define PVR_TA_CMD_CLRFMT          GENMASK(5, 4)
+#define PVR_TA_CMD_TXRENABLE       BIT(3)
+#define PVR_TA_CMD_SPECULAR        BIT(2)
+#define PVR_TA_CMD_SHADE           BIT(1)
+#define PVR_TA_CMD_UVFMT           BIT(0)
+#define PVR_TA_PM1_DEPTHCMP        GENMASK(31, 29)
+#define PVR_TA_PM1_CULLING         GENMASK(28, 27)
+#define PVR_TA_PM1_DEPTHWRITE      BIT(26)
+#define PVR_TA_PM1_TXRENABLE       BIT(25)
+#define PVR_TA_PM1_MODIFIERINST    GENMASK(30, 29)
+#define PVR_TA_PM2_SRCBLEND        GENMASK(31, 29)
+#define PVR_TA_PM2_DSTBLEND        GENMASK(28, 26)
+#define PVR_TA_PM2_SRCENABLE       BIT(25)
+#define PVR_TA_PM2_DSTENABLE       BIT(24)
+#define PVR_TA_PM2_FOG             GENMASK(23, 22)
+#define PVR_TA_PM2_CLAMP           BIT(21)
+#define PVR_TA_PM2_ALPHA           BIT(20)
+#define PVR_TA_PM2_TXRALPHA        BIT(19)
+#define PVR_TA_PM2_UVFLIP          GENMASK(18, 17)
+#define PVR_TA_PM2_UVCLAMP         GENMASK(16, 15)
+#define PVR_TA_PM2_FILTER          GENMASK(14, 12)
+#define PVR_TA_PM2_MIPBIAS         GENMASK(11, 8)
+#define PVR_TA_PM2_TXRENV          GENMASK(7, 6)
+#define PVR_TA_PM2_USIZE           GENMASK(5, 3)
+#define PVR_TA_PM2_VSIZE           GENMASK(2, 0)
+#define PVR_TA_PM3_MIPMAP          BIT(31)
+#define PVR_TA_PM3_TXRFMT          GENMASK(30, 21)
 /** @} */
 
 /**** Register macros ***************************************************/


### PR DESCRIPTION
Add a new `<kos/regfield.h>` header, which will provide the `BIT()`, `GENMASK()`, `FIELD_GET()` and `FIELD_PREP()` macros which are really useful to deal with register fields.

Add  a new `<kos/deprecated.h>` header, to which deprecated stuff can be moved to avoid polluting the main API, while still staying API-compatible until the next major release.

Use the new regfield macros to clean up the PVR code.