### PR TITLE
Remove redefined 'BSD-style' types.

### DIFF
--- a/examples/dreamcast/conio/wump/wump.c
+++ b/examples/dreamcast/conio/wump/wump.c
@@ -652,7 +652,7 @@ cave_init() {
      * make it easier on the intrepid adventurer.
      */
     for(i = 1; i <= room_num; ++i)
-        qsort(cave[i].tunnel, (u_int)link_num,
+        qsort(cave[i].tunnel, link_num,
               sizeof(cave[i].tunnel[0]), int_compare);
 
 #ifdef DEBUG

--- a/kernel/arch/dreamcast/include/arch/types.h
+++ b/kernel/arch/dreamcast/include/arch/types.h
@@ -51,31 +51,6 @@ typedef volatile int8 vint8;        /**< \brief 8-bit volatile signed type */
 /* Pointer arithmetic types */
 typedef uint32 ptr_t;               /**< \brief Pointer arithmetic type */
 
-/* another format for type names */
-#ifndef _BSDTYPES_DEFINED
-
-/* \cond */
-#define __u_char_defined
-#define __u_short_defined
-#define __u_int_defined
-#define __u_long_defined
-#define __ushort_defined
-#define __uint_defined
-/* \endcond */
-
-typedef unsigned char   u_char;     /**< \brief BSD-style unsigned char */
-typedef unsigned short  u_short;    /**< \brief BSD-style unsigned short */
-typedef unsigned int    u_int;      /**< \brief BSD-style unsigned integer */
-typedef unsigned long   u_long;     /**< \brief BSD-style unsigned long */
-typedef unsigned short  ushort;     /**< \brief BSD-style unsigned short */
-typedef unsigned int    uint;       /**< \brief BSD-style unsigned integer */
-
-/* \cond */
-#define _BSDTYPES_DEFINED
-/* \endcond */
-
-#endif  /* _BSDTYPES_DEFINED */
-
 /* This type may be used for any generic handle type that is allowed
    to be negative (for errors) and has no specific bit count
    restraints. */


### PR DESCRIPTION
This should help reduce the possible impact of #840 which describes how types defined in this file escape out and can conflict with other codebases.

This is in-line with our general move to stdint types and, as far as I can tell, there was only one use of these types in the codebase.