### PR TITLE
Replace or remove GCC attributes

### DIFF
--- a/include/kos/net.h
+++ b/include/kos/net.h
@@ -220,12 +220,6 @@ typedef struct knetif {
 /** \cond */
 /* Define the list type */
 LIST_HEAD(netif_list, knetif);
-
-#ifdef PACKED
-#undef PACKED
-#endif
-
-#define PACKED __attribute__((packed))
 /** \endcond */
 
 /** \defgroup networking_ip     IP
@@ -253,7 +247,7 @@ typedef struct ip_hdr_s {
     uint16  checksum;           /**< \brief IP checksum */
     uint32  src;                /**< \brief Source IP address */
     uint32  dest;               /**< \brief Destination IP address */
-} PACKED ip_hdr_t;
+} ip_hdr_t;
 
 /** \defgroup networking_ipv6   IPv6
     \brief                      IPv6 Network Stack
@@ -275,10 +269,7 @@ typedef struct ipv6_hdr_s {
     uint8           hop_limit;      /**< \brief Hop limit */
     struct in6_addr src_addr;       /**< \brief Source IP address */
     struct in6_addr dst_addr;       /**< \brief Destination IP address */
-} PACKED ipv6_hdr_t;
-
-#undef PACKED
-
+} ipv6_hdr_t;
 
 /***** net_arp.c **********************************************************/
 

--- a/kernel/arch/dreamcast/fs/fs_dclsocket.c
+++ b/kernel/arch/dreamcast/fs/fs_dclsocket.c
@@ -39,26 +39,24 @@
 #define DCLOAD_PORT 31313
 #define NAME "dcload-ip over KOS sockets"
 
-#define PACKED __attribute__((packed))
 typedef struct {
     unsigned char id[4];
     unsigned int address;
     unsigned int size;
     unsigned char data[];
-} PACKED command_t;
+} command_t;
 
 typedef struct {
     unsigned char id[4];
     unsigned int value0;
-} PACKED command_int_t;
+} command_int_t;
 
 typedef struct {
     unsigned char id[4];
     unsigned int value0;
     unsigned int value1;
     unsigned int value2;
-} PACKED command_3int_t;
-#undef PACKED
+} command_3int_t;
 
 static struct {
     unsigned int addr;

--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -121,7 +121,7 @@ void sq_wait(void) {
 }
 
 /* Copies n bytes from src to dest, dest must be 32-byte aligned */
-__attribute__((noinline)) void *sq_cpy(void *dest, const void *src, size_t n) {
+__no_inline void *sq_cpy(void *dest, const void *src, size_t n) {
     const uint32_t *s = src;
     void *curr_dest = dest;
     uint32_t *d;

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -323,7 +323,7 @@ typedef struct kbd_state {
                             keyboard layouts and is deprecated. Please use the
                             individual queues instead for future code.
 */
-void kbd_set_queue(int active) __attribute__((deprecated));
+void kbd_set_queue(int active) __deprecated;
 
 /** \brief   Pop a key off the global keyboard queue.
     \ingroup kbd
@@ -345,7 +345,7 @@ void kbd_set_queue(int active) __attribute__((deprecated));
                             keyboards.
     \see                    kbd_queue_pop()
 */
-int kbd_get_key(void) __attribute__((deprecated));
+int kbd_get_key(void) __deprecated;
 
 /** \brief   Pop a key off a specific keyboard's queue.
     \ingroup kbd

--- a/kernel/arch/dreamcast/include/dc/vmufs.h
+++ b/kernel/arch/dreamcast/include/dc/vmufs.h
@@ -34,10 +34,6 @@ __BEGIN_DECLS
     @{
 */
 
-/* \cond */
-#define __packed__ __attribute__((packed))
-/* \endcond */
-
 /** \brief  BCD timestamp, used several places in the vmufs.
     \headerfile dc/vmufs.h
 */
@@ -50,7 +46,7 @@ typedef struct {
     uint8   min;    /**< \brief Minutes */
     uint8   sec;    /**< \brief Seconds */
     uint8   dow;    /**< \brief Day of week (0 = monday, etc) */
-} __packed__ vmu_timestamp_t;
+} vmu_timestamp_t;
 
 /** \brief  VMU FS Root block layout.
     \headerfile dc/vmufs.h
@@ -70,7 +66,7 @@ typedef struct {
     uint16          icon_shape;     /**< \brief Icon shape for this VMS */
     uint16          blk_cnt;        /**< \brief Number of user blocks */
     uint8           unk2[430];      /**< \brief ??? */
-} __packed__ vmu_root_t;
+} vmu_root_t;
 
 /** \brief  VMU FS Directory entries, 32 bytes each.
     \headerfile dc/vmufs.h
@@ -85,8 +81,7 @@ typedef struct {
     uint16          hdroff;         /**< \brief Offset of header, in blocks from start of file */
     uint8           dirty;          /**< \brief See header notes */
     uint8           pad1[3];        /**< \brief All zeros */
-} __packed__ vmu_dir_t;
-#undef __packed__
+} vmu_dir_t;
 
 /* Notes about the "dirty" field on vmu_dir_t :)
 

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -87,18 +87,18 @@ void snd_sfx_unload(sfxhnd_t idx) {
     free(t);
 }
 
-typedef struct __attribute__((__packed__)) {
+typedef struct {
     uint8_t riff[4];
     int32_t totalsize;
     uint8_t riff_format[4];
 } wavmagic_t;
 
-typedef struct __attribute__((__packed__)) {
+typedef struct {
     uint8_t id[4];
     size_t size;
 } chunkhdr_t;
 
-typedef struct __attribute__((__packed__)) {
+typedef struct {
     int16_t format;
     int16_t channels;
     int32_t sample_rate;
@@ -108,7 +108,7 @@ typedef struct __attribute__((__packed__)) {
 } fmthdr_t;
 
 /* WAV header */
-typedef struct __attribute__((__packed__)) {
+typedef struct {
     wavmagic_t magic;
 
     chunkhdr_t chunk;

--- a/kernel/net/net_arp.c
+++ b/kernel/net/net_arp.c
@@ -23,7 +23,6 @@
 */
 
 /* ARP Packet Structure */
-#define packed __attribute__((packed))
 typedef struct {
     uint8 hw_type[2];
     uint8 pr_type[2];
@@ -34,8 +33,7 @@ typedef struct {
     uint8 pr_send[4];
     uint8 hw_recv[6];
     uint8 pr_recv[6];
-} packed arp_pkt_t;
-#undef packed
+} arp_pkt_t;
 
 /* Structure describing an ARP entry; each entry contains a MAC address,
    an IP address, and a timestamp from 'jiffies'. The timestamp allows

--- a/kernel/net/net_dhcp.h
+++ b/kernel/net/net_dhcp.h
@@ -141,7 +141,7 @@ typedef struct dhcp_pkt {
     char    sname[64];
     char    file[128];
     uint8   options[];
-} __attribute__((packed)) dhcp_pkt_t;
+} dhcp_pkt_t;
 
 int net_dhcp_init(void);
 

--- a/kernel/net/net_icmp.h
+++ b/kernel/net/net_icmp.h
@@ -15,7 +15,6 @@ __BEGIN_DECLS
 #include <kos/net.h>
 #include "net_ipv4.h"
 
-#define packed __attribute__((packed))
 typedef struct {
     uint8 type;
     uint8 code;
@@ -25,8 +24,7 @@ typedef struct {
         uint16 m16[2];
         uint32 m32;
     } misc;
-} packed icmp_hdr_t;
-#undef packed
+} icmp_hdr_t;
 
 #define ICMP_MESSAGE_ECHO_REPLY         0
 #define ICMP_MESSAGE_DEST_UNREACHABLE   3

--- a/kernel/net/net_icmp6.h
+++ b/kernel/net/net_icmp6.h
@@ -11,17 +11,11 @@
 #include <kos/net.h>
 #include "net_ipv6.h"
 
-#ifdef PACKED
-#undef PACKED
-#endif
-
-#define PACKED __attribute__((packed))
-
 typedef struct icmp6_hdr_s {
     uint8   type;
     uint8   code;
     uint16  checksum;
-} PACKED icmp6_hdr_t;
+} icmp6_hdr_t;
 
 /* Header for Destination Unreachable packets (type 1) */
 typedef struct icmp6_dest_unreach_s {
@@ -29,7 +23,7 @@ typedef struct icmp6_dest_unreach_s {
     uint8   code;
     uint16  checksum;
     uint32  unused;
-} PACKED icmp6_dest_unreach_t;
+} icmp6_dest_unreach_t;
 
 /* Header for Packet Too Big packets (type 2) */
 typedef struct icmp6_pkt_too_big_s {
@@ -37,7 +31,7 @@ typedef struct icmp6_pkt_too_big_s {
     uint8   code;
     uint16  checksum;
     uint32  mtu;
-} PACKED icmp6_pkt_too_big_t;
+} icmp6_pkt_too_big_t;
 
 /* Header for Time Exceeded packets (type 3) */
 typedef struct icmp6_time_exceeded_s {
@@ -45,7 +39,7 @@ typedef struct icmp6_time_exceeded_s {
     uint8   code;
     uint16  checksum;
     uint32  unused;
-} PACKED icmp6_time_exceeded_t;
+} icmp6_time_exceeded_t;
 
 /* Header for Parameter Problem packets (type 4) */
 typedef struct icmp6_param_problem_s {
@@ -53,7 +47,7 @@ typedef struct icmp6_param_problem_s {
     uint8   code;
     uint16  checksum;
     uint32  ptr;
-} PACKED icmp6_param_problem_t;
+} icmp6_param_problem_t;
 
 /* Header for Echo/Echo Reply packets (types 128/129) */
 typedef struct icmp6_echo_hdr_s {
@@ -62,7 +56,7 @@ typedef struct icmp6_echo_hdr_s {
     uint16  checksum;
     uint16  ident;
     uint16  seq;
-} PACKED icmp6_echo_hdr_t;
+} icmp6_echo_hdr_t;
 
 /* Format for Router Solicitation packets (type 133) - RFC 4861 */
 typedef struct icmp6_router_sol_s {
@@ -71,7 +65,7 @@ typedef struct icmp6_router_sol_s {
     uint16  checksum;
     uint32  reserved;
     uint8   options[];
-} PACKED icmp6_router_sol_t;
+} icmp6_router_sol_t;
 
 /* Format for Router Advertisement packets (type 134) - RFC 4861 */
 typedef struct icmp6_router_adv_s {
@@ -84,7 +78,7 @@ typedef struct icmp6_router_adv_s {
     uint32  reachable_time;
     uint32  retrans_timer;
     uint8   options[];
-} PACKED icmp6_router_adv_t;
+} icmp6_router_adv_t;
 
 /* Format for Neighbor Solicitation packets (type 135) - RFC 4861 */
 typedef struct icmp6_neighbor_sol_s {
@@ -94,7 +88,7 @@ typedef struct icmp6_neighbor_sol_s {
     uint32          reserved;
     struct in6_addr target;
     uint8           options[];
-} PACKED icmp6_neighbor_sol_t;
+} icmp6_neighbor_sol_t;
 
 /* Format for Neighbor Advertisement packets (type 136) - RFC 4861 */
 typedef struct icmp6_neighbor_adv_s {
@@ -105,7 +99,7 @@ typedef struct icmp6_neighbor_adv_s {
     uint8           reserved[3];
     struct in6_addr target;
     uint8           options[];
-} PACKED icmp6_neighbor_adv_t;
+} icmp6_neighbor_adv_t;
 
 /* Link-layer address option for neighbor advertisement/solictation packets for
    ethernet. */
@@ -113,7 +107,7 @@ typedef struct icmp6_nsol_lladdr_s {
     uint8           type;
     uint8           length;
     uint8           mac[6];
-} PACKED icmp6_nsol_lladdr_t;
+} icmp6_nsol_lladdr_t;
 
 /* Redirect packet (type 137) - RFC 4861 */
 typedef struct icmp6_redirect_s {
@@ -124,7 +118,7 @@ typedef struct icmp6_redirect_s {
     struct in6_addr target;
     struct in6_addr dest;
     uint8           options[];
-} PACKED icmp6_redirect_t;
+} icmp6_redirect_t;
 
 /* Prefix information for router advertisement packets */
 typedef struct icmp6_ndp_prefix_s {
@@ -136,9 +130,7 @@ typedef struct icmp6_ndp_prefix_s {
     uint32          preferred_time;
     uint32          reserved;
     struct in6_addr prefix;
-} PACKED icmp6_ndp_prefix_t;
-
-#undef PACKED
+} icmp6_ndp_prefix_t;
 
 /* ICMPv6 Message types */
 /* Error messages (type < 127) */

--- a/kernel/net/net_ipv4.h
+++ b/kernel/net/net_ipv4.h
@@ -11,12 +11,11 @@
 #include <kos/net.h>
 
 /* These structs are from AndrewK's dcload-ip. */
-#define packed __attribute__((packed))
 typedef struct {
     uint8   dest[6];
     uint8   src[6];
     uint8   type[2];
-} packed eth_hdr_t;
+} eth_hdr_t;
 
 typedef struct {
     uint32 src_addr;
@@ -24,8 +23,7 @@ typedef struct {
     uint8 zero;
     uint8 proto;
     uint16 length;
-} packed ipv4_pseudo_hdr_t;
-#undef packed
+} ipv4_pseudo_hdr_t;
 
 uint16 net_ipv4_checksum(const uint8 *data, size_t bytes, uint16 start);
 int net_ipv4_send_packet(netif_t *net, ip_hdr_t *hdr, const uint8 *data,

--- a/kernel/net/net_ipv6.h
+++ b/kernel/net/net_ipv6.h
@@ -12,17 +12,11 @@
 
 #include "net_ipv4.h"
 
-#ifdef PACKED
-#undef PACKED
-#endif
-
-#define PACKED __attribute__((packed))
-
 typedef struct ipv6_ext_hdr_s {
     uint8       next_header;
     uint8       ext_length;
     uint8       data[];
-} PACKED ipv6_ext_hdr_t;
+} ipv6_ext_hdr_t;
 
 typedef struct ipv6_pseudo_hdr_s {
     struct in6_addr src_addr;
@@ -30,9 +24,7 @@ typedef struct ipv6_pseudo_hdr_s {
     uint32          upper_layer_len;
     uint8           zero[3];
     uint8           next_header;
-} PACKED ipv6_pseudo_hdr_t;
-
-#undef PACKED
+} ipv6_pseudo_hdr_t;
 
 #define IPV6_HDR_EXT_HOP_BY_HOP     0
 #define IPV6_HDR_EXT_ROUTING        43

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -100,7 +100,7 @@ typedef struct tcp_hdr {
     uint16_t checksum;
     uint16_t urg;
     uint8_t options[];
-} __attribute__((packed)) tcp_hdr_t;
+} tcp_hdr_t;
 
 /* Listening socket. Each one of these is an incoming connection from a socket
    that is in the listen state */

--- a/kernel/net/net_udp.c
+++ b/kernel/net/net_udp.c
@@ -33,14 +33,12 @@
 /* Default hop limit (or ttl for IPv4) for new sockets */
 #define UDP_DEFAULT_HOPS    64
 
-#define packed __attribute__((packed))
 typedef struct {
-    uint16 src_port    packed;
-    uint16 dst_port    packed;
-    uint16 length      packed;
-    uint16 checksum    packed;
+    uint16 src_port;
+    uint16 dst_port;
+    uint16 length;
+    uint16 checksum;
 } udp_hdr_t;
-#undef packed
 
 struct udp_pkt {
     TAILQ_ENTRY(udp_pkt) pkt_queue;


### PR DESCRIPTION
This PR replaces some GCC attributes with their macro equivalent from <kos/cdefs.h>.

It also removes the "packed" attributes scattered across the code, as they were useless in every single case.