### PR TITLE
irq: Shrink IRQ table size

### DIFF
--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -251,8 +251,8 @@ typedef enum irq_exception {
     EXC_SCIF_RXI           = 0x0720, /**< `[POST  ]` SCIF Receive ready */
     EXC_SCIF_BRI           = 0x0740, /**< `[POST  ]` SCIF break */
     EXC_SCIF_TXI           = 0x0760, /**< `[POST  ]` SCIF Transmit ready */
-    EXC_DOUBLE_FAULT       = 0x0ff0, /**< `[SOFT  ]` Exception happened in an ISR */
-    EXC_UNHANDLED_EXC      = 0x0fe0  /**< `[SOFT  ]` Exception went unhandled */
+    EXC_DOUBLE_FAULT       = 0x0780, /**< `[SOFT  ]` Exception happened in an ISR */
+    EXC_UNHANDLED_EXC      = 0x07e0  /**< `[SOFT  ]` Exception went unhandled */
 } irq_t;
 
 

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -39,7 +39,7 @@ struct trapa_cb {
 };
 
 /* Individual exception handlers */
-static struct irq_cb   irq_handlers[0x100];
+static struct irq_cb   irq_handlers[0x40];
 /* TRAPA exception handlers */
 static struct trapa_cb trapa_handlers[0x100];
 
@@ -62,7 +62,7 @@ int irq_set_handler(irq_t code, irq_handler hnd, void *data) {
     if(code >= 0x1000 || (code & 0x000f))
         return -1;
 
-    code >>= 4;
+    code >>= 5;
     irq_handlers[code] = (struct irq_cb){ hnd, data };
 
     return 0;
@@ -74,7 +74,7 @@ irq_handler irq_get_handler(irq_t code) {
     if(code >= 0x1000 || (code & 0x000f))
         return NULL;
 
-    code >>= 4;
+    code >>= 5;
 
     return irq_handlers[code].hdl;
 }
@@ -226,7 +226,7 @@ void irq_handle_exception(int code) {
     }
 
     if(inside_int) {
-        hnd = &irq_handlers[EXC_DOUBLE_FAULT >> 4];
+        hnd = &irq_handlers[EXC_DOUBLE_FAULT >> 5];
         if(hnd->hdl != NULL)
             hnd->hdl(EXC_DOUBLE_FAULT, irq_srt_addr, hnd->data);
         else
@@ -266,7 +266,7 @@ void irq_handle_exception(int code) {
 
     /* If there's a handler, call it */
     {
-        hnd = &irq_handlers[evt >> 4];
+        hnd = &irq_handlers[evt >> 5];
         if(hnd->hdl != NULL) {
             hnd->hdl(evt, irq_srt_addr, hnd->data);
             handled = 1;
@@ -274,7 +274,7 @@ void irq_handle_exception(int code) {
     }
 
     if(!handled) {
-        hnd = &irq_handlers[EXC_UNHANDLED_EXC >> 4];
+        hnd = &irq_handlers[EXC_UNHANDLED_EXC >> 5];
         if(hnd->hdl != NULL)
             hnd->hdl(evt, irq_srt_addr, hnd->data);
         else


### PR DESCRIPTION
All exception codes were divisible by 32, except for the two soft exceptions. Since they do not represent any hardware value, modify these code so that they are also divisible by 32, and make them smaller than 0x800.

This means that all exception codes can now be represented in just 6 bits, and the IRQ table can be reduced from 0x100 entries to just 0x40 entries.

This saves 1.5 KiB, but more importantly, the table now fits in just 16 cache lines instead of 64 cache lines.