### PR TITLE
pvr_list_prim(): avoid buffer overflow

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -280,11 +280,11 @@ int pvr_list_prim(pvr_list_t list, const void *data, size_t size) {
     /* Ensure at least 4-byte alignment. */
     assert(!((uintptr_t)data & 0x3));
 
+    /* Ensure we won't overflow the vertex buffer. */
+    assert(b->ptr[list] + size <= b->size[list]);
+
     memcpy(b->base[list] + b->ptr[list], data, size);
     b->ptr[list] += size;
-
-    /* Ensure we didn't overflow the vertex buffer. */
-    assert(b->ptr[list] <= b->size[list]);
 
     return 0;
 }


### PR DESCRIPTION
AS-IS: 
   When submitting vertices via DMA, and you try to send too many vertices, the system will hang without any message.

Root cause:
   In pvr_list_prim(), the assert to check for buffer overflow is done too late, after a potential memory corruption

TO-BE:
  We get the correct assertion failure message:
      *** ASSERTION FAILURE ***
      Assertion "b->ptr[list] + size <= b->size[list]" failed at pvr_scene.c:293 in `pvr_list_prim'