### PR TITLE
Improved control of protection system on the G1 bus for ATA/ATAPI devices.

### DIFF
--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -5,7 +5,7 @@
    Copyright (C) 2000 Megan Potter
    Copyright (C) 2014 Lawrence Sebald
    Copyright (C) 2014 Donald Haase
-   Copyright (C) 2023, 2024 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024, 2025 Ruslan Rostovtsev
    Copyright (C) 2024 Andy Barajas
 
  */
@@ -408,35 +408,69 @@ int cdrom_spin_down(void) {
     return rv;
 }
 
+/*
+    Unlocks G1 ATA DMA access to all memory on the root bus, not just system memory.
+    Patches syscall region where the DMA protection register is set,
+    ensuring it allows broader memory access, and updates the register accordingly.
+ */
+static void unlock_dma_memory(void) {
+    uint32_t i, patched = 0;
+    size_t flush_size;
+    volatile uint32_t *prot_reg = (uint32_t *)(G1_ATA_DMA_PROTECTION | MEM_AREA_P2_BASE);
+    uintptr_t patch_addr[2] = {0x0c001c20, 0x0c0023fc};
+
+    for(i = 0; i < sizeof(patch_addr) / sizeof(uintptr_t); ++i) {
+        if(*(uint32_t *)(patch_addr[i] | MEM_AREA_P2_BASE) == (uint32_t)G1_ATA_DMA_UNLOCK_SYSMEM) {
+            *(uint32_t *)(patch_addr[i] | MEM_AREA_P2_BASE) = G1_ATA_DMA_UNLOCK_ALLMEM;
+            ++patched;
+        }
+    }
+    if(patched) {
+        flush_size = (patch_addr[1] - patch_addr[0]) + CPU_CACHE_BLOCK_SIZE;
+        flush_size &= ~(CPU_CACHE_BLOCK_SIZE - 1);
+        icache_flush_range(patch_addr[0] | MEM_AREA_P1_BASE, flush_size);
+    }
+    *prot_reg = G1_ATA_DMA_UNLOCK_ALLMEM;
+}
+
 /* Initialize: assume no threading issues */
 void cdrom_init(void) {
     uint32_t p;
-    volatile uint32_t *react = (uint32_t *)(0x005f74e4 | MEM_AREA_P2_BASE);
+    volatile uint32_t *react = (uint32_t *)(G1_ATA_BUS_PROTECTION | MEM_AREA_P2_BASE);
+    volatile uint32_t *state = (uint32_t *)(G1_ATA_BUS_PROTECTION_STATUS | MEM_AREA_P2_BASE);
     volatile uint32_t *bios = (uint32_t *)MEM_AREA_P2_BASE;
 
     mutex_lock(&_g1_ata_mutex);
 
-    /* Reactivate drive: send the BIOS size and then read each
-       word across the bus so the controller can verify it.
-       If first bytes are 0xe6ff instead of usual 0xe3ff, then
-       hardware is fitted with custom BIOS using magic bootstrap
-       which can and must pass controller verification with only
-       the first 1024 bytes */
-    if((*(uint16_t *)MEM_AREA_P2_BASE) == 0xe6ff) {
-        *react = 0x3ff;
-        for(p = 0; p < 0x400 / sizeof(bios[0]); p++) {
-            (void)bios[p];
-        }
-    } else {
-        *react = 0x1fffff;
-        for(p = 0; p < 0x200000 / sizeof(bios[0]); p++) {
-            (void)bios[p];
+    /*
+        First, check the protection status to determine if it's necessary 
+        to pass check the entire BIOS again.
+    */
+    if (*state != G1_ATA_BUS_PROTECTION_STATUS_PASSED) {
+        /* Reactivate drive: send the BIOS size and then read each
+        word across the bus so the controller can verify it.
+        If first bytes are 0xe6ff instead of usual 0xe3ff, then
+        hardware is fitted with custom BIOS using magic bootstrap
+        which can and must pass controller verification with only
+        the first 1024 bytes */
+        if((*(uint16_t *)MEM_AREA_P2_BASE) == 0xe6ff) {
+            *react = 0x3ff;
+            for(p = 0; p < 0x400 / sizeof(bios[0]); p++) {
+                (void)bios[p];
+            }
+        } else {
+            *react = 0x1fffff;
+            for(p = 0; p < 0x200000 / sizeof(bios[0]); p++) {
+                (void)bios[p];
+            }
         }
     }
 
     /* Reset system functions */
     syscall_gdrom_reset();
     syscall_gdrom_init();
+
+    unlock_dma_memory();
     mutex_unlock(&_g1_ata_mutex);
 
     cdrom_reinit();

--- a/kernel/arch/dreamcast/include/dc/g1ata.h
+++ b/kernel/arch/dreamcast/include/dc/g1ata.h
@@ -2,7 +2,7 @@
 
    dc/g1ata.h
    Copyright (C) 2013, 2014 Lawrence Sebald
-   Copyright (C) 2023, 2024 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024, 2025 Ruslan Rostovtsev
 */
 
 /** \file    dc/g1ata.h
@@ -106,6 +106,61 @@ __BEGIN_DECLS
     about this one at all. This bit is irrelevant for packet devices.
 */
 #define G1_ATA_LBA_MODE     0x40
+/** @} */
+
+/** \defgroup g1ata_protect   G1 ATA protection
+    \brief                 G1 Bus and DMA protection
+    \ingroup                g1ata
+    @{
+*/
+/** \brief   G1 ATA bus protection register.
+    \ingroup g1ata
+
+    Used to check BIOS contents in the Holly.
+*/
+#define G1_ATA_BUS_PROTECTION       0x005F74E4
+
+/** \brief   G1 ATA bus protection status register.
+    \ingroup g1ata
+
+    Used to determine the status of the check in the Holly.
+*/
+#define G1_ATA_BUS_PROTECTION_STATUS 0x005F74EC
+
+/** \brief   G1 ATA bus protection in progress state.
+    \ingroup g1ata
+*/
+#define G1_ATA_BUS_PROTECTION_STATUS_IN_PROGRESS 0x00
+
+/** \brief   G1 ATA bus protection failed state.
+    \ingroup g1ata
+*/
+#define G1_ATA_BUS_PROTECTION_STATUS_FAILED      0x02
+
+/** \brief   G1 ATA bus protection passed state.
+    \ingroup g1ata
+*/
+#define G1_ATA_BUS_PROTECTION_STATUS_PASSED      0x03
+
+/** \brief   G1 ATA DMA protection register.
+    \ingroup g1ata
+*/
+#define G1_ATA_DMA_PROTECTION    0x005F74B8
+
+/** \brief   G1 ATA DMA protection register code.
+    \ingroup g1ata
+*/
+#define G1_ATA_DMA_UNLOCK_CODE   0x8843
+
+/** \brief   System memory DMA protection unlock value.
+    \ingroup g1ata
+*/
+#define G1_ATA_DMA_UNLOCK_SYSMEM (G1_ATA_DMA_UNLOCK_CODE << 16 | 0x407F)
+
+/** \brief   All memory DMA protection unlock value.
+    \ingroup g1ata
+*/
+#define G1_ATA_DMA_UNLOCK_ALLMEM (G1_ATA_DMA_UNLOCK_CODE << 16 | 0x007F)
 /** @} */
 
 /** \brief   Is there a G1 DMA in progress currently?


### PR DESCRIPTION
- Added defines for the protection system on the G1 bus for ATA/ATAPI devices.
- Initiating BIOS checking only if needed.
- Unlocking all memory on the Root Bus for CDROM DMA transfers.

Ready for review. Someone else also needs to check this.
Information about the BIOS check status register is taken from here:
http://www.dc-swat.ru/forum/thread-2150-post-32005.html#pid32005