### PR TITLE
Unhack fs dcload

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -4,6 +4,7 @@
    Copyright (C) 2002 Andrew Kieschnick
    Copyright (C) 2004 Megan Potter
    Copyright (C) 2012 Lawrence Sebald
+   Copyright (C) 2025 Donald Haase
 
 */
 
@@ -19,24 +20,21 @@ printf goes to the dc-tool console
 
 #include <dc/fifo.h>
 #include <dc/fs_dcload.h>
-#include <kos/thread.h>
 #include <arch/spinlock.h>
-#include <arch/arch.h>
 #include <kos/dbgio.h>
 #include <kos/fs.h>
+#include <kos/init.h>
 
 #include <errno.h>
 #include <stdio.h>
-#include <ctype.h>
 #include <string.h>
 #include <malloc.h>
-#include <errno.h>
 #include <sys/queue.h>
 
 /* A linked list of dir entries. */
 typedef struct dcl_dir {
     LIST_ENTRY(dcl_dir) fhlist;
-    int hnd;  /* Actually a DIR* but on the host side */
+    int hnd;
     char *path;
     dirent_t dirent;
 } dcl_dir_t;
@@ -176,7 +174,7 @@ static int dcload_close(void * h) {
         /* Check if it's a dir */
         i = hnd_is_dir(hnd);
 
-        /* We found it in the list, so it's a DIR */
+        /* We found it in the list, so it's a dir */
         if(!i) {
             dclsc(DCLOAD_CLOSEDIR, hnd);
             LIST_REMOVE(i, fhlist);
@@ -460,8 +458,8 @@ static vfs_handler_t vh = {
     NULL                /* fstat */
 };
 
-// We have to provide a minimal interface in case dcload usage is
-// disabled through init flags.
+/* We have to provide a minimal interface in case dcload usage is
+   disabled through init flags. */
 static int never_detected(void) {
     return 0;
 }
@@ -501,8 +499,8 @@ void fs_dcload_init_console(void) {
     dbgio_dcload.write_buffer = dcload_write_buffer;
     // dbgio_dcload.read = dcload_read_cons;
 
-    // We actually need to detect here to make sure we're not on
-    // dcload-serial, or scif_init must not proceed.
+    /* We actually need to detect here to make sure we're not on
+       dcload-serial, or scif_init must not proceed. */
     if(*DCLOADMAGICADDR != DCLOADMAGICVALUE)
         return;
 

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -90,7 +90,7 @@ size_t dcload_gdbpacket(const char* in_buf, size_t in_size, char* out_buf, size_
     return dclsc(DCLOAD_GDBPACKET, in_buf, (in_size << 16) | (out_size & 0xffff), out_buf);
 }
 
-void *dcload_open(vfs_handler_t * vfs, const char *fn, int mode) {
+static void *dcload_open(vfs_handler_t * vfs, const char *fn, int mode) {
     char *dcload_path = NULL;
     dcl_dir_t *entry;
     int hnd = 0;
@@ -165,7 +165,7 @@ void *dcload_open(vfs_handler_t * vfs, const char *fn, int mode) {
     return (void *)hnd;
 }
 
-int dcload_close(void * h) {
+static int dcload_close(void * h) {
     uint32 hnd = (uint32)h;
     dcl_dir_t *i;
 
@@ -191,7 +191,7 @@ int dcload_close(void * h) {
     return 0;
 }
 
-ssize_t dcload_read(void * h, void *buf, size_t cnt) {
+static ssize_t dcload_read(void * h, void *buf, size_t cnt) {
     ssize_t ret = -1;
     uint32 hnd = (uint32)h;
 
@@ -205,7 +205,7 @@ ssize_t dcload_read(void * h, void *buf, size_t cnt) {
     return ret;
 }
 
-ssize_t dcload_write(void * h, const void *buf, size_t cnt) {
+static ssize_t dcload_write(void * h, const void *buf, size_t cnt) {
     ssize_t ret = -1;
     uint32 hnd = (uint32)h;
 
@@ -219,7 +219,7 @@ ssize_t dcload_write(void * h, const void *buf, size_t cnt) {
     return ret;
 }
 
-off_t dcload_seek(void * h, off_t offset, int whence) {
+static off_t dcload_seek(void * h, off_t offset, int whence) {
     off_t ret = -1;
     uint32 hnd = (uint32)h;
 
@@ -233,7 +233,7 @@ off_t dcload_seek(void * h, off_t offset, int whence) {
     return ret;
 }
 
-off_t dcload_tell(void * h) {
+static off_t dcload_tell(void * h) {
     off_t ret = -1;
     uint32 hnd = (uint32)h;
 
@@ -247,7 +247,7 @@ off_t dcload_tell(void * h) {
     return ret;
 }
 
-size_t dcload_total(void * h) {
+static size_t dcload_total(void * h) {
     size_t ret = -1;
     size_t cur;
     uint32 hnd = (uint32)h;
@@ -266,7 +266,7 @@ size_t dcload_total(void * h) {
 
 /* Not thread-safe, but that's ok because neither is the FS */
 static dirent_t dirent;
-dirent_t *dcload_readdir(void * h) {
+static dirent_t *dcload_readdir(void * h) {
     dirent_t *rv = NULL;
     dcload_dirent_t *dcld;
     dcload_stat_t filestat;
@@ -312,7 +312,7 @@ dirent_t *dcload_readdir(void * h) {
     return rv;
 }
 
-int dcload_rename(vfs_handler_t * vfs, const char *fn1, const char *fn2) {
+static int dcload_rename(vfs_handler_t * vfs, const char *fn1, const char *fn2) {
     int ret;
 
     (void)vfs;
@@ -329,7 +329,7 @@ int dcload_rename(vfs_handler_t * vfs, const char *fn1, const char *fn2) {
     return ret;
 }
 
-int dcload_unlink(vfs_handler_t * vfs, const char *fn) {
+static int dcload_unlink(vfs_handler_t * vfs, const char *fn) {
     (void)vfs;
 
     spinlock_lock_scoped(&mutex);

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -38,6 +38,7 @@ typedef struct dcl_dir {
     LIST_ENTRY(dcl_dir) fhlist;
     int hnd;  /* Actually a DIR* but on the host side */
     char *path;
+    dirent_t dirent;
 } dcl_dir_t;
 
 LIST_HEAD(dcl_de, dcl_dir);
@@ -264,8 +265,6 @@ static size_t dcload_total(void * h) {
     return ret;
 }
 
-/* Not thread-safe, but that's ok because neither is the FS */
-static dirent_t dirent;
 static dirent_t *dcload_readdir(void * h) {
     dirent_t *rv = NULL;
     dcload_dirent_t *dcld;
@@ -284,7 +283,7 @@ static dirent_t *dcload_readdir(void * h) {
     dcld = (dcload_dirent_t *)dclsc(DCLOAD_READDIR, hnd);
 
     if(dcld) {
-        rv = &dirent;
+        rv = &(entry->dirent);
         strcpy(rv->name, dcld->d_name);
         rv->size = 0;
         rv->time = 0;

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -274,12 +274,12 @@ static dirent_t *dcload_readdir(void * h) {
     uint32 hnd = (uint32)h;
     dcl_dir_t *entry;
 
+    spinlock_lock_scoped(&mutex);
+
     if(!(entry = hnd_is_dir(hnd))) {
         errno = EBADF;
         return NULL;
     }
-
-    spinlock_lock_scoped(&mutex);
 
     dcld = (dcload_dirent_t *)dclsc(DCLOAD_READDIR, hnd);
 

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -408,6 +408,17 @@ static int dcload_fcntl(void *h, int cmd, va_list ap) {
     return rv;
 }
 
+static int dcload_rewinddir(void *h) {
+    uint32_t hnd = (uint32_t)h;
+
+    spinlock_lock_scoped(&mutex);
+
+    if(!hnd_is_dir(hnd))
+        return -1;
+
+    return dclsc(DCLOAD_REWINDDIR, hnd);
+}
+
 /* Pull all that together */
 static vfs_handler_t vh = {
     /* Name handler */
@@ -446,7 +457,7 @@ static vfs_handler_t vh = {
     NULL,               /* tell64 */
     NULL,               /* total64 */
     NULL,               /* readlink */
-    NULL,               /* rewinddir */
+    dcload_rewinddir,
     NULL                /* fstat */
 };
 

--- a/kernel/arch/dreamcast/include/dc/fs_dcload.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dcload.h
@@ -80,6 +80,7 @@ extern int dcload_type;
 #define DCLOAD_READDIR 18
 #define DCLOAD_GETHOSTINFO 19
 #define DCLOAD_GDBPACKET 20
+#define DCLOAD_REWINDDIR 21
 
 /* dcload syscall function */
 

--- a/kernel/arch/dreamcast/include/dc/fs_dcload.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dcload.h
@@ -25,7 +25,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <kos/fs.h>
 #include <kos/dbgio.h>
 
@@ -59,28 +58,28 @@ extern int dcload_type;
 /* \cond */
 /* Available dcload console commands */
 
-#define DCLOAD_READ 0
-#define DCLOAD_WRITE 1
-#define DCLOAD_OPEN 2
-#define DCLOAD_CLOSE 3
-#define DCLOAD_CREAT 4
-#define DCLOAD_LINK 5
-#define DCLOAD_UNLINK 6
-#define DCLOAD_CHDIR 7
-#define DCLOAD_CHMOD 8
-#define DCLOAD_LSEEK 9
-#define DCLOAD_FSTAT 10
-#define DCLOAD_TIME 11
-#define DCLOAD_STAT 12
-#define DCLOAD_UTIME 13
+#define DCLOAD_READ         0
+#define DCLOAD_WRITE        1
+#define DCLOAD_OPEN         2
+#define DCLOAD_CLOSE        3
+#define DCLOAD_CREAT        4
+#define DCLOAD_LINK         5
+#define DCLOAD_UNLINK       6
+#define DCLOAD_CHDIR        7
+#define DCLOAD_CHMOD        8
+#define DCLOAD_LSEEK        9
+#define DCLOAD_FSTAT        10
+#define DCLOAD_TIME         11
+#define DCLOAD_STAT         12
+#define DCLOAD_UTIME        13
 #define DCLOAD_ASSIGNWRKMEM 14
-#define DCLOAD_EXIT 15
-#define DCLOAD_OPENDIR 16
-#define DCLOAD_CLOSEDIR 17
-#define DCLOAD_READDIR 18
-#define DCLOAD_GETHOSTINFO 19
-#define DCLOAD_GDBPACKET 20
-#define DCLOAD_REWINDDIR 21
+#define DCLOAD_EXIT         15
+#define DCLOAD_OPENDIR      16
+#define DCLOAD_CLOSEDIR     17
+#define DCLOAD_READDIR      18
+#define DCLOAD_GETHOSTINFO  19
+#define DCLOAD_GDBPACKET    20
+#define DCLOAD_REWINDDIR    21
 
 /* dcload syscall function */
 

--- a/kernel/arch/dreamcast/include/dc/fs_dcload.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dcload.h
@@ -127,17 +127,6 @@ void dcload_printk(const char *str);
 /* GDB tunnel */
 size_t dcload_gdbpacket(const char* in_buf, size_t in_size, char* out_buf, size_t out_size);
 
-/* File functions */
-void*   dcload_open(vfs_handler_t * vfs, const char *fn, int mode);
-int     dcload_close(void * hnd);
-ssize_t dcload_read(void * hnd, void *buf, size_t cnt);
-off_t   dcload_seek(void * hnd, off_t offset, int whence);
-off_t   dcload_tell(void * hnd);
-size_t  dcload_total(void * hnd);
-dirent_t* dcload_readdir(void * hnd);
-int     dcload_rename(vfs_handler_t * vfs, const char *fn1, const char *fn2);
-int     dcload_unlink(vfs_handler_t * vfs, const char *fn);
-
 /* Init func */
 void fs_dcload_init_console(void);
 void fs_dcload_init(void);

--- a/kernel/arch/dreamcast/include/dc/fs_dcload.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dcload.h
@@ -143,9 +143,6 @@ void fs_dcload_init_console(void);
 void fs_dcload_init(void);
 void fs_dcload_shutdown(void);
 
-/* Init func for dcload-ip + lwIP */
-int fs_dcload_init_lwip(void *p);
-
 /* \endcond */
 
 /** @} */


### PR DESCRIPTION
Minor overhaul to `fs_dcload`. I tried to be very atomic with the commits and their messages. The core change here is to track opened dirs to remove a hack that was in place to try to detect dirs by their FD value. In the past, dcload was set up so that the FD being returned for dirs was a raw copy of the `DIR *` opened on the pc side. Unfortunately when moving to 64-bit systems that broke functionality and had to be changed to pass an arbitrary value (as noted in https://github.com/KallistiOS/dcload-serial/pull/27/ ). Using that kind of arbitrary value above 100 made it more likely for a clash of fds between a file and dir.

Now with the tracking of opened dirs we can also cache the path and dirent values which is important for ensuring the correct behavior of `readdir` which was previously always only returning based on the most recently opened dir rather than the one being passed to it, and which could only be done on one dir at a time due to a static `dirent`.

While at it, cleaned up some obsolete portions and added `rewinddir` which was supported in both dcloads for quite some time.

Some additional TODOs from this:
- With the `fd>100` hack removed, we should consider eventually adjusting the host-side to track all opened files to ensure there can't be a random conflict where the fd of a file == the fd of a dir + 1337.
- I think the dcload syscall can be adjusted slightly to not rely on the separate assembly and VA_ARGS macro to work. Not sure if there'd be too much benefit to that though.
- `dcl_dir_t` could likely be optimized better to not use as much space (or require fewer mallocs). I considered using a static buffer, but the size benefits seemed to be a wash unless you are opening an absolutely massive number of dirs which wouldn't be supported by a static buffer anyways.