### PR TITLE
Correct out-of-memory test in scandir

### DIFF
--- a/kernel/libc/koslib/scandir.c
+++ b/kernel/libc/koslib/scandir.c
@@ -48,7 +48,7 @@ static int push_back(struct dirent ***list, int *size, int *capacity,
         *list = realloc(*list, *capacity * sizeof(struct dirent*));
 
         /* Handle out-of-memory in case realloc() failed. */
-        if(!list)
+        if(!*list)
             goto out_of_memory;
         else
             list_tmp = list;


### PR DESCRIPTION
The test after realloc was improperly testing 'list' for NULL rather than '*list'.