### PR TITLE
Harmonizing minifont and bfont

### DIFF
--- a/examples/dreamcast/video/bfont/bfont.c
+++ b/examples/dreamcast/video/bfont/bfont.c
@@ -23,18 +23,29 @@ int main(int argc, char **argv) {
        top of the screen and two widths from the left */
     o = (640 * BFONT_HEIGHT) + (BFONT_THIN_WIDTH * 2);
 
+    /* Test with ASCII encoding */
+    bfont_set_encoding(BFONT_CODE_ASCII);
+    bfont_draw_str(vram_s + o, 640, 1, "Test of basic ASCII");
+    /* After each string, we'll increment the offset down by one row */
+    o += 640 * BFONT_HEIGHT;
+    bfont_draw_str(vram_s + o, 640, 1, "The brackets below should be empty:");
+    o += 640 * BFONT_HEIGHT;
+    /* These characters are all part of ISO 8859-1 and not in ASCII */
+    bfont_draw_str(vram_s + o, 640, 1, "[¡Àæ¾ç]");
+    o += 640 * BFONT_HEIGHT;
+
+
     /* Test with ISO8859-1 encoding */
     bfont_set_encoding(BFONT_CODE_ISO8859_1);
-    bfont_draw_str(vram_s + o, 640, 1, "Test of basic ASCII");  
-    /* After each string, we'll increment the offset down by one row */
+    bfont_draw_str(vram_s + o, 640, 1, "ISO8859-1 math symbols: «±×÷¼½¾»");
     o += 640 * BFONT_HEIGHT;
     bfont_draw_str(vram_s + o, 640, 1, "Parlez-vous français?");
     o += 640 * BFONT_HEIGHT;
 
     /* Do a second set drawn transparently */
-    bfont_draw_str(vram_s + o, 640, 0, "Test of basic ASCII");
+    bfont_draw_str(vram_s + o, 640, 0, "ISO8859-1 math symbols: «±×÷¼½¾»");
     o += 640 * BFONT_HEIGHT;
-    bfont_draw_str(vram_s + o, 640, 0, "Parlez-vous français?");
+    bfont_draw_str(vram_s + o, 640, 0, "Você fala português?");
     o += 640 * BFONT_HEIGHT;
 
     /* Test with EUC encoding */

--- a/kernel/arch/dreamcast/include/dc/biosfont.h
+++ b/kernel/arch/dreamcast/include/dc/biosfont.h
@@ -291,10 +291,11 @@ uint32_t bfont_set_background_color(uint32_t c);
 
 /* Constants for the function below */
 typedef enum bfont_code {
-    BFONT_CODE_ISO8859_1 = 0,   /**< \brief ISO-8859-1 (western) charset */
-    BFONT_CODE_EUC       = 1,   /**< \brief EUC-JP charset */
-    BFONT_CODE_SJIS      = 2,   /**< \brief Shift-JIS charset */
-    BFONT_CODE_RAW       = 3   /**< \brief Raw indexing to the BFONT */
+    BFONT_CODE_ASCII     = 0,
+    BFONT_CODE_ISO8859_1 = 1,   /**< \brief ISO-8859-1 (western) charset */
+    BFONT_CODE_EUC       = 2,   /**< \brief EUC-JP charset */
+    BFONT_CODE_SJIS      = 3,   /**< \brief Shift-JIS charset */
+    BFONT_CODE_RAW       = 4    /**< \brief Raw indexing to the BFONT */
 } bfont_code_t;
 
 /** \brief   Set the font encoding.

--- a/kernel/arch/dreamcast/include/dc/minifont.h
+++ b/kernel/arch/dreamcast/include/dc/minifont.h
@@ -28,7 +28,7 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
+#include <stdint.h>
 
 /** \defgroup video_fonts_mini Mini
     \brief                     Extra mini-font provided for Dreamcast and NAOMI
@@ -41,13 +41,13 @@ __BEGIN_DECLS
 
     This function draws a single character to the given buffer.
 
-    \param  buffer          The buffer to draw to (at least 8 x 16 pixels)
-    \param  bufwidth        The width of the buffer in pixels
-    \param  c               The character to draw
+    \param  buffer          The buffer to draw to (at least 8 x 16 pixels).
+    \param  bufwidth        The width of the buffer in pixels.
+    \param  c               The character to draw.
     
-    \return                 Amount of width covered in 16-bit increments.
+    \return                 Amount of width covered in pixels.
 */
-int minifont_draw(uint16 *buffer, uint32 bufwidth, uint32 c);
+int minifont_draw(uint16_t *buffer, uint32_t bufwidth, char c);
 
 /** \brief  Draw a full string to any sort of buffer.
 
@@ -56,12 +56,12 @@ int minifont_draw(uint16 *buffer, uint32 bufwidth, uint32 c);
     Unicode, JIS, EUC, etc).
 
     \param  b               The buffer to draw to.
-    \param  bufwidth           The width of the buffer in pixels.
+    \param  bufwidth        The width of the buffer in pixels.
     \param  str             The string to draw.
     
-    \return                 Amount of width covered in 16-bit increments.
+    \return                 Amount of width covered in pixels.
 */
-int minifont_draw_str(uint16 *b, uint32 bufwidth, const char *str);
+int minifont_draw_str(uint16_t *b, uint32_t bufwidth, const char *str);
 
 /** @} */
 

--- a/kernel/arch/dreamcast/util/minifont.c
+++ b/kernel/arch/dreamcast/util/minifont.c
@@ -22,7 +22,7 @@ int minifont_draw(uint16 *buffer, uint32 bufwidth, uint32 c) {
     if(c < 33 || c > 126)
         return CHAR_WIDTH;
 
-    pos = (c - 33) * BYTES_PER_CHAR;
+    pos = (c - 32) * BYTES_PER_CHAR;
 
     for(i = 0; i < CHAR_HEIGHT; ++i) {
         cur = buffer;

--- a/kernel/arch/dreamcast/util/minifont.c
+++ b/kernel/arch/dreamcast/util/minifont.c
@@ -9,26 +9,22 @@
 #include <dc/minifont.h>
 #include "minifont.h"
 
-#define CHAR_WIDTH 8
-#define CHAR_HEIGHT 16
+int minifont_draw(uint16_t *buffer, uint32_t bufwidth, char c) {
+    uint16_t pos;
+    uint8_t byte, i, j, k;
+    uint16_t *cur;
 
-#define BYTES_PER_CHAR ((CHAR_WIDTH / 8) * CHAR_HEIGHT)
+    /* Treat other characters as a space */
+    if(c <= ' ' || c > '~')
+        return char_width;
 
-int minifont_draw(uint16 *buffer, uint32 bufwidth, uint32 c) {
-    int pos, i, j, k;
-    uint8 byte;
-    uint16 *cur;
+    pos = (c - char_start) * ((char_width / 8) * char_height);
 
-    if(c < 33 || c > 126)
-        return CHAR_WIDTH;
-
-    pos = (c - 32) * BYTES_PER_CHAR;
-
-    for(i = 0; i < CHAR_HEIGHT; ++i) {
+    for(i = 0; i < char_height; ++i) {
         cur = buffer;
 
-        for(j = 0; j < CHAR_WIDTH / 8; ++j) {
-            byte = minifont_data[pos + (i * (CHAR_WIDTH / 8)) + j];
+        for(j = 0; j < char_width / 8; ++j) {
+            byte = minifont_data[pos + (i * (char_width / 8)) + j];
 
             for(k = 0; k < 8; ++k) {
                 if(byte & (1 << (7 - k)))
@@ -41,10 +37,10 @@ int minifont_draw(uint16 *buffer, uint32 bufwidth, uint32 c) {
         buffer += bufwidth;
     }
 
-    return CHAR_WIDTH;
+    return char_width;
 }
 
-int minifont_draw_str(uint16 *buffer, uint32 bufwidth, const char *str) {
+int minifont_draw_str(uint16_t *buffer, uint32_t bufwidth, const char *str) {
     char c;
     int adv = 0;
 

--- a/kernel/arch/dreamcast/util/minifont.h
+++ b/kernel/arch/dreamcast/util/minifont.h
@@ -13,6 +13,10 @@
     Only ASCII characters 32-126 are present here. Each one taking up 16 bytes
     of the data. Each character is 8x16 pixels in size. */
 
+static const uint8_t char_width = 8;    /**< \brief Width of each character. */
+static const uint8_t char_height = 16;  /**< \brief Height of each character. */
+static const uint8_t char_start = 32;   /**< \brief First ASCII character encoded. */
+
 static const int minifont_size = 1520;
 static const unsigned char minifont_data[1520] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/kernel/arch/dreamcast/util/minifont.h
+++ b/kernel/arch/dreamcast/util/minifont.h
@@ -10,11 +10,13 @@
     Naomi because, well, it was specifically put to use there first of all for
     my early debugging with it.
 
-    Only ASCII characters 33-126 are present here. Each one taking up 16 bytes
+    Only ASCII characters 32-126 are present here. Each one taking up 16 bytes
     of the data. Each character is 8x16 pixels in size. */
 
-static const int minifont_size = 1504;
-static const unsigned char minifont_data[1504] = {
+static const int minifont_size = 1520;
+static const unsigned char minifont_data[1520] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
     0x18, 0x00, 0x00, 0x18, 0x18, 0x00, 0x00, 0x00,
     0x00, 0x36, 0x36, 0x12, 0x24, 0x00, 0x00, 0x00,


### PR DESCRIPTION
It may look like a jumble of unrelated changes but this is meant to work towards #858 where we have a common 1-bit interface for fonts.

To do this it's taking steps to move minifont, vmufont, and bfont towards being more interoperable. The biggest gap between them is that minifont and vmufont both presume only 7-bit ASCII and bfont currently doesn't support this (in the sense of 'to the exclusion of further characters).

Putting this in mostly to not lose the work that I almost accidentally cleared out of my local repo.
