### PR TITLE
Make the fs_iso9660 file table dynamically sized.

### DIFF
--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -114,9 +114,9 @@ __BEGIN_DECLS
 #define VMUFS_DEBUG 1
 #endif
 
-/** \brief  The maximum number of cd files that can be open at a time. */
+/** \brief  The maximum number of cd files that can be open at a time. 0 no max. */
 #ifndef FS_CD_MAX_FILES
-#define FS_CD_MAX_FILES 8
+#define FS_CD_MAX_FILES 0
 #endif
 
 /** \brief  The maximum number of romdisk files that can be open at a time. */


### PR DESCRIPTION
Move the file table out of being a static array and to being in dynamically allocated memory. Start at the previous default size of 8 and expand by doubling in size with the same fail condition if we cannot expand in that way.

The `FS_CD_MAX_FILES` define now has the same basic meaning but its usage is reversed. The reason to set it would be to limit the size of the table, rather than to expand the allowed size. Accordingly the default has been set to 0 which indicates 'no max limit'.

Need to write some test for it, as I wrote it without any but hopefully could get some real-world validation from anyone who has had to use `FS_CD_MAX_FILES` in the past to expand the table would be able to give it a go.