### PR TITLE
Fix Naomi 23 feb 2025 (broken since 6 sept 2024)

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -182,6 +182,7 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     else {
         /* dbglog(DBG_KDEBUG, "maple: unknown response %d on device %c%c\n",
             resp->response, 'A'+p, '0'+u); */
+        state->scan_ready_mask |= 1 << p;
         maple_frame_unlock(frm);
     }
 }

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -172,7 +172,8 @@ int  __weak arch_auto_init(void) {
     timer_init();           /* Timers */
     hardware_sys_init();        /* DC low-level hardware init */
 
-    syscall_sysinfo_init();
+    if (!KOS_PLATFORM_IS_NAOMI)
+        syscall_sysinfo_init();
 
     /* Initialize our timer */
     perf_cntr_timer_enable();


### PR DESCRIPTION
Fix for 2 PRs that broke the Naomi build:
- 6 sept 2024:
	Refactor sysinfo_icon/id (https://github.com/KallistiOS/KallistiOS/pull/734)
	Calling DC syscalls is a no-go on Naomi
	
- 8 oct 2024: 
	maple: Rework device detection, allocation and status buffers (https://github.com/KallistiOS/KallistiOS/pull/552)
	The Naomi has some different hardware connected to the Maple Bus (ie, the MIE), eg it will respond with a MAPLE_RESPONSE_BADCMD to a MAPLE_COMMAND_DEVINFO to A0.
	So the 'catch all' else in vbl_autodet_callback() must set scan_ready_mask, otherwise maple_wait_scan() in arch_auto_init() will wait endlessly

With these 2 fixes, the current master branch for Naomi (23 feb 2025) creates useable programs again
