### PR TITLE
math: Add mat_multiply()

### DIFF
--- a/kernel/arch/dreamcast/include/dc/matrix.h
+++ b/kernel/arch/dreamcast/include/dc/matrix.h
@@ -85,6 +85,22 @@ void mat_identity(void);
 */
 void mat_apply(const matrix_t *src);
 
+/** \brief  Multiply a matrix.
+
+    This function multiplies a matrix in memory with the internal matrix
+    and stores the result into a new matrix.
+
+    \warning
+    \p src and dst MUST be at least 8-byte aligned!
+
+    \note
+    For best performance, 32-byte alignment of \p src and \p dst is recommended.
+
+    \param  dst             A pointer to the destination matrix.
+    \param  src             A pointer to the matrix to multiply.
+*/
+void mat_multiply(matrix_t *dst, const matrix_t *src);
+
 /** \brief  Transform vectors by the internal matrix.
 
     This function transforms zero or more sets of vectors by the current

--- a/kernel/arch/dreamcast/math/matrix.s
+++ b/kernel/arch/dreamcast/math/matrix.s
@@ -218,6 +218,78 @@ _mat_apply:
         rts
         fmov.s      @r15+, fr15
 
+.globl _mat_multiply
+_mat_multiply:
+    fmov.s          fr15, @-r15
+    fmov.s          fr14, @-r15
+    fmov.s          fr13, @-r15
+    fmov.s          fr12, @-r15
+    fschg
+!   nop
+
+    fmov        @r5+,dr0 ! Load up first row.
+!   nop
+    fmov        @r5+, dr2
+!   nop
+    fmov        @r5+, dr4 ! Load up second row.
+!   nop
+    fmov        @r5+, dr6
+!   nop
+
+    ftrv        xmtrx, fv0
+!   nop
+
+    fmov        @r5+, dr8
+!   nop
+    fmov        @r5+, dr10
+!   nop
+
+!   nop nop
+
+    ftrv        xmtrx, fv4
+!   nop
+
+    fmov        @r5+, dr12
+!   nop
+    fmov        @r5+, dr14
+!   nop
+
+!   nop nop
+
+    ftrv        xmtrx, fv8
+!   nop
+
+!   nop nop
+!   nop nop
+!   nop nop
+
+    ftrv        xmtrx, fv12
+!   nop
+
+    fmov        dr0, @r4
+    add         #8, r4
+    fmov        dr2, @r4
+    add         #8, r4
+    fmov        dr4, @r4
+    add         #8, r4
+    fmov        dr6, @r4
+    add         #8, r4
+    fmov        dr8, @r4
+    add         #8, r4
+    fmov        dr10, @r4
+    add         #8, r4
+    fmov        dr12, @r4
+    add         #8, r4
+    fmov        dr14, @r4
+!   nop
+
+    fschg
+    fmov.s      @r15+, fr12
+    fmov.s      @r15+, fr13
+    fmov.s      @r15+, fr14
+    rts
+    fmov.s      @r15+, fr15
+
 
 ! Transform zero or more sets of vectors using the current internal
 ! matrix. Each vector is three floats long.


### PR DESCRIPTION
This function is similar to mat_apply(), except that it does not write the result matrix back to the internal matrix, but to a destination pointer in memory.