### PR TITLE
dc-chain: Use "which" instead of "command"

### DIFF
--- a/utils/dc-chain/scripts/utils.mk
+++ b/utils/dc-chain/scripts/utils.mk
@@ -11,7 +11,7 @@ ifneq ($(force_downloader),)
   web_downloader = $(if $(filter $(downloaders),$(force_downloader)),$(force_downloader))
 else
 # If no downloader specified, check to see if any are detected
-  web_downloader = $(if $(shell command -v curl),curl,$(if $(shell command -v wget),wget))
+  web_downloader = $(if $(shell which curl),curl,$(if $(shell which wget),wget))
 endif
 
 # Make sure valid downloader was found


### PR DESCRIPTION
"command" is technically the right one as it is recommended over "which". However, Ubuntu 20.04 does not seem to have a built-in "command", or at least it is not callable from a Makefile's $(shell).

Fixes #860.