### PR TITLE
Add GDC post-install fixes.

### DIFF
--- a/utils/dc-chain/Makefile
+++ b/utils/dc-chain/Makefile
@@ -66,6 +66,7 @@ include scripts/binutils.mk
 include scripts/gcc-pass1.mk
 include scripts/newlib.mk
 include scripts/gcc-pass2.mk
+include scripts/gdc-post.mk
 
 # ---- }}}}
 

--- a/utils/dc-chain/patches/gdc/config.d
+++ b/utils/dc-chain/patches/gdc/config.d
@@ -1,0 +1,19 @@
+// THIS IS AN UGLY HACK TO ACCOUNT FOR THE LACK OF BEING
+// ABLE TO COMPILE PHOBOS FOR THIS PLATFORM.
+module gcc.config;
+
+// Map from thread model to thread interface.
+enum ThreadModel {
+    Single,
+    Posix,
+    Win32,
+}
+
+enum GNU_ARM_EABI_Unwinder = false;
+enum ThreadModel GNU_Thread_Model = ThreadModel.Posix;
+enum OS_Have_Dlpi_Tls_Modid = false;
+enum GNU_Have_Atomics = true;
+enum GNU_Have_64Bit_Atomics = false;
+enum GNU_Have_LibAtomic = false;
+enum Have_Qsort_R = false;
+enum GNU_Enable_CET = false;

--- a/utils/dc-chain/scripts/gdc-post.mk
+++ b/utils/dc-chain/scripts/gdc-post.mk
@@ -1,0 +1,17 @@
+# Sega Dreamcast Toolchains Maker (dc-chain)
+# This file is part of KallistiOS.
+
+ifdef enable_d
+  ifneq (0,$(enable_d))
+	$(gdc_post_install): prefix = $(sh_toolchain_path)
+	$(gdc_post_install): gdc_target = $(target)
+	$(gdc_post_install): gdc_ver = $(gcc_ver)
+	$(gdc_post_install): src_dir = gcc-$(gcc_ver)
+	$(gdc_post_install): out_dir = $(prefix)
+	$(gdc_post_install): logdir
+		@echo "+++ Running post-install fixups for GNU D..."
+		-mkdir -p $(prefix)/lib/gcc/$(gdc_target)/$(gdc_ver)/include/d
+		cp -r ./$(src_dir)/libphobos/libdruntime/* $(prefix)/lib/gcc/$(gdc_target)/$(gdc_ver)/include/d
+		cp $(patches)/gdc/config.d $(prefix)/lib/gcc/$(gdc_target)/$(gdc_ver)/include/d/gcc/config.d
+  endif
+endif


### PR DESCRIPTION
This pull-request aims to allow using DLang with classes by copying the libphobos sources to the correct path for the compiler; this is neccesary as otherwise dependencies added via dub will not be able to resolve essential symbols.