### PR TITLE
Fix Alpine dc-chain instructions

### DIFF
--- a/utils/dc-chain/doc/alpine.md
+++ b/utils/dc-chain/doc/alpine.md
@@ -24,7 +24,7 @@ build the whole toolchains.
 
 The packages below need to be installed:
 ```
-apk --update add build-base patch bash texinfo gmp-dev libjpeg-turbo-dev libpng-dev elfutils-dev curl wget python3 git subversion
+apk --update add build-base patch bash coreutils-fmt texinfo gmp-dev mpfr-dev libjpeg-turbo-dev libpng-dev elfutils-dev curl wget python3 git subversion
 ```	
 
 ## Preparing the environment installation ##
@@ -59,7 +59,7 @@ To build the toolchain, do the following:
 
 3. Enter the following to start downloading and building toolchain:
 	```
-	make
+	make use_custom_dependencies=1
 	```
 
 Now it's time to have a coffee as this process can be long: several minutes to


### PR DESCRIPTION
I found that (at least on Alpine Linux 3.21 but I suspect this affects multiple versions) I needed to have the `mpfr-dev` package installed, and to use the `use_custom_dependencies=1` when building (both items stolen from the Dockerfile). I also found that building `pvrtex` required the `coreutils-fmt` package (simply for formatting the readme...).

Without `use_custom_dependencies=1` I got this error when running `make all`:

```
2025-02-22 10:59:55 URL: ftp://gcc.gnu.org/pub/gcc/infrastructure/isl-0.18.tar.bz2 [1658291] -> "./isl-0.18.tar.bz2" [1]                                                                      
sha512sum: unrecognized option: check                                                                                                                                                         
BusyBox v1.37.0 (2025-01-17 18:12:01 UTC) multi-call binary.                                   
                                                                                               
Usage: sha512sum [-c[sw]] [FILE]...                                                                                                                                                           
                                                                                               
Print or check SHA512 checksums                                                                
                                                                                                                                                                                              
        -c      Check sums against list in FILEs                                               
        -s      Don't output anything, status code shows success                                                                                                                              
        -w      Warn about improperly formatted checksum lines                                 
error: Cannot verify integrity of possibly corrupted file gmp-6.1.0.tar.bz2                    
make: *** [scripts/download.mk:114: gcc-8.5.0/gcc_download.stamp] Error 1      
```

Without the `mpfr-dev` dependency, I got this error when running `make all` or `make`:
```
configure: error: Building GDB requires GMP 4.2+, and MPFR 3.1.0+.
Try the --with-gmp and/or --with-mpfr options to specify
their locations.  If you obtained GMP and/or MPFR from a vendor
distribution package, make sure that you have installed both the libraries
and the header files.  They may be located in separate packages.
make: *** [scripts/gdb.mk:45: gdb-15.1/gdb_build.stamp] Error 1
```

Without `coreutils-fmt`:

```
make[2]: Entering directory '/home/[REDACTED]/src/kallistios/utils/pvrtex'
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o stb_image_impl.o stb_imag
e_impl.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o stb_image_write_impl.o st
b_image_write_impl.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o stb_image_resize_impl.o s
tb_image_resize_impl.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o optparse_impl.o optparse_
impl.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o pvr_texture.o pvr_texture
.c
g++ -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o dither.o dither.cpp
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o tddither.o tddither.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o vqcompress.o vqcompress.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o mycommon.o mycommon.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o file_common.o file_common
.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o file_pvr.o file_pvr.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o file_tex.o file_tex.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o file_dctex.o file_dctex.c
cc -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O3 -Wno-pointer-sign -std=gnu17 -Ilibavutil -I. -DCONFIG_MEMORY_POISONING=0 -DHAVE_FAST_UNALIGNED=0  -c -o pvr_texture_encoder.o pvr
_texture_encoder.c
fmt -s readme_unformatted.txt > README
/bin/sh: fmt: not found
make[2]: *** [Makefile:41: README] Error 127
```

Thanks to darc and Tchan on discord for the help with these.