### PR TITLE
fs_vmu: Improve handling of VMU file headers

### DIFF
--- a/examples/dreamcast/vmu/vmu_pkg/vmu.c
+++ b/examples/dreamcast/vmu/vmu_pkg/vmu.c
@@ -98,8 +98,6 @@ void write_entry(void) {
     pkg.icon_data = vmu_icon;
     pkg.icon_anim_speed = 8;
     pkg.eyecatch_type = VMUPKG_EC_NONE;
-    pkg.data_len = 4096;
-    pkg.data = data;
 
     for(i = 0; i < 4096; i++)
         data[i] = i & 255;
@@ -115,7 +113,8 @@ void write_entry(void) {
         return;
     }
 
-    fs_write(f, pkg_out, pkg_size);
+    fs_write(f, data, sizeof(data));
+    fs_vmu_set_header(f, &pkg);
     fs_close(f);
 }
 

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -18,6 +18,7 @@
 #include <dc/vmufs.h>
 #include <dc/maple.h>
 #include <dc/maple/vmu.h>
+#include <dc/vmu_pkg.h>
 #include <sys/queue.h>
 
 /*
@@ -57,9 +58,11 @@ typedef struct vmu_fh_str {
     char path[17];                      /* full path of the file */
     char name[13];                      /* name of the file */
     off_t loc;                          /* current position in the file (bytes) */
+    off_t start;                        /* start of the data in the file (bytes) */
     maple_device_t *dev;                /* maple address of the vmu to use */
     uint32 filesize;                    /* file length from dirent (in 512-byte blks) */
     uint8 *data;                        /* copy of the whole file */
+    vmu_pkg_t *header;                  /* VMU file header */
 } vmu_fh_t;
 
 /* Directory handles */
@@ -81,6 +84,50 @@ TAILQ_HEAD(vmu_fh_list, vmu_fh_str) vmu_fh;
 /* Thread mutex for vmu_fh access */
 static mutex_t fh_mutex;
 
+static vmu_pkg_t *dft_header;
+
+static vmu_pkg_t * vmu_pkg_dup(const vmu_pkg_t *old_hdr) {
+    size_t ec_size, icon_size;
+    vmu_pkg_t *hdr;
+
+    hdr = malloc(sizeof(*hdr));
+    if(!hdr)
+        return NULL;
+
+    memcpy(hdr, old_hdr, sizeof(*hdr));
+
+    if(old_hdr->eyecatch_type && old_hdr->eyecatch_data) {
+        ec_size = (72 * 56 / 2) << (3 - old_hdr->eyecatch_type);
+
+        hdr->eyecatch_data = malloc(ec_size);
+        if(!hdr->eyecatch_data)
+            goto err_free_hdr;
+
+        memcpy(hdr->eyecatch_data, old_hdr->eyecatch_data, ec_size);
+    } else {
+        hdr->eyecatch_data = NULL;
+    }
+
+    if(old_hdr->icon_cnt) {
+        icon_size = 512 * old_hdr->icon_cnt;
+
+        hdr->icon_data = malloc(icon_size);
+        if(!hdr->icon_data)
+            goto err_free_ec_data;
+
+        memcpy(hdr->icon_data, old_hdr->icon_data, icon_size);
+    } else {
+        hdr->icon_data = NULL;
+    }
+
+    return hdr;
+
+err_free_ec_data:
+    free(hdr->eyecatch_data);
+err_free_hdr:
+    free(hdr);
+    return NULL;
+}
 
 /* Take a VMUFS path and return the requested address */
 static maple_device_t * vmu_path_to_addr(const char *p) {
@@ -182,6 +229,7 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
     int     realmode, rv;
     void        * data;
     int     datasize;
+    vmu_pkg_t vmu_pkg;
 
     /* Malloc a new fh struct */
     if(!(fd = malloc(sizeof(vmu_fh_t))))
@@ -193,7 +241,9 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
     strncpy(fd->path, path, 16);
     strncpy(fd->name, path + 4, 12);
     fd->loc = 0;
+    fd->start = 0;
     fd->dev = dev;
+    fd->header = NULL;
 
     /* What mode are we opening in? If we're reading or writing without O_TRUNC
        then we need to read the old file if there is one. */
@@ -228,6 +278,10 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
         }
         datasize = 512;
         memset(data, 0, 512);
+    } else if(!vmu_pkg_parse(data, datasize, &vmu_pkg)) {
+        fd->header = vmu_pkg_dup(&vmu_pkg);
+        fd->start = (unsigned int)vmu_pkg.data - (unsigned int)data;
+        fd->loc = fd->start;
     }
 
     fd->data = (uint8 *)data;
@@ -308,10 +362,28 @@ static int vmu_verify_hnd(void * hnd, int type) {
 
 /* write a file out before closing it: we aren't perfect on error handling here */
 static int vmu_write_close(void * hnd) {
-    vmu_fh_t    *fh;
+    vmu_fh_t    *fh = (vmu_fh_t*)hnd;
+    uint8_t     *data = fh->data + fh->start;
+    int         ret, data_len = fh->filesize * 512;
+    vmu_pkg_t   *hdr = fh->header ?: dft_header;
 
-    fh = (vmu_fh_t*)hnd;
-    return vmufs_write(fh->dev, fh->name, fh->data, fh->filesize * 512, VMUFS_OVERWRITE);
+    if(!hdr) {
+        dbglog(DBG_WARNING, "VMUFS: file written without header\n");
+    } else {
+        hdr->data_len = data_len;
+        hdr->data = data;
+
+        ret = vmu_pkg_build(hdr, &data, &data_len);
+        if(ret < 0)
+            return ret;
+    }
+
+    ret = vmufs_write(fh->dev, fh->name, data, data_len, VMUFS_OVERWRITE);
+
+    if(hdr)
+        free(data);
+
+    return ret;
 }
 
 /* close a file */
@@ -349,6 +421,11 @@ static int vmu_close(void * hnd) {
                 }
             }
 
+            if(fh->header) {
+                free(fh->header->eyecatch_data);
+                free(fh->header->icon_data);
+                free(fh->header);
+            }
             free(fh->data);
             break;
 
@@ -474,9 +551,10 @@ static off_t vmu_seek(void * hnd, off_t offset, int whence) {
     /* Update current position according to arguments */
     switch(whence) {
         case SEEK_SET:
+            offset += fh->start;
             break;
         case SEEK_CUR:
-            offset += fh->loc;
+            offset += fh->loc + fh->start;
             break;
         case SEEK_END:
             offset = fh->filesize * 512 - offset;
@@ -486,7 +564,7 @@ static off_t vmu_seek(void * hnd, off_t offset, int whence) {
     }
 
     /* Check bounds; allow seek past EOF. */
-    if(offset < 0) offset = 0;
+    if(offset < 0) offset = fh->start;
 
     fh->loc = offset;
 
@@ -499,7 +577,7 @@ static off_t vmu_tell(void * hnd) {
     if(!vmu_verify_hnd(hnd, VMU_FILE))
         return -1;
 
-    return ((vmu_fh_t *) hnd)->loc;
+    return ((vmu_fh_t *) hnd)->loc + ((vmu_fh_t *) hnd)->start;
 }
 
 /* return the filesize */
@@ -553,6 +631,45 @@ static dirent_t *vmu_readdir(void * fd) {
     dh->entry++;
 
     return &dh->dirent;
+}
+
+static int vmu_ioctl(void *fd, int cmd, va_list ap) {
+    vmu_fh_t *fh = (vmu_fh_t*)fd;
+    vmu_dh_t *dh = (vmu_dh_t*)fd;
+    vmu_pkg_t *old_hdr, *hdr = NULL;
+    const vmu_pkg_t *new_hdr;
+
+    if(!dh || (dh->strtype == VMU_DIR && !dh->rootdir)) {
+        errno = EBADF;
+        return -1;
+    }
+
+    switch(cmd) {
+    case IOCTL_VMU_SET_HDR:
+        new_hdr = va_arg(ap, const vmu_pkg_t *);
+        if(new_hdr) {
+            hdr = vmu_pkg_dup(new_hdr);
+            if(!hdr)
+                return -1;
+        }
+
+        if(fh->strtype == VMU_FILE) {
+            old_hdr = fh->header;
+            fh->header = hdr;
+        } else {
+            old_hdr = dft_header;
+            dft_header = hdr;
+        }
+
+        if(old_hdr) {
+            free(old_hdr->icon_data);
+            free(old_hdr->eyecatch_data);
+            free(old_hdr);
+        }
+        break;
+    }
+
+    return 0;
 }
 
 /* Delete a file */
@@ -718,7 +835,7 @@ static vfs_handler_t vh = {
     vmu_tell,
     vmu_total,
     vmu_readdir,
-    NULL,               /* ioctl */
+    vmu_ioctl,
     NULL,               /* rename/move */
     vmu_unlink,
     vmu_mmap,
@@ -774,6 +891,12 @@ int fs_vmu_shutdown(void) {
 
     mutex_unlock(&fh_mutex);
     mutex_destroy(&fh_mutex);
+
+    if(dft_header) {
+        free(dft_header->eyecatch_data);
+        free(dft_header->icon_data);
+        free(dft_header);
+    }
 
     return nmmgr_handler_remove(&vh.nmmgr);
 }

--- a/kernel/arch/dreamcast/include/dc/fs_vmu.h
+++ b/kernel/arch/dreamcast/include/dc/fs_vmu.h
@@ -34,6 +34,7 @@
 __BEGIN_DECLS
 
 #include <kos/fs.h>
+#include <dc/vmu_pkg.h>
 
 /** \defgroup vfs_vmu   VMU
     \brief              VFS driver for accessing Visual Memory Unit storage
@@ -46,7 +47,65 @@ __BEGIN_DECLS
 /* Initialization */
 int fs_vmu_init(void);
 int fs_vmu_shutdown(void);
+
+#define IOCTL_VMU_SET_HDR     0x564d5530 /* "VMU0" */
 /* \endcond */
+
+/** \brief  Set a header to an opened VMU file
+
+    This function can be used to set a specific header (which contains the
+    metadata, icons...) to an opened VMU file, replacing the one it previously
+    had (if any).
+
+    Note that the "pkg" pointer as well as the eyecatch/icon data pointers it
+    contain can be freed (if dynamically allocated) as soon as this function
+    return, as the filesystem code will keep an internal copy.
+
+    It is valid to pass NULL as the header pointer, in which case the header
+    for the file will be discarded.
+
+    \param fd               A file descriptor corresponding to the VMU file
+    \param pkg              The header to set to the VMU file
+    \retval 0               On success.
+    \retval -1              On error.
+*/
+static inline int fs_vmu_set_header(file_t fd, const vmu_pkg_t *pkg) {
+    return fs_ioctl(fd, IOCTL_VMU_SET_HDR, pkg);
+}
+
+/** \brief  Set a default header for newly created VMU files
+
+    This function will set a default header, that will be used for new files
+    which were not assignated their own header.
+
+    Note that files which already have a header, either because they were opened
+    read-write or because they were given one, will use their own header instead
+    of the default one.
+
+    Note that the "pkg" pointer as well as the eyecatch/icon data pointers it
+    contain can be freed (if dynamically allocated) as soon as this function
+    return, as the filesystem code will keep an internal copy.
+
+    It is valid to pass NULL as the header pointer, in which case the default
+    header will be discarded.
+
+    \param pkg              The header to set to the VMU file
+    \retval 0               On success.
+    \retval -1              On error.
+*/
+static inline int fs_vmu_set_default_header(const vmu_pkg_t *pkg) {
+    file_t fd;
+    int ret;
+
+    fd = fs_open("/vmu", O_RDONLY | O_DIR);
+    if(!fd)
+        return -1;
+
+    ret = fs_vmu_set_header(fd, pkg);
+    fs_close(fd);
+
+    return ret;
+}
 
 /** @} */
 

--- a/kernel/arch/dreamcast/include/dc/vmu_pkg.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_pkg.h
@@ -115,11 +115,12 @@ int vmu_pkg_build(vmu_pkg_t *src, uint8_t ** dst, int * dst_size);
     files read in.
 
     \param  data            The buffer to parse.
+    \param  data_size       The size of the buffer, in bytes.
     \param  pkg             Where to store the vmu_pkg_t.
     \retval -1              On invalid CRC in the data.
     \retval 0               On success.
 */
-int vmu_pkg_parse(uint8_t *data, vmu_pkg_t *pkg);
+int vmu_pkg_parse(uint8_t *data, size_t data_size, vmu_pkg_t *pkg);
 
 /** \brief   Load a .ico file to use as a VMU file's icon.
     \ingroup vmu_package

--- a/kernel/arch/dreamcast/include/dc/vmu_pkg.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_pkg.h
@@ -53,7 +53,7 @@ typedef struct vmu_pkg {
     int             data_len;           /**< \brief Number of data (payload) bytes */
     uint16_t        icon_pal[16];       /**< \brief Icon palette (ARGB4444) */
     uint8_t         *icon_data;         /**< \brief 512*n bytes of icon data */
-    const uint8_t   *eyecatch_data;     /**< \brief Eyecatch data */
+    uint8_t         *eyecatch_data;     /**< \brief Eyecatch data */
     const uint8_t   *data;              /**< \brief Payload data */
 } vmu_pkg_t;
 

--- a/kernel/arch/dreamcast/util/vmu_pkg.c
+++ b/kernel/arch/dreamcast/util/vmu_pkg.c
@@ -151,7 +151,7 @@ int vmu_pkg_build(vmu_pkg_t *src, uint8_t **dst, int *dst_size) {
 
 /* Parse an array of uint8_t's (i.e. a VMU data file) into a
  * vmu_pkg_t package structure. */
-int vmu_pkg_parse(uint8_t *data, vmu_pkg_t *pkg) {
+int vmu_pkg_parse(uint8_t *data, size_t data_size, vmu_pkg_t *pkg) {
     uint16_t crc, crc_save;
     int ec_size, hdr_size, total_size, icon_size;
     vmu_hdr_t *hdr;
@@ -164,6 +164,11 @@ int vmu_pkg_parse(uint8_t *data, vmu_pkg_t *pkg) {
     ec_size = vmu_eyecatch_size(hdr->eyecatch_type);
     hdr_size = sizeof(vmu_hdr_t) + icon_size + ec_size;
     total_size = hdr->data_len + hdr_size;
+
+    if(total_size < 0 || (size_t)total_size > data_size) {
+        dbglog(DBG_ERROR, "vmu_pkg_parse: file header is corrupted, or no header?\n");
+        return -1;
+    }
 
     /* Verify the CRC.  Note: this writes a zero byte into data[].
      * The byte is later restored in case data is an mmapped pointer to a


### PR DESCRIPTION
- Add function fs_vmu_set_header().
  This function can be used to set a specific header (which contains the
  metadata, icons...) to an opened VMU file, replacing the one it previously
  had (if any).

- Add function fs_vmu_set_default_header().
  This function will set a default header, that will be used for new files
  which were not assignated their own header.

The header is now skipped when opening a VMU file (that has a header),
which is a breaking change from the previous behaviour of KallistiOS. It
is however kept internally, which means that a file opened read-write
will reuse its header (unless overwritten by fs_vmu_set_header()).

The point of this change is to hide the header from the application
completely, which can now read/write the VMU files with a proper header
as if they were PC files. It is then much easier for PC ports to
read/write savestates that look good.

A VMU file can still be opened as raw by specifying the O_META flag in the fs_open() call.