### PR TITLE
Clean up malloc.h references, memalign usage

### DIFF
--- a/addons/libkosutils/img.c
+++ b/addons/libkosutils/img.c
@@ -6,8 +6,8 @@
    Platform independent image handling
 */
 
-#include <malloc.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <kos/img.h>
 
 /* Free a kos_img_t which was created by an image loader; set struct_also to non-zero

--- a/examples/dreamcast/kgl/basic/elements/gl-elements.c
+++ b/examples/dreamcast/kgl/basic/elements/gl-elements.c
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 
 #include <KGL/gl.h>
 #include <KGL/glu.h>

--- a/examples/dreamcast/kgl/basic/zclip_arrays/gl-arrays.c
+++ b/examples/dreamcast/kgl/basic/zclip_arrays/gl-arrays.c
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 
 #include <KGL/gl.h>
 #include <KGL/glu.h>

--- a/examples/dreamcast/kgl/demos/specular/font.c
+++ b/examples/dreamcast/kgl/demos/specular/font.c
@@ -7,8 +7,8 @@
    DC Font Render Routine using GL and KOS (C) Josh PH3NOM Pearson 2013
 */
 
-#include <malloc.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <KGL/gl.h>
 

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -54,7 +54,7 @@ static void sphere(sphere_t *s) { /* {{{ */
     float   yaw;
     pvr_vertex_t *v;
 
-    s->data = (pvr_vertex_t *)memalign(32, s->stacks * (s->slices + 2) * sizeof(pvr_vertex_t));
+    s->data = (pvr_vertex_t *)aligned_alloc(32, s->stacks * (s->slices + 2) * sizeof(pvr_vertex_t));
     if(s->data == NULL) return;
 
     v = s->data;

--- a/examples/dreamcast/pvr/plasma/plasma.c
+++ b/examples/dreamcast/pvr/plasma/plasma.c
@@ -125,7 +125,7 @@ void pvr_setup(void) {
     for(i = 0; i < 2; i++) {
         txr[i] = pvr_mem_malloc(64 * 64 * 2);
         memset(txr[i], 0, 64 * 64 * 2);
-        txr_buf[i] = memalign(32, 64 * 64 * 2);
+        txr_buf[i] = aligned_alloc(32, 64 * 64 * 2);
 
         pvr_poly_cxt_txr(&cxt, PVR_LIST_OP_POLY, PVR_TXRFMT_RGB565, 64, 64, txr[i], PVR_FILTER_BILINEAR);
         pvr_poly_compile(&hdr[i], &cxt);

--- a/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
@@ -35,7 +35,7 @@
 */
 
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <arch/arch.h>
 #include <arch/cache.h>
 
@@ -71,9 +71,9 @@ static int load_image(void) {
         goto error;
     }
 
-    y_plane = memalign(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT);
-    u_plane = memalign(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT / 4);
-    v_plane = memalign(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT / 4);
+    y_plane = aligned_alloc(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT);
+    u_plane = aligned_alloc(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT / 4);
+    v_plane = aligned_alloc(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT / 4);
 
     if(!y_plane || !u_plane || !v_plane) {
         printf("Could not allocate memory for y,u, or v plane\n");

--- a/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
@@ -35,7 +35,7 @@
 */
 
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <arch/arch.h>
 #include <arch/cache.h>
 
@@ -71,9 +71,9 @@ static int load_image(void) {
         goto error;
     }
 
-    y_plane = memalign(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT);
-    u_plane = memalign(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT / 2);
-    v_plane = memalign(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT / 2);
+    y_plane = aligned_alloc(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT);
+    u_plane = aligned_alloc(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT / 2);
+    v_plane = aligned_alloc(32, FRAME_TEXTURE_WIDTH * FRAME_TEXTURE_HEIGHT / 2);
 
     if(!y_plane || !u_plane || !v_plane) {
         printf("Could not allocate memory for y,u, or v plane\n");

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -27,8 +27,8 @@ printf goes to the dc-tool console
 
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 #include <sys/queue.h>
 
 /* A linked list of dir entries. */

--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -42,7 +42,6 @@ ISO9660 systems, as these were used as references as well.
 #include <ctype.h>
 #include <string.h>
 #include <strings.h>
-#include <malloc.h>
 #include <errno.h>
 
 static int init_percd(void);
@@ -1124,7 +1123,7 @@ void fs_iso9660_init(void) {
     mutex_init(&fh_mutex, MUTEX_TYPE_NORMAL);
 
     /* Allocate cache block space, properly aligned for DMA access */
-    cache_data = memalign(32, 2 * NUM_CACHE_BLOCKS * 2048);
+    cache_data = aligned_alloc(32, 2 * NUM_CACHE_BLOCKS * 2048);
     caches = malloc(2 * NUM_CACHE_BLOCKS * sizeof(cache_block_t));
 
     for(i = 0; i < NUM_CACHE_BLOCKS; i++) {

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -9,9 +9,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <errno.h>
 #include <time.h>
+
 #include <arch/types.h>
 #include <kos/mutex.h>
 #include <dc/fs_vmu.h>
@@ -19,7 +19,6 @@
 #include <dc/maple.h>
 #include <dc/maple/vmu.h>
 #include <sys/queue.h>
-#include <errno.h>
 
 /*
 

--- a/kernel/arch/dreamcast/fs/vmufs.c
+++ b/kernel/arch/dreamcast/fs/vmufs.c
@@ -6,9 +6,10 @@
 */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 #include <time.h>
+
 #include <kos/mutex.h>
 #include <dc/vmufs.h>
 #include <dc/maple.h>

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -4,9 +4,9 @@
    Copyright (C) 2002 Megan Potter
  */
 
-#include <malloc.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <arch/memory.h>
 #include <dc/maple.h>
@@ -58,9 +58,9 @@ static void maple_hw_init(void) {
 
     /* Allocate the DMA send buffer */
 #if MAPLE_DMA_DEBUG
-    maple_state.dma_buffer = memalign(32, MAPLE_DMA_SIZE + 1024);
+    maple_state.dma_buffer = aligned_alloc(32, MAPLE_DMA_SIZE + 1024);
 #else
-    maple_state.dma_buffer = memalign(32, MAPLE_DMA_SIZE);
+    maple_state.dma_buffer = aligned_alloc(32, MAPLE_DMA_SIZE);
 #endif
     assert_msg(maple_state.dma_buffer != NULL, "Couldn't allocate maple DMA buffer");
     assert_msg((((uint32)maple_state.dma_buffer) & 0x1f) == 0, "DMA buffer was unaligned; bug in dlmalloc; please report!");

--- a/kernel/arch/dreamcast/hardware/vblank.c
+++ b/kernel/arch/dreamcast/hardware/vblank.c
@@ -4,7 +4,7 @@
    Copyright (C)2003 Megan Potter
 */
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <sys/queue.h>
 

--- a/kernel/arch/dreamcast/kernel/mmu.c
+++ b/kernel/arch/dreamcast/kernel/mmu.c
@@ -7,7 +7,7 @@
 /* SH-4 MMU related functions, ported up from KOS-MMU */
 
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include <kos/thread.h>
 #include <arch/arch.h>

--- a/kernel/arch/dreamcast/kernel/panic.c
+++ b/kernel/arch/dreamcast/kernel/panic.c
@@ -5,7 +5,6 @@
 */
 
 #include <stdio.h>
-#include <malloc.h>
 #include <arch/arch.h>
 
 /* If something goes badly wrong in the kernel and you don't think you

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
-#include <malloc.h>
 
 #include <sys/queue.h>
 #include <sys/ioctl.h>
@@ -220,7 +219,7 @@ static int read_wav_header_buf(char *buf, wavhdr_t *wavhdr, size_t *bufidx) {
 
 static uint8_t *read_wav_data(file_t fd, wavhdr_t *wavhdr) {
     /* Allocate memory for WAV data */
-    uint8_t *wav_data = memalign(32, wavhdr->chunk.size);
+    uint8_t *wav_data = aligned_alloc(32, wavhdr->chunk.size);
 
     if(wav_data == NULL)
         return NULL;
@@ -240,7 +239,7 @@ static uint8_t *read_wav_data_buf(char *buf, wavhdr_t *wavhdr, size_t *bufidx) {
     size_t tmp_bufidx = *bufidx;
 
     /* Allocate memory for WAV data */
-    uint8_t *wav_data = memalign(32, wavhdr->chunk.size);
+    uint8_t *wav_data = aligned_alloc(32, wavhdr->chunk.size);
 
     if(wav_data == NULL)
         return NULL;
@@ -313,12 +312,12 @@ static snd_effect_t *create_snd_effect(wavhdr_t *wavhdr, uint8_t *wav_data) {
     }
     else if(channels == 2 && fmt == WAVE_FMT_PCM && bitsize == 8) {
         /* Stereo 8-bit PCM */
-        uint32_t *left_buf = memalign(32, len / 2), *right_buf;
+        uint32_t *left_buf = aligned_alloc(32, len / 2), *right_buf;
 
         if(left_buf == NULL)
             goto err_occurred;
 
-        right_buf = memalign(32, len / 2);
+        right_buf = aligned_alloc(32, len / 2);
         if(right_buf == NULL) {
             free(left_buf);
             goto err_occurred;
@@ -337,7 +336,7 @@ static snd_effect_t *create_snd_effect(wavhdr_t *wavhdr, uint8_t *wav_data) {
         int ownmem = 0;
 
         if(((uintptr_t)right_buf) & 3) {
-            right_buf = (uint8_t *)memalign(32, len / 2);
+            right_buf = (uint8_t *)aligned_alloc(32, len / 2);
 
             if(right_buf == NULL)
                 goto err_occurred;
@@ -354,12 +353,12 @@ static snd_effect_t *create_snd_effect(wavhdr_t *wavhdr, uint8_t *wav_data) {
     }
     else if(channels == 2 && fmt == WAVE_FMT_YAMAHA_ADPCM) {
         /* Stereo Yamaha ADPCM (channels are interleaved) */
-        uint32_t *left_buf = (uint32_t *)memalign(32, len / 2), *right_buf;
+        uint32_t *left_buf = (uint32_t *)aligned_alloc(32, len / 2), *right_buf;
 
         if(left_buf == NULL)
             goto err_occurred;
 
-        right_buf = (uint32_t *)memalign(32, len / 2);
+        right_buf = (uint32_t *)aligned_alloc(32, len / 2);
 
         if(right_buf == NULL) {
             free(left_buf);
@@ -519,7 +518,7 @@ sfxhnd_t snd_sfx_load_fd(file_t fd, size_t len, uint32_t rate, uint16_t bitsize,
     }
     */
     if(read_len > 0) {
-        tmp_buff = memalign(32, read_len);
+        tmp_buff = aligned_alloc(32, read_len);
 
         if(fs_read(fd, tmp_buff, read_len) <= 0) {
             goto err_occurred;
@@ -677,7 +676,7 @@ sfxhnd_t snd_sfx_load_raw_buf(char *buf, size_t len, uint32_t rate, uint16_t bit
 
     read_len = chan_len;
     if(read_len > 0) {
-        tmp_buff = memalign(32, read_len);
+        tmp_buff = aligned_alloc(32, read_len);
         memcpy(tmp_buff, buf, read_len);
         bufidx += read_len;
 

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -14,7 +14,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <malloc.h>
 #include <errno.h>
 #include <sys/queue.h>
 
@@ -349,7 +348,7 @@ int snd_stream_init_ex(int channels, size_t buffer_size) {
            polling doesn't read more than half buffer at time.
            This can also be used for mono streams on unaligned data.
         */
-        sep_buffer[0] = memalign(32, buffer_size);
+        sep_buffer[0] = aligned_alloc(32, buffer_size);
 
         if(sep_buffer[0] == NULL) {
             dbglog(DBG_ERROR, "snd_stream_init_ex(): memory allocation failed\n");

--- a/kernel/exports/library.c
+++ b/kernel/exports/library.c
@@ -8,7 +8,7 @@
 #include <assert.h>
 #include <string.h>
 #include <strings.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
 

--- a/kernel/exports/nmmgr.c
+++ b/kernel/exports/nmmgr.c
@@ -17,9 +17,10 @@ interface at the front of their struct.
 
 #include <stdbool.h>
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+
 #include <kos/init_base.h>
 #include <kos/nmmgr.h>
 #include <kos/mutex.h>

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -4,9 +4,10 @@
    Copyright (C)2000,2001,2003 Megan Potter
 */
 
-#include <malloc.h>
 #include <string.h>
+#include <stdlib.h>
 #include <stdio.h>
+
 #include <arch/cache.h>
 #include <arch/arch.h>
 #include <kos/fs.h>
@@ -79,7 +80,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
     sz = fs_total(fd);
     DBG(("Loading ELF file of size %d\n", sz));
 
-    img = memalign(32, sz);
+    img = aligned_alloc(32, sz);
 
     if(img == NULL) {
         dbglog(DBG_ERROR, "elf_load: can't allocate %d bytes for ELF load\n", sz);

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -28,12 +28,12 @@ something like this:
 */
 
 #include <stdio.h>
-#include <malloc.h>
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <limits.h>
+
 #include <kos/fs.h>
 #include <kos/thread.h>
 #include <kos/mutex.h>

--- a/kernel/fs/fs_dev.c
+++ b/kernel/fs/fs_dev.c
@@ -8,8 +8,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <malloc.h>
 #include <errno.h>
+
 #include <arch/types.h>
 #include <kos/fs_dev.h>
 #include <sys/queue.h>

--- a/kernel/fs/fs_null.c
+++ b/kernel/fs/fs_null.c
@@ -8,13 +8,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <malloc.h>
 #include <errno.h>
+
 #include <arch/types.h>
 #include <kos/mutex.h>
 #include <kos/fs_null.h>
 #include <sys/queue.h>
-#include <errno.h>
 
 /* File handles */
 typedef struct null_fh_str {

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -29,7 +29,7 @@ or space present.
 #include <kos/cond.h>
 #include <kos/fs_pty.h>
 #include <sys/queue.h>
-#include <malloc.h>
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -35,7 +35,7 @@ cache data from disk rather than as a general purpose file system.
 #include <kos/mutex.h>
 #include <kos/fs_ramdisk.h>
 #include <kos/opts.h>
-#include <malloc.h>
+
 #include <string.h>
 #include <strings.h>
 #include <stdio.h>

--- a/kernel/fs/fs_random.c
+++ b/kernel/fs/fs_random.c
@@ -8,14 +8,13 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <malloc.h>
 #include <errno.h>
 #include <time.h>
+
 #include <arch/types.h>
 #include <kos/mutex.h>
 #include <kos/fs_random.h>
 #include <sys/queue.h>
-#include <errno.h>
 #include <sys/time.h>
 
 /* This function is declared in <stdlib.h> but behind an if __BSD_VISIBLE

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -21,7 +21,7 @@ on sunsite.unc.edu in /pub/Linux/system/recovery/, or as a package under Debian 
 #include <kos/mutex.h>
 #include <kos/fs_romdisk.h>
 #include <kos/opts.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
 #include <strings.h>

--- a/kernel/fs/fs_socket.c
+++ b/kernel/fs/fs_socket.c
@@ -11,8 +11,9 @@
 #include <kos/net.h>
 
 #include <errno.h>
+#include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
+
 #include <sys/queue.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/kernel/fs/fs_utils.c
+++ b/kernel/fs/fs_utils.c
@@ -15,7 +15,7 @@ XXX This probably belongs in something like libc...
 
 #include <kos/fs.h>
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <string.h>
 #include <errno.h>

--- a/kernel/mm/cplusplus.c
+++ b/kernel/mm/cplusplus.c
@@ -6,7 +6,7 @@
    This is just a wrapper around malloc() and free() for C++ programs.
  */
 
-#include <malloc.h>
+#include <stdlib.h>
 
 void *__builtin_new(int size) {
     return malloc(size);

--- a/kernel/net/net_arp.c
+++ b/kernel/net/net_arp.c
@@ -7,8 +7,9 @@
 */
 
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
+
 #include <kos/net.h>
 #include <kos/thread.h>
 #include <arch/timer.h>

--- a/kernel/net/net_core.c
+++ b/kernel/net/net_core.c
@@ -7,8 +7,9 @@
 */
 
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
+
 #include <kos/net.h>
 #include <kos/fs_socket.h>
 

--- a/kernel/net/net_icmp.c
+++ b/kernel/net/net_icmp.c
@@ -9,12 +9,14 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
+
 #include <sys/queue.h>
 #include <kos/net.h>
 #include <kos/thread.h>
 #include <arch/timer.h>
 #include <arpa/inet.h>
+
 #include "net_icmp.h"
 #include "net_ipv4.h"
 

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -15,7 +15,6 @@
    as well as some more advanced stuff. */
 
 #include <string.h>
-#include <malloc.h>
 #include <stdio.h>
 #include <assert.h>
 #include <errno.h>

--- a/kernel/thread/sem.c
+++ b/kernel/thread/sem.c
@@ -10,7 +10,7 @@
 /**************************************/
 
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 #include <errno.h>

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -408,7 +408,7 @@ static void *thd_create_tls_data(void) {
         tls_size += (align - align_rem);
 
     /* Allocate combined chunk with calculated size and alignment.  */
-    tcbhead = memalign(align, tls_size);
+    tcbhead = aligned_alloc(align, tls_size);
     assert(tcbhead);    
     assert(!((uintptr_t)tcbhead % 8)); 
 
@@ -474,7 +474,7 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
 
     if(tid >= 0) {
         /* Create a new thread structure */
-        nt = memalign(32, sizeof(kthread_t));
+        nt = aligned_alloc(32, sizeof(kthread_t));
 
         if(nt != NULL) {
             /* Clear out potentially unused stuff */


### PR DESCRIPTION
Following from some of the cleanups that were suggested in #623 . Memalign has been disfavored for quite some time and now that we have moved to c11, this replaces the usage of it with the standard `aligned_alloc`. Additionally remove inclusions of `malloc.h` which is only needed/meant to be used for custom defined functions like the malloc_stats stuff.