### PR TITLE
PVR hybrid mode + IRQ handling rework

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@ Platform-specific changes are prefixed with the platform name, otherwise the cha
 - Add/Fixed stat() implementations for all filesystems [AB]
 - **Dreamcast**: Add network speedtest and pvr palette examples [AB]
 - **Dreamcast**: Cleaned up, documented, and enhanced BIOS font API [FG]
+- Rework PVR hybrid mode + IRQ handling [PC]
 
 ## KallistiOS version 2.1.0
 - Cleaned up generated stubs files on a make clean [Lawrence Sebald == LS]

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -194,9 +194,6 @@ int pvr_init(pvr_init_params_t *params) {
     mutex_init((mutex_t *)&pvr_state.dma_lock, MUTEX_TYPE_NORMAL);
     pvr_dma_init();
 
-    /* Setup our wait-ready semaphore */
-    sem_init((semaphore_t *)&pvr_state.ready_sem, 0);
-
     /* Set us as valid and return success */
     pvr_state.valid = 1;
 
@@ -245,8 +242,7 @@ int pvr_shutdown(void) {
     /* Invalidate our memory pool */
     pvr_mem_reset();
 
-    /* Destroy the semaphore */
-    sem_destroy((semaphore_t *)&pvr_state.ready_sem);
+    /* Destroy the mutex */
     mutex_destroy((mutex_t *)&pvr_state.dma_lock);
 
     /* Clear video memory */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -140,7 +140,7 @@ int pvr_init(pvr_init_params_t *params) {
     }
 
     /* Hook the PVR interrupt events on G2 */
-    pvr_state.vbl_handle = vblank_handler_add(pvr_int_handler, NULL);
+    pvr_state.vbl_handle = vblank_handler_add(pvr_vblank_handler, NULL);
     
     asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEDONE, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_OPAQUEDONE, ASIC_IRQ_DEFAULT);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -168,6 +168,7 @@ typedef struct {
     uint32  lists_dmaed;                // (1 << idx) for each list which has been DMA'd (DMA mode only)
 
     mutex_t dma_lock;                   // Locked if a DMA is in progress (vertex or texture)
+    int     ta_ready;                   // >0 if the TA is ready for the new scene
     int     ta_busy;                    // >0 if a scene is ongoing and the TA hasn't signaled completion
     int     render_busy;                // >0 if a render is in progress
     int     render_completed;           // >1 if a render has recently finished

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -288,8 +288,9 @@ void pvr_blank_polyhdr_buf(int type, pvr_poly_hdr_t * buf);
 
 /**** pvr_irq.c *******************************************************/
 
-/* Interrupt handler for PVR events */
+/* Interrupt handlers for PVR events */
 void pvr_int_handler(uint32 code, void *data);
+void pvr_vblank_handler(uint32 code, void *data);
 
 void pvr_start_dma(void);
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -16,7 +16,6 @@
    code. If something is needed from this, an external interface should
    be added to dc/pvr.h. */
 
-#include <kos/sem.h>
 #include <kos/mutex.h>
 
 /**** State stuff ***************************************************/
@@ -169,7 +168,7 @@ typedef struct {
     uint32  lists_dmaed;                // (1 << idx) for each list which has been DMA'd (DMA mode only)
 
     mutex_t dma_lock;                   // Locked if a DMA is in progress (vertex or texture)
-    int     ta_busy;                    // >0 if a DMA is in progress and the TA hasn't signaled completion
+    int     ta_busy;                    // >0 if a scene is ongoing and the TA hasn't signaled completion
     int     render_busy;                // >0 if a render is in progress
     int     render_completed;           // >1 if a render has recently finished
 
@@ -203,10 +202,6 @@ typedef struct {
     size_t   frame_count;                // Total number of viewed frames
     size_t   vtx_buf_used;               // Vertex buffer used size for the last frame
     size_t   vtx_buf_used_max;           // Maximum used vertex buffer size
-
-    /* Wait-ready semaphore: this will be signaled whenever the pvr_wait_ready()
-       call should be ready to return. */
-    semaphore_t ready_sem;
 
     // Handle for the vblank interrupt
     int     vbl_handle;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -295,5 +295,6 @@ void pvr_blank_polyhdr_buf(int type, pvr_poly_hdr_t * buf);
 /* Interrupt handler for PVR events */
 void pvr_int_handler(uint32 code, void *data);
 
+void pvr_start_dma(void);
 
 #endif

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -333,6 +333,8 @@ int pvr_scene_finish(void) {
         irq_restore(o);
 
         pvr_sync_stats(PVR_SYNC_BUFDONE);
+
+        pvr_start_dma();
     }
     else {
         /* If a list was open, close it */


### PR DESCRIPTION
This set of commits fix the hybrid rendering mode (direct + differed using DMA), and rework IRQ handling. It yields great performance benefits even for apps doing regular/direct rendering (e.g. Doom64 gets +4 fps in one of the most complex scenes) without any drawback detected so far.

See the description of the individual commits for a full description of the change.