### PR TITLE
AICAOS step2

### DIFF
--- a/kernel/arch/dreamcast/hardware/Makefile
+++ b/kernel/arch/dreamcast/hardware/Makefile
@@ -21,6 +21,9 @@ OBJS += g2dma.o
 # Sound
 OBJS += spu.o
 
+# Sound RAM
+OBJS += aram.o
+
 # Bus support
 OBJS += asic.o g2bus.o
 

--- a/kernel/arch/dreamcast/hardware/aram.c
+++ b/kernel/arch/dreamcast/hardware/aram.c
@@ -1,0 +1,98 @@
+/* KallistiOS ##version##
+
+   aram.c
+   Copyright (C) 2024 Paul Cercueil <paul@crapouillou.net>
+*/
+
+#include <stdint.h>
+#include <dc/g2bus.h>
+#include <dc/aram.h>
+
+static void aram_copy(char *dst, const char *src, size_t size)
+{
+    uint32_t cnt = 0;
+
+    g2_lock_scoped();
+
+    if (!(((uintptr_t)dst | (uintptr_t)src) & 0x3)) {
+        for (; size >= 4; size -= 4) {
+            /* Fifo wait if necessary */
+            if (!(cnt % 8))
+                g2_fifo_wait();
+
+            *(uint32_t *)dst = *(const uint32_t *)src;
+            dst += 4;
+            src += 4;
+            cnt++;
+        }
+    }
+
+    /* Reset FIFO counter */
+    cnt = 0;
+
+    for (; size; size--) {
+        /* Fifo wait if necessary */
+        if (!(cnt % 8))
+            g2_fifo_wait();
+
+        *dst++ = *src++;
+        cnt++;
+    }
+}
+
+void aram_read(void *dst, aram_addr_t addr, size_t size)
+{
+    const char *src = (const char *)aram_addr_to_host(addr);
+
+    aram_copy((char *)dst, src, size);
+}
+
+void aram_write(aram_addr_t addr, const void *src, size_t size)
+{
+    char *dst = (char *)aram_addr_to_host(addr);
+
+    aram_copy(dst, (const char *)src, size);
+}
+
+static inline uint32_t has_eof(uint32_t dword)
+{
+    uint32_t ret = 0;
+
+    __asm__ __inline__("cmp/str %[ret], %[dword]\n\t"
+                       "movt %[ret]\n\t"
+                       : [ret]"+r"(ret) : [dword]"r"(dword));
+
+    return ret;
+}
+
+char *aram_read_string(aram_addr_t addr, uint32_t *dst, size_t size)
+{
+    const uint32_t *src;
+    uint32_t value, cnt = 0;
+    char *ret = (char *)dst;
+
+    if (addr & 0x3) {
+        ret += 4 - (addr & 0x3);
+        addr &= ~0x3;
+    }
+
+    src = (const uint32_t *)aram_addr_to_host(addr);
+
+    g2_lock_scoped();
+
+    for (; size >= 4; size -= 4) {
+        /* Fifo wait if necessary */
+        if (!(cnt % 8))
+            g2_fifo_wait();
+
+        value = *src++;
+        *dst++ = value;
+
+        if (has_eof(value))
+            break;
+
+        cnt++;
+    }
+
+    return ret;
+}

--- a/kernel/arch/dreamcast/include/dc/aram.h
+++ b/kernel/arch/dreamcast/include/dc/aram.h
@@ -1,0 +1,71 @@
+/* KallistiOS ##version##
+
+   aram.h
+   Copyright (C) 2024 Paul Cercueil
+
+*/
+
+/** \file    dc/aram.h
+  \brief   Sound RAM macros and routines.
+  \ingroup system_aram
+
+  \author Paul Cercueil
+  */
+
+#ifndef __DC_ARAM_H
+#define __DC_ARAM_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+#include <stdint.h>
+#include <dc/g2bus.h>
+#include <dc/spu.h>
+
+typedef uint32_t aram_addr_t;
+
+static inline void * aram_addr_to_host(aram_addr_t addr)
+{
+    return (void *)(addr + SPU_RAM_UNCACHED_BASE);
+}
+
+static inline uint8_t aram_read_8(aram_addr_t addr)
+{
+    g2_lock_scoped();
+    g2_fifo_wait();
+
+    return *(volatile uint8_t *)aram_addr_to_host(addr);
+}
+
+static inline uint32_t aram_read_32(aram_addr_t addr)
+{
+    g2_lock_scoped();
+    g2_fifo_wait();
+
+    return *(volatile uint32_t *)aram_addr_to_host(addr);
+}
+
+static inline void aram_write_8(aram_addr_t addr, uint8_t val)
+{
+    g2_lock_scoped();
+    g2_fifo_wait();
+
+    *(volatile uint8_t *)aram_addr_to_host(addr) = val;
+}
+
+static inline void aram_write_32(aram_addr_t addr, uint32_t val)
+{
+    g2_lock_scoped();
+    g2_fifo_wait();
+
+    *(volatile uint32_t *)aram_addr_to_host(addr) = val;
+}
+
+void aram_read(void *out, aram_addr_t addr, size_t size);
+void aram_write(aram_addr_t dst, const void *src, size_t size);
+
+char *aram_read_string(aram_addr_t addr, uint32_t *dst, size_t size);
+
+__END_DECLS
+
+#endif  /* __DC_ARAM_H */

--- a/kernel/arch/dreamcast/include/dc/g2bus.h
+++ b/kernel/arch/dreamcast/include/dc/g2bus.h
@@ -191,6 +191,25 @@ static inline void g2_unlock(g2_ctx_t ctx) {
     irq_restore(ctx.irq_state);
 }
 
+/** \cond */
+static inline void __g2_scoped_cleanup(g2_ctx_t *state) {
+    g2_unlock(*state);
+}
+
+#define ___g2_lock_scoped(l) \
+    g2_ctx_t __scoped_g2_lock_##l __attribute__((cleanup(__g2_scoped_cleanup))) = g2_lock()
+
+#define __g2_lock_scoped(l) ___g2_lock_scoped(l)
+/** \endcond */
+
+/** \brief  Disable IRQs and G2 DMA with scope management
+
+    This function makes the following g2_read_*()/g2_write_*() functions atomic
+    by disabling IRQs and G2 DMA and storing their states. The state will
+    automatically be restored once the execution exits the functional block in
+    which the macro was called.
+*/
+#define g2_lock_scoped() __g2_lock_scoped(__LINE__)
 
 #undef G2_DMA_SUSPEND_SPU
 #undef G2_DMA_SUSPEND_BBA

--- a/kernel/arch/dreamcast/include/dc/sound/aica_comm.h
+++ b/kernel/arch/dreamcast/include/dc/sound/aica_comm.h
@@ -80,6 +80,33 @@ typedef struct aica_channel {
     uint32      pad[5];     /**< \brief Padding */
 } aica_channel_t;
 
+/** \brief AICA firmware header
+
+    This structure contains all the information about the firmware that
+    both sides need to know: the addresses of the command and response
+    queues, the sample buffer address and size, and the channels array
+    address.
+
+    On the ARM side, the fields are valid pointers and can be deferred directly.
+    On the SH4 side, the fields are ARM addresses (aka. aram_addr_t) and should
+    exclusively be manipulated with the ARAM API.
+*/
+typedef struct aica_header {
+    aica_queue_t   *cmd_queue;  /**< Address of the command queue */
+    aica_queue_t   *resp_queue; /**< Address of the response queue */
+    aica_channel_t *channels;   /**< Address of the channels array */
+    void           *buffer;     /**< Address of the sample buffer */
+    unsigned int   buffer_size; /**< Sample buffer size in bytes */
+} aica_header_t;
+
+/** \brief Cached AICA firmware header
+
+    This structure is directly accessible from both ARM and SH4 sides.
+    Note that on the SH4 side the pointers are ARM addresses (aka. aram_addr_t)
+    and should exclusively be manipulated with the ARAM API.
+*/
+extern aica_header_t aica_header;
+
 /** \brief Macro for declaring an aica channel command
 
     Declare an aica_cmd_t big enough to hold an aica_channel_t

--- a/kernel/arch/dreamcast/sound/arm/aica_cmd_iface.h
+++ b/kernel/arch/dreamcast/sound/arm/aica_cmd_iface.h
@@ -40,8 +40,4 @@
 /* Quick access to the AICA channels */
 #define AICA_CHANNEL(x)     (AICA_MEM_CHANNELS + (x) * sizeof(aica_channel_t))
 
-/* Channels status register bits */
-#define AICA_CHANNEL_KEYONEX   0x8000
-#define AICA_CHANNEL_KEYONB    0x4000
-
 #endif  /* __ARM_AICA_CMD_IFACE_H */

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -20,6 +20,10 @@
 
 #include "arm/aica_cmd_iface.h"
 
+/* Channels status register bits */
+#define AICA_CHANNEL_KEYONEX   0x8000
+#define AICA_CHANNEL_KEYONB    0x4000
+
 /* Are we initted? */
 static int initted = 0;
 

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -24,6 +24,14 @@
 #define AICA_CHANNEL_KEYONEX   0x8000
 #define AICA_CHANNEL_KEYONB    0x4000
 
+struct aica_header aica_header = {
+    .cmd_queue = (struct aica_queue *)AICA_MEM_CMD_QUEUE,
+    .resp_queue = (struct aica_queue *)AICA_MEM_RESP_QUEUE,
+    .channels = (struct aica_channel *)AICA_MEM_CHANNELS,
+    .buffer = (void *)AICA_RAM_START,
+    .buffer_size = AICA_RAM_END - AICA_RAM_START,
+};
+
 /* Are we initted? */
 static int initted = 0;
 

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -86,9 +86,8 @@ void snd_shutdown(void) {
 
 /* Submit a request to the SH4->AICA queue; size is in uint32's */
 int snd_sh4_to_aica(void *packet, uint32_t size) {
-    uint32_t qa, bot, start, top, *pkt32, cnt;
+    aram_addr_t bot, start, top;
     aica_queue_t cmd_queue;
-    g2_ctx_t ctx;
 
     assert_msg(size < AICA_CMD_MAX_SIZE, "SH4->AICA packets may not be >256 uint32's long");
 
@@ -97,37 +96,28 @@ int snd_sh4_to_aica(void *packet, uint32_t size) {
 
     assert_msg(cmd_queue.valid, "Queue is not yet valid");
 
-    qa = (uint32_t)aica_header.cmd_queue + SPU_RAM_UNCACHED_BASE;
-    bot = SPU_RAM_UNCACHED_BASE + (uintptr_t)cmd_queue.data;
+    bot = (aram_addr_t)cmd_queue.data;
     top = bot + cmd_queue.size;
     start = bot + cmd_queue.head;
-    pkt32 = (uint32_t *)packet;
-    cnt = 0;
 
-    ctx = g2_lock();
+    /* From now on count the size as bytes */
+    size *= 4;
 
-    while(size-- > 0) {
-        /* Fifo wait if necessary */
-        if((cnt++ & 7) == 0)
-            g2_fifo_wait();
+    if (size > top - start) {
+        aram_write(start, packet, top - start);
 
-        /* Write the next dword */
-        g2_write_32_raw(start, *pkt32++);
-
-        /* Move our counters */
-        start += 4;
-
-        if(start >= top)
-            start = bot;
+        size -= top - start;
+        packet += top - start;
+        start = bot;
     }
+
+    aram_write(start, packet, size);
+    start += size;
 
     /* Finally, write a new head value to signify that we've added
        a packet for it to process */
-    if((cnt & 7) == 0)
-        g2_fifo_wait();
-
-    g2_write_32_raw(qa + offsetof(aica_queue_t, head), start - bot);
-    g2_unlock(ctx);
+    aram_write_32((aram_addr_t)aica_header.cmd_queue + offsetof(aica_queue_t, head),
+                  start - bot);
 
     /* We could wait until head == tail here for processing, but there's
        not really much point; it'll just slow things down. */
@@ -136,18 +126,14 @@ int snd_sh4_to_aica(void *packet, uint32_t size) {
 
 /* Start processing requests in the queue */
 void snd_sh4_to_aica_start(void) {
-    g2_write_32((uint32_t)aica_header.cmd_queue
-                + SPU_RAM_UNCACHED_BASE
-                + offsetof(aica_queue_t, process_ok), 1);
+    aram_write_32((aram_addr_t)aica_header.cmd_queue + offsetof(aica_queue_t, process_ok), 1);
     mutex_unlock(&queue_proc_mutex);
 }
 
 /* Stop processing requests in the queue */
 void snd_sh4_to_aica_stop(void) {
     mutex_lock(&queue_proc_mutex);
-    g2_write_32((uint32_t)aica_header.cmd_queue
-                + SPU_RAM_UNCACHED_BASE
-                + offsetof(aica_queue_t, process_ok), 0);
+    aram_write_32((aram_addr_t)aica_header.cmd_queue + offsetof(aica_queue_t, process_ok), 0);
 }
 
 /* Transfer one packet of data from the AICA->SH4 queue. Expects to
@@ -155,67 +141,52 @@ void snd_sh4_to_aica_stop(void) {
    if failure, 0 for no packets available, 1 otherwise. Failure
    might mean a permanent failure since the queue is probably out of sync. */
 int snd_aica_to_sh4(void *packetout) {
-    uint32_t bot, top, start, stop, size, cnt, *pkt32;
+    aram_addr_t bot, top, start, stop;
     aica_queue_t resp_queue;
-    g2_ctx_t ctx;
+    uint32_t size;
 
     /* Read the response queue's structure */
     aram_read(&resp_queue, (aram_addr_t)aica_header.resp_queue, sizeof(resp_queue));
 
     assert_msg(resp_queue.valid, "Queue is not yet valid");
 
-    bot = SPU_RAM_UNCACHED_BASE + (uintptr_t)resp_queue.data;
+    bot = (aram_addr_t)resp_queue.data;
     top = bot + resp_queue.size;
     start = bot + resp_queue.tail;
     stop = bot + resp_queue.head;
-    pkt32 = (uint32_t *)packetout;
-    cnt = 0;
 
     /* Is there anything? */
     if(start == stop)
         return 0;
 
     /* Check for packet size overflow */
-    size = g2_read_32(start + offsetof(aica_cmd_t, size));
+    size = aram_read_32(start + offsetof(aica_cmd_t, size));
 
     if(size >= AICA_CMD_MAX_SIZE) {
         dbglog(DBG_ERROR, "snd_aica_to_sh4(): packet larger than %d dwords\n", AICA_CMD_MAX_SIZE);
         return -1;
     }
 
+    /* Count in bytes now */
+    size *= 4;
+
     /* Find stop point for this packet */
-    stop = start + size * 4;
+    stop = start + size;
 
-    if(stop > top)
-        stop -= top - bot;
+    if(stop > top) {
+        aram_read(packetout, start, top - start);
 
-    ctx = g2_lock();
-
-    while(start != stop) {
-        /* Fifo wait if necessary */
-        if((cnt++ & 7) == 0)
-            g2_fifo_wait();
-
-        /* Read the next dword */
-        *pkt32++ = g2_read_32_raw(start);
-
-        /* Move our counters */
-        start += 4;
-
-        if(start >= top)
-            start = bot;
+        size -= top - start;
+        packetout += top - start;
+        start = bot;
     }
 
+    aram_read(packetout, start, size);
+    start += size;
+
     /* Finally, write a new tail value to signify that we've removed a packet */
-    if((cnt & 7) == 0)
-        g2_fifo_wait();
-
-    g2_write_32_raw((uint32_t)aica_header.resp_queue
-                    + SPU_RAM_UNCACHED_BASE
-                    + offsetof(aica_queue_t, tail),
-                    start - bot);
-    g2_unlock(ctx);
-
+    aram_write_32((aram_addr_t)aica_header.resp_queue + offsetof(aica_queue_t, tail),
+                  start - bot);
 
     return 1;
 }
@@ -240,10 +211,9 @@ void snd_poll_resp(void) {
 }
 
 uint16_t snd_get_pos(unsigned int ch) {
-    return g2_read_32(SPU_RAM_UNCACHED_BASE +
-                      (aram_addr_t)aica_header.channels +
-                      ch * sizeof(*aica_header.channels) +
-                      offsetof(aica_channel_t, pos));
+    return aram_read_32((aram_addr_t)aica_header.channels +
+                        ch * sizeof(*aica_header.channels) +
+                        offsetof(aica_channel_t, pos));
 }
 
 bool snd_is_playing(unsigned int ch) {

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -789,10 +789,7 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
     }
 
     /* Get channels position */
-    current_play_pos = g2_read_32(SPU_RAM_UNCACHED_BASE +
-                        AICA_CHANNEL(stream->ch[0]) +
-                        offsetof(aica_channel_t, pos)) & 0xffff;
-
+    current_play_pos = snd_get_pos(stream->ch[0]);
     needed_bytes = samples_to_bytes(hnd, current_play_pos);
 
     if(needed_bytes >= stream->buffer_size) {


### PR DESCRIPTION
AICAOS Step 2. This PR can be merged before or after step 1, they are independent and do not conflict between each other.

Introduce `g2_lock_scoped()` as a scoped variant of `g2_lock().`
Add a new `<dc/aram.h>` API to simplify transfers from/to the sound RAM.
Add a firmware header structure, that right now contains hardcoded pointers to the memory offsets that are currently used in the firmware for the message queue, channels array and sample buffer. In the future, this header will be provided by the firmware.
Update the interface code to use the new ARAM API as well as the header structure.