### PR TITLE
Fix undefined references to free with lto.

### DIFF
--- a/examples/dreamcast/sound/sfxbuf/main.c
+++ b/examples/dreamcast/sound/sfxbuf/main.c
@@ -8,6 +8,7 @@
 */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <kos/init.h>
 #include <dc/biosfont.h>


### PR DESCRIPTION
I can only presume that the strict include list in this (as opposed to kos.h) meant that there happened to be no references to stdlib in its includes.