### PR TITLE
environ.sh: Disable -fno-builtin, enable -ffast-math

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -165,13 +165,9 @@ export KOS_CFLAGS="${KOS_CFLAGS} -fomit-frame-pointer"
 
 # GCC Builtin Functions
 #
-# Comment out this line to enable GCC to use its own builtin implementations of
-# certain standard library functions. Under certain conditions, this can allow
-# compiler-optimized implementations to replace standard function invocations.
-# The downside of this is that it COULD interfere with Newlib or KOS implementations
-# of these functions, and it has not been tested thoroughly to ensure compatibility.
-#
-export KOS_CFLAGS="${KOS_CFLAGS} -fno-builtin"
+# Uncomment this line to prevent GCC from using its own builtin implementations
+# of certain standard library functions.
+#export KOS_CFLAGS="${KOS_CFLAGS} -fno-builtin"
 
 # Fast Math Instructions
 #

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -171,13 +171,12 @@ export KOS_CFLAGS="${KOS_CFLAGS} -fomit-frame-pointer"
 
 # Fast Math Instructions
 #
-# Uncomment this line to enable the optimized fast-math instructions (FSSRA,
-# FSCA, and FSQRT) for calculating sin/cos, inverse square root, and square roots.
-# These can result in substantial performance gains for these kinds of operations;
-# however, they do so at the price of accuracy and are not IEEE compliant.
+# Comment this line to disable the use of optimized fast-math instructions (FSSRA,
+# FSCA) for calculating sin/cos and inverse square root, and any math optimization
+# that does not guarantee compliance with the IEEE floating-point standard.
 # NOTE: Enabling this option will also override -fno-builtin!
 #
-#export KOS_CFLAGS="${KOS_CFLAGS} -fbuiltin -ffast-math -ffp-contract=fast"
+export KOS_CFLAGS="${KOS_CFLAGS} -fbuiltin -ffast-math -ffp-contract=fast"
 
 # SH4 Floating Point Arithmetic Precision
 #

--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -181,7 +181,7 @@ export KOS_CFLAGS="${KOS_CFLAGS} -fno-builtin"
 # however, they do so at the price of accuracy and are not IEEE compliant.
 # NOTE: Enabling this option will also override -fno-builtin!
 #
-#export KOS_CFLAGS="${KOS_CFLAGS} -fbuiltin -ffast-math -ffp-contract=fast -mfsrra -mfsca"
+#export KOS_CFLAGS="${KOS_CFLAGS} -fbuiltin -ffast-math -ffp-contract=fast"
 
 # SH4 Floating Point Arithmetic Precision
 #

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -16,7 +16,7 @@ if [ -z "${KOS_SH4_PRECISION}" ] ; then
     export KOS_SH4_PRECISION="-m4-single-only"
 fi
 
-export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_SH4_PRECISION} -ml -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec"
+export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_SH4_PRECISION} -ml -mfsrra -mfsca -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec"
 export KOS_AFLAGS="${KOS_AFLAGS} -little"
 
 if [ x${KOS_SUBARCH} = xnaomi ]; then


### PR DESCRIPTION
- Enable `-mfsrra` and `-mfsca` unconditionally in environ_dreamcast.sh, as those instructions will only be used alongside -ffast-math anyway;
- Disable -fno-builtin, as I do not see any reason to have it enabled by default;
- Enable -ffast-math by default, since everybody seems to be using it anyway.