### PR TITLE
asic: Add ability to set a chain of handlers for IRQ's.

### DIFF
--- a/kernel/arch/dreamcast/hardware/asic.c
+++ b/kernel/arch/dreamcast/hardware/asic.c
@@ -114,11 +114,6 @@
 #define ASIC_EVT_REGS 3
 #define ASIC_EVT_REG_HNDS 32
 
-typedef struct {
-    asic_evt_handler hdl;
-    void *data;
-} asic_evt_handler_entry_t;
-
 struct asic_thdata {
     asic_evt_handler hdl;
     uint32_t source;
@@ -135,15 +130,18 @@ static asic_evt_handler_entry_t
 asic_evt_handlers[ASIC_EVT_REGS][ASIC_EVT_REG_HNDS];
 
 /* Set a handler, or remove a handler */
-void asic_evt_set_handler(uint16_t code, asic_evt_handler hnd, void *data) {
+asic_evt_handler_entry_t asic_evt_set_handler(uint16_t code, asic_evt_handler hnd, void *data) {
     uint8_t evtreg, evt;
+    asic_evt_handler_entry_t old;
 
     evtreg = (code >> 8) & 0xff;
     evt = code & 0xff;
 
     assert((evtreg < ASIC_EVT_REGS) && (evt < ASIC_EVT_REG_HNDS));
 
+    old = asic_evt_handlers[evtreg][evt];
     asic_evt_handlers[evtreg][evt] = (asic_evt_handler_entry_t){ hnd, data };
+    return old;
 }
 
 /* The ASIC event handler; this is called from the global IRQ handler

--- a/kernel/arch/dreamcast/include/dc/asic.h
+++ b/kernel/arch/dreamcast/include/dc/asic.h
@@ -187,6 +187,14 @@ __BEGIN_DECLS
 */
 typedef void (*asic_evt_handler)(uint32_t code, void *data);
 
+/** \brief   ASIC event handler table entry.
+    \ingroup asic
+ */
+typedef struct {
+    asic_evt_handler hdl;
+    void *data;
+} asic_evt_handler_entry_t;
+
 /** \brief   Set or remove an ASIC handler.
     \ingroup asic
 
@@ -198,7 +206,7 @@ typedef void (*asic_evt_handler)(uint32_t code, void *data);
     \param  data            A user pointer that will be passed to the callback.
 
 */
-void asic_evt_set_handler(uint16_t code, asic_evt_handler handler, void *data);
+asic_evt_handler_entry_t asic_evt_set_handler(uint16_t code, asic_evt_handler handler, void *data);
 
 /** \brief   Register a threaded handler with the given ASIC event.
     \ingroup asic


### PR DESCRIPTION
I will need this for interrupts on the G1 bus for different device drivers. More precisely, for the CDROM driver, on par with the driver for G1ATA.