### PR TITLE
Update GCC 15.0.0-dev profile name to GCC 15.0.1-dev

### DIFF
--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -19,7 +19,7 @@
 # Development versions:
 # - 13.3.1-dev    Bleeding edge GCC 13 series from git.
 # - 14.2.1-dev    Bleeding edge GCC 14 series from git.
-# - 15.0.0-dev    Bleeding edge GCC 15 series from git.
+# - 15.0.1-dev    Bleeding edge GCC 15 series from git.
 # - gccrs-dev:    GCC fork for development of the GCCRS Rust compiler.
 # - rustc-dev:    GCC fork for development of the libgccjit rustc GCC codegen.
 # If unsure, select stable. See README.md for more detailed descriptions.

--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -108,7 +108,7 @@ The following toolchain profiles are available for users to select in
 | 14.2.0 | 14.2.0 | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | Latest release in the GCC 14 series, released 2024-08-01 |
 | 13.3.1-dev | 13.3.1 (git) | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | Bleeding edge GCC 13 series from git |
 | 14.2.1-dev | 14.2.1 (git) | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | Bleeding edge GCC 14 series from git |
-| 15.0.0-dev | 15.0.0 (git) | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | Bleeding edge GCC 15 series from git |
+| 15.0.1-dev | 15.0.1 (git) | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | Bleeding edge GCC 15 series from git |
 | gccrs-dev | 14.x | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | GCC fork for development of the GCCRS Rust compiler |
 | rustc-dev | 14.x | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | GCC fork for development of the libgccjit rustc GCC codegen |
 

--- a/utils/dc-chain/docker/README.md
+++ b/utils/dc-chain/docker/README.md
@@ -23,6 +23,6 @@ building them can take hours and the process doesn't change often.
 Of course, the Docker image produced here can also be used for CI/CD pipelines!
 
 This Dockerfile builds the `stable` toolchain by default, but can be used to
-build the other toolchains like `9.3.0-legacy`, `15.0.0-dev`, etc., as long as
+build the other toolchains like `9.3.0-legacy`, `15.0.1-dev`, etc., as long as
 you pass the `dc_chain` argument in the docker command line (see the Dockerfile
 for an example of the syntax).

--- a/utils/dc-chain/patches/gcc-15.0.1-kos.diff
+++ b/utils/dc-chain/patches/gcc-15.0.1-kos.diff
@@ -1,6 +1,6 @@
-diff -ruN gcc-15.0.0/gcc/config/sh/sh-c.cc gcc-15.0.0-kos/gcc/config/sh/sh-c.cc
---- gcc-15.0.0/gcc/config/sh/sh-c.cc	2024-01-04 16:01:33.790051712 -0600
-+++ gcc-15.0.0-kos/gcc/config/sh/sh-c.cc	2024-01-04 16:01:42.910094466 -0600
+diff -ruN gcc-15.0.1/gcc/config/sh/sh-c.cc gcc-15.0.1-kos/gcc/config/sh/sh-c.cc
+--- gcc-15.0.1/gcc/config/sh/sh-c.cc	2024-01-04 16:01:33.790051712 -0600
++++ gcc-15.0.1-kos/gcc/config/sh/sh-c.cc	2024-01-04 16:01:42.910094466 -0600
 @@ -141,4 +141,11 @@
  
    cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
@@ -13,9 +13,9 @@ diff -ruN gcc-15.0.0/gcc/config/sh/sh-c.cc gcc-15.0.0-kos/gcc/config/sh/sh-c.cc
 +  /* Toolchain supports setting up stack for 32MB */
 +  builtin_define ("__KOS_GCC_32MB__");
  }
-diff -ruN gcc-15.0.0/gcc/configure gcc-15.0.0-kos/gcc/configure
---- gcc-15.0.0/gcc/configure	2024-01-04 16:01:33.801051764 -0600
-+++ gcc-15.0.0-kos/gcc/configure	2024-01-04 16:01:42.913094480 -0600
+diff -ruN gcc-15.0.1/gcc/configure gcc-15.0.1-kos/gcc/configure
+--- gcc-15.0.1/gcc/configure	2024-01-04 16:01:33.801051764 -0600
++++ gcc-15.0.1-kos/gcc/configure	2024-01-04 16:01:42.913094480 -0600
 @@ -13122,7 +13122,7 @@
      target_thread_file='single'
      ;;
@@ -25,9 +25,9 @@ diff -ruN gcc-15.0.0/gcc/configure gcc-15.0.0-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff -ruN gcc-15.0.0/libgcc/config/sh/t-sh gcc-15.0.0-kos/libgcc/config/sh/t-sh
---- gcc-15.0.0/libgcc/config/sh/t-sh	2024-01-04 16:01:37.134067388 -0600
-+++ gcc-15.0.0-kos/libgcc/config/sh/t-sh	2024-01-04 16:01:42.914094485 -0600
+diff -ruN gcc-15.0.1/libgcc/config/sh/t-sh gcc-15.0.1-kos/libgcc/config/sh/t-sh
+--- gcc-15.0.1/libgcc/config/sh/t-sh	2024-01-04 16:01:37.134067388 -0600
++++ gcc-15.0.1-kos/libgcc/config/sh/t-sh	2024-01-04 16:01:42.914094485 -0600
 @@ -23,6 +23,8 @@
    $(LIB1ASMFUNCS_CACHE)
  LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
@@ -37,9 +37,9 @@ diff -ruN gcc-15.0.0/libgcc/config/sh/t-sh gcc-15.0.0-kos/libgcc/config/sh/t-sh
  crt1.o: $(srcdir)/config/sh/crt1.S
  	$(gcc_compile) -c $<
  
-diff -ruN gcc-15.0.0/libgcc/configure gcc-15.0.0-kos/libgcc/configure
---- gcc-15.0.0/libgcc/configure	2024-01-04 16:01:37.139067412 -0600
-+++ gcc-15.0.0-kos/libgcc/configure	2024-01-04 16:01:42.914094485 -0600
+diff -ruN gcc-15.0.1/libgcc/configure gcc-15.0.1-kos/libgcc/configure
+--- gcc-15.0.1/libgcc/configure	2024-01-04 16:01:37.139067412 -0600
++++ gcc-15.0.1-kos/libgcc/configure	2024-01-04 16:01:42.914094485 -0600
 @@ -5733,6 +5733,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -48,9 +48,9 @@ diff -ruN gcc-15.0.0/libgcc/configure gcc-15.0.0-kos/libgcc/configure
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
-diff -ruN gcc-15.0.0/libobjc/configure gcc-15.0.0-kos/libobjc/configure
---- gcc-15.0.0/libobjc/configure	2024-01-04 16:01:37.499069099 -0600
-+++ gcc-15.0.0-kos/libobjc/configure	2024-01-04 16:01:42.915094489 -0600
+diff -ruN gcc-15.0.1/libobjc/configure gcc-15.0.1-kos/libobjc/configure
+--- gcc-15.0.1/libobjc/configure	2024-01-04 16:01:37.499069099 -0600
++++ gcc-15.0.1-kos/libobjc/configure	2024-01-04 16:01:42.915094489 -0600
 @@ -2924,11 +2924,9 @@
  
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -63,9 +63,9 @@ diff -ruN gcc-15.0.0/libobjc/configure gcc-15.0.0-kos/libobjc/configure
    ;
    return 0;
  }
-diff -ruN gcc-15.0.0/libobjc/Makefile.in gcc-15.0.0-kos/libobjc/Makefile.in
---- gcc-15.0.0/libobjc/Makefile.in	2024-01-04 16:01:37.499069099 -0600
-+++ gcc-15.0.0-kos/libobjc/Makefile.in	2024-01-04 16:01:42.915094489 -0600
+diff -ruN gcc-15.0.1/libobjc/Makefile.in gcc-15.0.1-kos/libobjc/Makefile.in
+--- gcc-15.0.1/libobjc/Makefile.in	2024-01-04 16:01:37.499069099 -0600
++++ gcc-15.0.1-kos/libobjc/Makefile.in	2024-01-04 16:01:42.915094489 -0600
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -96,9 +96,9 @@ diff -ruN gcc-15.0.0/libobjc/Makefile.in gcc-15.0.0-kos/libobjc/Makefile.in
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff -ruN gcc-15.0.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-15.0.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-15.0.0/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:37.608069611 -0600
-+++ gcc-15.0.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:42.916094494 -0600
+diff -ruN gcc-15.0.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-15.0.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-15.0.1/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:37.608069611 -0600
++++ gcc-15.0.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2024-01-04 16:01:42.916094494 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -149,9 +149,9 @@ diff -ruN gcc-15.0.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-15.0.0-kos/libst
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-15.0.0/libstdc++-v3/configure gcc-15.0.0-kos/libstdc++-v3/configure
---- gcc-15.0.0/libstdc++-v3/configure	2024-01-04 16:01:37.616069648 -0600
-+++ gcc-15.0.0-kos/libstdc++-v3/configure	2024-01-04 16:01:42.919094508 -0600
+diff -ruN gcc-15.0.1/libstdc++-v3/configure gcc-15.0.1-kos/libstdc++-v3/configure
+--- gcc-15.0.1/libstdc++-v3/configure	2024-01-04 16:01:37.616069648 -0600
++++ gcc-15.0.1-kos/libstdc++-v3/configure	2024-01-04 16:01:42.919094508 -0600
 @@ -15974,6 +15974,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/profiles/profile.15.0.1-dev.mk
+++ b/utils/dc-chain/profiles/profile.15.0.1-dev.mk
@@ -4,13 +4,13 @@
 ###############################################################################
 ###############################################################################
 ### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
-## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2025-01-02.
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2025-01-24.
 ###############################################################################
 ###############################################################################
 
 # Toolchain versions for SH
 sh_binutils_ver=2.43.1
-sh_gcc_ver=15.0.0
+sh_gcc_ver=15.0.1
 newlib_ver=4.5.0.20241231
 gdb_ver=15.2
 


### PR DESCRIPTION
This is a minor housekeeping PR.
GCC 15 series is now in bugfixing stage, and thus has been bumped from 15.0.0 to 15.0.1.