### PR TITLE
Add pvr_wait_render_done() and pvr_get_front_buffer()

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -42,7 +42,10 @@ int pvr_init_defaults(void) {
         0,
 
         /* Extra OPBs */
-        3
+        3,
+
+        /* Vertex buffer double-buffering enabled */
+        0
     };
 
     return pvr_init(&params);
@@ -88,6 +91,8 @@ int pvr_init(pvr_init_params_t *params) {
 
     // Copy over FSAA setting.
     pvr_state.fsaa = params->fsaa_enabled;
+
+    pvr_state.vbuf_doublebuf = !params->vbuf_doublebuf_disabled;
 
     /* Everything's clear, do the initial buffer pointer setup */
     pvr_allocate_buffers(params);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -210,6 +210,9 @@ typedef struct {
     // Non-zero if FSAA was enabled at init time.
     int     fsaa;
 
+    // Non-zero if using double-buffering for the vertex buffer.
+    int     vbuf_doublebuf;
+
     // Non-zero if we are rendering to a texture
     int     to_texture[2];
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -191,6 +191,8 @@ void pvr_int_handler(uint32 code, void *data) {
             pvr_state.render_busy = 0;
             pvr_state.render_completed = 1;
             pvr_sync_stats(PVR_SYNC_RNDDONE);
+
+            genwait_wake_all((void *)&pvr_state.render_busy);
             break;
     }
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -112,7 +112,7 @@ static void pvr_render_lists(void) {
         // Begin rendering from the dirty TA buffer into the clean
         // frame buffer.
         //DBG(("start_render(%d -> %d)\n", pvr_state.ta_target, pvr_state.view_target ^ 1));
-        pvr_state.ta_target ^= 1;
+        pvr_state.ta_target ^= pvr_state.vbuf_doublebuf;
         pvr_begin_queued_render();
         pvr_state.render_busy = 1;
         pvr_sync_stats(PVR_SYNC_RNDSTART);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -187,7 +187,7 @@ void pvr_begin_queued_render(void) {
     } zclip;
 
     /* Get the appropriate buffer */
-    tbuf = pvr_state.ta_buffers + (pvr_state.ta_target ^ 1);
+    tbuf = pvr_state.ta_buffers + (pvr_state.ta_target ^ pvr_state.vbuf_doublebuf);
     rbuf = pvr_state.frame_buffers + (bufn ^ 1);
 
     /* Calculate background value for below */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -269,3 +269,21 @@ void pvr_blank_polyhdr_buf(int type, pvr_poly_hdr_t * poly) {
     poly->d1 = poly->d2 = poly->d3 = poly->d4 = 0xffffffff;
 
 }
+
+pvr_ptr_t pvr_get_front_buffer(void) {
+    unsigned int idx;
+    uint32_t addr;
+
+    irq_disable_scoped();
+
+    /* The front buffer may not have been fully rendered or submitted to the
+       video hardware yet. In case this has yet to happen, we want the second
+       view target, aka. the one not currently being displayed. */
+    idx = pvr_state.view_target ^ pvr_state.render_completed;
+
+    addr = pvr_state.frame_buffers[idx].frame;
+
+    /* The front buffer is in 32-bit memory, convert its address to make it
+       addressable from the 64-bit memory */
+    return (pvr_ptr_t)(((addr << 1) & (PVR_RAM_SIZE - 1)) + PVR_RAM_BASE);
+}

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -423,3 +423,14 @@ int pvr_check_ready(void) {
     else
         return -1;
 }
+
+int pvr_wait_render_done(void) {
+    int t = 0;
+
+    irq_disable_scoped();
+
+    if(pvr_state.render_busy)
+        t = genwait_wait((void *)&pvr_state.render_busy, "PVR wait render done", 100, NULL);
+
+    return t;
+}

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -91,6 +91,12 @@ static void pvr_start_ta_rendering(void) {
     // Make sure to wait until the TA is ready to start rendering a new scene
     if(!pvr_state.ta_ready) {
         pvr_wait_ready();
+
+        // If using a single vertex buffer, we have to wait until the PVR is
+        // done rendering to use the TA again.
+        if(!pvr_state.vbuf_doublebuf)
+            pvr_wait_render_done();
+
         pvr_state.ta_ready = 1;
     }
 

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -2123,6 +2123,19 @@ int pvr_wait_ready(void);
 */
 int pvr_check_ready(void);
 
+/** \brief   Block the caller until the PVR has finished rendering the previous
+             frame.
+    \ingroup pvr_scene_mgmt
+
+    This function can be used to wait until the PVR is done rendering a previous
+    scene. This can be useful for instance to make sure that the PVR is done
+    using textures that have to be updated, before updating those.
+
+    \retval 0               On success.
+    \retval -1              On error. Something is probably very wrong...
+*/
+int pvr_wait_render_done(void);
+
 
 /* Primitive handling ************************************************/
 

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1416,6 +1416,13 @@ typedef struct {
 
     int     opb_overflow_count;
 
+    /** \brief  Disable vertex buffer double-buffering.
+
+        Use only one single vertex buffer. This means that the PVR must finish
+        rendering before the Tile Accelerator is used to prepare a new frame;
+        but it allows using much smaller vertex buffers. */
+    int     vbuf_doublebuf_disabled;
+
 } pvr_init_params_t;
 
 /** \brief   Initialize the PVR chip to ready status.

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -2413,6 +2413,20 @@ void pvr_txr_load_ex(const void *src, pvr_ptr_t dst,
 */
 void pvr_txr_load_kimg(const kos_img_t *img, pvr_ptr_t dst, uint32_t flags);
 
+/** \brief   Get a pointer to the front buffer.
+    \ingroup pvr_txr_mgmt
+
+    This function can be used to retrieve a pointer to the front buffer, aka.
+    the last fully rendered buffer that is either being displayed right now,
+    or is queued to be displayed.
+
+    Note that the frame buffers lie in 32-bit memory, while textures lie in
+    64-bit memory. The address returned will point to 64-bit memory, but the
+    front buffer cannot be used directly as a regular texture.
+
+    \return                 A pointer to the front buffer.
+*/
+pvr_ptr_t pvr_get_front_buffer(void);
 
 /* PVR DMA ***********************************************************/
 /** \defgroup pvr_dma   DMA


### PR DESCRIPTION
The `pvr_wait_render_done()` differs from `pvr_wait_ready()` as the latter only waits until a new scene can be rendered, which does not mean that the PVR is done rendering.
Having a new `pvr_wait_render_done()` function is useful for when the program needs to swap out textures that may be used by the PVR for rendering, or when it needs to access the front buffer.

The `pvr_get_front_buffer()` returns a pointer to the front buffer, in 64-bit memory space. This allows programs to do some special effects, like re-loading the previous frame for overpainting, or to do blur effects.