### PR TITLE
Fix CDDA on GDEMU clones

### DIFF
--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -466,8 +466,6 @@ void cdrom_init(void) {
         }
     }
 
-    /* Reset system functions */
-    syscall_gdrom_reset();
     syscall_gdrom_init();
 
     unlock_dma_memory();


### PR DESCRIPTION
Remove GDROM reset syscall as it triggers an issue with GDEMU clones where the subsequent CMD_INIT is ignored as it is sent within 147ms of the reset. This is because CMD_INIT is sent while the GDEMU is still in the BUSY state.

I had a previous fix for this issue with full details here: https://github.com/KallistiOS/KallistiOS/pull/957

However, this broke lxdream and lxdream-nitro which wouldn't _exit_ the BUSY state until CMD_INIT is sent. Removing the reset call is a simpler fix as it maintains compatibility with everything.

That said, I submitted patches to both lxdream and lxdream-nitro to ensure the default drive state is PAUSED instead of BUSY to match real hardware and both have been accepted.

As for the safety of this change, I have confirmed that official Dreamcast games don't call reset as part of their usual init flow - just the INIT syscall and then CMD_INIT. This PR brings KallistiOS back in line with that. I also confirmed with DC-SWAT that it's safe to remove the reset call.

Here is the commit that originally added the reset call: https://github.com/kilgariff/KallistiOS/commit/a246cbfe5f2756e526da17f3d67c2910a4765cf7