### PR TITLE
Remove non-arch perf counter use / fix `thd_pslist` times

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -731,6 +731,14 @@ int thd_each(int (*cb)(kthread_t *thd, void *user_data), void *data);
 
 /** \brief   Print a list of all threads using the given print function.
 
+    Each thread is printed with its address, tid, priority level, flags,
+    it's wait timeout (if sleeping) the amount of cpu time usage in ns
+    (this includes time in IRQs), state, and name.
+
+    In addition a '[system]' item is provided that represents time since
+    initialization not spent in a thread (context switching, updating
+    wait timeouts, etc).
+
     \param  pf              The printf-like function to print with.
 
     \retval 0               On success.

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -608,25 +608,27 @@ int *thd_get_errno(kthread_t *thd);
 */
 struct _reent *thd_get_reent(kthread_t *thd);
 
-
 /** \brief       Retrieves the thread's elapsed CPU time
     \relatesalso kthread_t
 
     Returns the amount of active CPU time the thread has consumed in
     nanoseconds.
 
-    \warning
-    The implementation uses perf_cntr_timer_ns() internally when maintaining
-    this CPU time, so disabling or clearing the nanosecond timer will
-    interfere with this time keeping.
+    \param thd          The thead to retrieve the CPU time for.
 
-    \param thd          The thead to retrieve the CPU time for
-
-    \retval             Total utilized CPU time in nanoseconds OR
-                        0 if the nanosecond timer of the performance
-                        counters has been disturbed.
+    \retval             Total utilized CPU time in nanoseconds.
 */
 uint64_t thd_get_cpu_time(kthread_t *thd);
+
+/** \brief       Retrieves all thread's elapsed CPU time
+    \relatesalso kthread_t
+
+    Returns the amount of active CPU time all threads have consumed in
+    nanoseconds.
+
+    \retval             Total utilized CPU time in nanoseconds.
+*/
+uint64_t thd_get_total_cpu_time(void);
 
 /** \brief   Change threading modes.
 

--- a/kernel/libc/newlib/newlib_times.c
+++ b/kernel/libc/newlib/newlib_times.c
@@ -12,18 +12,14 @@
 #include <sys/reent.h>
 #include <sys/times.h>
 #include <arch/timer.h>
-#include <dc/perfctr.h>
 
 int _times_r(struct _reent *re, struct tms *tmsbuf) {
     (void)re;
 
     if(tmsbuf) {
-        /*  User CPU Time:
-            Use performance counters when available. */
+        /*  User CPU Time: */
         const uint64_t precise_clock =
-            (perf_cntr_timer_enabled())?
-                (perf_cntr_timer_ns() / 1000) : 
-                 timer_us_gettime64();
+                  timer_us_gettime64();
 
         /* We have to protect against overflow. */
         tmsbuf->tms_utime =


### PR DESCRIPTION
This bundles two interrelated changes, and there's significant detail on each in the commit messages.

In short: first, remove the references to the dc-specific performance counter driver from the outer kernel. This was violating API between the kernel and arch-specific drivers. It needs some more followup, but access to the timer based on the performance counters should be mediated through the arch/timer API. To do so would be involve basically treating it as an additionally timer channel that would be generally available for use like `TMU0` `TMU1` and `TMU2`. 

I didn't include it here because I think that should also be paired with a deeper cleanup of that API as we would likely want to add the functionality for a user to be able to say 'give me the first available timer for my own use' and a way to track the special characteristics of the timer (resolution, the non-sleep tracking of the perf counters, maybe the WDT and BSC).

Second is to revamp the `thd_pslist` that was the main user of the perf counter-based per-thread cpu_time in order to be more consistent. I've attached samples of the output from the [general threading example](https://github.com/KallistiOS/KallistiOS/blob/master/examples/dreamcast/basic/threading/general/general_threading_test.c)  where you can see that before this change the results of the various printouts totaled to: 98.285%, 100.119%, 99.126%, 99.371%, 79.172%, and 83.509% respectively. After the change it's: 99.999%, 99.998%, 100%, 99.999%, 100%, and 99.999% respectively.

So it went from some pretty significant discrepancies (due to a combination of the methodology of the tallying and the perf counters ignoring sleep) to *just* the +/- 0.001% per thread rounding error.
[output_post_change.txt](https://github.com/user-attachments/files/19118733/output_post_change.txt)
[output_pre_change.txt](https://github.com/user-attachments/files/19118739/output_pre_change.txt)
