### PR TITLE
Convert some macros to inline functions and improve inline ASM

### DIFF
--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -370,10 +370,7 @@ static inline void arch_sleep(void) {
 static inline uintptr_t arch_get_ret_addr(void) {
     uintptr_t pr;
 
-    __asm__ __volatile__("sts pr,%0\n"
-                         : "=&z"(pr)
-                         : /* no inputs */ \
-                         : "memory" ); \
+    __asm__ __volatile__("sts pr,%0\n" : "=r"(pr));
 
     return pr;
 }
@@ -390,12 +387,7 @@ static inline uintptr_t arch_get_ret_addr(void) {
     \note                   This only works if you don't disable frame pointers.
 */
 static inline uintptr_t arch_get_fptr(void) {
-    uintptr_t fp;
-
-    __asm__ __volatile__("mov	r14,%0\n"
-                         : "=&z" (fp)
-                         : /* no inputs */
-                         : "memory" );
+    register uintptr_t fp asm("r14");
 
     return fp;
 }

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -157,14 +157,22 @@ static __always_inline void dcache_pref_block(const void *src) {
 
     This function allocate a block of the data/operand cache.
 
-    \param  src             The physical address to allocate.
+    \param  src             The address to allocate (32-byte aligned)
     \param  value           The value written to first 4-byte.
 */
-static __always_inline void dcache_alloc_block(const void *src, uint32_t value) {
-    __asm__ __volatile__ ("movca.l r0, @%0\n\t"
-                         :
-                         : "r" (src), "z" (value)
-                         : "memory"
+static __always_inline void dcache_alloc_block(void *src, uint32_t value) {
+    uint32_t *src32 = (uint32_t *)src;
+
+    __asm__ ("movca.l r0, @%8\n\t"
+             : "=m"(src32[0]),
+               "=m"(src32[1]),
+               "=m"(src32[2]),
+               "=m"(src32[3]),
+               "=m"(src32[4]),
+               "=m"(src32[5]),
+               "=m"(src32[6]),
+               "=m"(src32[7])
+             : "r" (src32), "z" (value)
     );
 }
 

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -139,9 +139,9 @@ void dcache_purge_all_with_buffer(uintptr_t start, size_t count);
 */
 static __always_inline void dcache_pref_block(const void *src) {
     __asm__ __volatile__("pref @%0\n"
-                         :
+                         : /* No outputs */
                          : "r" (src)
-                         : "memory"
+                         : /* No clobbers */
     );
 }
 


### PR DESCRIPTION
This PR updates arch.h to use inline functions instead of macros, and improves the inline ASM of several functions.