### PR TITLE
Correct logic for looking up a dir in dcload_close.

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -175,7 +175,7 @@ static int dcload_close(void * h) {
         i = hnd_is_dir(hnd);
 
         /* We found it in the list, so it's a dir */
-        if(!i) {
+        if(i) {
             dclsc(DCLOAD_CLOSEDIR, hnd);
             LIST_REMOVE(i, fhlist);
             free(i->path);


### PR DESCRIPTION
Fix a mistake made in #893 . Had the logic backwards for selecting to close dir vs file.