### PR TITLE
Volatility fix for PVR DR API.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,7 +43,7 @@ Joe Fenton: 2016
 Stefan Galowicz: 2016, 2017
 Luke Benstead: 2020, 2021, 2022, 2023
 Eric Fradella: 2023, 2024, 2025
-Falco Girgis: 2023, 2024
+Falco Girgis: 2023, 2024, 2025
 Ruslan Rostovtsev: 2014, 2016, 2023, 2024
 Colton Pawielski: 2023
 Andy Barajas: 2023, 2024

--- a/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
+++ b/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
@@ -89,8 +89,9 @@ inline static void get_vert(int *seed, int *x, int *y, int *col) {
 }
 
 static void do_frame(void) {
-    pvr_vertex_t *vert;
-    int x=0, y=0, z=0, col=0;
+    volatile pvr_vertex_t *vert;
+    int x=0, y=0, col=0;
+    float z = 0.0f;
     int i;
     static int oldseed = 0xdeadbeef;
     int seed = oldseed;


### PR DESCRIPTION
1) Made the return-type for pvr_dr_target() a pointer to volatile
   memory, so that the compiler will be forced to actually do the
intended writes, rather than keeping values within registers, and so that it cannot simply optimize away all writes due to not seeing the values ever get read and used later in the program. 2) Made the return-type for pvr_dr_target() void*, since you are free to
   submit ANY 32-byte type through it, including polygon headers, pvr
sprites, and modifier volumes.
3) Improved documentation on pvr_dr_target() and pvr_dr_commit(). 4) Fixed warnings that were introduced due to not storing the return
   value from pvr_dr_target() within a pointer to volatile memory in
pvrmark_strips_direct example.
5) Quick update to pvrmark_strips_direct's T&L loop to not do an
   integer->float conversion for z coordinat every iteration (thanks
darc).
6) Fixed parameter type to pvr_send_to_ta() to be const-correct. 7) Updated AUTHORS with this year for my entry.