### PR TITLE
pvr: Do not check DMA completion in pvr_sq functions

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
@@ -200,12 +200,6 @@ void pvr_dma_shutdown(void) {
 void *pvr_sq_load(void *dest, const void *src, size_t n, pvr_dma_type_t type) {
     void *dma_area_ptr;
 
-    if(pvr_dma[PVR_DST] != 0) {
-        dbglog(DBG_ERROR, "pvr_sq_load: PVR DMA has not finished\n");
-        errno = EINPROGRESS;
-        return NULL;
-    }
-
     dma_area_ptr = (void *)pvr_dest_addr((uintptr_t)dest, type);
     sq_cpy(dma_area_ptr, src, n);
 
@@ -216,12 +210,6 @@ void *pvr_sq_load(void *dest, const void *src, size_t n, pvr_dma_type_t type) {
 void *pvr_sq_set16(void *dest, uint32_t c, size_t n, pvr_dma_type_t type) {
     void *dma_area_ptr;
 
-    if(pvr_dma[PVR_DST] != 0) {
-        dbglog(DBG_ERROR, "pvr_sq_set16: PVR DMA has not finished\n");
-        errno = EINPROGRESS;
-        return NULL;
-    }
-
     dma_area_ptr = (void *)pvr_dest_addr((uintptr_t)dest, type);
     sq_set16(dma_area_ptr, c, n);
 
@@ -231,12 +219,6 @@ void *pvr_sq_set16(void *dest, uint32_t c, size_t n, pvr_dma_type_t type) {
 /* Fills n bytes at PVR dest with 32-bit c, dest must be 32-byte aligned */
 void *pvr_sq_set32(void *dest, uint32_t c, size_t n, pvr_dma_type_t type) {
     void *dma_area_ptr;
-
-    if(pvr_dma[PVR_DST] != 0) {
-        dbglog(DBG_ERROR, "pvr_sq_set32: PVR DMA has not finished\n");
-        errno = EINPROGRESS;
-        return NULL;
-    }
 
     dma_area_ptr = (void *)pvr_dest_addr((uintptr_t)dest, type);
     sq_set32(dma_area_ptr, c, n);


### PR DESCRIPTION
The only reason why you would want to wait for any pending DMA transfer to complete before using the SQs is when the DMA transfer targets the TA, in which case a SQ transfer to the TA would be asking for trouble.

However, the PVR scene code is already making sure that the TA is ready before a new list can be opened; this means that it is guaranteed that lists configured for DMA will be done transferring before anything is transferred to the TA via SQs.

Therefore, with the current driver code, there is no point in waiting for DMA completion.

With that said, the code actually did not wait for DMA completion, but was doing something much worse: in the case where a DMA transfer was in progress, it would simply display an error, and return without processing the SQ transfer. This caused heavy errors, including crashes, for instance when a list's "EOL marker" could not be added.

Address this issue by simply not checking for the DMA completion in the pvr_sq functions.

Fixes #878.