### PR TITLE
Fix and improve performance counters

### DIFF
--- a/kernel/arch/dreamcast/kernel/perfctr.c
+++ b/kernel/arch/dreamcast/kernel/perfctr.c
@@ -106,12 +106,9 @@ void perf_cntr_timer_disable(void) {
 }
 
 uint64_t perf_cntr_timer_ns(void) {
-    /* Grab value first, before checking, to not record overhead. */
-    const uint64_t count = perf_cntr_count(PRFC0);
-
     /* If timer is configured and is running, use perf counters. */
-    if(perf_cntr_timer_enabled()) 
-        return count * NS_PER_CYCLE;
+    if(perf_cntr_timer_enabled())
+        return perf_cntr_count(PRFC0) * NS_PER_CYCLE;
     else /* Otherwise fall-through to TMU2. */
         return timer_ns_gettime64();
 }

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -277,7 +277,7 @@ static timer_val_t timer_getticks(const uint32_t *tns, uint32_t shift) {
         counter2 = TIMER32(tcnts[TMU2]);
         tmu2 = TIMER16(tcrs[TMU2]);
         unf2 = !!(tmu2 & UNF);
-    } while (unf1 != unf2 || counter1 < counter2);
+    } while (__unlikely(unf1 != unf2 || counter1 < counter2));
 
     delta = timer_ms_countdown - counter2;
 


### PR DESCRIPTION
The `perf_cntr_count()` function had a (very unlikely) bug, where a value read could be off by about 21.5 seconds. This would happen when the high part of the counter was read before and the low part of the counter was read after a 32-bit overflow.

This can be addressed easily by reading the high part twice and comparing the two reads. The overhead should be minimal as it only adds one extra register read and a comparison + a rarely taken branch, while removing the superfluous 16-bit mask.

The `perf_cntr_timer_ns()` was also updated, so that the counter value is not read before the `perf_cntr_timer_enabled()` call. As written in the commit's description, the argument used was bogus, and reading the counter as late as possible slightly reduces the latency incurred.