### PR TITLE
Fix versioning macros

### DIFF
--- a/include/kos/version.h
+++ b/include/kos/version.h
@@ -249,7 +249,7 @@
     \returns        Packed version identifier.
 */
 #define KOS_VERSION_MAKE(major, minor, patch) \
-    ((kos_version_t)((major) << 16) | ((minor) << 8) | (patch))
+    (((major) << 16) | ((minor) << 8) | (patch))
 
 /** Creates a version string from its constituents. 
 
@@ -305,7 +305,7 @@
     \retval false   The given version is at or below \p version.
 */
 #define KOS_VERSION_MAKE_ABOVE(major, minor, patch, version) \
-    (KOS_VERSION_MAKE_COMPARISON(major, minor, patch, >, version))
+    (KOS_VERSION_MAKE_COMPARISON(major, minor, patch, <, version))
 
 /** Creates a minimum version check. 
 
@@ -323,7 +323,7 @@
     \retval false   The given version is below \p version.
 */
 #define KOS_VERSION_MAKE_MIN(major, minor, patch, version) \
-    (KOS_VERSION_MAKE_COMPARISON(major, minor, patch, >=, version))
+    (KOS_VERSION_MAKE_COMPARISON(major, minor, patch, <=, version))
 
 /** Creates an exact version check. 
 
@@ -360,7 +360,7 @@
 
 */
 #define KOS_VERSION_MAKE_MAX(major, minor, patch, version) \
-    (KOS_VERSION_MAKE_COMPARISON(major, minor, patch, <=, version))
+    (KOS_VERSION_MAKE_COMPARISON(major, minor, patch, >=, version))
 
 /** Creates a check for being below a given version.
 
@@ -378,7 +378,7 @@
     \retval false   The given version is at or above \p version.
 */
 #define KOS_VERSION_MAKE_BELOW(major, minor, patch, version) \
-    (KOS_VERSION_MAKE_COMPARISON(major, minor, patch, <, version))
+    (KOS_VERSION_MAKE_COMPARISON(major, minor, patch, >, version))
 /** @} */
 
 /** \cond INTERNAL */


### PR DESCRIPTION
Recently a PR was reverted for SDL kos-ports(https://github.com/Dreamcast-Projects/kos-ports/commit/852443252b09cc635da3ae6e72a1add37cee2d30)

The fix for the versioning issue is already included in an existing big PR but since this is an emergency I pulled the versioning fixes out into its own PR which makes sense anyway.