### PR TITLE
Added thread attribs to cont_btn_callback worker.

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -2,6 +2,7 @@
 
    controller.c
    Copyright (C) 2002 Megan Potter
+   Copyright (C) 2025 Falco Girgis
 
  */
 
@@ -17,6 +18,10 @@
 
 /* Location of controller capabilities within function_data array */
 #define CONT_FUNCTION_DATA_INDEX  0
+
+#ifndef CONT_BTN_CALLBACK_THD_STACK_SIZE
+#define CONT_BTN_CALLBACK_THD_STACK_SIZE (8 * 1024)
+#endif
 
 /* Raw controller condition structure */
 typedef struct cont_cond {
@@ -110,8 +115,14 @@ int cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb) {
         return 0;
     }
 
+    const kthread_attr_t thd_attr = {
+        .stack_size = CONT_BTN_CALLBACK_THD_STACK_SIZE,
+        .prio = PRIO_DEFAULT,
+        .label = "cont_btn_callback"
+    };
+
     params->worker =
-        thd_worker_create_ex(NULL, &cont_btn_cb_thread, params);
+        thd_worker_create_ex(&thd_attr, &cont_btn_cb_thread, params);
 
     if(!params->worker) {
         free(params);


### PR DESCRIPTION
1) When using the cont_btn_callback() mechanism, a new thread is created, which is left unnamed. This looks kind of janky and confusing when seen in the thread listing when dumping thread info or after an exception.
    - Added a default label to the worker thread to identify it 
    
2) By far, the most commonly implemented callback with this mechanism tends to be some absolutely trivial logic like a simple call to exit(0). Because of this, games which are low on RAM are typically paying an exuberantly high amount of memory overhead just to call one function with a default stack size of 32KB for the worker.
    - Added a default stack size of 8KB, which can be overridden at compile-time, consistently with how other default thread sizes can be overwritten.