### PR TITLE
Update profiles listed in Makefile.default.cfg

### DIFF
--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -6,22 +6,15 @@
 #########################
 
 # Choose a toolchain profile from the following available options:
-# No longer supported upstream:
-# - 9.3.0-legacy: Former 'stable' option, based on GCC 9.3.0 and Newlib 3.3.0.
-# - 9.5.0-winxp:  Most recent versions of tools which run on Windows XP.
-# - 10.5.0:       Last release in the GCC 10 series, released 2023-07-07.
-# - 11.5.0:       Last release in the GCC 11 series, released 2024-07-19.
-# Supported upstream:
-# - 12.4.0:       Latest release in the GCC 12 series, released 2024-06-20.
-# - stable:       Tested stable; based on GCC 13.2.0, released 2023-07-27.
-# - 13.3.0:       Latest release in the GCC 13 series, released 2024-05-21.
-# - 14.2.0:       Latest release in the GCC 14 series, released 2024-08-01.
-# Development versions:
+# Release toolchains:
+# - 9.5.0-winxp:  Legacy: Most recent versions of tools which run on Windows XP.
+# - stable:       Stable: Well-tested; based on GCC 13.2.0, released 2023-07-27.
+# - 13.3.0:       Testing: Latest release in the GCC 13 series, released 2024-05-21.
+# - 14.2.0:       Testing: Latest release in the GCC 14 series, released 2024-08-01.
+# Development toolchains:
 # - 13.3.1-dev    Bleeding edge GCC 13 series from git.
 # - 14.2.1-dev    Bleeding edge GCC 14 series from git.
 # - 15.0.1-dev    Bleeding edge GCC 15 series from git.
-# - gccrs-dev:    GCC fork for development of the GCCRS Rust compiler.
-# - rustc-dev:    GCC fork for development of the libgccjit rustc GCC codegen.
 # If unsure, select stable. See README.md for more detailed descriptions.
 toolchain_profile=stable
 


### PR DESCRIPTION
Somehow, I forgot to remove the old profiles from the top of `Makefile.default.cfg` in the last PR.