### PR TITLE
Added PantherDC to Controller Capability Typelist

### DIFF
--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -3,7 +3,7 @@
    dc/maple/controller.h
    Copyright (C) 2000-2002 Jordan DeLong
    Copyright (C) 2000-2002 Megan Potter
-   Copyright (C) 2023 Falco Girgis
+   Copyright (C) 2023, 2025 Falco Girgis
 
    Thanks to Marcus Comstedt for information on the controller.
 */

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -471,6 +471,14 @@ int cont_has_capabilities(const struct maple_device *cont, uint32_t capabilities
                                              CONT_CAPABILITIES_EXTENDED_BUTTONS | \
                                              CONT_CAPABILITY_D | \
                                              CONT_CAPABILITIES_DPAD)
+
+/** \brief Madcatz PantherDC "Flight Stick + Trackball" controller type */
+#define CONT_TYPE_PANTHERDC                 (CONT_CAPABILITIES_STANDARD_BUTTONS | \
+                                             CONT_CAPABILITIES_EXTENDED_BUTTONS | \
+                                             CONT_CAPABILITY_D | \
+                                             CONT_CAPABILITIES_TRIGGERS | \
+                                             CONT_CAPABILITIES_DPAD | \
+                                             CONT_CAPABILITIES_DUAL_ANALOG)
 /** @} */
 
 /** \brief   Check for controller type


### PR DESCRIPTION
An ancient wrong must be righted... I forgot to add an entry for the most niche (but epic) of DC peripherals, the PantherDC controller, to our controller capabilities type lists... 

So now you can easily query for whether a controller supports all of the inputs supported by the PantherDC controller.