### PR TITLE
Allow `loopstart`, `loopend` setting for `snd_sfx_play_ex`

### DIFF
--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -69,8 +69,8 @@ typedef struct sfx_play_data {
                             to the right. */
     int loop;       /**< \brief Whether to loop the sound effect or not. */
     int freq;       /**< \brief Frequency */
-    int loopstart;  /**< \brief Loop start index (in samples). */
-    int loopend;    /**< \brief Loop end index (in samples). If loopend == 0, 
+    unsigned int loopstart;  /**< \brief Loop start index (in samples). */
+    unsigned int loopend;    /**< \brief Loop end index (in samples). If loopend == 0, 
                             the loop end will default to sfx size in samples. */
 } sfx_play_data_t;
 

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -68,11 +68,10 @@ typedef struct sfx_play_data {
                             the way to the left, 128 is center, 255 is all the way
                             to the right. */
     int loop;       /**< \brief Whether to loop the sound effect or not. */
-    int loopstart;  /**< \brief Loop start index (in samples). If loopstart < 1,
-                            the loop start will default to 0. */
-    int loopend;    /**< \brief Loop end index (in samples). If loopend < 1, 
-                            the loop end will default to sfx size in samples. */
     int freq;       /**< \brief Frequency */
+    int loopstart;  /**< \brief Loop start index (in samples). */
+    int loopend;    /**< \brief Loop end index (in samples). If loopend == 0, 
+                            the loop end will default to sfx size in samples. */
 } sfx_play_data_t;
 
 /** \brief  Load a sound effect.

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -68,6 +68,10 @@ typedef struct sfx_play_data {
                             the way to the left, 128 is center, 255 is all the way
                             to the right. */
     int loop;       /**< \brief Whether to loop the sound effect or not. */
+    int loopstart;  /**< \brief Loop start index in samples. If loop_start == -1,
+                            the loop start will be set to 0.*/
+    int loopend;    /**< \brief Loop end index in samples. If loop_end == -1, the
+                            size of the sound effect in samples will be used. */
     int freq;       /**< \brief Frequency */
 } sfx_play_data_t;
 

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -68,10 +68,10 @@ typedef struct sfx_play_data {
                             the way to the left, 128 is center, 255 is all the way
                             to the right. */
     int loop;       /**< \brief Whether to loop the sound effect or not. */
-    int loopstart;  /**< \brief Loop start index in samples. If loop_start == -1,
-                            the loop start will be set to 0.*/
-    int loopend;    /**< \brief Loop end index in samples. If loop_end == -1, the
-                            size of the sound effect in samples will be used. */
+    int loopstart;  /**< \brief Loop start index (in samples). If loopstart < 1,
+                            the loop start will default to 0. */
+    int loopend;    /**< \brief Loop end index (in samples). If loopend < 1, 
+                            the loop end will default to sfx size in samples. */
     int freq;       /**< \brief Frequency */
 } sfx_play_data_t;
 

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -760,8 +760,6 @@ int snd_sfx_play(sfxhnd_t idx, int vol, int pan) {
     data.idx = idx;
     data.vol = vol;
     data.pan = pan;
-    data.loopstart = -1;
-    data.loopend = -1;
     return snd_sfx_play_ex(&data);
 }
 
@@ -790,8 +788,8 @@ int snd_sfx_play_ex(sfx_play_data_t *data) {
     chan->type = t->fmt;
     chan->length = size;
     chan->loop = data->loop;
-    chan->loopstart = data->loopstart < 0 ? 0 : data->loopstart;
-    chan->loopend = data->loopend < 0 ? size : data->loopend;
+    chan->loopstart = data->loopstart < 1 ? 0 : data->loopstart;
+    chan->loopend = data->loopend < 1 ? size : data->loopend;
     chan->freq = data->freq > 0 ? data->freq : t->rate;
     chan->vol = data->vol;
 

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -760,6 +760,8 @@ int snd_sfx_play(sfxhnd_t idx, int vol, int pan) {
     data.idx = idx;
     data.vol = vol;
     data.pan = pan;
+    data.loopstart = -1;
+    data.loopend = -1;
     return snd_sfx_play_ex(&data);
 }
 
@@ -788,8 +790,8 @@ int snd_sfx_play_ex(sfx_play_data_t *data) {
     chan->type = t->fmt;
     chan->length = size;
     chan->loop = data->loop;
-    chan->loopstart = 0;
-    chan->loopend = size;
+    chan->loopstart = data->loopstart < 0 ? 0 : data->loopstart;
+    chan->loopend = data->loopend < 0 ? size : data->loopend;
     chan->freq = data->freq > 0 ? data->freq : t->rate;
     chan->vol = data->vol;
 

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -788,7 +788,7 @@ int snd_sfx_play_ex(sfx_play_data_t *data) {
     chan->type = t->fmt;
     chan->length = size;
     chan->loop = data->loop;
-    chan->loopstart = data->loopstart ? data->loopstart : 0;
+    chan->loopstart = data->loopstart;
     chan->loopend = data->loopend ? data->loopend : size;
     chan->freq = data->freq > 0 ? data->freq : t->rate;
     chan->vol = data->vol;

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -788,8 +788,8 @@ int snd_sfx_play_ex(sfx_play_data_t *data) {
     chan->type = t->fmt;
     chan->length = size;
     chan->loop = data->loop;
-    chan->loopstart = data->loopstart < 1 ? 0 : data->loopstart;
-    chan->loopend = data->loopend < 1 ? size : data->loopend;
+    chan->loopstart = data->loopstart ? data->loopstart : 0;
+    chan->loopend = data->loopend ? data->loopend : size;
     chan->freq = data->freq > 0 ? data->freq : t->rate;
     chan->vol = data->vol;
 


### PR DESCRIPTION
The new looping support from `snd_sfx_play_ex` and `sfx_play_data_t` is pretty good, but it does not take into account the fact one might want to loop a limited range of the entire sound effect.

I have proposed a very small extension to both (the aforementioned function and struct) to allow setting the `loopstart` and `loopend` parameters for a looping sound effect played with the `snd_sfx_play_ex` function.

My motivating example was the electricity buzz sound effect for the plasma rifle in Doom 64. It is the only sound effect in Doom 64 repeated with a looping channel.

While the sound effect does start at 0 and play through the full length in samples before looping, the loop start point is 1713 samples after the start of the sound effect.

I am using the extended struct and call as follows:

```
void P_StartElectricLoop(void)
{
        sfx_play_data_t data = {0};
        plasma_loop_channel = snd_sfx_chn_alloc();
        data.chn = plasma_loop_channel;
        data.idx = sounds[sfx_electric];
        data.vol = (int)((float)124 * soundscale);
        data.pan = 128;
        data.loop = 1;
        data.loopstart = 1713;
        snd_sfx_play_ex(&data);
}
```