### PR TITLE
PVR Function Prototypes Cleanup (pvr.h refactor #539 part 1)

### DIFF
--- a/examples/dreamcast/pvr/cheap_shadow/shadow.c
+++ b/examples/dreamcast/pvr/cheap_shadow/shadow.c
@@ -96,11 +96,11 @@ int check_start(void) {
 
         if(state->joyy > 64) {
             shadow = CLAMP(0.0f, 1.0f, shadow + 0.01f);
-            pvr_set_shadow_scale(1, shadow);
+            pvr_set_shadow_scale(true, shadow);
         }
         else if(state->joyy < -64) {
             shadow = CLAMP(0.0f, 1.0f, shadow - 0.01f);
-            pvr_set_shadow_scale(1, shadow);
+            pvr_set_shadow_scale(true, shadow);
         }
 
         if(state->buttons & CONT_START)
@@ -212,7 +212,7 @@ int main(int argc, char *argv[]) {
 
     /* Enable Cheap Shadow mode and set affected polygons to be at half of their
        normal intensity. */
-    pvr_set_shadow_scale(1, shadow);
+    pvr_set_shadow_scale(true, shadow);
 
     setup();
 

--- a/examples/dreamcast/pvr/modifier_volume_zclip/example.c
+++ b/examples/dreamcast/pvr/modifier_volume_zclip/example.c
@@ -252,7 +252,7 @@ int main(int argc, char* argv[])
     pvr_init(&params);
     pvr_set_bg_color(0, 0.5f, 1.0f);
     /* Enable cheap shadow */
-    pvr_set_shadow_scale(1, 0.5f);
+    pvr_set_shadow_scale(true, 0.5f);
 
     /* init plane */
     box_tex = pvr_mem_malloc(256 * 256 * 2);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
@@ -34,7 +34,7 @@
 /* Fill Tile Matrix buffers. This function takes a base address and sets up
    the rendering structures there. Each tile of the screen (32x32) receives
    a small buffer space. */
-static void pvr_init_tile_matrix(int which, int presort) {
+static void pvr_init_tile_matrix(int which, bool presort) {
     volatile pvr_ta_buffers_t   *buf;
     int     x, y, tn;
     uint32      *vr;  /* Note: We're working in 4-byte pointer maths in this function */
@@ -125,14 +125,14 @@ static void pvr_init_tile_matrix(int which, int presort) {
 }
 
 /* Fill all tile matrices */
-void pvr_init_tile_matrices(int presort) {
+void pvr_init_tile_matrices(bool presort) {
     int i;
 
     for(i = 0; i < 2; i++)
         pvr_init_tile_matrix(i, presort);
 }
 
-void pvr_set_presort_mode(int presort) {
+void pvr_set_presort_mode(bool presort) {
     pvr_init_tile_matrix(pvr_state.ta_target, presort);
 }
 
@@ -151,7 +151,7 @@ up and placed at 0x000000 and 0x400000.
 #define BUF_ALIGN_MASK (BUF_ALIGN - 1)
 #define APPLY_ALIGNMENT(addr) (((addr) + BUF_ALIGN_MASK) & ~BUF_ALIGN_MASK)
 
-void pvr_allocate_buffers(pvr_init_params_t *params) {
+void pvr_allocate_buffers(const pvr_init_params_t *params) {
     volatile pvr_ta_buffers_t   *buf;
     volatile pvr_frame_buffers_t    *fbuf;
     int i, j;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_fog.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_fog.c
@@ -158,7 +158,7 @@ union ieee32_t {
 /* A fast negative argument only exp function - That is it treats any
  * argument as a negative number
  */
-float neg_exp(float arg) {
+static float neg_exp(float arg) {
 
     float result, f;
     int k;
@@ -206,7 +206,7 @@ float neg_exp(float arg) {
      The special values for infinity and NaN are not dealt with at all.
 
  */
-uint32 float16(float f) {
+static uint32 float16(float f) {
     union ieee32_t float32;
     uint32 float16;
     uint32 sign, exponent, mantissa;
@@ -343,14 +343,14 @@ void pvr_fog_table_linear(float start, float end) {
  * 0th entry is farthest from eye. Last entry is nearest to eye.
  * The larger the value the heavier the fog.
  */
-void pvr_fog_table_custom(float tbl1[]) {
+void pvr_fog_table_custom(float *table) {
     uint32 idx, i;
     uint32 value, valh, vall;
 
-    valh = (uint32)(fog_alpha * 255.0f * CLAMP01(tbl1[0])) & 0xff;
+    valh = (uint32)(fog_alpha * 255.0f * CLAMP01(table[0])) & 0xff;
 
     for(idx = PVR_FOG_TABLE_BASE, i = 1; idx < TABLE_LEN; idx += 4, i++) {
-        vall = (uint32)(fog_alpha * 255.0f * CLAMP01(tbl1[i])) & 0xff;
+        vall = (uint32)(fog_alpha * 255.0f * CLAMP01(table[i])) & 0xff;
         value = (((valh) << 8 & 0xff00) + vall);
         PVR_SET(idx, value);
         valh = vall;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -25,7 +25,7 @@
    and translucent lists, and 0's for everything else; 512k of vertex
    buffer. This is equivalent to the old ta_init_defaults() for now. */
 int pvr_init_defaults(void) {
-    pvr_init_params_t params = {
+    const pvr_init_params_t params = {
         /* Enable opaque and translucent polygons with size 16 */
         { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0 },
 
@@ -52,7 +52,7 @@ int pvr_init_defaults(void) {
    and using the specified parameters; note that bins and vertex buffers
    come from the texture memory pool! Expects that a 2D mode was
    initialized already using the vid_* API. */
-int pvr_init(pvr_init_params_t *params) {
+int pvr_init(const pvr_init_params_t *params) {
     /* If we're already initialized, fail */
     if(pvr_state.valid == 1) {
         dbglog(DBG_WARNING, "pvr: pvr_init called twice!\n");

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -16,6 +16,7 @@
    code. If something is needed from this, an external interface should
    be added to dc/pvr.h. */
 
+#include <stdbool.h>
 #include <kos/mutex.h>
 
 /**** State stuff ***************************************************/
@@ -248,10 +249,10 @@ typedef struct pvr_bkg_poly {
 /**** pvr_buffers.c ***************************************************/
 
 /* Initialize buffers for TA/ISP/TSP usage */
-void pvr_allocate_buffers(pvr_init_params_t *params);
+void pvr_allocate_buffers(const pvr_init_params_t *params);
 
 /* Fill the tile matrices (after it's initialized) */
-void pvr_init_tile_matrices(int presort);
+void pvr_init_tile_matrices(bool presort);
 
 
 /**** pvr_misc.c ******************************************************/

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -171,19 +171,19 @@ void pvr_mem_print_list(void) {
 }
 
 /* Return the number of bytes available still in the memory pool */
-static uint32 pvr_mem_available_int(void) {
+static size_t pvr_mem_available_int(void) {
     struct mallinfo mi = pvr_int_mallinfo();
 
     /* This magic formula is modeled after mstats() */
     return mi.arena - mi.uordblks;
 }
 
-uint32 pvr_mem_available(void) {
+size_t pvr_mem_available(void) {
     if(!pvr_mem_base)
         return 0;
 
     return pvr_mem_available_int() + 
-        (PVR_RAM_INT_TOP - (uint32)pvr_mem_base);
+        (PVR_RAM_INT_TOP - (size_t)pvr_mem_base);
 }
 
 /* Reset the memory pool, equivalent to freeing all textures currently

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -35,10 +35,10 @@ void pvr_set_bg_color(float r, float g, float b) {
 }
 
 /* Enable/disable cheap shadow mode and set the cheap shadow scale register. */
-void pvr_set_shadow_scale(int enable, float scale_value) {
+void pvr_set_shadow_scale(bool enable, float scale_value) {
     int s = (int)(scale_value * 255);
 
-    PVR_SET(PVR_CHEAP_SHADOW, ((!!enable) << 8) | (s & 0xFF));
+    PVR_SET(PVR_CHEAP_SHADOW, (enable << 8) | (s & 0xFF));
 }
 
 /* Set the Z-Clip value (that is to say the depth of the background layer). */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -24,8 +24,8 @@
 
 */
 
-void * pvr_set_vertbuf(pvr_list_t list, void * buffer, int len) {
-    void * oldbuf;
+void *pvr_set_vertbuf(pvr_list_t list, void *buffer, size_t len) {
+    void *oldbuf;
 
     // Make sure we have global DMA usage enabled. The DMA can still
     // be used in other situations, but the user must take care of
@@ -58,8 +58,8 @@ void * pvr_set_vertbuf(pvr_list_t list, void * buffer, int len) {
     return oldbuf;
 }
 
-void * pvr_vertbuf_tail(pvr_list_t list) {
-    uint8 * bufbase;
+void *pvr_vertbuf_tail(pvr_list_t list) {
+    uint8 *bufbase;
 
     // Check the validity of the request.
     assert(list < PVR_OPB_COUNT);
@@ -73,7 +73,7 @@ void * pvr_vertbuf_tail(pvr_list_t list) {
     return bufbase + pvr_state.dma_buffers[pvr_state.ram_target].ptr[list];
 }
 
-void pvr_vertbuf_written(pvr_list_t list, uint32 amt) {
+void pvr_vertbuf_written(pvr_list_t list, size_t amt) {
     uint32 val;
 
     // Check the validity of the request.
@@ -235,7 +235,7 @@ int pvr_list_finish(void) {
     return 0;
 }
 
-int pvr_prim(void * data, int size) {
+int pvr_prim(const void *data, size_t size) {
     /* Check to make sure we can do this */
 #ifndef NDEBUG
     if(pvr_state.list_reg_open == -1) {
@@ -262,7 +262,7 @@ int pvr_prim(void * data, int size) {
     return 0;
 }
 
-int pvr_list_prim(pvr_list_t list, void * data, int size) {
+int pvr_list_prim(pvr_list_t list, const void *data, size_t size) {
     volatile pvr_dma_buffers_t * b;
 
     b = pvr_state.dma_buffers + pvr_state.ram_target;

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1493,12 +1493,12 @@ void pvr_set_bg_color(float r, float g, float b);
     their final color by the scale value set here when shadows are enabled and
     the polygon is inside the modifier (or outside for exclusion volumes).
 
-    \param  enable          Set to non-zero to enable cheap shadow mode.
+    \param  enable          Set to true to enable cheap shadow mode.
     \param  scale_value     Floating point value (between 0 and 1) representing
                             how colors of polygons affected by and inside the
                             volume will be modified by the shadow volume.
 */
-void pvr_set_shadow_scale(int enable, float scale_value);
+void pvr_set_shadow_scale(bool enable, float scale_value);
 
 /** \brief   Set Z clipping depth.
     \ingroup pvr_global

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1759,7 +1759,7 @@ void pvr_mem_free(pvr_ptr_t chunk);
 
     \return                 The number of bytes available
 */
-uint32_t pvr_mem_available(void);
+size_t pvr_mem_available(void);
 
 /** \brief   Reset the PVR RAM pool.
     \ingroup pvr_mem_mgmt

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1432,7 +1432,7 @@ typedef struct {
     \retval -1              If the PVR has already been initialized or the video
                             mode active is not suitable for 3D
 */
-int pvr_init(pvr_init_params_t *params);
+int pvr_init(const pvr_init_params_t *params);
 
 /** \brief   Simple PVR initialization.
     \ingroup pvr_init

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -2451,7 +2451,7 @@ typedef enum pvr_dma_type {
     \param  count           The number of bytes to copy. Must be a multiple of
                             32.
     \param  type            The type of DMA transfer to do (see list of modes).
-    \param  block           Non-zero if you want the function to block until the
+    \param  block           True if you want the function to block until the
                             DMA completes.
     \param  callback        A function to call upon completion of the DMA.
     \param  cbdata          Data to pass to the callback function.
@@ -2466,7 +2466,7 @@ typedef enum pvr_dma_type {
     \see    pvr_dma_type_t
 */
 int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count,
-                     pvr_dma_type_t type, int block,
+                     pvr_dma_type_t type, bool block,
                      pvr_dma_callback_t callback, void *cbdata);
 
 /** \brief   Load a texture using TA DMA.
@@ -2479,7 +2479,7 @@ int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count,
     \param  dest            Where to copy to. Must be 32-byte aligned.
     \param  count           The number of bytes to copy. Must be a multiple of
                             32.
-    \param  block           Non-zero if you want the function to block until the
+    \param  block           True if you want the function to block until the
                             DMA completes.
     \param  callback        A function to call upon completion of the DMA.
     \param  cbdata          Data to pass to the callback function.
@@ -2491,7 +2491,7 @@ int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count,
     \em     EFAULT - dest is not 32-byte aligned \n
     \em     EIO - I/O error
 */
-int pvr_txr_load_dma(void *src, pvr_ptr_t dest, size_t count, int block,
+int pvr_txr_load_dma(const void *src, pvr_ptr_t dest, size_t count, bool block,
                      pvr_dma_callback_t callback, void *cbdata);
 
 /** \brief   Load vertex data to the TA using TA DMA.
@@ -2503,7 +2503,7 @@ int pvr_txr_load_dma(void *src, pvr_ptr_t dest, size_t count, int block,
     \param  src             Where to copy from. Must be 32-byte aligned.
     \param  count           The number of bytes to copy. Must be a multiple of
                             32.
-    \param  block           Non-zero if you want the function to block until the
+    \param  block           True if you want the function to block until the
                             DMA completes.
     \param  callback        A function to call upon completion of the DMA.
     \param  cbdata          Data to pass to the callback function.
@@ -2515,7 +2515,7 @@ int pvr_txr_load_dma(void *src, pvr_ptr_t dest, size_t count, int block,
     \em     EFAULT - dest is not 32-byte aligned \n
     \em     EIO - I/O error
  */
-int pvr_dma_load_ta(void *src, size_t count, int block,
+int pvr_dma_load_ta(const void *src, size_t count, bool block,
                     pvr_dma_callback_t callback, void *cbdata);
 
 /** \brief   Load yuv data to the YUV converter using TA DMA.
@@ -2527,7 +2527,7 @@ int pvr_dma_load_ta(void *src, size_t count, int block,
     \param  src             Where to copy from. Must be 32-byte aligned.
     \param  count           The number of bytes to copy. Must be a multiple of
                             32.
-    \param  block           Non-zero if you want the function to block until the
+    \param  block           True if you want the function to block until the
                             DMA completes.
     \param  callback        A function to call upon completion of the DMA.
     \param  cbdata          Data to pass to the callback function.
@@ -2539,15 +2539,15 @@ int pvr_dma_load_ta(void *src, size_t count, int block,
     \em     EFAULT - dest is not 32-byte aligned \n
     \em     EIO - I/O error
 */
-int pvr_dma_yuv_conv(void *src, size_t count, int block,
+int pvr_dma_yuv_conv(const void *src, size_t count, bool block,
                      pvr_dma_callback_t callback, void *cbdata);
 
 /** \brief   Is PVR DMA is inactive?
     \ingroup pvr_dma
-    \return                 Non-zero if there is no PVR DMA active, thus a DMA
-                            can begin or 0 if there is an active DMA.
+    \return                 True if there is no PVR DMA active, thus a DMA
+                            can begin or false if there is an active DMA.
 */
-int pvr_dma_ready(void);
+bool pvr_dma_ready(void);
 
 /** \brief   Initialize TA/PVR DMA. 
     \ingroup pvr_dma

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1864,7 +1864,7 @@ int pvr_vertex_dma_enabled(void);
     
     \return                 The old buffer location (if any)
 */
-void *pvr_set_vertbuf(pvr_list_t list, void *buffer, int len);
+void *pvr_set_vertbuf(pvr_list_t list, void *buffer, size_t len);
 
 /** \brief   Retrieve a pointer to the current output location in the DMA buffer
              for the requested list.
@@ -1890,7 +1890,7 @@ void *pvr_vertbuf_tail(pvr_list_t list);
     \param  list            The primitive list that was modified.
     \param  amt             Number of bytes written. Must be a multiple of 32.
 */
-void pvr_vertbuf_written(pvr_list_t list, uint32_t amt);
+void pvr_vertbuf_written(pvr_list_t list, size_t amt);
 
 /** \brief   Set the translucent polygon sort mode for the next frame.
     \ingroup pvr_scene_mgmt
@@ -1994,7 +1994,7 @@ int pvr_list_finish(void);
     \retval 0               On success.
     \retval -1              On error.
 */
-int pvr_prim(void *data, int size);
+int pvr_prim(const void *data, size_t size);
 
 /** \defgroup pvr_direct  Direct Rendering
     \brief                API for using direct rendering with the PVR
@@ -2071,7 +2071,7 @@ void pvr_send_to_ta(void *data);
     \retval 0               On success.
     \retval -1              On error.
 */
-int pvr_list_prim(pvr_list_t list, void *data, int size);
+int pvr_list_prim(pvr_list_t list, const void *data, size_t size);
 
 /** \brief   Flush the buffered data of the given list type to the TA.
     \ingroup pvr_list_mgmt

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1711,9 +1711,9 @@ void pvr_fog_table_linear(float start, float end);
     have 129 entries, where the 0th entry is farthest from the eye and the last
     entry is nearest. Higher values = heavier fog.
 
-    \param  tbl1            The table of fog values to set
+    \param  table           The table of fog values to set
 */
-void pvr_fog_table_custom(float tbl1[]);
+void pvr_fog_table_custom(float *table);
 
 
 /* Memory management *************************************************/

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -40,6 +40,7 @@
 __BEGIN_DECLS
 
 #include <stdalign.h>
+#include <stdbool.h>
 
 #include <arch/memory.h>
 #include <arch/types.h>
@@ -1903,10 +1904,10 @@ void pvr_vertbuf_written(pvr_list_t list, uint32_t amt);
     function to change the mode that you should set it each frame to ensure that
     the mode is set properly.
 
-    \param  presort         Set to 1 to set the presort mode for translucent
-                            polygons, set to 0 to use autosort mode.
+    \param  presort         Set to true to set the presort mode for translucent
+                            polygons, set to false to use autosort mode.
 */
-void pvr_set_presort_mode(int presort);
+void pvr_set_presort_mode(bool presort);
 
 /** \brief   Begin collecting data for a frame of 3D output to the off-screen
              frame buffer.


### PR DESCRIPTION
This implements the changes noted in item 2 of #539 as a set of atomic changes for reviewability.

@gyrovorbis Whenever you can a review of this would be appreciated. Some of the key differences:
1) There were a few places where you changed something to bool in the function prototype but did not follow that through to the uses of the param like `dma_blocking` or the internal functions around tile matrix initialization.
2) In many places you had switched types to `size_t` which didn't seem appropriate, like texture dimensions or the vbl count. To my understanding the point is to measure memory usage/size of objects. I can kind of see how that *might* apply for texture dimensions (width is a size of pixels, height is a size of lines) but it doesn't seem to me to improve clarity, so I've left most of those out.