### PR TITLE
pvr: Use only one IRQ for all lists

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -143,15 +143,10 @@ int pvr_init(pvr_init_params_t *params) {
     pvr_state.vbl_handle = vblank_handler_add(pvr_vblank_handler, NULL);
     
     asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEDONE, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_OPAQUEDONE, ASIC_IRQ_DEFAULT);
     asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEMODDONE, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_OPAQUEMODDONE, ASIC_IRQ_DEFAULT);
     asic_evt_set_handler(ASIC_EVT_PVR_TRANSDONE, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_TRANSDONE, ASIC_IRQ_DEFAULT);
     asic_evt_set_handler(ASIC_EVT_PVR_TRANSMODDONE, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_TRANSMODDONE, ASIC_IRQ_DEFAULT);
     asic_evt_set_handler(ASIC_EVT_PVR_PTDONE, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_PTDONE, ASIC_IRQ_DEFAULT);
     asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE_TSP, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_RENDERDONE_TSP, ASIC_IRQ_DEFAULT);
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -163,8 +163,9 @@ typedef struct {
                                         // (^1 == frame buffer we're rendering to)
 
     int     list_reg_open;              // Which list is open for registration, if any? (non-DMA only)
+    int     last_list_used;             // Index of the last list that was opened
     uint32  lists_closed;               // (1 << idx) for each list which the SH4 has lost interest in
-    uint32  lists_transferred;          // (1 << idx) for each list which has completely transferred to the TA
+    int     lists_transferred;          // 1 when all lists were processed by the TA
     uint32  lists_dmaed;                // (1 << idx) for each list which has been DMA'd (DMA mode only)
 
     mutex_t dma_lock;                   // Locked if a DMA is in progress (vertex or texture)


### PR DESCRIPTION
Instead of using one IRQ for each list type, use one IRQ that corresponds to the last list that will be transferred by the Tile Accelerator.

This will reduce the number of IRQs per frame when multiple lists are used, and should therefore slightly improve performance.