### PR TITLE
Don't block for rumble and vmu beep/screen commands

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -14,16 +14,6 @@
 /* Be warned, not all purus are created equal, in fact, most of
    them act different for just about everything you feed to them. */
 
-static void purupuru_rumble_cb(maple_state_t *st, maple_frame_t *frame) {
-    (void)st;
-
-    /* Unlock the frame */
-    maple_frame_unlock(frame);
-
-    /* Wake up! */
-    genwait_wake_all(frame);
-}
-
 int purupuru_rumble_raw(maple_device_t *dev, uint32 effect) {
     uint32 *send_buf;
 
@@ -42,20 +32,9 @@ int purupuru_rumble_raw(maple_device_t *dev, uint32 effect) {
     dev->frame.dst_port = dev->port;
     dev->frame.dst_unit = dev->unit;
     dev->frame.length = 2;
-    dev->frame.callback = purupuru_rumble_cb;
+    dev->frame.callback = NULL;
     dev->frame.send_buf = send_buf;
     maple_queue_frame(&dev->frame);
-
-    /* Wait for the purupuru to accept it */
-    if(genwait_wait(&dev->frame, "purupuru_rumble", 500, NULL) < 0) {
-        if(dev->frame.state != MAPLE_FRAME_VACANT) {
-            /* Something went wrong.... */
-            dev->frame.state = MAPLE_FRAME_VACANT;
-            dbglog(DBG_ERROR, "purupuru_rumble: timeout to unit %c%c\n",
-                   dev->port + 'A', dev->unit + '0');
-            return MAPLE_ETIMEOUT;
-        }
-    }
 
     return MAPLE_EOK;
 }

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -296,20 +296,9 @@ int vmu_beep_raw(maple_device_t *dev, uint32_t beep) {
     dev->frame.dst_port = dev->port;
     dev->frame.dst_unit = dev->unit;
     dev->frame.length = 2;
-    dev->frame.callback = vmu_gen_callback;
+    dev->frame.callback = NULL;
     dev->frame.send_buf = send_buf;
     maple_queue_frame(&dev->frame);
-
-    /* Wait for the timer to accept it */
-    if(genwait_wait(&dev->frame, "vmu_beep_raw", 500, NULL) < 0) {
-        if(dev->frame.state != MAPLE_FRAME_VACANT) {
-            /* Something went wrong.... */
-            dev->frame.state = MAPLE_FRAME_VACANT;
-            dbglog(DBG_ERROR, "vmu_beep_raw: timeout to unit %c%c, beep: %lu\n",
-                   dev->port + 'A', dev->unit + '0', beep);
-            return MAPLE_ETIMEOUT;
-        }
-    }
 
     return MAPLE_EOK;
 }
@@ -342,20 +331,9 @@ int vmu_draw_lcd(maple_device_t *dev, const void *bitmap) {
     dev->frame.dst_port = dev->port;
     dev->frame.dst_unit = dev->unit;
     dev->frame.length = 2 + VMU_SCREEN_WIDTH;
-    dev->frame.callback = vmu_gen_callback;
+    dev->frame.callback = NULL;
     dev->frame.send_buf = send_buf;
     maple_queue_frame(&dev->frame);
-
-    /* Wait for the LCD to accept it */
-    if(genwait_wait(&dev->frame, "vmu_draw_lcd", 500, NULL) < 0) {
-        if(dev->frame.state != MAPLE_FRAME_VACANT) {
-            /* It's probably never coming back, so just unlock the frame */
-            dev->frame.state = MAPLE_FRAME_VACANT;
-            dbglog(DBG_ERROR, "vmu_draw_lcd: timeout to unit %c%c\n",
-                   dev->port + 'A', dev->unit + '0');
-            return MAPLE_ETIMEOUT;
-        }
-    }
 
     return MAPLE_EOK;
 }

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -167,7 +167,6 @@ typedef struct purupuru_effect  {
     \param  effect          The effect to send.
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
-    \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
 */
 int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect);
 
@@ -181,7 +180,6 @@ int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect);
     \param  effect          The effect to send.
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
-    \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
 */
 int purupuru_rumble_raw(maple_device_t *dev, uint32 effect);
 

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -252,7 +252,6 @@ int vmu_get_icon_shape(maple_device_t *dev, uint8_t *icon_shape);
 
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
-    \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
 
     \sa vmu_draw_lcd_rotated, vmu_draw_lcd_xbm, vmu_set_icon
 */
@@ -274,7 +273,6 @@ int vmu_draw_lcd(maple_device_t *dev, const void *bitmap);
     \param  bitmap          The bitmap to show.
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
-    \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
 
     \sa vmu_draw_lcd, vmu_draw_lcd_xbm, vmu_set_icon
 */
@@ -291,7 +289,6 @@ int vmu_draw_lcd_rotated(maple_device_t *dev, const void *bitmap);
 
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
-    \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
 
     \sa vmu_draw_lcd, vmu_set_icon
 */
@@ -412,7 +409,6 @@ int vmu_block_write(maple_device_t *dev, uint16_t blocknum, const uint8_t *buffe
 
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
-    \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
 
     \sa vmu_beep_waveform
 */
@@ -474,7 +470,6 @@ int vmu_beep_raw(maple_device_t *dev, uint32_t beep);
 
     \retval MAPLE_EOK           On success.
     \retval MAPLE_EAGAIN        If the command couldn't be sent. Try again later.
-    \retval MAPLE_ETIMEOUT      If the command timed out while blocking.
 */
 int vmu_beep_waveform(maple_device_t *dev, uint8_t period1, uint8_t duty_cycle1, uint8_t period2, uint8_t duty_cycle2);
 


### PR DESCRIPTION
There simply isn't anyone that is relying on this blocking behavior and all users end up working around it. The nature of the maple queue makes it so that the blocking time is significant and there really isn't much of anything that an end user could do in the case of a failure.

Though I had originally considered (in #786) adding new functions to select blocking/non-blocking there doesn't seem to be any reason for it. If some use cases are discovered in the future, then the API expansion should be to add intentionally blocking versions.