### PR TITLE
Fix warnings in snd_sfxmgr.c

### DIFF
--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -68,7 +68,7 @@ typedef struct sfx_play_data {
                             the way to the left, 128 is center, 255 is all the way
                             to the right. */
     int loop;       /**< \brief Whether to loop the sound effect or not. */
-    int freq;       /**< \brief Frequency */
+    unsigned int freq;       /**< \brief Frequency */
     unsigned int loopstart;  /**< \brief Loop start index (in samples). */
     unsigned int loopend;    /**< \brief Loop end index (in samples). If loopend == 0, 
                             the loop end will default to sfx size in samples. */

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -771,7 +771,7 @@ int snd_sfx_play_ex(sfx_play_data_t *data) {
         }
     }
 
-    int size;
+    uint32_t size;
     snd_effect_t *t = (snd_effect_t *)data->idx;
     AICA_CMDSTR_CHANNEL(tmp, cmd, chan);
 


### PR DESCRIPTION
We currently have two warnings in `snd_sfxmgr.c`:

```c
snd_sfxmgr.c:792:53: warning: operand of ‘?:’ changes signedness from ‘int’ to ‘unsigned int’ due to unsignedness of other operand [-Wsign-compare]
  792 |     chan->loopend = data->loopend ? data->loopend : size;
      |                                                     ^~~~
```

This is fixed by making the temp variable `size` a `uint32_t` since it's only assigned to and by other `uint32_t` values.

```c
snd_sfxmgr.c:793:35: warning: operand of ‘?:’ changes signedness from ‘int’ to ‘uint32_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
  793 |     chan->freq = data->freq > 0 ? data->freq : t->rate;
      |                                   ^~~~~~~~~~
```

This is fixed by making the `freq` field of `sfx_play_data_t` an `unsigned int`. Some other fields should probably be unsigned as well, but this PR is only to fix the warnings.