### PR TITLE
Spinlock cleanups

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -35,16 +35,10 @@ printf goes to the dc-tool console
 static spinlock_t mutex = SPINLOCK_INITIALIZER;
 
 #define plain_dclsc(...) ({ \
-        int old = 0, rv; \
-        if(!irq_inside_int()) { \
-            old = irq_disable(); \
-        } \
+        irq_disable_scoped(); \
         while(FIFO_STATUS & FIFO_SH4) \
             ; \
-        rv = dcloadsyscall(__VA_ARGS__); \
-        if(!irq_inside_int()) \
-            irq_restore(old); \
-        rv; \
+        dcloadsyscall(__VA_ARGS__); \
     })
 
 // #define plain_dclsc(...) dcloadsyscall(__VA_ARGS__)

--- a/kernel/arch/dreamcast/include/arch/spinlock.h
+++ b/kernel/arch/dreamcast/include/arch/spinlock.h
@@ -30,6 +30,8 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
+#include <stdbool.h>
+
 /* DC implementation uses threads most of the time */
 #include <kos/thread.h>
 
@@ -45,80 +47,74 @@ typedef volatile int spinlock_t;
 
 /** \brief  Initialize a spinlock.
 
-    This function-like macro abstracts initializing a spinlock, in case the
+    This function abstracts initializing a spinlock, in case the
     initializer is not applicable to what you are doing.
 
-    \param  A               A pointer to the spinlock to be initialized.
+    \param  lock            A pointer to the spinlock to be initialized.
 */
-#define spinlock_init(A) *(A) = SPINLOCK_INITIALIZER
+static inline void spinlock_init(spinlock_t *lock) {
+    *lock = SPINLOCK_INITIALIZER;
+}
 
 /* Note here that even if threads aren't enabled, we'll still set the
    lock so that it can be used for anti-IRQ protection (e.g., malloc) */
 
-/** \brief  Spin on a lock.
-
-    This macro will spin on the lock, and will not return until the lock has
-    been obtained for the calling thread.
-
-    \param  A               A pointer to the spinlock to be locked.
-*/
-#define spinlock_lock(A) do { \
-        spinlock_t * __lock = A; \
-        int __gotlock = 0; \
-        while(1) { \
-            __asm__ __volatile__("tas.b @%1\n\t" \
-                                 "movt %0\n\t" \
-                                 : "=r" (__gotlock) \
-                                 : "r" (__lock) \
-                                 : "t", "memory"); \
-            if(!__gotlock) \
-                thd_pass(); \
-            else break; \
-        } \
-    } while(0)
-
 /** \brief  Try to lock, without spinning.
 
-    This macro will attempt to lock the lock, but will not spin. Instead, it
+    This function will attempt to lock the lock, but will not spin. Instead, it
     will return whether the lock was obtained or not.
 
-    \param  A               A pointer to the spinlock to be locked.
-    \return                 0 if the lock is held by another thread. Non-zero if
+    \param  lock            A pointer to the spinlock to be locked.
+    \return                 False if the lock is held by another thread. True if
                             the lock was successfully obtained.
 */
-#define spinlock_trylock(A) ({ \
-        int __gotlock = 0; \
-        do { \
-            spinlock_t *__lock = A; \
-            __asm__ __volatile__("tas.b @%1\n\t" \
-                                 "movt %0\n\t" \
-                                 : "=r" (__gotlock) \
-                                 : "r" (__lock) \
-                                 : "t", "memory"); \
-        } while(0); \
-        __gotlock; \
-    })
+static inline bool spinlock_trylock(spinlock_t *lock) {
+    bool locked = false;
+
+    __asm__ __volatile__("tas.b @%1\n\t"
+                         "movt %0\n\t"
+                         : "=r"(locked)
+                         : "r"(lock)
+                         : "t", "memory");
+
+    return locked;
+}
+
+/** \brief  Spin on a lock.
+
+    This function will spin on the lock, and will not return until the lock has
+    been obtained for the calling thread.
+
+    \param  lock            A pointer to the spinlock to be locked.
+*/
+static inline void spinlock_lock(spinlock_t *lock) {
+    while(!spinlock_trylock(lock))
+        thd_pass();
+}
 
 /** \brief  Free a lock.
 
-    This macro will unlock the lock that is currently held by the calling
-    thread. Do not use this macro unless you actually hold the lock!
+    This function will unlock the lock that is currently held by the calling
+    thread. Do not use this function unless you actually hold the lock!
 
-    \param  A               A pointer to the spinlock to be unlocked.
+    \param  lock            A pointer to the spinlock to be unlocked.
 */
-#define spinlock_unlock(A) do { \
-        *(A) = 0; \
-    } while(0)
+static inline void spinlock_unlock(spinlock_t *lock) {
+    *lock = 0;
+}
 
 /** \brief  Determine if a lock is locked.
 
-    This macro will return whether or not the lock specified is actually locked
+    This function will return whether or not the lock specified is actually locked
     when it is called. This is NOT a thread-safe way of determining if a lock
     will be locked when you get around to locking it!
 
-    \param  A               A pointer to the spinlock to be checked.
+    \param  lock            A pointer to the spinlock to be checked.
+    \return                 True if the spinlock is locked, false otherwise.
 */
-#define spinlock_is_locked(A) ( *(A) != 0 )
+static inline bool spinlock_is_locked(spinlock_t *lock) {
+    return *lock != 0;
+}
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/include/arch/spinlock.h
+++ b/kernel/arch/dreamcast/include/arch/spinlock.h
@@ -92,6 +92,23 @@ static inline void spinlock_lock(spinlock_t *lock) {
         thd_pass();
 }
 
+/** \brief  Spin on a lock.
+
+    This function will spin on the lock, and will not return until the lock has
+    been obtained for the calling thread, unless it is called from within an
+    interrupt context.
+
+    \param  lock            A pointer to the spinlock to be locked.
+    \return                 True if the spinlock could be locked, false otherwise.
+*/
+static inline bool spinlock_lock_irqsafe(spinlock_t *lock) {
+    if(irq_inside_int())
+        return spinlock_trylock(lock);
+
+    spinlock_lock(lock);
+    return true;
+}
+
 /** \brief  Free a lock.
 
     This function will unlock the lock that is currently held by the calling

--- a/kernel/arch/dreamcast/include/arch/spinlock.h
+++ b/kernel/arch/dreamcast/include/arch/spinlock.h
@@ -71,11 +71,11 @@ static inline void spinlock_init(spinlock_t *lock) {
 static inline bool spinlock_trylock(spinlock_t *lock) {
     bool locked = false;
 
-    __asm__ __volatile__("tas.b @%1\n\t"
+    __asm__ __volatile__("tas.b @%2\n\t"
                          "movt %0\n\t"
-                         : "=r"(locked)
+                         : "=r"(locked), "=m"(*lock)
                          : "r"(lock)
-                         : "t", "memory");
+                         : "t");
 
     return locked;
 }

--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -136,11 +136,8 @@ void __atomic_load(size_t size,
 
     (void)memorder;
 
-    spinlock_lock(&locks[lock]);
-
+    spinlock_lock_scoped(&locks[lock]);
     memcpy(ret, (const void *)ptr, size);
-
-    spinlock_unlock(&locks[lock]);
 }
 
 void __atomic_store(size_t size,
@@ -151,11 +148,8 @@ void __atomic_store(size_t size,
 
     (void)memorder;
 
-    spinlock_lock(&locks[lock]);
-
+    spinlock_lock_scoped(&locks[lock]);
     memcpy((void *)ptr, val, size);
-
-    spinlock_unlock(&locks[lock]);
 }
 
 void __atomic_exchange(size_t size,
@@ -167,12 +161,9 @@ void __atomic_exchange(size_t size,
 
     (void)memorder;
 
-    spinlock_lock(&locks[lock]);
-
+    spinlock_lock_scoped(&locks[lock]);
     memcpy(ret, (const void *)ptr, size);
     memcpy((void *)ptr, val, size);
-
-    spinlock_unlock(&locks[lock]);
 }
 
 bool __atomic_compare_exchange(size_t size,
@@ -181,26 +172,21 @@ bool __atomic_compare_exchange(size_t size,
                                void* desired,
                                int success_memorder,
                                int fail_memorder) {
-    bool retval;
     const uintptr_t lock = address_to_spinlock(ptr);
 
     (void)success_memorder;
     (void)fail_memorder;
 
-    spinlock_lock(&locks[lock]);
+    spinlock_lock_scoped(&locks[lock]);
 
     if(memcmp((const void *)ptr, expected, size) == 0) {
         memcpy((void *)ptr, desired, size);
-        retval = true;
+        return true;
     }
     else {
         memcpy(expected, (const void *)ptr, size);
-        retval = false;
+        return false;
     }
-
-    spinlock_unlock(&locks[lock]);
-
-    return retval;
 }
 
 /* All atomics for builtin types are lock-free, while our

--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -4,9 +4,9 @@
    Copyright (C) 2023 Falco Girgis
 */
 
-/* This file provides the additional symbols required to provide 
-   support for C11 atomics with the "-matomic-model=soft-imask" 
-   build flag. 
+/* This file provides the additional symbols required to provide
+   support for C11 atomics with the "-matomic-model=soft-imask"
+   build flag.
 */
 
 #include <arch/arch.h>
@@ -17,8 +17,8 @@
 #include <stdbool.h>
 #include <string.h>
 
-/* Create a set of macros to codegen atomic symbols for primitive types. 
-   For these types, we simply disable interrupts then re-enable them 
+/* Create a set of macros to codegen atomic symbols for primitive types.
+   For these types, we simply disable interrupts then re-enable them
    around accesses to our atomics to ensure their atomicity.
 */
 #define ATOMIC_LOAD_N_(type, n) \
@@ -39,7 +39,7 @@
         *(type *)ptr = val; \
         irq_restore(irq); \
     }
-    
+
 #define ATOMIC_EXCHANGE_N_(type, n) \
     type \
     __atomic_exchange_##n(volatile void* ptr, type val, int model) { \
@@ -113,15 +113,15 @@ ATOMIC_FETCH_N_(unsigned long long, 8, or, |=)
 ATOMIC_FETCH_N_(unsigned long long, 8, xor, ^=)
 ATOMIC_FETCH_NAND_N_(unsigned long long, 8)
 
-/* Provide GCC with symbols and logic required to implement 
-   generically sized atomics. Rather than disabling an enabling 
-   interrupts around primitive assignments, we use spinlocks 
+/* Provide GCC with symbols and logic required to implement
+   generically sized atomics. Rather than disabling an enabling
+   interrupts around primitive assignments, we use spinlocks
    around memcpy() calls. */
 
 /* Size of each memory region covered by an individual lock. */
 #define GENERIC_LOCK_BLOCK_SIZE     (CPU_CACHE_BLOCK_SIZE * 4)
 
-/* Locks have to be shared for each page with the MMU enabled, 
+/* Locks have to be shared for each page with the MMU enabled,
    otherwise we can fail when aliasing an address range to multiple
    pages. */
 #define GENERIC_LOCK_COUNT          (PAGESIZE / GENERIC_LOCK_BLOCK_SIZE)
@@ -132,38 +132,38 @@ static spinlock_t locks[GENERIC_LOCK_COUNT] = {
 };
 
 /* Our hash function which maps an address to its corresponding lock index. */
-inline static uintptr_t 
+inline static uintptr_t
 address_to_spinlock(const volatile void *ptr) {
     return ((uintptr_t)ptr / GENERIC_LOCK_BLOCK_SIZE) % GENERIC_LOCK_COUNT;
 }
 
-void __atomic_load(size_t size, 
-                   const volatile void *ptr, 
-                   void *ret, 
+void __atomic_load(size_t size,
+                   const volatile void *ptr,
+                   void *ret,
                    int memorder) {
     const uintptr_t lock = address_to_spinlock(ptr);
 
     (void)memorder;
 
     spinlock_lock(&locks[lock]);
-    
+
     memcpy(ret, (const void *)ptr, size);
-    
+
     spinlock_unlock(&locks[lock]);
 }
 
-void __atomic_store(size_t size, 
-                    volatile void *ptr, 
-                    void *val, 
+void __atomic_store(size_t size,
+                    volatile void *ptr,
+                    void *val,
                     int memorder) {
     const uintptr_t lock = address_to_spinlock(ptr);
 
     (void)memorder;
-    
+
     spinlock_lock(&locks[lock]);
-    
+
     memcpy((void *)ptr, val, size);
-    
+
     spinlock_unlock(&locks[lock]);
 }
 
@@ -177,11 +177,11 @@ void __atomic_exchange(size_t size,
     (void)memorder;
 
     spinlock_lock(&locks[lock]);
-    
+
     memcpy(ret, (const void *)ptr, size);
     memcpy((void *)ptr, val, size);
-    
-    spinlock_unlock(&locks[lock]);                       
+
+    spinlock_unlock(&locks[lock]);
 }
 
 bool __atomic_compare_exchange(size_t size,
@@ -195,9 +195,9 @@ bool __atomic_compare_exchange(size_t size,
 
     (void)success_memorder;
     (void)fail_memorder;
-    
+
     spinlock_lock(&locks[lock]);
-    
+
     if(memcmp((const void *)ptr, expected, size) == 0) {
         memcpy((void *)ptr, desired, size);
         retval = true;
@@ -206,8 +206,8 @@ bool __atomic_compare_exchange(size_t size,
         memcpy(expected, (const void *)ptr, size);
         retval = false;
     }
-    
-    spinlock_unlock(&locks[lock]); 
+
+    spinlock_unlock(&locks[lock]);
 
     return retval;
 }

--- a/kernel/mm/malloc_debug.c
+++ b/kernel/mm/malloc_debug.c
@@ -63,7 +63,7 @@ void *malloc(size_t amt) {
     uint32 pr = arch_get_ret_addr();
     int i;
 
-    spinlock_lock(&mutex);
+    spinlock_lock_scoped(&mutex);
 
     /* Get a control block space */
     ctl = sbrk(1024);
@@ -107,8 +107,6 @@ void *malloc(size_t amt) {
     ctl->next = NULL;
     ctl->type = "malloc";
     last = ctl;
-
-    spinlock_unlock(&mutex);
 
     printf("Thread %d/%08lx allocated %ld bytes at %08lx; %08lx left\n",
            ctl->thread, ctl->addr, ctl->size, space, _arch_mem_top - (uint32)sbrk(0));
@@ -176,7 +174,7 @@ void free(void *block) {
     uint32 *nt1, *nt2, pr = arch_get_ret_addr();
     int i;
 
-    spinlock_lock(&mutex);
+    spinlock_lock_scoped(&mutex);
 
     printf("Thread %d/%08lx freeing block @ %08lx\n",
            thd_current->tid, pr, (uint32)block);
@@ -221,7 +219,6 @@ void free(void *block) {
     }
 
     ctl->inuse = 0;
-    spinlock_unlock(&mutex);
 }
 
 void malloc_stats(void) {


### PR DESCRIPTION
This PR adds `spinlock_lock_scoped()`, which works similarly to `irq_disable_scoped()` or `mutex_lock_scoped()`.
It also adds `spinlock_lock_irqsafe()` which works similarly to `mutex_lock_irqsafe()`.

The PR also updates some of the caller code that can benefit from using the new functions.