### PR TITLE
Add looping support to snd_sfxmgr

### DIFF
--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -116,10 +116,9 @@ snd_sfx_load
 snd_sfx_load_ex
 snd_sfx_load_fd
 snd_sfx_play
-snd_sfx_play_lp
 snd_sfx_stop_all
 snd_sfx_play_chn
-snd_sfx_play_chn_lp
+snd_sfx_play_ex
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -116,8 +116,10 @@ snd_sfx_load
 snd_sfx_load_ex
 snd_sfx_load_fd
 snd_sfx_play
+snd_sfx_play_lp
 snd_sfx_stop_all
 snd_sfx_play_chn
+snd_sfx_play_chn_lp
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -172,8 +172,10 @@ snd_sfx_load
 snd_sfx_load_ex
 snd_sfx_load_fd
 snd_sfx_play
+snd_sfx_play_lp
 snd_sfx_stop_all
 snd_sfx_play_chn
+snd_sfx_play_chn_lp
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -172,10 +172,9 @@ snd_sfx_load
 snd_sfx_load_ex
 snd_sfx_load_fd
 snd_sfx_play
-snd_sfx_play_lp
 snd_sfx_stop_all
 snd_sfx_play_chn
-snd_sfx_play_chn_lp
+snd_sfx_play_ex
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -54,6 +54,22 @@ typedef uint32_t sfxhnd_t;
 */
 #define SFXHND_INVALID 0
 
+/** \brief  Data structure for sound effect playback.
+
+    This structure is used to pass data to the extended version of sound effect
+    playback functions.
+*/
+typedef struct sfxplaydata {
+    int chn;        /**< \brief The channel to play on. If chn == -1, the next
+                            available channel will be used automatically. */
+    sfxhnd_t idx;   /**< \brief The handle to the sound effect to play. */
+    int vol;        /**< \brief The volume to play at (between 0 and 255). */
+    int pan;        /**< \brief The panning value of the sound effect. 0 is all
+                            the way to the left, 128 is center, 255 is all the way
+                            to the right. */
+    int loop;       /**< \brief Whether to loop the sound effect or not. */
+} sfxplaydata_t;
+
 /** \brief  Load a sound effect.
 
     This function loads a sound effect from a WAV file and returns a handle to
@@ -176,25 +192,6 @@ void snd_sfx_unload_all(void);
 */
 int snd_sfx_play(sfxhnd_t idx, int vol, int pan);
 
-/** \brief  Play a sound effect with looping.
-
-    This function plays a loaded sound effect with the specified volume (for
-    both stereo or mono) and panning values (for mono sounds only).
-
-    \param  idx             The handle to the sound effect to play.
-    \param  vol             The volume to play at (between 0 and 255).
-    \param  pan             The panning value of the sound effect. 0 is all the
-                            way to the left, 128 is center, 255 is all the way
-                            to the right.
-    \param  loop            Whether to loop the sound effect or not.
-
-    \return                 The channel used to play the sound effect (or the
-                            left channel in the case of a stereo sound, the
-                            right channel will be the next one) on success, or
-                            -1 on failure.
-*/
-int snd_sfx_play_lp(sfxhnd_t idx, int vol, int pan, int loop);
-
 /** \brief  Play a sound effect on a specific channel.
 
     This function works similar to snd_sfx_play(), but allows you to specify the
@@ -213,24 +210,20 @@ int snd_sfx_play_lp(sfxhnd_t idx, int vol, int pan, int loop);
 */
 int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan);
 
-/** \brief  Play a sound effect on a specific channel with looping.
+/** \brief  Extended sound effect playback function.
 
-    This function works similar to snd_sfx_play(), but allows you to specify the
-    channel to play on. No error checking is done with regard to the channel, so
-    be sure its safe to play on that channel before trying.
+    This function plays a sound effect with the specified parameters. This is
+    the extended version of the sound effect playback functions, and is used to
+    pass a structure containing the parameters to the function. With this
+    function, you can additionally specify the loop flag, which will cause the
+    sound effect to loop until manually stopped.
 
-    \param  chn             The channel to play on (or in the case of stereo,
-                            the left channel).
-    \param  idx             The handle to the sound effect to play.
-    \param  vol             The volume to play at (between 0 and 255).
-    \param  pan             The panning value of the sound effect. 0 is all the
-                            way to the left, 128 is center, 255 is all the way
-                            to the right.
-    \param  loop            Whether to loop the sound effect or not.
+    \param  data            The data structure containing the information needed
+                            to play the sound effect.
 
     \return                 chn
 */
-int snd_sfx_play_chn_lp(int chn, sfxhnd_t idx, int vol, int pan, int loop);
+int snd_sfx_play_ex(sfxplaydata_t *data);
 
 /** \brief  Stop a single channel of sound.
 

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -59,7 +59,7 @@ typedef uint32_t sfxhnd_t;
     This structure is used to pass data to the extended version of sound effect
     playback functions.
 */
-typedef struct sfxplaydata {
+typedef struct sfx_play_data {
     int chn;        /**< \brief The channel to play on. If chn == -1, the next
                             available channel will be used automatically. */
     sfxhnd_t idx;   /**< \brief The handle to the sound effect to play. */
@@ -68,7 +68,8 @@ typedef struct sfxplaydata {
                             the way to the left, 128 is center, 255 is all the way
                             to the right. */
     int loop;       /**< \brief Whether to loop the sound effect or not. */
-} sfxplaydata_t;
+    int freq;       /**< \brief Frequency */
+} sfx_play_data_t;
 
 /** \brief  Load a sound effect.
 
@@ -215,15 +216,15 @@ int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan);
     This function plays a sound effect with the specified parameters. This is
     the extended version of the sound effect playback functions, and is used to
     pass a structure containing the parameters to the function. With this
-    function, you can additionally specify the loop flag, which will cause the
-    sound effect to loop until manually stopped.
+    function, you can additionally specify extra parameters such as frequency
+    and looping (see sfx_play_data_t structure).
 
     \param  data            The data structure containing the information needed
                             to play the sound effect.
 
     \return                 chn
 */
-int snd_sfx_play_ex(sfxplaydata_t *data);
+int snd_sfx_play_ex(sfx_play_data_t *data);
 
 /** \brief  Stop a single channel of sound.
 

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -176,6 +176,25 @@ void snd_sfx_unload_all(void);
 */
 int snd_sfx_play(sfxhnd_t idx, int vol, int pan);
 
+/** \brief  Play a sound effect with looping.
+
+    This function plays a loaded sound effect with the specified volume (for
+    both stereo or mono) and panning values (for mono sounds only).
+
+    \param  idx             The handle to the sound effect to play.
+    \param  vol             The volume to play at (between 0 and 255).
+    \param  pan             The panning value of the sound effect. 0 is all the
+                            way to the left, 128 is center, 255 is all the way
+                            to the right.
+    \param  loop            Whether to loop the sound effect or not.
+
+    \return                 The channel used to play the sound effect (or the
+                            left channel in the case of a stereo sound, the
+                            right channel will be the next one) on success, or
+                            -1 on failure.
+*/
+int snd_sfx_play_lp(sfxhnd_t idx, int vol, int pan, int loop);
+
 /** \brief  Play a sound effect on a specific channel.
 
     This function works similar to snd_sfx_play(), but allows you to specify the
@@ -193,6 +212,25 @@ int snd_sfx_play(sfxhnd_t idx, int vol, int pan);
     \return                 chn
 */
 int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan);
+
+/** \brief  Play a sound effect on a specific channel with looping.
+
+    This function works similar to snd_sfx_play(), but allows you to specify the
+    channel to play on. No error checking is done with regard to the channel, so
+    be sure its safe to play on that channel before trying.
+
+    \param  chn             The channel to play on (or in the case of stereo,
+                            the left channel).
+    \param  idx             The handle to the sound effect to play.
+    \param  vol             The volume to play at (between 0 and 255).
+    \param  pan             The panning value of the sound effect. 0 is all the
+                            way to the left, 128 is center, 255 is all the way
+                            to the right.
+    \param  loop            Whether to loop the sound effect or not.
+
+    \return                 chn
+*/
+int snd_sfx_play_chn_lp(int chn, sfxhnd_t idx, int vol, int pan, int loop);
 
 /** \brief  Stop a single channel of sound.
 

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -719,6 +719,10 @@ err_occurred:
 }
 
 int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan) {
+    return snd_sfx_play_chn_lp(chn, idx, vol, pan, 0);
+}
+
+int snd_sfx_play_chn_lp(int chn, sfxhnd_t idx, int vol, int pan, int loop) {
     int size;
     snd_effect_t *t = (snd_effect_t *)idx;
     AICA_CMDSTR_CHANNEL(tmp, cmd, chan);
@@ -735,7 +739,7 @@ int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan) {
     chan->base = t->locl;
     chan->type = t->fmt;
     chan->length = size;
-    chan->loop = 0;
+    chan->loop = loop;
     chan->loopstart = 0;
     chan->loopend = size;
     chan->freq = t->rate;
@@ -762,6 +766,10 @@ int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan) {
 }
 
 int snd_sfx_play(sfxhnd_t idx, int vol, int pan) {
+    return snd_sfx_play_lp(idx, vol, pan, 0);
+}
+
+int snd_sfx_play_lp(sfxhnd_t idx, int vol, int pan, int loop) {
     int chn, moved, old;
 
     /* This isn't perfect.. but it should be good enough. */
@@ -785,7 +793,7 @@ int snd_sfx_play(sfxhnd_t idx, int vol, int pan) {
     }
     else {
         sfx_nextchan = (chn + 2) % 64;  /* in case of stereo */
-        return snd_sfx_play_chn(chn, idx, vol, pan);
+        return snd_sfx_play_chn_lp(chn, idx, vol, pan, loop);
     }
 }
 

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -719,7 +719,7 @@ err_occurred:
 }
 
 int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan) {
-    sfxplaydata_t data = {0};
+    sfx_play_data_t data = {0};
     data.chn = chn;
     data.idx = idx;
     data.vol = vol;
@@ -755,7 +755,7 @@ int find_free_channel(void) {
 }
 
 int snd_sfx_play(sfxhnd_t idx, int vol, int pan) {
-    sfxplaydata_t data = {0};
+    sfx_play_data_t data = {0};
     data.chn = -1;
     data.idx = idx;
     data.vol = vol;
@@ -763,7 +763,7 @@ int snd_sfx_play(sfxhnd_t idx, int vol, int pan) {
     return snd_sfx_play_ex(&data);
 }
 
-int snd_sfx_play_ex(sfxplaydata_t *data) {
+int snd_sfx_play_ex(sfx_play_data_t *data) {
     if (data->chn < 0) {
         data->chn = find_free_channel();
         if (data->chn < 0) {
@@ -790,7 +790,7 @@ int snd_sfx_play_ex(sfxplaydata_t *data) {
     chan->loop = data->loop;
     chan->loopstart = 0;
     chan->loopend = size;
-    chan->freq = t->rate;
+    chan->freq = data->freq > 0 ? data->freq : t->rate;
     chan->vol = data->vol;
 
     if(!t->stereo) {


### PR DESCRIPTION
Here is a proposal to add sound loop support to snd_sfxmgr. This allows to play sound effect repeatedly until it stopped manually. Very useful when you simulate sound behaviour like chains, static noise, etc