### PR TITLE
Improve ASM in fmath_base.h

### DIFF
--- a/kernel/arch/dreamcast/include/dc/fmath_base.h
+++ b/kernel/arch/dreamcast/include/dc/fmath_base.h
@@ -33,92 +33,84 @@ __BEGIN_DECLS
 
 /** \cond */
 #define __fsin(x) \
-    ({ float __value, __arg = (x), __scale = 10430.37835f; \
-        __asm__("fmul   %2,%1\n\t" \
-                "ftrc   %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fmov   fr0,%0" \
-                : "=f" (__value), "+&f" (__scale) \
+    ({ _Complex float __value; \
+       float __arg = (float)(x) * 10430.37835f; \
+        __asm__("ftrc   %1,fpul\n\t" \
+                "fsca   fpul,%0" \
+                : "=f" (__value) \
                 : "f" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
+                : "fpul"); \
+        __real__ __value; })
 
 #define __fcos(x) \
-    ({ float __value, __arg = (x), __scale = 10430.37835f; \
-        __asm__("fmul   %2,%1\n\t" \
-                "ftrc   %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fmov   fr1,%0" \
-                : "=f" (__value), "+&f" (__scale) \
+    ({ _Complex float __value; \
+       float __arg = (float)(x) * 10430.37835f; \
+        __asm__("ftrc   %1,fpul\n\t" \
+                "fsca   fpul,%0" \
+                : "=f" (__value) \
                 : "f" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
+                : "fpul"); \
+        __imag__ __value; })
 
 #define __ftan(x) \
-    ({ float __value, __arg = (x), __scale = 10430.37835f; \
-        __asm__("fmul   %2,%1\n\t" \
-                "ftrc   %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fdiv   fr1, fr0\n\t" \
-                "fmov   fr0,%0" \
-                : "=f" (__value), "+&f" (__scale) \
+    ({ _Complex float __value; \
+       float __arg = (float)(x) * 10430.37835f; \
+        __asm__("ftrc   %1,fpul\n\t" \
+                "fsca   fpul,%0" \
+                : "=f" (__value) \
                 : "f" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
-
+                : "fpul"); \
+        __real__ __value / __imag__ __value; })
 
 #define __fisin(x) \
-    ({ float __value, __arg = (x); \
+    ({ _Complex float __value; \
+       float __arg = (x); \
         __asm__("lds    %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fmov   fr0,%0" \
+                "fsca   fpul,%0" \
                 : "=f" (__value) \
                 : "r" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
+                : "fpul"); \
+        __real__ __value; })
 
 #define __ficos(x) \
-    ({ float __value, __arg = (x); \
+    ({ _Complex float __value; \
+       float __arg = (x); \
         __asm__("lds    %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fmov   fr1,%0" \
+                "fsca   fpul,%0" \
                 : "=f" (__value) \
                 : "r" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
+                : "fpul"); \
+        __imag__ __value; })
 
 #define __fitan(x) \
-    ({ float __value, __arg = (x); \
+    ({ _Complex float __value; \
+       float __arg = (x); \
         __asm__("lds    %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fdiv   fr1, fr0\n\t" \
-                "fmov   fr0,%0" \
+                "fsca   fpul,%0" \
                 : "=f" (__value) \
                 : "r" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
+                : "fpul"); \
+        __real__ __value / __imag__ __value; })
 
 #define __fsincos(r, s, c) \
-    ({  register float __r __asm__("fr10") = r; \
-        register float __a __asm__("fr11") = 182.04444443f; \
-        __asm__("fmul fr11, fr10\n\t" \
-                "ftrc fr10, fpul\n\t" \
-                "fsca fpul, dr10\n\t" \
-                : "+f" (__r), "+f" (__a) \
-                : "0" (__r), "1" (__a) \
+    ({ _Complex float __value; \
+       float __arg = (r) * 182.04444443f; \
+        __asm__("ftrc   %1,fpul\n\t" \
+                "fsca   fpul,%0" \
+                : "=f" (__value) \
+                : "f" (__arg) \
                 : "fpul"); \
-        s = __r; c = __a; })
+        s = __real__ __value; c = __imag__ __value; })
 
 #define __fsincosr(r, s, c) \
-    ({  register float __r __asm__("fr10") = r; \
-        register float __a __asm__("fr11") = 10430.37835f; \
-        __asm__("fmul fr11, fr10\n\t" \
-                "ftrc fr10, fpul\n\t" \
-                "fsca fpul, dr10\n\t" \
-                : "+f" (__r), "+f" (__a) \
-                : "0" (__r), "1" (__a) \
+    ({ _Complex float __value; \
+       float __arg = (r) * 10430.37835f; \
+        __asm__("ftrc   %1,fpul\n\t" \
+                "fsca   fpul,%0" \
+                : "=f" (__value) \
+                : "f" (__arg) \
                 : "fpul"); \
-        s = __r; c = __a; })
+        s = __real__ __value; c = __imag__ __value; })
 
 #define __fsqrt(x) \
     ({ float __arg = (x); \


### PR DESCRIPTION
- Avoid doing multiplications / divisions in ASM, and do them in C instead. The compiler has then much more insight about the possible pipeline stalls incurred.

- Avoid using dedicated registers. Use a complex variable to identify a floating-point register couple that can be used as a target for the fsca instruction, and use the __real__ keyword to identify the first result register, and the __imag__ keyword to identify the second result register. By doing this, the compiler won't have to move the arguments into specific registers or retrieve the results from specific registers, resulting in much better code generation.