### PR TITLE
Update changelogs and AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,7 +27,7 @@ Sam Steele: 2004
 Gil Megidish: 2002
 Florian Schulze: 2002
 Walter van Niftrik: 2005
-Donald Haase: 2008, 2014, 2023, 2024
+Donald Haase: 2008, 2014, 2023, 2024, 2025
 Andrew Kieschnick: 2000, 2001, 2002, 2003
 Jordan DeLong: 2000, 2001, 2002
 Bero: 2002
@@ -42,12 +42,12 @@ Josh Pearson: 2013, 2014, 2015, 2016
 Joe Fenton: 2016
 Stefan Galowicz: 2016, 2017
 Luke Benstead: 2020, 2021, 2022, 2023
-Eric Fradella: 2023, 2024
+Eric Fradella: 2023, 2024, 2025
 Falco Girgis: 2023, 2024
 Ruslan Rostovtsev: 2014, 2016, 2023, 2024
 Colton Pawielski: 2023
 Andy Barajas: 2023, 2024
-Paul Cercueil: 2023, 2024
+Paul Cercueil: 2023, 2024, 2025
 
 Files with Specific licenses:
 -----------------------------

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@ Platform-specific changes are prefixed with the platform name, otherwise the cha
 - **Dreamcast**: Add pvr palette example [AB]
 - **Dreamcast**: Cleaned up, documented, and enhanced BIOS font API [FG]
 - Rework PVR hybrid mode + IRQ handling [PC]
+- **Dreamcast**: Add support and update toolchain profiles for Newlib 4.5.0, Binutils 2.43.1, and GDB 15.2 [EF]
 
 ## KallistiOS version 2.1.1
 - Added pvrtex utility by TapamN to utils [Daniel Fairchild == DF]

--- a/utils/dc-chain/doc/CHANGELOG.md
+++ b/utils/dc-chain/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Date<br/>_____________ | Author(s)<br/>_____________ | Changes<br/>_____________ |
 |:-----------------------|:----------------------------|---------------------------|
+| 2025-01-05 | Eric Fradella | Add support and update toolchain profiles for Newlib 4.5.0, Binutils 2.43.1, and GDB 15.2. |
 | 2024-08-11 | Eric Fradella | Fix ARM toolchain build error when JIT is enabled for SH toolchain. |
 | 2024-08-07 | Eric Fradella | Updated binutils to 2.43. Updated GCC 11 profile with support for GCC 11.5.0. |
 | 2024-08-01 | Eric Fradella | Updated GCC 14 profile with support for GCC 14.2.0. |


### PR DESCRIPTION
As usual, I forgot to update the changelogs for my dc-chain updates 😛

Also, I updated the `AUTHORS` file with the years for contributors who have authored commits from 2025. 