### PR TITLE
Fix and improve CPU cache management for devices on G1 bus.

### DIFF
--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -3,7 +3,7 @@
    dc/cdrom.h
    Copyright (C) 2000-2001 Megan Potter
    Copyright (C) 2014 Donald Haase
-   Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024 Ruslan Rostovtsev
 */
 
 #ifndef __DC_CDROM_H
@@ -401,13 +401,18 @@ int cdrom_read_toc(CDROM_TOC *toc_buffer, int session);
     This function reads the specified number of sectors from the disc, starting
     where requested. This will respect the size of the sectors set with
     cdrom_change_datatype(). The buffer must have enough space to store the
-    specified number of sectors.
+    specified number of sectors and size must be a multiple of 32 for DMA.
 
     \param  buffer          Space to store the read sectors.
     \param  sector          The sector to start reading from.
     \param  cnt             The number of sectors to read.
-    \param  mode            DMA or PIO
+    \param  mode            \ref cd_read_sector_mode
     \return                 \ref cd_cmd_response
+
+    \note                   If the buffer address points to the P2 memory area,
+                            the caller function will be responsible for ensuring
+                            memory coherency.
+
     \see    cd_read_sector_mode
 */
 int cdrom_read_sectors_ex(void *buffer, int sector, int cnt, int mode);

--- a/kernel/arch/dreamcast/include/dc/g1ata.h
+++ b/kernel/arch/dreamcast/include/dc/g1ata.h
@@ -2,7 +2,7 @@
 
    dc/g1ata.h
    Copyright (C) 2013, 2014 Lawrence Sebald
-   Copyright (C) 2023 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024 Ruslan Rostovtsev
 */
 
 /** \file    dc/g1ata.h
@@ -281,6 +281,10 @@ int g1_ata_read_lba(uint64_t sector, size_t count, void *buf);
                             a PIO transfer function like g1_ata_read_lba()
                             instead.
 
+    \note                   If the buffer address points to the P2 memory area,
+                            the caller function will be responsible for ensuring
+                            memory coherency.
+
     \par    Error Conditions:
     \em     EIO - an I/O error occurred in reading data \n
     \em     ENXIO - ATA support not initialized or no device attached \n
@@ -343,6 +347,10 @@ int g1_ata_write_lba(uint64_t sector, size_t count, const void *buf);
                             function, DMA mode is not supported. You should use
                             a PIO transfer function like g1_ata_write_lba()
                             instead.
+
+    \note                   If the buffer address points to the P2 memory area,
+                            the caller function will be responsible for ensuring
+                            memory coherency.
 
     \par    Error Conditions:
     \em     ENXIO - ATA support not initialized or no device attached \n


### PR DESCRIPTION
- Added alignment checks for cdrom sector reading in PIO and DMA.
- Added CPU cache management for cdrom sector reading in DMA.
- Improved checking for the need for CPU cache management for G1ATA DMA.
- Updated docs for such changes.