### PR TITLE
Ensure sq_writeback is flagged as causing memory to change.

### DIFF
--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -149,9 +149,15 @@ static __always_inline void dcache_pref_block(const void *src) {
 
     This function initiates write-back for one Store Queue.
 
-    \param  ptr             The SQ mapped address to write-back.
+    \param  src             The SQ mapped address to write-back.
 */
-#define dcache_wback_sq(ptr) dcache_pref_block(ptr)
+static __always_inline void dcache_wback_sq(void *src) {
+    __asm__ __volatile__("pref @%0\n"
+                         : /* No outputs */
+                         : "r" (src)
+                         : "memory"
+    );
+}
 
 /** \brief  Allocate one block of the data/operand cache.
 


### PR DESCRIPTION
First reported with #897, a regression from #877. While it's appropriate for the generalized dcache_pref_block to not have outputs, setting the same for the store queue writeback causes it to be optimized away in some situations (specifically DR).

Hopefully not stepping on toes @gyrovorbis , but wanted to try to get this in quicker as we seem to have a number of people impacted by it.