### PR TITLE
Fixed build issue in irq.c.

### DIFF
--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -70,7 +70,7 @@ int irq_set_handler(irq_t code, irq_handler hnd, void *data) {
 irq_cb_t irq_get_handler(irq_t code) {
     /* Make sure they don't do something crackheaded */
     if(code >= 0x1000 || (code & 0x000f))
-        return NULL;
+        return (irq_cb_t){ NULL, NULL };
 
     code >>= 5;
 


### PR DESCRIPTION
irq_get_handler() was changed from returning a single function pointer to the old handler to return a function pointer/userdata pair with the new API, but this return statement hadn't been updated.

- Updated to return a pair of NULL pointers for the callback struct.