### PR TITLE
Update the changelog and relnotes for v2.1.1

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -3,16 +3,21 @@
 Platform-specific changes are prefixed with the platform name, otherwise the change is platform-independent. The name/initials of the person who is responsible for the change are listed in [square brackets] for most versions (where they are missing from early versions, assume that they should be attributed to Megan Potter).
 
 ## KallistiOS version 2.2.0
-- Added pvrtex utility by TapamN to utils [DF == Daniel Fairchild]
-- Added . & .. directories to filesystems that lack it [AB]
+- Added . & .. directories to filesystems that lack it [Andress Barajas == AB]
 - Replaced previous implementation of realpath() to remove license from AUTHORS [AB]
-- Enabled hybrid PVR DR/DMA vertex submission in driver + sped up pvr_prim() [FG]
-- Add thread priority boosting system [Paul Cercueil = PC]
+- Enabled hybrid PVR DR/DMA vertex submission in driver + sped up pvr_prim() [Falco Girgis == FG]
+- Add thread priority boosting system [Paul Cercueil == PC]
 - Add performance monitor API [PC]
 - Add/Fixed stat() implementations for all filesystems [AB]
-- **Dreamcast**: Add network speedtest and pvr palette examples [AB]
+- **Dreamcast**: Add pvr palette example [AB]
 - **Dreamcast**: Cleaned up, documented, and enhanced BIOS font API [FG]
 - Rework PVR hybrid mode + IRQ handling [PC]
+
+## KallistiOS version 2.1.1
+- Added pvrtex utility by TapamN to utils [Daniel Fairchild == DF]
+- **Dreamcast**: Added a set of known working purupuru bit patterns and a browsing mechanism to the rumble example [DF]
+- **Dreamcast**: Added new example to demonstrate the use of the PVR to draw lines with quads (pvr/pvrline) [Jason Martin == JM]
+- **Dreamcast**: Add network speedtest example [Andress Barajas == AB]
 
 ## KallistiOS version 2.1.0
 - Cleaned up generated stubs files on a make clean [Lawrence Sebald == LS]
@@ -235,7 +240,6 @@ Platform-specific changes are prefixed with the platform name, otherwise the cha
 - **Dreamcast**: Update GCC 14.x toolchain profile to 14.2 [EF]
 - **Dreamcast**: Update GCC 11.x toolchain profile to 11.5, update Binutils to 2.43 [EF]
 - **Dreamcast**: Fix ARM toolchain build error when JIT is enabled for SH toolchain [EF]
-- **Dreamcast**: Added a set of known working purupuru bit patterns and a browsing mechanism to the rumble example [DF == Daniel Fairchild]
 - Added full support for <time.h> additions from C23 standard. [FG]
 - Fixes mutexes not working properly [PC]
 - **Dreamcast**: fs_dcload: Set errno on error in dcload_stat() [PC]

--- a/doc/RELNOTES.md
+++ b/doc/RELNOTES.md
@@ -3,6 +3,21 @@ Copyright (C) 2002, 2003 Megan Potter
 Copyright (C) 2012-2019 Lawrence Sebald
 Copyright (C) 2024 Donald Haase
 
+RELEASE NOTES for 2.1.1
+-----------------------
+
+This minor patch version is primarily aimed at fixing the versioning system
+which simply didn't work as implemented in v2.1.0. Alongside that another few
+dozen PRs were included that containing minor bugfixes and documentation updates.
+
+Also included is a new host-side util pvrtex which converts standard images
+to formats used directly by the Dreamcast's PowerVR (utils/pvrtex), a significant
+rewrite of wav2adpcm which converts standard sound data into the smaller ADPCM
+format used by the Dreamcast's AICA (utils/wav2adpcm), an example that
+demonstrates how to draw lines with quads via the pvr (pvr/pvrline), one for
+testing network speed (network/speedtest) and another on how to use libADX
+from kos-ports for audio playback (sound/libADX).
+
 RELEASE NOTES for 2.1.0
 -----------------------
 


### PR DESCRIPTION
This is the splitting of the changelog and the update to the 'relnotes' that will go along with v2.1.1 ( https://github.com/KallistiOS/KallistiOS/milestone/4?closed=1 ).

I think moving into the future it might make sense to have the Changelog not be edited in individual PRs and rather maybe use a label to note if a PR should be reflected in the changelog or not. Fairly frequently we have snarls from PRs modifying the changelog and having to do so again for conflicts before merging. This same kind of cleanup processes then still had to happen to cut v2.1.0. It would streamline things for contributors to *just* have the final cleanup process.

Aside from just the splitting out of v2.1.1 in the changelog, I additionally found one entry that had accidentally gotten left in the v2.1.0 list and corrected some formatting mistake with the name references.