### PR TITLE
Ansi cleanups

### DIFF
--- a/addons/libnavi/navi_flash.c
+++ b/addons/libnavi/navi_flash.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <navi/flash.h>
+#include <kos/thread.h>
 
 /*
 
@@ -105,7 +106,7 @@ static int nvflash_wait_ready(uint32 addr, int timeout) {
 
     while(timeout-- && nvflash_busy(addr)) {
         if(wait)
-            usleep(1000);
+            thd_sleep(1);
     }
 
     if(timeout <= 0) {

--- a/include/sys/_pthread.h
+++ b/include/sys/_pthread.h
@@ -7,7 +7,7 @@
 #ifndef __SYS__PTHREAD_H
 #define __SYS__PTHREAD_H
 
-// Make sure pthreads compile ok.
+/* Make sure pthreads compile ok. */
 /** \brief  POSIX threads supported (sorta) */
 #define _POSIX_THREADS
 

--- a/include/sys/_types.h
+++ b/include/sys/_types.h
@@ -20,7 +20,7 @@ __BEGIN_DECLS
     @{
 */
 
-// This part copied from newlib's sys/_types.h.
+/* This part copied from newlib's sys/_types.h. */
 #ifndef __off_t_defined
 /** \brief  File offset type. */
 typedef long _off_t;

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -63,5 +63,4 @@ void __newlib_lock_release_recursive(__newlib_recursive_lock_t*);
 
 /** \endcond */
 
-#endif // __NEWLIB_LOCK_COMMON_H
-
+#endif /* __SYS_LOCK_H__ */

--- a/kernel/arch/dreamcast/include/dc/scif.h
+++ b/kernel/arch/dreamcast/include/dc/scif.h
@@ -40,7 +40,7 @@ __BEGIN_DECLS
 */
 void scif_set_parameters(int baud, int fifo);
 
-// The rest of these are the standard dbgio interface.
+/* The rest of these are the standard dbgio interface. */
 
 /** \brief  Enable or disable SCIF IRQ usage.
     \param  on              1 to enable IRQ usage, 0 for polled I/O.

--- a/kernel/arch/dreamcast/include/dc/video.h
+++ b/kernel/arch/dreamcast/include/dc/video.h
@@ -107,15 +107,15 @@ typedef enum vid_display_mode_generic {
 */
 #define DM_MULTIBUFFER  0x2000
 
-//-----------------------------------------------------------------------------
-// More specific modes (and actual indices into the mode table)
+/* ------------------------------------------------------------------------- */
+/* More specific modes (and actual indices into the mode table) */
 
 /** \brief   Specific Display Modes 
     \ingroup video_modes_display
 */
 typedef enum vid_display_mode {
     DM_INVALID = 0,                 /**< \brief Invalid display mode */
-    // Valid modes below
+    /* Valid modes below */
     DM_320x240_VGA = 1,             /**< \brief 320x240 VGA 60Hz */
     DM_320x240_NTSC,                /**< \brief 320x240 NTSC 60Hz */
     DM_640x480_VGA,                 /**< \brief 640x480 VGA 60Hz */
@@ -126,12 +126,11 @@ typedef enum vid_display_mode {
     DM_768x576_PAL_IL,              /**< \brief 768x576 PAL Interlaced 50Hz */
     DM_768x480_PAL_IL,              /**< \brief 768x480 PAL Interlaced 50Hz */
     DM_320x240_PAL,                 /**< \brief 320x240 PAL 50Hz */
-    // The below is only for counting..
+    /* The below is only for counting.. */
     DM_SENTINEL,                    /**< \brief Sentinel value, for counting */
     DM_MODE_COUNT                   /**< \brief Number of modes */
 } vid_display_mode_t;
 
-// These are for the "flags" field of "vid_mode_t"
 /** \defgroup vid_flags Flags
     \brief              vid_mode_t Field Flags
     \ingroup            video_modes
@@ -191,12 +190,13 @@ extern vid_mode_t vid_builtin[DM_MODE_COUNT];
 */
 extern vid_mode_t *vid_mode;
 
-// These point to the current drawing area. If you're not using a multi-buffered
-// mode, that means they do what KOS always used to do (they'll point at the
-// start of VRAM). If you're using a multi-buffered mode, they'll point at the
-// next framebuffer to be displayed. You must use vid_flip for this to work
-// though (if you use vid_set_start, they'll point at the display base, for
-// compatibility's sake).
+/*  These point to the current drawing area. If you're not using a multi-buffered
+    mode, that means they do what KOS always used to do (they'll point at the
+    start of VRAM). If you're using a multi-buffered mode, they'll point at the
+    next framebuffer to be displayed. You must use vid_flip for this to work
+    though (if you use vid_set_start, they'll point at the display base, for
+    compatibility's sake).
+*/
 
 /** \defgroup video_fb Framebuffer
     \brief             API for framebuffer management
@@ -435,5 +435,5 @@ size_t vid_screen_shot_data(uint8_t **buffer);
 
 __END_DECLS
 
-#endif  // __DC_VIDEO_H
+#endif  /* __DC_VIDEO_H */
 

--- a/kernel/libc/koslib/readdir.c
+++ b/kernel/libc/koslib/readdir.c
@@ -10,6 +10,13 @@
 #include <string.h>
 #include <kos/fs.h>
 
+#ifdef __STRICT_ANSI__
+/* Newlib doesn't prototype this function in strict standards compliant mode, so
+   we'll do it here. It is still provided either way, but it isn't prototyped if
+   we use -std=c17 (or any other non-gnuXX value). */
+size_t strnlen(const char *, size_t);
+#endif
+
 struct dirent *readdir(DIR *dir) {
     dirent_t *d;
     size_t len;


### PR DESCRIPTION
I started this trying to match a cleanup done in 2014 for behavior with `-ansi`. I think though since we've updated our language standards the right thing to do with the forced forward declares is likely to remove the other ones (rather than add a new one) as we now have `alignas` and `alloca` which require gnu extensions so we just don't support `c11`/`c17`.

Edit: I had forgotten that the key reason to keep this cleaned up is to more easily allow user software or other libs that link against us to do so safely (as we saw was an issue in #919 and #920 ).