### PR TITLE
DMA Controller API

### DIFF
--- a/examples/dreamcast/basic/dma/speedtest/Makefile
+++ b/examples/dreamcast/basic/dma/speedtest/Makefile
@@ -1,0 +1,20 @@
+#
+# DMA speedtest program
+# Copyright (C) 2025 Paul Cercueil
+#
+
+TARGET = speedtest.elf
+OBJS = speedtest.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $@ $^

--- a/examples/dreamcast/basic/dma/speedtest/speedtest.c
+++ b/examples/dreamcast/basic/dma/speedtest/speedtest.c
@@ -1,0 +1,133 @@
+/* KallistiOS ##version##
+
+   speedtest.c
+   Copyright (C) 2025 Paul Cercueil
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include <arch/dmac.h>
+#include <arch/timer.h>
+#include <arch/irq.h>
+#include <dc/pvr.h>
+#include <kos/genwait.h>
+
+#define ARRAY_SIZE(x) (sizeof(x) ? sizeof(x) / sizeof((x)[0]) : 0)
+
+#define BUF_SIZE (1024 * 1024)
+
+static alignas(32) char buf1[BUF_SIZE];
+static alignas(32) char buf2[BUF_SIZE];
+
+static void dma_done(void *d)
+{
+	*(uint64_t *)d = timer_us_gettime64();
+	genwait_wake_all(d);
+}
+
+static dma_config_t dma_cfg = {
+	.channel = 1,
+	.request = DMA_REQUEST_AUTO_MEM_TO_MEM,
+	.unit_size = DMA_UNITSIZE_32BYTE,
+	.src_mode = DMA_ADDRMODE_INCREMENT,
+	.dst_mode = DMA_ADDRMODE_INCREMENT,
+	.transmit_mode = DMA_TRANSMITMODE_BURST,
+	.callback = dma_done,
+};
+
+static uint64_t
+do_dma_transfer(unsigned int test, pvr_ptr_t vram1, pvr_ptr_t vram2)
+{
+	uint64_t before, after = 0;
+
+	irq_disable_scoped();
+
+	before = timer_us_gettime64();
+
+	switch (test) {
+	case 0:
+		/* RAM to RAM */
+		dma_transfer(&dma_cfg,
+			     dma_map_dst(buf1, BUF_SIZE),
+			     dma_map_src(buf2, BUF_SIZE),
+			     BUF_SIZE, &after);
+		break;
+	case 1:
+		/* RAM to VRAM */
+		dma_transfer(&dma_cfg,
+			     hw_to_dma_addr((uintptr_t)vram1),
+			     dma_map_src(buf2, BUF_SIZE),
+			     BUF_SIZE, &after);
+		break;
+	case 2:
+		/* VRAM to RAM */
+		dma_transfer(&dma_cfg,
+			     dma_map_dst(buf1, BUF_SIZE),
+			     hw_to_dma_addr((uintptr_t)vram1),
+			     BUF_SIZE, &after);
+		break;
+	case 3:
+		/* VRAM to VRAM */
+		dma_transfer(&dma_cfg,
+			     hw_to_dma_addr((uintptr_t)vram1),
+			     hw_to_dma_addr((uintptr_t)vram2),
+			     BUF_SIZE, &after);
+		break;
+	case 4:
+		/* RAM to VRAM using SQs */
+		pvr_txr_load(buf1, vram1, BUF_SIZE);
+
+		return timer_us_gettime64() - before;
+	case 5:
+		/* RAM to 64-bit VRAM using PVR DMA */
+		pvr_txr_load_dma(buf1, vram1, BUF_SIZE,
+				 0, dma_done, &after);
+		break;
+	case 6:
+		/* RAM to 32-bit VRAM using PVR DMA */
+		pvr_dma_transfer(buf1, (uintptr_t)vram1, BUF_SIZE,
+				 PVR_DMA_VRAM32, 0,
+				 dma_done, &after);
+		break;
+	}
+
+	while ((volatile uint64_t)after == 0)
+		genwait_wait(&after, "IRQ wait", 0, NULL);
+
+	return after - before;
+}
+
+static const char * const test_lbl[] = {
+	"DMAC, RAM to RAM:   ",
+	"DMAC, RAM to VRAM:  ",
+	"DMAC, VRAM to RAM:  ",
+	"DMAC, VRAM to VRAM: ",
+	"PVR SQs:            ",
+	"PVR DMA, 64-bit:    ",
+	"PVR DMA, 32-bit:    ",
+};
+
+int main(int argc, char **argv)
+{
+	pvr_ptr_t vram, vram2;
+	uint64_t time_us;
+	unsigned int i;
+
+	pvr_init_defaults();
+
+	vram = pvr_mem_malloc(BUF_SIZE);
+	vram2 = pvr_mem_malloc(BUF_SIZE);
+
+	for (i = 0; i < ARRAY_SIZE(test_lbl); i++) {
+		time_us = do_dma_transfer(i, vram, vram2);
+		printf("%s%f MiB/s\n",
+		       test_lbl[i], (float)BUF_SIZE / (float)time_us);
+
+	}
+
+	pvr_mem_free(vram);
+	pvr_mem_free(vram2);
+
+	return 0;
+}

--- a/kernel/arch/dreamcast/hardware/Makefile
+++ b/kernel/arch/dreamcast/hardware/Makefile
@@ -28,7 +28,7 @@ OBJS += asic.o g2bus.o
 OBJS += video.o vblank.o
 
 # CPU-related
-OBJS += sq.o sq_fast_cpy.o scif.o ubc.o
+OBJS += sq.o sq_fast_cpy.o scif.o ubc.o dmac.o
 
 # SPI device support
 OBJS += scif-spi.o sd.o

--- a/kernel/arch/dreamcast/hardware/dmac.c
+++ b/kernel/arch/dreamcast/hardware/dmac.c
@@ -1,0 +1,162 @@
+#include <arch/cache.h>
+#include <arch/dmac.h>
+#include <arch/irq.h>
+#include <arch/memory.h>
+#include <kos/dbglog.h>
+#include <kos/genwait.h>
+#include <kos/regfield.h>
+
+#include <errno.h>
+
+#define DMAC_BASE       0xffa00000
+
+typedef enum dma_register {
+    DMA_REG_SAR         = 0x00, /* Source Address Register */
+    DMA_REG_DAR         = 0x04, /* Destination Address Register */
+    DMA_REG_TCR         = 0x08, /* Transfer Count Register */
+    DMA_REG_CHCR        = 0x0C, /* Channel Control Register */
+    DMA_REG_DMAOR       = 0x40, /* DMA Operation Register */
+} dma_register_t;
+
+#define REG_CHCR_DST_ADDRMODE   GENMASK(15, 14)
+#define REG_CHCR_SRC_ADDRMODE   GENMASK(13, 12)
+#define REG_CHCR_REQUEST        GENMASK(11, 8)
+#define REG_CHCR_TRANSMIT_MODE  BIT(7)
+#define REG_CHCR_BUSWIDTH       GENMASK(6, 4)
+#define REG_CHCR_INTERRUPT_EN   BIT(2)
+#define REG_CHCR_TRANSFER_END   BIT(1)
+#define REG_CHCR_DMAC_EN        BIT(0)
+
+static const dma_config_t *channels_cfg[4];
+
+static const irq_t channel_to_irq[] = {
+    [0] = EXC_DMAC_DMTE0,
+    [1] = EXC_DMAC_DMTE1,
+    [2] = EXC_DMAC_DMTE2,
+    [3] = EXC_DMAC_DMTE3,
+};
+
+static inline unsigned char irq_to_channel(irq_t irq) {
+    return (irq - EXC_DMAC_DMTE0) >> 5;
+}
+
+static uint32_t dmac_read(dma_channel_t channel, dma_register_t reg) {
+    return *(volatile uint32_t *)(DMAC_BASE + channel * 0x10 + reg);
+}
+
+static void dmac_write(dma_channel_t channel, dma_register_t reg, uint32_t val) {
+    *(volatile uint32_t *)(DMAC_BASE + channel * 0x10 + reg) = val;
+}
+
+dma_addr_t hw_to_dma_addr(uintptr_t hw_addr) {
+    return (dma_addr_t)(hw_addr & MEM_AREA_CACHE_MASK);
+}
+
+static dma_addr_t dma_map_src_dst(uintptr_t addr, size_t len, bool is_dst) {
+    switch(addr & ~MEM_AREA_CACHE_MASK) {
+    case MEM_AREA_P0_BASE:
+    case MEM_AREA_P1_BASE:
+    case MEM_AREA_P3_BASE:
+        if(is_dst)
+            dcache_inval_range(addr, len);
+        else
+            dcache_flush_range(addr, len);
+        break;
+
+    default:
+        /* Nothing to do */
+        break;
+    }
+
+    return hw_to_dma_addr(addr);
+}
+
+dma_addr_t dma_map_src(const void *ptr, size_t len) {
+    return dma_map_src_dst((uintptr_t)ptr, len, false);
+}
+
+dma_addr_t dma_map_dst(void *ptr, size_t len) {
+    return dma_map_src_dst((uintptr_t)ptr, len, true);
+}
+
+static const unsigned char dma_unit_size[] = {
+    [DMA_UNITSIZE_64BIT] = 8,
+    [DMA_UNITSIZE_8BIT] = 1,
+    [DMA_UNITSIZE_16BIT] = 2,
+    [DMA_UNITSIZE_32BIT] = 4,
+    [DMA_UNITSIZE_32BYTE] = 32,
+};
+
+static void dma_irq_handler(irq_t code, irq_context_t *context, void *d) {
+    unsigned char channel = irq_to_channel(code);
+
+    (void)context;
+
+    /* ACK the IRQ by clearing CHCR */
+    dmac_write(channel, DMA_REG_CHCR, 0);
+
+    genwait_wake_all((void *)&channels_cfg[channel]->callback);
+    channels_cfg[channel]->callback(d);
+}
+
+static bool dma_is_running(dma_channel_t channel) {
+    uint32_t chcr = dmac_read(channel, DMA_REG_CHCR);
+
+    return (chcr & (REG_CHCR_TRANSFER_END | REG_CHCR_DMAC_EN)) == REG_CHCR_DMAC_EN;
+}
+
+void dma_wait_complete(dma_channel_t channel) {
+    irq_disable_scoped();
+
+    while(dma_is_running(channel)) {
+        if(!irq_inside_int()) {
+            if(channels_cfg[channel]->callback)
+                genwait_wait(channels_cfg[channel]->callback, "DMA complete wait", 0, NULL);
+            else
+                thd_pass();
+        }
+    }
+}
+
+int dma_transfer(const dma_config_t *cfg, dma_addr_t dst, dma_addr_t src,
+                 size_t len, void *cb_data) {
+    unsigned int transfer_size = dma_unit_size[cfg->unit_size];
+    uint32_t chcr;
+
+    if((len | dst | src) & (transfer_size - 1)) {
+        dbglog(DBG_ERROR, "dmac: src/dst/len not aligned to the bus width\n");
+        errno = EFAULT;
+        return -1;
+    }
+
+    irq_disable_scoped();
+
+    dma_wait_complete(cfg->channel);
+    channels_cfg[cfg->channel] = cfg;
+
+    dmac_write(cfg->channel, DMA_REG_CHCR, 0);
+    dmac_write(cfg->channel, DMA_REG_SAR, src);
+    dmac_write(cfg->channel, DMA_REG_DAR, dst);
+    dmac_write(cfg->channel, DMA_REG_TCR, len >> __builtin_ctz(transfer_size));
+
+    irq_set_handler(channel_to_irq[cfg->channel], dma_irq_handler, cb_data);
+
+    chcr = FIELD_PREP(REG_CHCR_DST_ADDRMODE, cfg->dst_mode)
+        | FIELD_PREP(REG_CHCR_SRC_ADDRMODE, cfg->src_mode)
+        | FIELD_PREP(REG_CHCR_REQUEST, cfg->request)
+        | FIELD_PREP(REG_CHCR_TRANSMIT_MODE, cfg->transmit_mode)
+        | FIELD_PREP(REG_CHCR_BUSWIDTH, cfg->unit_size)
+        | FIELD_PREP(REG_CHCR_INTERRUPT_EN, !!cfg->callback)
+        | FIELD_PREP(REG_CHCR_DMAC_EN, 1);
+
+    dmac_write(cfg->channel, DMA_REG_CHCR, chcr);
+
+    return 0;
+}
+
+size_t dma_transfer_get_remaining(dma_channel_t channel) {
+    unsigned char unit_size = channels_cfg[channel]->unit_size;
+    uint32_t tcr = dmac_read(channel, DMA_REG_TCR);
+
+    return tcr * dma_unit_size[unit_size];
+}

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
@@ -106,7 +106,7 @@ static const dma_config_t pvr_dma_config = {
 int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count,
                      pvr_dma_type_t type, bool block,
                      pvr_dma_callback_t callback, void *cbdata) {
-    dma_addr_t src_addr = hw_to_dma_addr((uintptr_t)src);
+    dma_addr_t src_addr = dma_map_src(src, count);
 
     /* Check for 32-byte alignment */
     if(src_addr & 0x1F) {

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -51,12 +51,6 @@ static void dma_next_list(void *data) {
                 continue;
             }
 
-            // Flush the last 32 bytes out of dcache, just in case.
-            // dcache_flush_range((ptr_t)(b->base[i] + b->ptr[i] - 32), 32);
-            dcache_flush_range((ptr_t)(b->base[i]), b->ptr[i] + 32);
-            //amt = b->ptr[i] > 16384 ? 16384 : b->ptr[i];
-            //dcache_flush_range((ptr_t)(b->base[i] + b->ptr[i] - amt), amt);
-
             // Start the DMA transfer, chaining to ourselves.
             //DBG(("dma_begin(buf %d, list %d, base %p, len %d)\n",
             //  pvr_state.ram_target ^ 1, i,

--- a/kernel/arch/dreamcast/hardware/scif.c
+++ b/kernel/arch/dreamcast/hardware/scif.c
@@ -165,7 +165,7 @@ int scif_set_irq_usage(int on) {
         irq_set_handler(EXC_SCIF_ERI, scif_err_irq, NULL);
         irq_set_handler(EXC_SCIF_BRI, scif_err_irq, NULL);
         irq_set_handler(EXC_SCIF_RXI, scif_data_irq, NULL);
-        *((vuint16*)0xffd0000c) |= 0x000e << 4;
+        irq_set_priority(IRQ_SRC_SCIF, 14);
 
         /* Enable transmit/receive, recv/recv error ints */
         SCSCR2 |= 0x48;
@@ -175,7 +175,7 @@ int scif_set_irq_usage(int on) {
         SCSCR2 &= ~0x48;
 
         /* Unhook the SCIF interrupt */
-        *((vuint16*)0xffd0000c) &= ~(0x000e << 4);
+        irq_set_priority(IRQ_SRC_SCIF, IRQ_PRIO_MASKED);
         irq_set_handler(EXC_SCIF_ERI, NULL, NULL);
         irq_set_handler(EXC_SCIF_BRI, NULL, NULL);
         irq_set_handler(EXC_SCIF_RXI, NULL, NULL);

--- a/kernel/arch/dreamcast/include/arch/dmac.h
+++ b/kernel/arch/dreamcast/include/arch/dmac.h
@@ -1,0 +1,246 @@
+/* KallistiOS ##version##
+
+   dmac.h
+   Copyright (C) 2024 Paul Cercueil
+
+*/
+
+/** \file    arch/dmac.h
+    \brief   SH4 DMA Controller API
+    \ingroup system_dmac
+
+    This header provies an API to use the DMA controller of the SH4.
+
+    \author Paul Cercueil
+*/
+
+#ifndef __ARCH_DMAC_H
+#define __ARCH_DMAC_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+#include <stdint.h>
+
+/** \defgroup dmac  DMA Controller API
+    \brief          API to use the SH4's DMA Controller
+    \ingroup        system
+
+    This API can be used to program DMA transfers from memory to memory,
+    from hardware to memory or from memory to hardware.
+
+    @{
+*/
+
+/** \brief   DMA callback type.
+    \ingroup dmac
+
+    Function type for DMA callbacks.
+    Those registered callbacks will be called when a DMA transfer completes.
+    They will be called in an interrupt context, so don't try anything funny.
+*/
+typedef void (*dma_callback_t)(void *data);
+
+/** \brief   DMA channel enum.
+    \ingroup dmac
+
+    Represents one of the 4 DMA channels available on the SH4.
+*/
+typedef enum dma_channel {
+    DMA_CHANNEL_0, /**< Channel #0: On Dreamcast, reserved for hardware. */
+    DMA_CHANNEL_1, /**< Channel #1: External, hardware or mem-to-mem requests. */
+    DMA_CHANNEL_2, /**< Channel #2: on Dreamcast, reserved for PVR use. */
+    DMA_CHANNEL_3, /**< Channel #3: mem-to-mem requests only. */
+} dma_channel_t;
+
+/** \brief   DMA request.
+    \ingroup dmac
+
+    List of the possible DMA requests.
+
+    "Auto" requests are started as soon as the DMA transfer is programmed to
+    the DMA controller. On the other hand, SCI/SCIF/TMU2 requests are only
+    started when the given hardware event occurs.
+
+    "External" requests are controlled by external pins of the SH4 CPU. These
+    can be wired to other parts of the mother board.
+*/
+typedef enum dma_request {
+    DMA_REQUEST_EXTERNAL_MEM_TO_MEM = 0,
+    DMA_REQUEST_EXTERNAL_MEM_TO_DEV = 2,
+    DMA_REQUEST_EXTERNAL_DEV_TO_MEM = 3,
+    DMA_REQUEST_AUTO_MEM_TO_MEM = 4,
+    DMA_REQUEST_AUTO_MEM_TO_DEV = 5,
+    DMA_REQUEST_AUTO_DEV_TO_MEM = 6,
+
+    DMA_REQUEST_SCI_TRANSMIT = 8,
+    DMA_REQUEST_SCI_RECEIVE = 9,
+    DMA_REQUEST_SCIF_TRANSMIT = 10,
+    DMA_REQUEST_SCIF_RECEIVE = 11,
+    DMA_REQUEST_TMU2_MEM_TO_MEM = 12,
+    DMA_REQUEST_TMU2_MEM_TO_DEV = 13,
+    DMA_REQUEST_TMU2_DEV_TO_MEM = 14,
+} dma_request_t;
+
+/** \brief   DMA unit size.
+    \ingroup dmac
+
+    The unit size controls the granularity at which the DMA will transfer data.
+    For instance, copying data to a 16-bit bus will require a 16-bit unit size.
+
+    For memory-to-memory transfers, it is recommended to use 32-byte transfers
+    for the maximum speed.
+*/
+typedef enum dma_unitsize {
+    DMA_UNITSIZE_64BIT,
+    DMA_UNITSIZE_8BIT,
+    DMA_UNITSIZE_16BIT,
+    DMA_UNITSIZE_32BIT,
+    DMA_UNITSIZE_32BYTE,
+} dma_unitsize_t;
+
+/** \brief   DMA address mode.
+    \ingroup dmac
+
+    The "address mode" specifies how the source or destination address of a DMA
+    transfer is modified as the transfer goes on. It is only valid when the DMA
+    transfer is configured as pointing to memory for that source or destination.
+*/
+typedef enum dma_addrmode {
+    DMA_ADDRMODE_FIXED,     /**< The source/destination address is not modified. */
+    DMA_ADDRMODE_INCREMENT, /**< The source/destination address is incremented. */
+    DMA_ADDRMODE_DECREMENT, /**< The source/destination address is decremented. */
+} dma_addrmode_t;
+
+/** \brief   DMA transmit mode.
+    \ingroup dmac
+
+    In "Cycle steal" mode, the DMA controller will release the bus at the end of
+    each transfer unit (configured by the unit size). This allows the CPU to
+    access the bus if it needs to.
+
+    In "Burst" mode, the DMA controller will hold the bus until the DMA transfer
+    completes.
+*/
+typedef enum dma_transmitmode {
+    DMA_TRANSMITMODE_CYCLE_STEAL,
+    DMA_TRANSMITMODE_BURST,
+} dma_transmitmode_t;
+
+/** \brief   DMA transfer configuration.
+    \ingroup dmac
+
+    This structure represents the configuration used for a given DMA channel.
+*/
+typedef struct dma_config {
+    dma_channel_t channel;              /**< DMA channel used for the transfer. */
+    dma_request_t request;              /**< DMA request type. */
+    dma_unitsize_t unit_size;           /**< Unit size used for the DMA transfer. */
+    dma_addrmode_t src_mode, dst_mode;  /**< Source/destination address mode. */
+    dma_transmitmode_t transmit_mode;   /**< DMA Transfer transmit mode. */
+    dma_callback_t callback;            /**< Optional callback function for
+					     end-of-transfer notification. */
+} dma_config_t;
+
+/** \brief   DMA address.
+    \ingroup dmac
+
+    This type represents an address that can be used for DMA transfers.
+*/
+typedef uint32_t dma_addr_t;
+
+/** \brief   Convert a hardware address to a DMA address.
+    \ingroup dmac
+
+    This function will convert a hardware address (pointing to a device's FIFO,
+    or to one of the various mapped memories) to an address suitable for use
+    with the DMA controller.
+
+    \param  hw_addr         The hardware address.
+    \return                 The converted DMA address.
+*/
+dma_addr_t hw_to_dma_addr(uintptr_t hw_addr);
+
+/** \brief   Prepare a source memory buffer for a DMA transfer.
+    \ingroup dmac
+
+    This function will flush the data cache for the memory area covered by the
+    buffer to ensure memory coherency, and return an address suitable for use
+    with the DMA controller.
+
+    \param  ptr             A pointer to the source buffer.
+    \param  len             The size in bytes of the source buffer.
+    \return                 The converted DMA address.
+
+    \sa dma_map_dst()
+*/
+dma_addr_t dma_map_src(const void *ptr, size_t len);
+
+/** \brief   Prepare a destination memory buffer for a DMA transfer.
+    \ingroup dmac
+
+    This function will invalidate the data cache for the memory area covered by
+    the buffer to ensure memory coherency, and return an address suitable for
+    use with the DMA controller.
+
+    \param  ptr             A pointer to the destination buffer.
+    \param  len             The size in bytes of the destination buffer.
+    \return                 The converted DMA address.
+
+    \sa dma_map_src()
+*/
+dma_addr_t dma_map_dst(void *ptr, size_t len);
+
+/** \brief   Program a DMA transfer.
+    \ingroup dmac
+
+    This function will program a DMA transfer using the specified configuration,
+    source/destination addresses and transfer length.
+
+    It will return as soon as the DMA transfer is programmed, which means that
+    it will not work for the DMA transfer to complete before returning.
+
+    \param  cfg             A pointer to the configuration structure.
+    \param  dst             The destination address, if targetting memory;
+                            can be 0 otherwise.
+    \param  src             The source address, if targetting memory;
+                            can be 0 otherwise.
+    \param  len             The size in bytes of the DMA transfer.
+    \param  cb_data         The parameter that will be passed to the
+                            end-of-transfer callback, if a callback has been
+                            specified in the configuration structure.
+    \retval 0               On success.
+    \retval -1              On error.
+
+    \sa dma_wait_complete()
+*/
+int dma_transfer(const dma_config_t *cfg, dma_addr_t dst, dma_addr_t src,
+                 size_t len, void *cb_data);
+
+/** \brief   Wait for a DMA transfer to complete
+    \ingroup dmac
+
+    This function will block until any previously programmed DMA transfer for
+    the given DMA channel has completed.
+
+    \param  channel         The DMA channel to wait for.
+*/
+void dma_wait_complete(dma_channel_t channel);
+
+/** \brief   Get the remaining size of a DMA transfer
+    \ingroup dmac
+
+    This function will return the number of bytes remaining to transfer, if a
+    transfer was previously programmed.
+
+    \param  channel         The DMA channel to wait for.
+    \return                 The number of bytes remaining to transfer, or zero
+                            if the previous transfer completed.
+*/
+size_t dma_transfer_get_remaining(dma_channel_t channel);
+
+/** @} */
+
+__END_DECLS
+
+#endif /* __ARCH_DMAC_H */

--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -486,6 +486,58 @@ static inline void __irq_scoped_cleanup(int *state) {
 */
 #define irq_disable_scoped() __irq_disable_scoped(__LINE__)
 
+/** \brief  Minimum/maximum values for IRQ priorities
+
+    A priority of zero means the interrupt is masked.
+    The maximum priority that can be set is 15.
+ */
+#define IRQ_PRIO_MAX    15
+#define IRQ_PRIO_MIN    1
+#define IRQ_PRIO_MASKED 0
+
+/** \brief  Interrupt sources
+
+   Interrupt sources at the SH4 level.
+ */
+typedef enum irq_src {
+    IRQ_SRC_RTC,
+    IRQ_SRC_TMU2,
+    IRQ_SRC_TMU1,
+    IRQ_SRC_TMU0,
+    _IRQ_SRC_RESV,
+    IRQ_SRC_SCI1,
+    IRQ_SRC_REF,
+    IRQ_SRC_WDT,
+    IRQ_SRC_HUDI,
+    IRQ_SRC_SCIF,
+    IRQ_SRC_DMAC,
+    IRQ_SRC_GPIO,
+    IRQ_SRC_IRL3,
+    IRQ_SRC_IRL2,
+    IRQ_SRC_IRL1,
+    IRQ_SRC_IRL0,
+} irq_src_t;
+
+/** \brief  Set the priority of a given IRQ source
+
+    This function can be used to set the priority of a given IRQ source.
+
+    \param  src             The interrupt source whose priority should be set
+    \param  prio            The priority to set, in the range [0..15],
+                            0 meaning the IRQs from that source are masked.
+*/
+void irq_set_priority(irq_src_t src, unsigned int prio);
+
+/** \brief  Get the priority of a given IRQ source
+
+    This function returns the priority of a given IRQ source.
+
+    \param  src             The interrupt source whose priority should be set
+    \return                 The priority of the IRQ source.
+                            A value of 0 means the IRQs are masked.
+*/
+unsigned int irq_get_priority(irq_src_t src);
+
 /** @} */
 
 __END_DECLS

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -26,6 +26,11 @@
 #define EXPEVT ( *((volatile uint32_t *)(0xff000024)) ) /* Exception Event Register */
 #define INTEVT ( *((volatile uint32_t *)(0xff000028)) ) /* Interrupt Event Register */
 
+#define IPRA   ( *((volatile uint16_t *)(0xffd00004)) ) /* Interrupt priority register A */
+#define IPRB   ( *((volatile uint16_t *)(0xffd00008)) ) /* Interrupt priority register A */
+#define IPRC   ( *((volatile uint16_t *)(0xffd0000c)) ) /* Interrupt priority register A */
+#define IPRD   ( *((volatile uint16_t *)(0xffd00010)) ) /* Interrupt priority register A */
+
 /* IRQ handler closure */
 struct irq_cb {
     irq_handler hdl;
@@ -396,6 +401,9 @@ int irq_init(void) {
 
     /* Set a default FPU exception handler */
     irq_set_handler(EXC_FPU, irq_def_fpu, NULL);
+
+    /* Unmask DMA IRQs */
+    IPRC = 0x300;
 
     /* Set a default context (will be superseded if threads are
        enabled later) */

--- a/kernel/arch/dreamcast/kernel/ser_console.c
+++ b/kernel/arch/dreamcast/kernel/ser_console.c
@@ -23,7 +23,6 @@ static char buffer[256];
 static semaphore_t *chr_ready;
 
 static vuint16 * const SCSCR2 = (vuint16*)0xffe80008;
-static vuint16 * const iprc = (vuint16*)0xffd0000c;
 
 int thd_pslist();
 
@@ -118,14 +117,14 @@ static void real_start(void *param) {
     /* Hook the serial IRQ */
     /* irq_set_handler(EXC_SCIF_RXI, ser_irq);
     *SCSCR2 |= 1 << 6;
-    *iprc |= 0x000e << 4; */
+    irq_set_priority(IRQ_SRC_SCIF, 14); */
 
     /* Do the shell */
     interact();
     dbgio_write_str("shell exiting\n");
 
     /* Unhook serial IRQ */
-    /* *iprc &= ~(0x000e << 4);
+    /* irq_set_priority(IRQ_SRC_SCIF, IRQ_PRIO_MASKED);
     *SCSCR2 &= ~(1 << 6);
     irq_set_handler(EXC_SCIF_RXI, NULL); */
 

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -189,20 +189,17 @@ void timer_spin_delay_us(unsigned short us) {
 
 /* Enable timer interrupts; needs to move to irq.c sometime. */
 void timer_enable_ints(int which) {
-    volatile uint16_t *ipra = (uint16_t *)0xffd00004;
-    *ipra |= (TIMER_PRIO << (12 - 4 * which));
+    irq_set_priority(IRQ_SRC_TMU0 - which, TIMER_PRIO);
 }
 
 /* Disable timer interrupts; needs to move to irq.c sometime. */
 void timer_disable_ints(int which) {
-    volatile uint16_t *ipra = (uint16_t *)0xffd00004;
-    *ipra &= ~(TIMER_PRIO << (12 - 4 * which));
+    irq_set_priority(IRQ_SRC_TMU0 - which, IRQ_PRIO_MASKED);
 }
 
 /* Check whether ints are enabled */
 int timer_ints_enabled(int which) {
-    volatile uint16_t *ipra = (uint16_t *)0xffd00004;
-    return (*ipra & (TIMER_PRIO << (12 - 4 * which))) != 0;
+    return irq_get_priority(IRQ_SRC_TMU0 - which) > 0;
 }
 
 /* Seconds elapsed (since KOS startup), updated from the TMU2 underflow ISR */


### PR DESCRIPTION
Introduce an API to use the DMA Controller of the SH4.
This new API can be used to program DMA transfers between memory and devices, or from memory to memory.