### PR TITLE
Posixify environ_*.sh files

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -18,12 +18,12 @@ export KOS_ARCH_DIR="${KOS_BASE}/kernel/arch/${KOS_ARCH}"
 . ${KOS_BASE}/environ_${KOS_ARCH}.sh
 
 # Add the compiler bins dir to the path if it is not already.
-if [[ ":$PATH:" != *":${KOS_CC_BASE}/bin:"* ]]; then
+if ! expr ":$PATH:" : ".*:${KOS_CC_BASE}/bin:.*" > /dev/null ; then
   export PATH="${PATH}:${KOS_CC_BASE}/bin"
 fi
 
 # Add the build wrappers dir to the path if it is not already.
-if [[ ":$PATH:" != *":${KOS_BASE}/utils/build_wrappers:"* ]]; then
+if ! expr ":$PATH:" : ".*:${KOS_BASE}/utils/build_wrappers:.*" > /dev/null ; then
   export PATH="${PATH}:${KOS_BASE}/utils/build_wrappers"
 fi
 

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -7,7 +7,7 @@ if [ -z "${DC_TOOLS_BASE}" ] ; then
 fi
 
 # Add the external DC tools dir to the path if it is not already.
-if [[ ":$PATH:" != *":${DC_TOOLS_BASE}:"* ]]; then
+if ! expr ":$PATH:" : ".*:${DC_TOOLS_BASE}:.*" > /dev/null ; then
   export PATH="${PATH}:${DC_TOOLS_BASE}"
 fi
 


### PR DESCRIPTION
This PR makes the scripts `environ_base.sh` and `environ_dreamcast.sh` POSIX compliant.

I need this in order to source these files from within a default Makefile shell, for my project [doom64-dc-makefile](https://github.com/hcartiaux/doom64-dc-makefile).

Thanks for reviewing :)