### PR TITLE
IRQ Cleanup Part 3

### DIFF
--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -417,6 +417,16 @@ void irq_force_return(void);
 */
 typedef void (*irq_handler)(irq_t code, irq_context_t *context, void *data);
 
+
+/** The type of a full callback of an IRQ handler and userdata.
+
+    This type is used to set or get IRQ handlers and their data.
+*/
+typedef struct irq_cb {
+    irq_handler hdl;    /**< A pointer to a procedure to handle an exception. */
+    void       *data;   /**< A pointer that will be passed along to the callback. */
+} irq_cb_t;
+
 /** \defgroup irq_handlers_ind  Individual
     \brief                      API for managing individual IRQ handlers.
 
@@ -444,12 +454,13 @@ int irq_set_handler(irq_t code, irq_handler hnd, void *data);
 /** Get the address of the current handler for the IRQ type.
 
     \param  code            The IRQ type to look up.
-    
-    \return                 A pointer to the procedure to handle the exception.
+
+    \return                 The current handler for the IRQ type and
+                            its userdata.
 
     \sa irq_set_handler()
 */
-irq_handler irq_get_handler(irq_t code);
+irq_cb_t irq_get_handler(irq_t code);
 
 /** @} */
 
@@ -476,10 +487,10 @@ int irq_set_global_handler(irq_handler handler, void *data);
 
 /** Get the global exception handler.
 
-    \return                 The global exception handler set with
+    \return                 The global exception handler and userdata set with
                             irq_set_global_handler(), or NULL if none is set.
 */
-irq_handler irq_get_global_handler(void);
+irq_cb_t irq_get_global_handler(void);
 /** @} */
 
 /** @} */

--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -309,6 +309,20 @@ int irq_inside_int(void);
 
 /** Type representing an interrupt mask state. */
 typedef uint32_t irq_mask_t;
+
+/** Get status register contents.
+
+    Returns the current value of the status register, as irq_disable() does.
+    The function can be found in arch\dreamcast\kernel\entry.s
+
+    \note
+    This is the entire status register word, not just the `IMASK` field.
+
+    \retval                 Status register word
+    \sa irq_disable()
+*/
+irq_mask_t irq_get_sr(void);
+
 /** Disable interrupts.
 
     This function will disable interrupts, but will leave exceptions enabled.

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -30,12 +30,6 @@
 /* Interrupt priority registers */
 #define REG_IPR(x) ( *((volatile uint16_t *)(0xffd00004 + (x) * 4)) )
 
-/* IRQ handler closure */
-struct irq_cb {
-    irq_handler hdl;
-    void       *data;
-};
-
 /* TRAPA handler closure */
 struct trapa_cb {
     trapa_handler hdl;
@@ -43,13 +37,13 @@ struct trapa_cb {
 };
 
 /* Individual exception handlers */
-static struct irq_cb   irq_handlers[0x40];
+static irq_cb_t        irq_handlers[0x40];
 /* TRAPA exception handlers */
 static struct trapa_cb trapa_handlers[0x100];
 
 /* Global exception handler -- hook this if you want to get each and every
    exception; you might get more than you bargained for, but it can be useful. */
-static struct irq_cb   global_irq_handler;
+static irq_cb_t        global_irq_handler;
 
 /* Default IRQ context location */
 static irq_context_t   irq_context_default;
@@ -73,14 +67,14 @@ int irq_set_handler(irq_t code, irq_handler hnd, void *data) {
 }
 
 /* Get the address of the current handler */
-irq_handler irq_get_handler(irq_t code) {
+irq_cb_t irq_get_handler(irq_t code) {
     /* Make sure they don't do something crackheaded */
     if(code >= 0x1000 || (code & 0x000f))
         return NULL;
 
     code >>= 5;
 
-    return irq_handlers[code].hdl;
+    return irq_handlers[code];
 }
 
 /* Set a global handler */
@@ -91,8 +85,8 @@ int irq_set_global_handler(irq_handler hnd, void *data) {
 }
 
 /* Get the global exception handler */
-irq_handler irq_get_global_handler(void) {
-    return global_irq_handler.hdl;
+irq_cb_t irq_get_global_handler(void) {
+    return global_irq_handler;
 }
 
 /* Set or remove a trapa handler */


### PR DESCRIPTION
After more of the back and forth with #618 , I found that I could separate out a few more bits of the updates from the larger functional updates. Included here are:
* Some updates to comments and cleanup.
* Swapping to use alignas rather than __attribute
* Updating the handler getters to allow getting the *data
* Adding a prototype in irq.h for irq_get_sr defined in entry.s
* Removing the forced timer clearing within the top level handler