### PR TITLE
Revert alignas change in irq.h to fix toolchain building

### DIFF
--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -93,8 +93,7 @@ __BEGIN_DECLS
     The size of this structure should be less than or equal to the
     \ref REG_BYTE_CNT value.
 */
-typedef struct irq_context {
-alignas(32)
+typedef __attribute__((aligned(32))) struct irq_context {
     uint32_t  pc;         /**< Program counter */
     uint32_t  pr;         /**< Procedure register (aka return address) */
     uint32_t  gbr;        /**< Global base register (TLS segment ptr) */


### PR DESCRIPTION
With the latest changes to `irq.h`, the toolchain is no longer building properly due to the `irq.h` file being pulled in by some C++98 crap in `libstdc++`. Example from @Memorix101:

![image](https://github.com/user-attachments/assets/d20282f6-c9a8-4588-a15e-c00b170b5483)

This emergency fix reverts the `__attribute__((aligned(32)))` -> `alignas(32)` change until something more satisfactory can be done.