### PR TITLE
Return the proper data of the irq_cb struct rather than NULL

### DIFF
--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -70,7 +70,7 @@ int irq_set_handler(irq_t code, irq_handler hnd, void *data) {
 irq_cb_t irq_get_handler(irq_t code) {
     /* Make sure they don't do something crackheaded */
     if(code >= 0x1000 || (code & 0x000f))
-        return NULL;
+        return (irq_cb_t){NULL, NULL};
 
     code >>= 5;
 


### PR DESCRIPTION
Not sure if this is only due to some higher warning settings that I currently have enabled, but since we're returning the full struct for the irq_cb, I get an error for the size being wrong with *just* NULL.