### PR TITLE
arch.h: Use __asm__ instead of asm

### DIFF
--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -387,7 +387,7 @@ static inline uintptr_t arch_get_ret_addr(void) {
     \note                   This only works if you don't disable frame pointers.
 */
 static inline uintptr_t arch_get_fptr(void) {
-    register uintptr_t fp asm("r14");
+    register uintptr_t fp __asm__("r14");
 
     return fp;
 }


### PR DESCRIPTION
Using just "asm" seems to cause compilation errors when building some external software that use ISO compliant C and not the GNU version.