### PR TITLE
Various minor fixes found via `-fanalyzer`

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -288,6 +288,12 @@ static dirent_t *dcload_readdir(void * h) {
         rv->attr = 0; /* what the hell is attr supposed to be anyways? */
 
         fn = malloc(strlen(entry->path) + strlen(dcld->d_name) + 1);
+
+        if(!fn) {
+            errno = ENOMEM;
+            return NULL;
+        }
+
         strcpy(fn, entry->path);
         strcat(fn, dcld->d_name);
 

--- a/kernel/arch/dreamcast/include/arch/exec.h
+++ b/kernel/arch/dreamcast/include/arch/exec.h
@@ -39,7 +39,7 @@ __BEGIN_DECLS
     \param  length          The length of the binary.
     \param  address         The address of the binary's starting point.
 */
-void arch_exec_at(const void *image, uint32 length, uint32 address) __noreturn;
+void arch_exec_at(const void *image, uint32_t length, uint32_t address) __noreturn;
 
 /** \brief  Replace the currently running binary at the default address.
 
@@ -50,7 +50,7 @@ void arch_exec_at(const void *image, uint32 length, uint32 address) __noreturn;
     \param  image           The binary to run (already loaded into RAM).
     \param  length          The length of the binary.
 */
-void arch_exec(const void *image, uint32 length) __noreturn;
+void arch_exec(const void *image, uint32_t length) __noreturn;
 
 /** @} */
 

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -28,7 +28,7 @@
 
 #include "initall_hdrs.h"
 
-extern int _bss_start, end;
+extern uintptr_t _bss_start, end;
 
 /* ctor/dtor stuff from libgcc. */
 #if __GNUC__ == 4
@@ -262,7 +262,6 @@ void  __weak arch_auto_shutdown(void) {
 /* This is the entry point inside the C program */
 void arch_main(void) {
     uint8 *bss_start = (uint8 *)(&_bss_start);
-    uint8 *bss_end = (uint8 *)(&end);
     int rv;
 
     if (KOS_PLATFORM_IS_NAOMI) {
@@ -284,7 +283,7 @@ void arch_main(void) {
         __kos_init_early_fn();
 
     /* Clear out the BSS area */
-    memset(bss_start, 0, bss_end - bss_start);
+    memset(bss_start, 0, (uintptr_t)(&end) - (uintptr_t)bss_start);
 
     /* Do auto-init stuff */
     arch_auto_init();

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -24,8 +24,8 @@
 static int initted = 0;
 
 /* This will come from a separately linked object file */
-extern uint8_t snd_stream_drv[];
-extern uint8_t snd_stream_drv_end[];
+extern uintptr_t snd_stream_drv;
+extern uintptr_t snd_stream_drv_end;
 
 /* The queue processing mutex for snd_sh4_to_aica_start and snd_sh4_to_aica_stop.
    There are some cases like stereo stream control + stereo sfx control
@@ -35,7 +35,7 @@ static mutex_t queue_proc_mutex = MUTEX_INITIALIZER;
 /* Initialize driver; note that this replaces the AICA program so that
    if you had anything else going on, it's gone now! */
 int snd_init(void) {
-    int amt;
+    size_t amt;
 
     /* Finish loading the stream driver */
     if(!initted) {
@@ -46,8 +46,8 @@ int snd_init(void) {
         if(amt % 4)
             amt = (amt + 4) & ~3;
 
-        dbglog(DBG_DEBUG, "snd_init(): loading %d bytes into SPU RAM\n", amt);
-        spu_memload_sq(0, snd_stream_drv, amt);
+        dbglog(DBG_DEBUG, "snd_init(): loading %u bytes into SPU RAM\n", amt);
+        spu_memload_sq(0, (void* )snd_stream_drv, amt);
 
         /* Enable the AICA and give it a few ms to start up */
         spu_enable();

--- a/kernel/arch/dreamcast/util/screenshot.c
+++ b/kernel/arch/dreamcast/util/screenshot.c
@@ -36,6 +36,11 @@ size_t vid_screen_shot_data(uint8_t **buffer) {
     /* Allocate buffer to store the 24bpp image data */
     numpix = vid_mode->width * vid_mode->height;
     buffer_size = numpix * BYTES_PER_PIXEL;
+    if(!buffer_size) {
+        dbglog(DBG_ERROR, "vid_screen_shot_data: invalid video mode.\n");
+        return 0;
+    }
+
     *buffer = (uint8_t *)malloc(buffer_size);
     if(*buffer == NULL) {
         dbglog(DBG_ERROR, "vid_screen_shot_data: can't allocate memory\n"); 


### PR DESCRIPTION
Some changes were similar in multiple files:
- Ensuring pointer math is being done with the correct types - init.c, snd_iface.c
- Simple allocation failure checks - fs_dcload.c, thread.c

- exec.c updates should functionally be only to use the right types for pointer math, but as the file was not using stdint types, updated it to do so. Additionally fixed a comment that was naming the wrong file, used a memory area define on top of the default start of exec, and added a new variable casting parity/cleanup.

- screenshot.c's update regards a leak with `malloc(0)` which I figure is fine to test against such bad behavior in a util (as opposed to a critical path).

- scandir.c was testing a value for null *after* already derefing it. While I was there I removed some pieces that seemed unnecessary. I also added a null check that is a bit redundant but calmed a warning. @gyrovorbis would be great if you could give this a good looking at.

EDIT: I've integrated the changes that were here for thread.c into #956 