### PR TITLE
Adjust SFX properties on the fly

### DIFF
--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -119,6 +119,7 @@ snd_sfx_play
 snd_sfx_stop_all
 snd_sfx_play_chn
 snd_sfx_play_ex
+snd_sfx_update
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -175,6 +175,7 @@ snd_sfx_play
 snd_sfx_stop_all
 snd_sfx_play_chn
 snd_sfx_play_ex
+snd_sfx_update
 snd_sfx_stop
 snd_sfx_chn_alloc
 snd_sfx_chn_free

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -229,6 +229,17 @@ int snd_sfx_play_chn(int chn, sfxhnd_t idx, int vol, int pan);
 */
 int snd_sfx_play_ex(sfx_play_data_t *data);
 
+/** \brief  Update the parameters of a sound channel.
+
+    Update a specified channel's vol, pan, or freq.
+
+    \param  data            The data structure containing the information needed
+                            to play the sound effect.
+
+    \return                 -1 if data or data->chn were invalid, 0 otherwise.
+*/
+int snd_sfx_update(sfx_play_data_t *data);
+
 /** \brief  Stop a single channel of sound.
 
     This function stops the specified channel of sound from playing. It does no

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -813,6 +813,30 @@ int snd_sfx_play_ex(sfx_play_data_t *data) {
     return data->chn;
 }
 
+int snd_sfx_update(sfx_play_data_t *data) {
+
+    if(!data || (data->chn < 0))
+        return -1;
+
+    AICA_CMDSTR_CHANNEL(tmp, cmd, chan);
+
+    cmd->cmd = AICA_CMD_CHAN;
+    cmd->timestamp = 0;
+    cmd->size = AICA_CMDSTR_CHANNEL_SIZE;
+    cmd->cmd_id = data->chn;
+    chan->cmd = AICA_CH_CMD_UPDATE |
+                AICA_CH_UPDATE_SET_VOL |
+                AICA_CH_UPDATE_SET_PAN |
+                AICA_CH_UPDATE_SET_FREQ;
+    chan->freq = data->freq;
+    chan->vol = data->vol;
+    chan->pan = data->pan;
+
+    snd_sh4_to_aica(tmp, cmd->size);
+
+    return 0;
+}
+
 void snd_sfx_stop(int chn) {
     AICA_CMDSTR_CHANNEL(tmp, cmd, chan);
     cmd->cmd = AICA_CMD_CHAN;


### PR DESCRIPTION
Based on #738 and #885 . I'm not entirely sure about keeping the data structure. It seems like it should be shared, at least in part, with `aica_channel_t` . 

Additionally I'm not sure if the usage makes much sense. The idea would be that you retain your `sfx_play_data_t` and can adjust the vol/pan/freq after using `snd_sfx_play_ex` (even if you set `chn = -1`, as it writes the chosen channel back) then send it over to `snd_sfx_update` with the new values.