### PR TITLE
cache: Fix non-working dcache_{flush,purge}_all()

### DIFF
--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -262,7 +262,7 @@ ifr_addr:
 
 ! D-cache (Data cache)
 dca_addr:
-    .long    0xf4000000    ! dcache array address
+    .long    0xf4000008    ! dcache array address
 dc_ubit_mask:
     .long    0xfffffffd    ! Mask to zero out U bit
 


### PR DESCRIPTION
The algorithm of dcache_flush_all() and dcache_purge_all() were
sometimes exhibiting problems under unidentified conditions, in which
case some cache lines were not written back properly to RAM.

This caused all kind of memory corruption problems, when the PVR DMA was
used for transfers with a size above the threshold at which the
"dcache_flush_all()" function is called.

Fix these functions by accessing the cache address array using
association. Since the underlying problem is not fully understood, the
fix is not fully understood either, but it was reported as fixing the
memory corruption in Doom64.

Fixes #928.