### PR TITLE
pvr: Fix render-to-texture

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -214,14 +214,26 @@ typedef struct {
     // Non-zero if using double-buffering for the vertex buffer.
     int     vbuf_doublebuf;
 
-    // Non-zero if we are rendering to a texture
-    int     to_texture[2];
+    // True if the next frame is rendered to a texture
+    bool    next_to_texture;
 
-    // Render pitch for to-texture mode
-    int     to_txr_rp[2];
+    // True if the frame processed by the TA is rendered to a texture
+    bool    curr_to_texture;
 
-    // Output address for to-texture mode
-    uint32  to_txr_addr[2];
+    // True if the frame processed by the CORE is rendered to a texture
+    bool    was_to_texture;
+
+    // Render pitch for to-texture mode for the current frame
+    int     to_txr_rp;
+
+    // Render pitch for to-texture mode for the next frame
+    int     next_to_txr_rp;
+
+    // Output address for to-texture mode for the current frame
+    uint32  to_txr_addr;
+
+    // Output address for to-texture mode for the next frame
+    uint32  next_to_txr_addr;
 
     // Whether direct rendering is active or not
     uint32  dr_used;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -225,11 +225,11 @@ void pvr_begin_queued_render(void) {
     PVR_SET(PVR_ISP_TILEMAT_ADDR, tbuf->tile_matrix);
     PVR_SET(PVR_ISP_VERTBUF_ADDR, tbuf->vertex);
 
-    if(!pvr_state.to_texture[bufn])
+    if(!pvr_state.curr_to_texture)
         PVR_SET(PVR_RENDER_ADDR, rbuf->frame);
     else {
-        PVR_SET(PVR_RENDER_ADDR, pvr_state.to_txr_addr[bufn] | BIT(24));
-        PVR_SET(PVR_RENDER_ADDR_2, pvr_state.to_txr_addr[bufn] | BIT(24));
+        PVR_SET(PVR_RENDER_ADDR, pvr_state.to_txr_addr | BIT(24));
+        PVR_SET(PVR_RENDER_ADDR_2, pvr_state.to_txr_addr | BIT(24));
     }
 
     PVR_SET(PVR_BGPLANE_CFG, vert_end); /* Bkg plane location */
@@ -238,10 +238,10 @@ void pvr_begin_queued_render(void) {
     PVR_SET(PVR_PCLIP_X, pvr_state.pclip_x);
     PVR_SET(PVR_PCLIP_Y, pvr_state.pclip_y);
 
-    if(!pvr_state.to_texture[bufn])
+    if(!pvr_state.curr_to_texture)
         PVR_SET(PVR_RENDER_MODULO, (pvr_state.w * vid_pmode_bpp[vid_mode->pm]) / 8);
     else
-        PVR_SET(PVR_RENDER_MODULO, pvr_state.to_txr_rp[bufn]);
+        PVR_SET(PVR_RENDER_MODULO, pvr_state.to_txr_rp);
 
     // XXX Do we _really_ need this every time?
     // SETREG(PVR_FB_CFG_2, 0x00000009);        /* Alpha mode */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -98,6 +98,9 @@ static void pvr_start_ta_rendering(void) {
             pvr_wait_render_done();
 
         pvr_state.ta_ready = 1;
+        pvr_state.curr_to_texture = pvr_state.next_to_texture;
+        pvr_state.to_txr_rp = pvr_state.next_to_txr_rp;
+        pvr_state.to_txr_addr = pvr_state.next_to_txr_addr;
     }
 
     // Starting from that point, we consider that the Tile Accelerator
@@ -110,6 +113,7 @@ static void pvr_start_ta_rendering(void) {
 void pvr_scene_begin(void) {
     int i;
 
+    pvr_state.next_to_texture = 0;
     pvr_state.ta_ready = 0;
     pvr_state.lists_closed = 0;
 
@@ -139,22 +143,22 @@ void pvr_scene_begin(void) {
    rx and ry are appropriate (i.e. *rx = 1024 and *ry = 512 for 640x480).
    Also, note that this probably won't work with DMA mode for now... */
 void pvr_scene_begin_txr(pvr_ptr_t txr, uint32 *rx, uint32 *ry) {
-    int buf = pvr_state.view_target ^ 1;
     (void)ry;
 
     /* For the most part, this isn't very much different than the normal render setup.
        And, yes, if you remember KOS 1.1.6, this pretty much looks similar to what was
        there. I'm quite uncreative with my variable naming ;) */
-    // Mark us as rendering to a texture
-    pvr_state.to_texture[buf] = 1;
 
     // Set the render pitch up
-    pvr_state.to_txr_rp[buf] = (*rx) * 2 / 8;
+    pvr_state.next_to_txr_rp = (*rx) * 2 / 8;
 
     // Set the output address
-    pvr_state.to_txr_addr[buf] = (uint32)(txr) - PVR_RAM_INT_BASE;
+    pvr_state.next_to_txr_addr = (uint32)(txr) - PVR_RAM_INT_BASE;
 
     pvr_scene_begin();
+
+    // Mark us as rendering to a texture
+    pvr_state.next_to_texture = 1;
 }
 
 static bool pvr_list_dma;


### PR DESCRIPTION
Render-to-texture was broken since the recent changes that decoupled the Tile Accelerator with the PVR rendering. This was because the code checked the "render to texture" flag on the back buffer, which made sense back then, but now the back and front buffers can be flipped in the middle of a scene draw.

This did not show in KOS' example for RTT
(examples/dreamcast/pvr/texture_render/), for the reason that the code there was rendering fast enough to reach 60 fps and be throttled by VSYNC.

Address this issue by keeping track of RTT for the next frame (the one for which we're preparing a new scene), and the current frame (being processed by the TA or being rendered by the PVR CORE), without taking the "view target" into account.