### PR TITLE
Kbd update i

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -2268,7 +2268,8 @@ PREDEFINED             = _arch_$(KOS_ARCH)=1 \
                          __END_DECLS= \
                          __extension__= \
                          __packed__= \
-                         __attribute__(x)=
+                         __attribute__(x)= \
+                         __depr 
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/examples/dreamcast/libdream/keyboard/keyboard.c
+++ b/examples/dreamcast/libdream/keyboard/keyboard.c
@@ -8,25 +8,21 @@ void kb_test(void) {
     printf("Now doing keyboard test\n");
 
     while(1) {
-        cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
+        /* Query for the first detected controller */
+        if((cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER))) {
+            /* Fetch controller button state structure. */
+            state = maple_dev_status(cont);
 
-        if(!cont) continue;
+            /* Quit if start is pressed on the controller. */
+            if(state->start) {
+                printf("Pressed start!\n");
+                return;
+            }
+        }
 
         kbd = maple_enum_type(0, MAPLE_FUNC_KEYBOARD);
 
         if(!kbd) continue;
-
-        /* Check for start on the controller */
-        state = (cont_state_t *)maple_dev_status(cont);
-
-        if(!state) {
-            return;
-        }
-
-        if(state->buttons & CONT_START) {
-            printf("Pressed start\n");
-            return;
-        }
 
         thd_sleep(10);
 

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -66,6 +66,11 @@
 #define __weak      __attribute__((weak))
 #endif
 
+#ifndef __packed
+/** \brief  Force a structure, enum, or other type to be packed as small as possible. */
+#define __packed    __attribute__((packed))
+#endif
+
 #ifndef __dead2
 /** \brief  Alias for \ref __noreturn. For BSD compatibility. */
 #define __dead2     __noreturn  /* BSD compat */

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -566,10 +566,10 @@ static void kbd_check_poll(maple_frame_t *frm) {
     /* Now normalize the key matrix */
     /* If it was determined no keys are pressed, wipe the matrix */
     if(state->matrix[KBD_KEY_NONE] == KEY_STATE_PRESSED)
-        memset (state->matrix, KEY_STATE_NONE, MAX_KBD_KEYS);
+        memset (state->matrix, KEY_STATE_NONE, KBD_MAX_KEYS);
     /* Otherwise, walk through the whole matrix */
     else    {
-        for(i = 0; i < MAX_KBD_KEYS; i++) {
+        for(i = 0; i < KBD_MAX_KEYS; i++) {
             if(state->matrix[i] == KEY_STATE_NONE) continue;
 
             else if(state->matrix[i] == KEY_STATE_WAS_PRESSED) state->matrix[i] = KEY_STATE_NONE;

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -460,6 +460,19 @@ int kbd_get_key(void) {
     return rv;
 }
 
+kbd_state_t *kbd_get_state(maple_device_t *device) {
+    if(!device)
+        return NULL;
+
+    if(!device->status_valid)
+        return NULL;
+
+    if(!(device->info.functions & MAPLE_FUNC_KEYBOARD))
+        return NULL;
+
+    return (kbd_state_t *)device->status;
+}
+
 /* Take a key off of a specific key queue. */
 int kbd_queue_pop(maple_device_t *dev, int xlat) {
     kbd_state_t *state = (kbd_state_t *)dev->status;

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -523,9 +523,6 @@ int kbd_queue_pop(maple_device_t *dev, bool xlat) {
     if(!xlat)
         return (int)rv;
 
-    if(region < KBD_REGION_JP || region > KBD_NUM_KEYMAPS)
-        return (int)(rv & 0xFF) << 8;
-
     mods = rv >> 8;
 
     if((mods & KBD_MOD_RALT) || (mods & (KBD_MOD_LCTRL | KBD_MOD_LALT)) == (KBD_MOD_LCTRL | KBD_MOD_LALT))

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -10,6 +10,9 @@
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
+
+#include <kos/dbglog.h>
+
 #include <arch/timer.h>
 #include <dc/maple.h>
 #include <dc/maple/keyboard.h>
@@ -661,14 +664,17 @@ static int kbd_attach(maple_driver_t *drv, maple_device_t *dev) {
     /* Maple functions are enumerated, from MSB, to determine which functions
        are on each device. The only one above the keyboard function is lightgun.
        Only if it is ALSO a lightgun, will the keyboard function be second. */
-    if(dev->info.functions&MAPLE_FUNC_LIGHTGUN) d = 1;
+    if(dev->info.functions & MAPLE_FUNC_LIGHTGUN)
+        d = 1;
 
     /* Retrieve the region data */
     state->region = dev->info.function_data[d] & 0xFF;
 
     /* Unrecognized keyboards will appear as US keyboards... */
-    if(state->region > KBD_NUM_KEYMAPS)
+    if(!state->region || state->region > KBD_NUM_KEYMAPS) {
+        dbglog(DBG_ERROR, "Unknown Keyboard region %u\n", state->region);
         state->region = KBD_REGION_US;
+    }
 
     /* Make sure all the queue variables are set up properly... */
     state->queue_tail = state->queue_head = state->queue_len = 0;

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -66,9 +66,22 @@ void kbd_set_repeat_timing(uint16_t start, uint16_t interval) {
     repeat_timing.interval = interval;
 }
 
+/*  Keyboard keymap.
+
+    This structure represents a mapping from raw key values to ASCII values, if
+    appropriate. This handles base values as well as shifted ("shift" and "Alt"
+    keys) values.
+
+*/
+typedef struct kbd_keymap {
+    uint8_t base[KBD_MAX_KEYS];
+    uint8_t shifted[KBD_MAX_KEYS];
+    uint8_t alt[KBD_MAX_KEYS];
+} kbd_keymap_internal_t;
+
 /* Built-in keymaps. */
 #define KBD_NUM_KEYMAPS (sizeof(keymaps) / sizeof(keymaps[0]))
-static const kbd_keymap_t keymaps[] = {
+static const kbd_keymap_internal_t keymaps[] = {
     {
         /* Japanese keyboard */
         {

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -445,17 +445,17 @@ static int kbd_enqueue(kbd_state_t *state, uint8_t keycode, int mods) {
     return 0;
 }
 
-/* Take a key off the key queue, or return -1 if there is none waiting */
+/* Take a key off the key queue, or return KBD_QUEUE_END if there is none waiting */
 int kbd_get_key(void) {
     int rv;
 
     /* If queueing isn't active, there won't be anything to get */
     if(!kbd_queue_active)
-        return -1;
+        return KBD_QUEUE_END;
 
     /* Check available */
     if(kbd_queue_head == kbd_queue_tail)
-        return -1;
+        return KBD_QUEUE_END;
 
     rv = kbd_queue[kbd_queue_tail];
     kbd_queue_tail = (kbd_queue_tail + 1) & (KBD_QUEUE_SIZE - 1);
@@ -486,7 +486,7 @@ int kbd_queue_pop(maple_device_t *dev, int xlat) {
 
     if(!state->queue_len) {
         irq_restore(irqs);
-        return -1;
+        return KBD_QUEUE_END;
     }
 
     rv = state->key_queue[state->queue_tail];

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -28,7 +28,7 @@ repeat handling.
     It seems unreasonable that one might want different repeat
     timings set on each keyboard.
     The values are arbitrary based off a survey of common values. */
-uint16 kbd_repeat_start = 600, kbd_repeat_interval = 20;
+uint16_t kbd_repeat_start = 600, kbd_repeat_interval = 20;
 
 /* Built-in keymaps. */
 #define KBD_NUM_KEYMAPS 8
@@ -364,7 +364,7 @@ static kbd_keymap_t keymaps[KBD_NUM_KEYMAPS] = {
 /* The keyboard queue (global for now) */
 static volatile int kbd_queue_active = 1;
 static volatile int kbd_queue_tail = 0, kbd_queue_head = 0;
-static volatile uint16  kbd_queue[KBD_QUEUE_SIZE];
+static volatile uint16_t  kbd_queue[KBD_QUEUE_SIZE];
 
 /* Turn keyboard queueing on or off. This is mainly useful if you want
    to use the keys for a game where individual keypresses don't mean
@@ -383,7 +383,7 @@ void kbd_set_queue(int active) {
 
     NOTE: We are only calling this within an IRQ context, so operations on
           kbd_state::queue_size are essentially atomic. */
-static int kbd_enqueue(kbd_state_t *state, uint8 keycode, int mods) {
+static int kbd_enqueue(kbd_state_t *state, uint8_t keycode, int mods) {
     static char keymap_noshift[] = {
         /*0*/   0, 0, 0, 0, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
         'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
@@ -406,7 +406,7 @@ static int kbd_enqueue(kbd_state_t *state, uint8 keycode, int mods) {
         /*53*/  0, '/', '*', '-', '+', 13, '1', '2', '3', '4', '5', '6',
         /*5f*/  '7', '8', '9', '0', '.', 0
     };
-    uint16 ascii = 0;
+    uint16_t ascii = 0;
 
     /* Don't bother with bad keycodes. */
     if(keycode <= 1)
@@ -432,7 +432,7 @@ static int kbd_enqueue(kbd_state_t *state, uint8 keycode, int mods) {
     }
 
     if(ascii == 0)
-        ascii = ((uint16)keycode) << 8;
+        ascii = ((uint16_t)keycode) << 8;
 
     /* Ok... now do the enqueue to the global queue */
     kbd_queue[kbd_queue_head] = ascii;
@@ -463,8 +463,8 @@ int kbd_get_key(void) {
 /* Take a key off of a specific key queue. */
 int kbd_queue_pop(maple_device_t *dev, int xlat) {
     kbd_state_t *state = (kbd_state_t *)dev->status;
-    uint32 rv, mods;
-    uint8 ascii;
+    uint32_t rv, mods;
+    uint8_t ascii;
 
     const int irqs = irq_disable();
 
@@ -488,11 +488,11 @@ int kbd_queue_pop(maple_device_t *dev, int xlat) {
     mods = rv >> 8;
 
     if((mods & KBD_MOD_RALT) || (mods & (KBD_MOD_LCTRL | KBD_MOD_LALT)) == (KBD_MOD_LCTRL | KBD_MOD_LALT))
-        ascii = keymaps[state->region - 1].alt[(uint8)rv];
+        ascii = keymaps[state->region - 1].alt[(uint8_t)rv];
     else if(mods & (KBD_MOD_LSHIFT | KBD_MOD_RSHIFT | (1 << 9)))
-        ascii = keymaps[state->region - 1].shifted[(uint8)rv];
+        ascii = keymaps[state->region - 1].shifted[(uint8_t)rv];
     else
-        ascii = keymaps[state->region - 1].base[(uint8)rv];
+        ascii = keymaps[state->region - 1].base[(uint8_t)rv];
 
     if(ascii)
         return (int)ascii;
@@ -551,7 +551,7 @@ static void kbd_check_poll(maple_frame_t *frm) {
             else if(state->matrix[cond->keys[i]] == KEY_STATE_WAS_PRESSED) {
                 state->matrix[cond->keys[i]] = KEY_STATE_PRESSED;
                 if(state->kbd_repeat_key == cond->keys[i]) {
-                    uint64 time = timer_ms_gettime64();
+                    uint64_t time = timer_ms_gettime64();
                     /* We have passed the prescribed amount of time, and will repeat the key */
                     if(time >= (state->kbd_repeat_timer)) {
                         kbd_enqueue(state, cond->keys[i], mods);
@@ -584,7 +584,7 @@ static void kbd_reply(maple_state_t *st, maple_frame_t *frm) {
     (void)st;
 
     maple_response_t *resp;
-    uint32 *respbuf;
+    uint32_t *respbuf;
     kbd_state_t *state;
     kbd_cond_t *cond;
 
@@ -597,7 +597,7 @@ static void kbd_reply(maple_state_t *st, maple_frame_t *frm) {
     if(resp->response != MAPLE_RESPONSE_DATATRF)
         return;
 
-    respbuf = (uint32 *)resp->data;
+    respbuf = (uint32_t *)resp->data;
 
     if(respbuf[0] != MAPLE_FUNC_KEYBOARD)
         return;
@@ -617,13 +617,13 @@ static void kbd_reply(maple_state_t *st, maple_frame_t *frm) {
 }
 
 static int kbd_poll_intern(maple_device_t *dev) {
-    uint32 * send_buf;
+    uint32_t *send_buf;
 
     if(maple_frame_lock(&dev->frame) < 0)
         return 0;
 
     maple_frame_init(&dev->frame);
-    send_buf = (uint32 *)dev->frame.recv_buf;
+    send_buf = (uint32_t *)dev->frame.recv_buf;
     send_buf[0] = MAPLE_FUNC_KEYBOARD;
     dev->frame.cmd = MAPLE_COMMAND_GETCOND;
     dev->frame.dst_port = dev->port;

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -487,7 +487,7 @@ kbd_state_t *kbd_get_state(maple_device_t *device) {
 }
 
 /* Take a key off of a specific key queue. */
-int kbd_queue_pop(maple_device_t *dev, int xlat) {
+int kbd_queue_pop(maple_device_t *dev, bool xlat) {
     kbd_state_t *state = (kbd_state_t *)dev->status;
     uint32_t rv, mods;
     uint8_t ascii;

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -178,22 +178,20 @@ __BEGIN_DECLS
 #define KBD_KEY_S3              0x65
 /** @} */
 
-/** \defgroup   kbd_regions Region Codes
-    \brief                  Region codes for the Dreamcast keyboard
-    \ingroup                kbd
+/** \brief      Region Codes for the Dreamcast keyboard
+    \ingroup    kbd
 
-    This is the list of possible values for the "region" field in the
-    kbd_state_t structure.
-    @{
+    This is the list of possible values for kbd_state_t::region.
 */
-#define KBD_REGION_JP       1           /**< \brief Japanese keyboard */
-#define KBD_REGION_US       2           /**< \brief US keyboard */
-#define KBD_REGION_UK       3           /**< \brief UK keyboard */
-#define KBD_REGION_DE       4           /**< \brief German keyboard */
-#define KBD_REGION_FR       5           /**< \brief French keyboard */
-#define KBD_REGION_IT       6           /**< \brief Italian keyboard (not supported yet) */
-#define KBD_REGION_ES       7           /**< \brief Spanish keyboard */
-/** @} */
+typedef enum kbd_region {
+    KBD_REGION_JP = 1, /**< \brief Japanese keyboard */
+    KBD_REGION_US = 2, /**< \brief US keyboard */
+    KBD_REGION_UK = 3, /**< \brief UK keyboard */
+    KBD_REGION_DE = 4, /**< \brief German keyboard */
+    KBD_REGION_FR = 5, /**< \brief French keyboard */
+    KBD_REGION_IT = 6, /**< \brief Italian keyboard (not supported yet) */
+    KBD_REGION_ES = 7  /**< \brief Spanish keyboard */
+} kbd_region_t;
 
 /** \defgroup   key_states  Key States
     \brief                  States each key can be in.
@@ -292,7 +290,7 @@ typedef struct kbd_state {
     int shift_keys;
 
     /** \brief  Keyboard type/region. */
-    int region;
+    kbd_region_t region;
 
     /** \brief  Individual keyboard queue.
         You should not access this variable directly. Please use the appropriate

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -329,20 +329,7 @@ typedef enum kbd_region {
 /* Short-term compatibility helper. */
 static const int MAX_KBD_KEYS   __depr("Please use KBD_MAX_KEYS.") = KBD_MAX_KEYS;
 
-/** \brief   Keyboard keymap.
-    \ingroup kbd
-
-    This structure represents a mapping from raw key values to ASCII values, if
-    appropriate. This handles base values as well as shifted ("shift" and "Alt"
-    keys) values.
-
-    \headerfile dc/maple/keyboard.h
-*/
-typedef struct kbd_keymap {
-    uint8_t base[KBD_MAX_KEYS];
-    uint8_t shifted[KBD_MAX_KEYS];
-    uint8_t alt[KBD_MAX_KEYS];
-} kbd_keymap_t;
+typedef void kbd_keymap_t __depr("Please open an issue, there should be no reason for external code to have used this.");
 
 /** \brief   Keyboard raw condition structure.
     \ingroup kbd

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -352,9 +352,9 @@ typedef struct kbd_keymap {
     \headerfile dc/maple/keyboard.h
 */
 typedef struct {
-    uint8_t modifiers;    /**< \brief Bitmask of set modifiers. */
-    uint8_t leds;         /**< \brief Bitmask of set LEDs */
-    uint8_t keys[MAX_PRESSED_KEYS];      /**< \brief Key codes for currently pressed keys. */
+    kbd_mods_t modifiers;    /**< \brief Bitmask of set modifiers. */
+    kbd_leds_t leds;         /**< \brief Bitmask of set LEDs */
+    kbd_key_t keys[MAX_PRESSED_KEYS];      /**< \brief Key codes for currently pressed keys. */
 } kbd_cond_t;
 
 /** \brief   Keyboard status structure.
@@ -379,8 +379,11 @@ typedef struct kbd_state {
     */
     uint8_t matrix[KBD_MAX_KEYS];
 
-    /** \brief  Modifier key status. */
-    int shift_keys;
+    /** \brief  Modifier key status. Stored to track changes. */
+    union {
+        int shift_keys __depr("Please see kbd_mods_t and use last_modifiers.raw to access this.");
+        kbd_mods_t last_modifiers;
+    };
 
     /** \brief  Keyboard type/region. */
     kbd_region_t region;

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -314,6 +314,78 @@ typedef enum kbd_region {
 #define KEY_STATE_PRESSED     2
 /** @} */
 
+/** \brief   Maximum number of keys the DC can read simultaneously.
+    \ingroup kbd
+    This is a hardware constant. The define prevents the magic number '6' from appearing.
+**/
+#define MAX_PRESSED_KEYS 6
+
+/** \brief   Maximum number of keys a DC keyboard can have.
+    \ingroup kbd
+    This is a hardware constant. The define prevents the magic number '256' from appearing.
+**/
+#define KBD_MAX_KEYS 256
+
+/* Short-term compatibility helper. */
+static const int MAX_KBD_KEYS   __depr("Please use KBD_MAX_KEYS.") = KBD_MAX_KEYS;
+
+/** \brief   Keyboard keymap.
+    \ingroup kbd
+
+    This structure represents a mapping from raw key values to ASCII values, if
+    appropriate. This handles base values as well as shifted ("shift" and "Alt"
+    keys) values.
+
+    \headerfile dc/maple/keyboard.h
+*/
+typedef struct kbd_keymap {
+    uint8_t base[KBD_MAX_KEYS];
+    uint8_t shifted[KBD_MAX_KEYS];
+    uint8_t alt[KBD_MAX_KEYS];
+} kbd_keymap_t;
+
+/** \brief   Keyboard raw condition structure.
+    \ingroup kbd
+
+    This structure is what the keyboard responds with as its current status.
+
+    \headerfile dc/maple/keyboard.h
+*/
+typedef struct {
+    uint8_t modifiers;    /**< \brief Bitmask of set modifiers. */
+    uint8_t leds;         /**< \brief Bitmask of set LEDs */
+    uint8_t keys[MAX_PRESSED_KEYS];      /**< \brief Key codes for currently pressed keys. */
+} kbd_cond_t;
+
+/** \brief   Keyboard status structure.
+    \ingroup kbd
+
+    This structure holds information about the current status of the keyboard
+    device. This is what maple_dev_status() will return.
+
+    \headerfile dc/maple/keyboard.h
+*/
+typedef struct kbd_state {
+    /** \brief  The latest raw condition of the keyboard. */
+    kbd_cond_t cond;
+
+    /** \brief  Key array.
+
+        This array lists the state of all possible keys on the keyboard. It can
+        be used for key repeat and debouncing. This will be non-zero if the key
+        is currently being pressed.
+
+        \see    kbd_keys
+    */
+    uint8_t matrix[KBD_MAX_KEYS];
+
+    /** \brief  Modifier key status. */
+    int shift_keys;
+
+    /** \brief  Keyboard type/region. */
+    kbd_region_t region;
+} kbd_state_t;
+
 /** \defgroup kbd_input     Querying for Input
     \brief                  Various methods for checking keyboard input
 
@@ -518,89 +590,6 @@ int kbd_get_key(void) __deprecated;
 /** @} */
 
 /** @} */
-
-/** \brief   Maximum number of keys the DC can read simultaneously.
-    \ingroup kbd
-    This is a hardware constant. The define prevents the magic number '6' from appearing.
-**/
-#define MAX_PRESSED_KEYS 6
-
-/** \brief   Maximum number of keys a DC keyboard can have.
-    \ingroup kbd
-    This is a hardware constant. The define prevents the magic number '256' from appearing.
-**/
-#define KBD_MAX_KEYS 256
-
-/* Short-term compatibility helper. */
-static const int MAX_KBD_KEYS   __depr("Please use KBD_MAX_KEYS.") = KBD_MAX_KEYS;
-
-/** \brief   Keyboard keymap.
-    \ingroup kbd
-
-    This structure represents a mapping from raw key values to ASCII values, if
-    appropriate. This handles base values as well as shifted ("shift" and "Alt"
-    keys) values.
-
-    \headerfile dc/maple/keyboard.h
-*/
-typedef struct kbd_keymap {
-    uint8_t base[KBD_MAX_KEYS];
-    uint8_t shifted[KBD_MAX_KEYS];
-    uint8_t alt[KBD_MAX_KEYS];
-} kbd_keymap_t;
-
-/** \brief   Keyboard raw condition structure.
-    \ingroup kbd
-
-    This structure is what the keyboard responds with as its current status.
-
-    \headerfile dc/maple/keyboard.h
-*/
-typedef struct {
-    uint8_t modifiers;    /**< \brief Bitmask of set modifiers. */
-    uint8_t leds;         /**< \brief Bitmask of set LEDs */
-    uint8_t keys[MAX_PRESSED_KEYS];      /**< \brief Key codes for currently pressed keys. */
-} kbd_cond_t;
-
-/** \brief   Keyboard status structure.
-    \ingroup kbd
-
-    This structure holds information about the current status of the keyboard
-    device. This is what maple_dev_status() will return.
-
-    \headerfile dc/maple/keyboard.h
-*/
-typedef struct kbd_state {
-    /** \brief  The latest raw condition of the keyboard. */
-    kbd_cond_t cond;
-
-    /** \brief  Key array.
-
-        This array lists the state of all possible keys on the keyboard. It can
-        be used for key repeat and debouncing. This will be non-zero if the key
-        is currently being pressed.
-
-        \see    kbd_keys
-    */
-    uint8_t matrix[KBD_MAX_KEYS];
-
-    /** \brief  Modifier key status. */
-    int shift_keys;
-
-    /** \brief  Keyboard type/region. */
-    kbd_region_t region;
-
-    /** \brief  Individual keyboard queue.
-        You should not access this variable directly. Please use the appropriate
-        function to access it. */
-    uint32_t key_queue[KBD_QUEUE_SIZE];
-    int queue_tail;                     /**< \brief Key queue tail. */
-    int queue_head;                     /**< \brief Key queue head. */
-    volatile int queue_len;             /**< \brief Current length of queue. */
-
-    uint8_t kbd_repeat_key;           /**< \brief Key that is repeating. */
-    uint64_t kbd_repeat_timer;        /**< \brief Time that the next repeat will trigger. */
-} kbd_state_t;
 
 /* \cond */
 /* Init / Shutdown */

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -349,6 +349,33 @@ typedef struct kbd_state {
     uint64_t kbd_repeat_timer;        /**< \brief Time that the next repeat will trigger. */
 } kbd_state_t;
 
+/** \brief   Pop a key off a specific keyboard's queue.
+    \ingroup kbd
+
+    This function pops the front element off of the specified keyboard queue,
+    and returns the value of that key to the caller.
+
+    If the xlat parameter is non-zero and the key represents an ISO-8859-1
+    character, that is the value that will be returned from this function.
+    Otherwise if xlat is non-zero, it will be the raw key code, shifted up by 8
+    bits.
+
+    If the xlat parameter is zero, the lower 8 bits of the returned value will
+    be the raw key code. The next 8 bits will be the modifier keys that were
+    down when the key was pressed (a bitfield of KBD_MOD_* values). The next 8
+    bits will be the lock key/LED statuses (kbd_leds_t).
+
+    \param  dev             The keyboard device to read from.
+    \param  xlat            Set to non-zero to do key translation. Otherwise,
+                            you'll simply get the raw key value. Raw key values
+                            are not mapped at all, so you are responsible for
+                            figuring out what it is by the region.
+
+    \return                 The value at the front of the queue, or -1 if there
+                            are no keys in the queue.
+*/
+int kbd_queue_pop(maple_device_t *dev, int xlat);
+
 /** \brief   Activate or deactivate global key queueing.
     \ingroup kbd
     \deprecated
@@ -392,33 +419,6 @@ void kbd_set_queue(int active) __deprecated;
     \see                    kbd_queue_pop()
 */
 int kbd_get_key(void) __deprecated;
-
-/** \brief   Pop a key off a specific keyboard's queue.
-    \ingroup kbd
-
-    This function pops the front element off of the specified keyboard queue,
-    and returns the value of that key to the caller.
-
-    If the xlat parameter is non-zero and the key represents an ISO-8859-1
-    character, that is the value that will be returned from this function.
-    Otherwise if xlat is non-zero, it will be the raw key code, shifted up by 8
-    bits.
-
-    If the xlat parameter is zero, the lower 8 bits of the returned value will
-    be the raw key code. The next 8 bits will be the modifier keys that were
-    down when the key was pressed (a bitfield of KBD_MOD_* values). The next 8
-    bits will be the lock key/LED statuses (kbd_leds_t).
-
-    \param  dev             The keyboard device to read from.
-    \param  xlat            Set to non-zero to do key translation. Otherwise,
-                            you'll simply get the raw key value. Raw key values
-                            are not mapped at all, so you are responsible for
-                            figuring out what it is by the region.
-
-    \return                 The value at the front of the queue, or -1 if there
-                            are no keys in the queue.
-*/
-int kbd_queue_pop(maple_device_t *dev, int xlat);
 
 /* \cond */
 /* Init / Shutdown */

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -41,6 +41,7 @@ __BEGIN_DECLS
 
 /** \defgroup kbd_status_grp    Device Status
     \brief                      Types relating to overall keyboard state
+    \ingroup  kbd
 
     Types and API functions revolving around individual constituents of
     the overall keyboard state. These values can either be retrieved manually
@@ -170,7 +171,6 @@ typedef union kbd_leds {
 /** @} */
 
 /** \brief      Region Codes for the Dreamcast keyboard
-    \ingroup    kbd
 
     This is the list of possible values for kbd_state_t::region.
 */
@@ -185,7 +185,6 @@ typedef enum kbd_region {
 } kbd_region_t;
 
 /** \brief Raw Keyboard Key Identifiers
-    \ingroup                kbd
 
     This is the list of keys that are on the keyboard that may be pressed. The
     keyboard returns keys in this format.
@@ -317,7 +316,6 @@ char kbd_key_to_ascii(kbd_key_t key, kbd_region_t region,
 
 /** \defgroup   key_states  Key States
     \brief                  States each key can be in.
-    \ingroup                kbd
 
     These are the different 'states' each key can be in. They are stored in
     kbd_state_t->matrix, and manipulated/checked by kbd_check_poll.
@@ -333,13 +331,13 @@ char kbd_key_to_ascii(kbd_key_t key, kbd_region_t region,
 /** @} */
 
 /** \brief   Maximum number of keys the DC can read simultaneously.
-    \ingroup kbd
+
     This is a hardware constant. The define prevents the magic number '6' from appearing.
 **/
 #define MAX_PRESSED_KEYS 6
 
 /** \brief   Maximum number of keys a DC keyboard can have.
-    \ingroup kbd
+
     This is a hardware constant. The define prevents the magic number '256' from appearing.
 **/
 #define KBD_MAX_KEYS 256
@@ -350,7 +348,6 @@ static const int MAX_KBD_KEYS   __depr("Please use KBD_MAX_KEYS.") = KBD_MAX_KEY
 typedef void kbd_keymap_t __depr("Please open an issue, there should be no reason for external code to have used this.");
 
 /** \brief   Keyboard raw condition structure.
-    \ingroup kbd
 
     This structure is what the keyboard responds with as its current status.
 
@@ -363,7 +360,6 @@ typedef struct {
 } kbd_cond_t;
 
 /** \brief   Keyboard status structure.
-    \ingroup kbd
 
     This structure holds information about the current status of the keyboard
     device. This is what maple_dev_status() will return.
@@ -394,8 +390,11 @@ typedef struct kbd_state {
     kbd_region_t region;
 } kbd_state_t;
 
+/** @} */
+
 /** \defgroup kbd_input     Querying for Input
     \brief                  Various methods for checking keyboard input
+    \ingroup kbd
 
     There are 2 different ways to check for input with the keyboard API:
 

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -27,6 +27,9 @@ __BEGIN_DECLS
 
 #include <arch/types.h>
 #include <dc/maple.h>
+#include <kos/regfield.h>
+
+#include <stdint.h>
 
 /** \defgroup kbd   Keyboard
     \brief          Driver for the Dreamcast's Keyboard Input Device
@@ -51,18 +54,60 @@ __BEGIN_DECLS
 #define KBD_MOD_S2          (1<<7)
 /** @} */
 
-/** \defgroup   kbd_leds    LEDs
-    \brief                  Values for the different keyboard LEDs
-    \ingroup                kbd
+/** \defgroup   kbd_leds_grp    LEDs
+    \brief                      Types associated with keyboard LEDs
+    \ingroup                    kbd
 
-    This is the LEDs that can be turned on and off on the keyboard. This list
-    may not be exhaustive. Think of these sorta like an extension of the
-    modifiers list.
+    LEDs are represented by the kbd_leds_t union type. Each individual LED
+    can be accessed by:
+        1. Directly using a convenience bit field.
+        2. Bitwise `AND` of kbd_leds_t::raw with one of the \ref kbd_led_flags.
+
     @{
 */
-#define KBD_LED_NUMLOCK     (1<<0)
-#define KBD_LED_CAPSLOCK    (1<<1)
-#define KBD_LED_SCRLOCK     (1<<2)
+
+/** \defgroup   kbd_led_flags   Flags
+    \brief                      Keyboard LED flags
+
+    These are the LEDs that can be turned on and off on the keyboard. This list
+    may not be exhaustive. Think of these sort of like an extension of the
+    modifiers list.
+
+    \sa kbd_leds_t::raw
+
+    @{
+*/
+#define KBD_LED_NUMLOCK     BIT(0)    /**< \brief Num Lock LED */
+#define KBD_LED_CAPSLOCK    BIT(1)    /**< \brief Caps Lock LED */
+#define KBD_LED_SCRLOCK     BIT(2)    /**< \brief Scroll Lock LED */
+#define KBD_LED_UNKNOWN1    BIT(3)    /**< \brief Unknown LED 1 */
+#define KBD_LED_UNKNOWN2    BIT(4)    /**< \brief Unknown LED 2 */
+#define KBD_LED_KANA        BIT(5)    /**< \brief Kana LED */
+#define KBD_LED_POWER       BIT(6)    /**< \brief Power LED */
+#define KBD_LED_SHIFT       BIT(7)    /**< \brief Shift LED */
+/** @} */
+
+/** \brief Keyboard LEDs
+
+    Union containing the state of all keyboard LEDs.
+
+    \sa kbd_led_flags, kbd_state_t::leds
+*/
+typedef union kbd_leds {
+    /** \brief Convenience Bitfields */
+    struct {
+        uint8_t num_lock    : 1;    /**< \brief Num Lock LED */
+        uint8_t caps_lock   : 1;    /**< \brief Caps Lock LED */
+        uint8_t scroll_lock : 1;    /**< \brief Scroll Lock LED */
+        uint8_t unknown1    : 1;    /**< \brief Unknown LED 1 */
+        uint8_t unknown2    : 1;    /**< \brief Unknown LED 2 */
+        uint8_t kana        : 1;    /**< \brief Kana LED */
+        uint8_t power       : 1;    /**< \brief Power LED */
+        uint8_t shift       : 1;    /**< \brief Shift LED */
+    };
+    uint8_t raw;    /**< \brief Packed 8-bit unsigned integer of bitflags */
+} kbd_leds_t;
+
 /** @} */
 
 /** \defgroup   kbd_keys    Keys
@@ -361,8 +406,8 @@ int kbd_get_key(void) __deprecated;
 
     If the xlat parameter is zero, the lower 8 bits of the returned value will
     be the raw key code. The next 8 bits will be the modifier keys that were
-    down when the key was pressed (a bitfield of KBD_MOD_* values). The next 3
-    bits will be the lock key status (a bitfield of KBD_LED_* values).
+    down when the key was pressed (a bitfield of KBD_MOD_* values). The next 8
+    bits will be the lock key/LED statuses (kbd_leds_t).
 
     \param  dev             The keyboard device to read from.
     \param  xlat            Set to non-zero to do key translation. Otherwise,

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -169,6 +169,21 @@ typedef union kbd_leds {
 
 /** @} */
 
+/** \brief      Region Codes for the Dreamcast keyboard
+    \ingroup    kbd
+
+    This is the list of possible values for kbd_state_t::region.
+*/
+typedef enum kbd_region {
+    KBD_REGION_JP = 1, /**< \brief Japanese keyboard */
+    KBD_REGION_US = 2, /**< \brief US keyboard */
+    KBD_REGION_UK = 3, /**< \brief UK keyboard */
+    KBD_REGION_DE = 4, /**< \brief German keyboard */
+    KBD_REGION_FR = 5, /**< \brief French keyboard */
+    KBD_REGION_IT = 6, /**< \brief Italian keyboard (not supported yet) */
+    KBD_REGION_ES = 7  /**< \brief Spanish keyboard */
+} kbd_region_t;
+
 /** \brief Raw Keyboard Key Identifiers
     \ingroup                kbd
 
@@ -282,20 +297,23 @@ typedef enum __packed kbd_key {
     KBD_KEY_S3           = 0x65  /**< \brief S3 key */
 } kbd_key_t;
 
-/** \brief      Region Codes for the Dreamcast keyboard
-    \ingroup    kbd
+/** \brief Converts a kbd_key_t value into its corresponding ASCII value
 
-    This is the list of possible values for kbd_state_t::region.
+    This function attempts to convert \p key to its ASCII representation
+    using an internal translation table and additional keyboard state context.
+    To note, this is actually ISO-8859-15 where applicable for non-English
+    regions.
+
+    \param  key         The raw key type to convert to ASCII.
+    \param  region      The region type of the keyboard containing the key.
+    \param  mods        The modifier flags impacting the key.
+    \param  leds        The LED state flags impacting the key.
+
+    \returns            The ASCII value corresponding to \p key or NULL if
+                        the translation was unsuccessful.
 */
-typedef enum kbd_region {
-    KBD_REGION_JP = 1, /**< \brief Japanese keyboard */
-    KBD_REGION_US = 2, /**< \brief US keyboard */
-    KBD_REGION_UK = 3, /**< \brief UK keyboard */
-    KBD_REGION_DE = 4, /**< \brief German keyboard */
-    KBD_REGION_FR = 5, /**< \brief French keyboard */
-    KBD_REGION_IT = 6, /**< \brief Italian keyboard (not supported yet) */
-    KBD_REGION_ES = 7  /**< \brief Spanish keyboard */
-} kbd_region_t;
+char kbd_key_to_ascii(kbd_key_t key, kbd_region_t region,
+                      kbd_mods_t mods, kbd_leds_t leds);
 
 /** \defgroup   key_states  Key States
     \brief                  States each key can be in.

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -291,9 +291,9 @@ static const int MAX_KBD_KEYS   __depr("Please use KBD_MAX_KEYS.") = KBD_MAX_KEY
     \headerfile dc/maple/keyboard.h
 */
 typedef struct kbd_keymap {
-    uint8 base[KBD_MAX_KEYS];
-    uint8 shifted[KBD_MAX_KEYS];
-    uint8 alt[KBD_MAX_KEYS];
+    uint8_t base[KBD_MAX_KEYS];
+    uint8_t shifted[KBD_MAX_KEYS];
+    uint8_t alt[KBD_MAX_KEYS];
 } kbd_keymap_t;
 
 /** \brief   Keyboard raw condition structure.
@@ -304,9 +304,9 @@ typedef struct kbd_keymap {
     \headerfile dc/maple/keyboard.h
 */
 typedef struct {
-    uint8 modifiers;    /**< \brief Bitmask of set modifiers. */
-    uint8 leds;         /**< \brief Bitmask of set LEDs */
-    uint8 keys[MAX_PRESSED_KEYS];      /**< \brief Key codes for currently pressed keys. */
+    uint8_t modifiers;    /**< \brief Bitmask of set modifiers. */
+    uint8_t leds;         /**< \brief Bitmask of set LEDs */
+    uint8_t keys[MAX_PRESSED_KEYS];      /**< \brief Key codes for currently pressed keys. */
 } kbd_cond_t;
 
 /** \brief   Keyboard status structure.
@@ -329,7 +329,7 @@ typedef struct kbd_state {
 
         \see    kbd_keys
     */
-    uint8 matrix[KBD_MAX_KEYS];
+    uint8_t matrix[KBD_MAX_KEYS];
 
     /** \brief  Modifier key status. */
     int shift_keys;
@@ -340,13 +340,13 @@ typedef struct kbd_state {
     /** \brief  Individual keyboard queue.
         You should not access this variable directly. Please use the appropriate
         function to access it. */
-    uint32 key_queue[KBD_QUEUE_SIZE];
+    uint32_t key_queue[KBD_QUEUE_SIZE];
     int queue_tail;                     /**< \brief Key queue tail. */
     int queue_head;                     /**< \brief Key queue head. */
     volatile int queue_len;             /**< \brief Current length of queue. */
 
-    uint8 kbd_repeat_key;           /**< \brief Key that is repeating. */
-    uint64 kbd_repeat_timer;        /**< \brief Time that the next repeat will trigger. */
+    uint8_t kbd_repeat_key;           /**< \brief Key that is repeating. */
+    uint64_t kbd_repeat_timer;        /**< \brief Time that the next repeat will trigger. */
 } kbd_state_t;
 
 /** \brief   Activate or deactivate global key queueing.

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -222,7 +222,10 @@ __BEGIN_DECLS
     \ingroup kbd
     This is a hardware constant. The define prevents the magic number '256' from appearing.
 **/
-#define MAX_KBD_KEYS 256
+#define KBD_MAX_KEYS 256
+
+/* Short-term compatibility helper. */
+static const int MAX_KBD_KEYS   __depr("Please use KBD_MAX_KEYS.") = KBD_MAX_KEYS;
 
 /** \brief   Size of a keyboard queue.
     \ingroup kbd
@@ -245,9 +248,9 @@ __BEGIN_DECLS
     \headerfile dc/maple/keyboard.h
 */
 typedef struct kbd_keymap {
-    uint8 base[MAX_KBD_KEYS];
-    uint8 shifted[MAX_KBD_KEYS];
-    uint8 alt[MAX_KBD_KEYS];
+    uint8 base[KBD_MAX_KEYS];
+    uint8 shifted[KBD_MAX_KEYS];
+    uint8 alt[KBD_MAX_KEYS];
 } kbd_keymap_t;
 
 /** \brief   Keyboard raw condition structure.
@@ -283,7 +286,7 @@ typedef struct kbd_state {
 
         \see    kbd_keys
     */
-    uint8 matrix[MAX_KBD_KEYS];
+    uint8 matrix[KBD_MAX_KEYS];
 
     /** \brief  Modifier key status. */
     int shift_keys;

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -336,7 +336,7 @@ kbd_state_t *kbd_get_state(maple_device_t *device);
 
         int k;
 
-        while((k = kbd_queue_pop(device, 1)) != -1)
+        while((k = kbd_queue_pop(device, 1)) != KBD_QUEUE_END)
             printf("Key pressed: %c!\n", (char)k);
 
     \par Repeated Presses
@@ -356,6 +356,15 @@ kbd_state_t *kbd_get_state(maple_device_t *device);
     \note   This <strong>MUST</strong> be a power of two.
 */
 #define KBD_QUEUE_SIZE 16
+
+/** \brief Delimiter value for kbd_queue_pop()
+
+    Value returned from kbd_queue_pop() when there are no more keys in the
+    queue.
+
+    \sa kbd_queue_pop()
+*/
+#define KBD_QUEUE_END     -1
 
 /** \brief   Pop a key off a specific keyboard's queue.
 
@@ -378,8 +387,8 @@ kbd_state_t *kbd_get_state(maple_device_t *device);
                             are not mapped at all, so you are responsible for
                             figuring out what it is by the region.
 
-    \return                 The value at the front of the queue, or -1 if there
-                            are no keys in the queue.
+    \return                 The value at the front of the queue, or KBD_QUEUE_END
+                            if there are no keys in the queue.
 */
 int kbd_queue_pop(maple_device_t *dev, int xlat);
 
@@ -414,8 +423,8 @@ void kbd_set_queue(int active) __deprecated;
     If a key does not have an ASCII value associated with it, the raw key code
     will be returned, shifted up by 8 bits.
 
-    \return                 The value at the front of the queue, or -1 if there
-                            are no keys in the queue or queueing is off.
+    \return                 The value at the front of the queue, or KBD_QUEUE_END
+                            if there are no keys in the queue or queueing is off.
     \note                   This function does not account for non-US keyboard
                             layouts properly (for compatibility with old code),
                             and is deprecated. Use the individual keyboard

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -31,6 +31,7 @@ __BEGIN_DECLS
 #include <dc/maple.h>
 #include <kos/regfield.h>
 
+#include <stdbool.h>
 #include <stdint.h>
 
 /** \defgroup kbd   Keyboard
@@ -451,18 +452,18 @@ void kbd_set_repeat_timing(uint16_t start, uint16_t interval);
     This function pops the front element off of the specified keyboard queue,
     and returns the value of that key to the caller.
 
-    If the xlat parameter is non-zero and the key represents an ISO-8859-1
+    If the \p xlat parameter is true and the key represents an ISO-8859-1
     character, that is the value that will be returned from this function.
-    Otherwise if xlat is non-zero, it will be the raw key code, shifted up by 8
-    bits.
+    If the key cannot be converted into a valid ISO-8859-1 character the
+    raw key code, shifted up by 8 bits, will be returned.
 
-    If the xlat parameter is zero, the lower 8 bits of the returned value will
-    be the raw key code. The next 8 bits will be the modifier keys that were
-    down when the key was pressed (kbd_mods_t). The next 8b its will
-    be the lock key/LED statuses (kbd_leds_t).
+    If the \p xlat parameter is false, the lower 8 bits of the returned
+    value will be the raw key code. The next 8 bits will be the modifier
+    keys that were down when the key was pressed (kbd_mods_t). The next
+    8 bits will be the lock key/LED statuses (kbd_leds_t).
 
     \param  dev             The keyboard device to read from.
-    \param  xlat            Set to non-zero to do key translation. Otherwise,
+    \param  xlat            Set to true to do key translation. Otherwise,
                             you'll simply get the raw key value. Raw key values
                             are not mapped at all, so you are responsible for
                             figuring out what it is by the region.
@@ -470,7 +471,7 @@ void kbd_set_repeat_timing(uint16_t start, uint16_t interval);
     \return                 The value at the front of the queue, or KBD_QUEUE_END
                             if there are no keys in the queue.
 */
-int kbd_queue_pop(maple_device_t *dev, int xlat);
+int kbd_queue_pop(maple_device_t *dev, bool xlat);
 
 /** \brief   Activate or deactivate global key queueing.
     \deprecated

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -3,6 +3,7 @@
    dc/maple/keyboard.h
    Copyright (C) 2000-2002 Jordan DeLong and Megan Potter
    Copyright (C) 2012 Lawrence Sebald
+   Copyright (C) 2025 Falco Girgis
 
 */
 
@@ -17,6 +18,7 @@
     \author Jordan DeLong
     \author Megan Potter
     \author Lawrence Sebald
+    \author Falco Girgis
 */
 
 #ifndef __DC_MAPLE_KEYBOARD_H
@@ -348,6 +350,59 @@ typedef struct kbd_state {
     uint8_t kbd_repeat_key;           /**< \brief Key that is repeating. */
     uint64_t kbd_repeat_timer;        /**< \brief Time that the next repeat will trigger. */
 } kbd_state_t;
+
+/** \defgroup kbd_polling   State Polling
+    \brief                  Frame-based polling for keyboard input
+    \ingroup                kbd
+
+    One method of checking for key input is to simply poll
+    kbd_state_t::matrix for the desired key states each frame.
+
+    First, lets grab a pointer to the kbd_state_t:
+
+        kbd_state_t *kbd = kbd_get_state(device);
+
+    Then let's "move" every frame an arrow key is held down:
+
+        if(kbd->matrix[KBD_KEY_LEFT] == KEY_STATE_PRESSED)
+            printf("Moving left!\n");
+        if(kbd->matrix[KBD_KEY_RIGHT] == KEY_STATE_PRESSED)
+            printf("Moving right!\n");
+        if(kbd->matrix[KBD_KEY_UP] == KEY_STATE_PRESSED)
+            printf("Moving up!\n");
+        if(kbd->matrix[KBD_KEY_DOWN] == KEY_STATE_PRESSED)
+            printf("Moving down!\n");
+
+    Finally, let's charge an "attack" incrementing the charge for each
+    frame that the key is held and resetting when the key is released:
+
+        if(kbd->matrix[KBD_KEY_SPACE] == KEY_STATE_PRESSED)
+            charge++;
+        if(kbd->matrix[KBD_KEY_SPACE] == KEY_STATE_WAS_PRESSED) {
+            printf("Releasing a charged attack of %i!\n", charge);
+            charge = 0;
+        }
+
+    @{
+*/
+
+/** \brief Retrieves the keyboard state from a maple device
+
+    Accessor method for safely retrieving a kbd_state_t from a maple_device_t
+    of a `MAPLE_FUNC_KEYBOARD` type. This function also checks for whether
+    the given device is actually a keyboard and for whether it is currently
+    valid.
+
+    \param  device          Handle corresponding to a `MAPLE_FUNC_KEYBOARD`
+                            device.
+
+    \retval kbd_state_t*    A pointer to the internal keyboard state on success.
+    \retval NULL            On failure.
+
+*/
+kbd_state_t *kbd_get_state(maple_device_t *device);
+
+/** @} */
 
 /** \brief   Pop a key off a specific keyboard's queue.
     \ingroup kbd

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -422,6 +422,30 @@ kbd_state_t *kbd_get_state(maple_device_t *device);
 */
 #define KBD_QUEUE_END     -1
 
+/** \brief Configures held key auto-repeat intervals
+
+    This function is used to configure the specific timing behavior for how the
+    internal queue treats a key which is being held down. Giving non-zero values
+    for both parameters will cause the held key to be re-enqueued every
+    \p interval milliseconds after it has been held for the initial \p start time
+    in milliseconds.
+
+    Specifying a value of zero for the two parameters disables this repeating key
+    behavior.
+
+    \note
+    By default, the \p start time is 600ms while the repeating \p interval is 20ms.
+
+    \param  start       The duration after which the held key starts to
+                        register as repeated key presses (or zero to disable
+                        this behavior).
+    \param  interval    The duration between subsequent key repeats after the
+                        initial \p start time has elapsed.
+
+    \sa kbd_queue_pop()
+*/
+void kbd_set_repeat_timing(uint16_t start, uint16_t interval);
+
 /** \brief   Pop a key off a specific keyboard's queue.
 
     This function pops the front element off of the specified keyboard queue,

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -38,22 +38,78 @@ __BEGIN_DECLS
     \ingroup        peripherals
 */
 
-/** \defgroup   kbd_mods    Modifier Keys
-    \brief                  Masks for the various keyboard modifier keys
-    \ingroup                kbd
+/** \defgroup kbd_status_grp    Device Status
+    \brief                      Types relating to overall keyboard state
 
-    These are the various modifiers that can be pressed on the keyboard, and are
-    reflected in the modifiers field of kbd_cond_t.
+    Types and API functions revolving around individual constituents of
+    the overall keyboard state. These values can either be retrieved manually
+    with \ref kbd_polling.
+
     @{
 */
-#define KBD_MOD_LCTRL       (1<<0)
-#define KBD_MOD_LSHIFT      (1<<1)
-#define KBD_MOD_LALT        (1<<2)
-#define KBD_MOD_S1          (1<<3)
-#define KBD_MOD_RCTRL       (1<<4)
-#define KBD_MOD_RSHIFT      (1<<5)
-#define KBD_MOD_RALT        (1<<6)
-#define KBD_MOD_S2          (1<<7)
+
+/** \defgroup   kbd_mods_grp    Modifier Keys
+    \brief                      Types associated with keyboard modifier keys
+    \ingroup                    kbd_status_grp
+
+    Modifier keys are represented by the kbd_mods_t union type. Each key state
+    can be accessed by:
+        1. Directly using a convenience bit field.
+        2. Bitwise `AND` of kbd_mods_t::raw with one of the \ref kbd_mods_flags.
+
+    @{
+*/
+
+/** \defgroup   kbd_mods_flags  Flags
+    \brief                      Keyboard modifier key flags
+
+    These are the various modifiers that can be pressed on the keyboard. Their
+    current state is stored within kbd_cond_t::modifiers.
+
+    \sa kbd_mods_t::raw
+
+    @{
+*/
+/* Single-Key Modifiers */
+#define KBD_MOD_LCTRL       BIT(0)    /**< \brief Left Control key */
+#define KBD_MOD_LSHIFT      BIT(1)    /**< \brief Left Shift key */
+#define KBD_MOD_LALT        BIT(2)    /**< \brief Left alternate key */
+#define KBD_MOD_S1          BIT(3)    /**< \brief S1 key */
+#define KBD_MOD_RCTRL       BIT(4)    /**< \brief Right Control key */
+#define KBD_MOD_RSHIFT      BIT(5)    /**< \brief Right Shift key */
+#define KBD_MOD_RALT        BIT(6)    /**< \brief Right Alternate key */
+#define KBD_MOD_S2          BIT(7)    /**< \brief S2 key */
+
+/* Multi-Key Modifiers */
+/** \brief Either Control key */
+#define KBD_MOD_CTRL        (KBD_MOD_LCTRL | KBD_MOD_RCTRL)
+/** \brief Either Shift key */
+#define KBD_MOD_SHIFT       (KBD_MOD_LSHIFT | KBD_MOD_RSHIFT)
+/** \brief Either Alternate key */
+#define KBD_MOD_ALT         (KBD_MOD_LALT | KBD_MOD_RALT)
+/** @} */
+
+/** \brief Modifier Keys
+
+    Convenience union containing the state of all keyboard modifier keys.
+
+    \sa kbd_mods_flags, kbd_state_t::modifiers
+*/
+typedef union kbd_mods {
+    /** \brief Convenience Bitfields */
+    struct {
+        uint8_t lctrl   : 1;    /**< \brief Left Control key */
+        uint8_t lshift  : 1;    /**< \brief Left Shift key */
+        uint8_t lalt    : 1;    /**< \brief Left Alternate key */
+        uint8_t s1      : 1;    /**< \brief S1 key */
+        uint8_t rctrl   : 1;    /**< \brief Right Control key */
+        uint8_t rshift  : 1;    /**< \brief Right Shift key */
+        uint8_t ralt    : 1;    /**< \brief Right Alternate key */
+        uint8_t s2      : 1;    /**< \brief S2 key */
+    };
+    uint8_t raw;    /**< \brief Packed 8-bit unsigned integer of bitflags */
+} kbd_mods_t;
+
 /** @} */
 
 /** \defgroup   kbd_leds_grp    LEDs
@@ -378,8 +434,8 @@ kbd_state_t *kbd_get_state(maple_device_t *device);
 
     If the xlat parameter is zero, the lower 8 bits of the returned value will
     be the raw key code. The next 8 bits will be the modifier keys that were
-    down when the key was pressed (a bitfield of KBD_MOD_* values). The next 8
-    bits will be the lock key/LED statuses (kbd_leds_t).
+    down when the key was pressed (kbd_mods_t). The next 8b its will
+    be the lock key/LED statuses (kbd_leds_t).
 
     \param  dev             The keyboard device to read from.
     \param  xlat            Set to non-zero to do key translation. Otherwise,

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -112,118 +112,118 @@ typedef union kbd_leds {
 
 /** @} */
 
-/** \defgroup   kbd_keys    Keys
-    \brief                  Values representing the various keyboard keys
+/** \brief Raw Keyboard Key Identifiers
     \ingroup                kbd
 
     This is the list of keys that are on the keyboard that may be pressed. The
     keyboard returns keys in this format.
 
+    \note
     These are the raw keycodes returned by the US keyboard, and thus only cover
-    the keys on US keyboards.
-    @{
+    the keys on US keyboards (even though they can be used with other keyboards).
 */
-#define KBD_KEY_NONE            0x00
-#define KBD_KEY_ERROR           0x01
-#define KBD_KEY_ERR2            0x02
-#define KBD_KEY_ERR3            0x03
-#define KBD_KEY_A               0x04
-#define KBD_KEY_B               0x05
-#define KBD_KEY_C               0x06
-#define KBD_KEY_D               0x07
-#define KBD_KEY_E               0x08
-#define KBD_KEY_F               0x09
-#define KBD_KEY_G               0x0a
-#define KBD_KEY_H               0x0b
-#define KBD_KEY_I               0x0c
-#define KBD_KEY_J               0x0d
-#define KBD_KEY_K               0x0e
-#define KBD_KEY_L               0x0f
-#define KBD_KEY_M               0x10
-#define KBD_KEY_N               0x11
-#define KBD_KEY_O               0x12
-#define KBD_KEY_P               0x13
-#define KBD_KEY_Q               0x14
-#define KBD_KEY_R               0x15
-#define KBD_KEY_S               0x16
-#define KBD_KEY_T               0x17
-#define KBD_KEY_U               0x18
-#define KBD_KEY_V               0x19
-#define KBD_KEY_W               0x1a
-#define KBD_KEY_X               0x1b
-#define KBD_KEY_Y               0x1c
-#define KBD_KEY_Z               0x1d
-#define KBD_KEY_1               0x1e
-#define KBD_KEY_2               0x1f
-#define KBD_KEY_3               0x20
-#define KBD_KEY_4               0x21
-#define KBD_KEY_5               0x22
-#define KBD_KEY_6               0x23
-#define KBD_KEY_7               0x24
-#define KBD_KEY_8               0x25
-#define KBD_KEY_9               0x26
-#define KBD_KEY_0               0x27
-#define KBD_KEY_ENTER           0x28
-#define KBD_KEY_ESCAPE          0x29
-#define KBD_KEY_BACKSPACE       0x2a
-#define KBD_KEY_TAB             0x2b
-#define KBD_KEY_SPACE           0x2c
-#define KBD_KEY_MINUS           0x2d
-#define KBD_KEY_PLUS            0x2e
-#define KBD_KEY_LBRACKET        0x2f
-#define KBD_KEY_RBRACKET        0x30
-#define KBD_KEY_BACKSLASH       0x31
-#define KBD_KEY_SEMICOLON       0x33
-#define KBD_KEY_QUOTE           0x34
-#define KBD_KEY_TILDE           0x35
-#define KBD_KEY_COMMA           0x36
-#define KBD_KEY_PERIOD          0x37
-#define KBD_KEY_SLASH           0x38
-#define KBD_KEY_CAPSLOCK        0x39
-#define KBD_KEY_F1              0x3a
-#define KBD_KEY_F2              0x3b
-#define KBD_KEY_F3              0x3c
-#define KBD_KEY_F4              0x3d
-#define KBD_KEY_F5              0x3e
-#define KBD_KEY_F6              0x3f
-#define KBD_KEY_F7              0x40
-#define KBD_KEY_F8              0x41
-#define KBD_KEY_F9              0x42
-#define KBD_KEY_F10             0x43
-#define KBD_KEY_F11             0x44
-#define KBD_KEY_F12             0x45
-#define KBD_KEY_PRINT           0x46
-#define KBD_KEY_SCRLOCK         0x47
-#define KBD_KEY_PAUSE           0x48
-#define KBD_KEY_INSERT          0x49
-#define KBD_KEY_HOME            0x4a
-#define KBD_KEY_PGUP            0x4b
-#define KBD_KEY_DEL             0x4c
-#define KBD_KEY_END             0x4d
-#define KBD_KEY_PGDOWN          0x4e
-#define KBD_KEY_RIGHT           0x4f
-#define KBD_KEY_LEFT            0x50
-#define KBD_KEY_DOWN            0x51
-#define KBD_KEY_UP              0x52
-#define KBD_KEY_PAD_NUMLOCK     0x53
-#define KBD_KEY_PAD_DIVIDE      0x54
-#define KBD_KEY_PAD_MULTIPLY    0x55
-#define KBD_KEY_PAD_MINUS       0x56
-#define KBD_KEY_PAD_PLUS        0x57
-#define KBD_KEY_PAD_ENTER       0x58
-#define KBD_KEY_PAD_1           0x59
-#define KBD_KEY_PAD_2           0x5a
-#define KBD_KEY_PAD_3           0x5b
-#define KBD_KEY_PAD_4           0x5c
-#define KBD_KEY_PAD_5           0x5d
-#define KBD_KEY_PAD_6           0x5e
-#define KBD_KEY_PAD_7           0x5f
-#define KBD_KEY_PAD_8           0x60
-#define KBD_KEY_PAD_9           0x61
-#define KBD_KEY_PAD_0           0x62
-#define KBD_KEY_PAD_PERIOD      0x63
-#define KBD_KEY_S3              0x65
-/** @} */
+typedef enum __packed kbd_key {
+    KBD_KEY_NONE         = 0x00, /**< \brief No key */
+    KBD_KEY_ERROR        = 0x01, /**< \brief ERROR_ROLLOVER */
+    KBD_KEY_ERR2         = 0x02, /**< \brief Unknown error */
+    KBD_KEY_ERR3         = 0x03, /**< \brief Unknown error */
+    KBD_KEY_A            = 0x04, /**< \brief A key */
+    KBD_KEY_B            = 0x05, /**< \brief B key */
+    KBD_KEY_C            = 0x06, /**< \brief C key */
+    KBD_KEY_D            = 0x07, /**< \brief D key */
+    KBD_KEY_E            = 0x08, /**< \brief E key */
+    KBD_KEY_F            = 0x09, /**< \brief F key */
+    KBD_KEY_G            = 0x0a, /**< \brief G key */
+    KBD_KEY_H            = 0x0b, /**< \brief H key */
+    KBD_KEY_I            = 0x0c, /**< \brief I key */
+    KBD_KEY_J            = 0x0d, /**< \brief J key */
+    KBD_KEY_K            = 0x0e, /**< \brief K key */
+    KBD_KEY_L            = 0x0f, /**< \brief L key */
+    KBD_KEY_M            = 0x10, /**< \brief M key */
+    KBD_KEY_N            = 0x11, /**< \brief N key */
+    KBD_KEY_O            = 0x12, /**< \brief O key */
+    KBD_KEY_P            = 0x13, /**< \brief P key */
+    KBD_KEY_Q            = 0x14, /**< \brief Q key */
+    KBD_KEY_R            = 0x15, /**< \brief R key */
+    KBD_KEY_S            = 0x16, /**< \brief S key */
+    KBD_KEY_T            = 0x17, /**< \brief T key */
+    KBD_KEY_U            = 0x18, /**< \brief U key */
+    KBD_KEY_V            = 0x19, /**< \brief V key */
+    KBD_KEY_W            = 0x1a, /**< \brief W key */
+    KBD_KEY_X            = 0x1b, /**< \brief X key */
+    KBD_KEY_Y            = 0x1c, /**< \brief Y key */
+    KBD_KEY_Z            = 0x1d, /**< \brief Z key */
+    KBD_KEY_1            = 0x1e, /**< \brief 1 key */
+    KBD_KEY_2            = 0x1f, /**< \brief 2 key */
+    KBD_KEY_3            = 0x20, /**< \brief 3 key */
+    KBD_KEY_4            = 0x21, /**< \brief 4 key */
+    KBD_KEY_5            = 0x22, /**< \brief 5 key */
+    KBD_KEY_6            = 0x23, /**< \brief 6 key */
+    KBD_KEY_7            = 0x24, /**< \brief 7 key */
+    KBD_KEY_8            = 0x25, /**< \brief 8 key */
+    KBD_KEY_9            = 0x26, /**< \brief 9 key */
+    KBD_KEY_0            = 0x27, /**< \brief 0 key */
+    KBD_KEY_ENTER        = 0x28, /**< \brief Enter key */
+    KBD_KEY_ESCAPE       = 0x29, /**< \brief Escape key */
+    KBD_KEY_BACKSPACE    = 0x2a, /**< \brief Backspace key */
+    KBD_KEY_TAB          = 0x2b, /**< \brief Tab key */
+    KBD_KEY_SPACE        = 0x2c, /**< \brief Space key */
+    KBD_KEY_MINUS        = 0x2d, /**< \brief Minus key */
+    KBD_KEY_PLUS         = 0x2e, /**< \brief Plus key */
+    KBD_KEY_LBRACKET     = 0x2f, /**< \brief [ key */
+    KBD_KEY_RBRACKET     = 0x30, /**< \brief ] key */
+    KBD_KEY_BACKSLASH    = 0x31, /**< \brief \ key */
+    KBD_KEY_SEMICOLON    = 0x33, /**< \brief ; key */
+    KBD_KEY_QUOTE        = 0x34, /**< \brief " key */
+    KBD_KEY_TILDE        = 0x35, /**< \brief ~ key */
+    KBD_KEY_COMMA        = 0x36, /**< \brief , key */
+    KBD_KEY_PERIOD       = 0x37, /**< \brief . key */
+    KBD_KEY_SLASH        = 0x38, /**< \brief Slash key */
+    KBD_KEY_CAPSLOCK     = 0x39, /**< \brief Caps Lock key */
+    KBD_KEY_F1           = 0x3a, /**< \brief F1 key */
+    KBD_KEY_F2           = 0x3b, /**< \brief F2 key */
+    KBD_KEY_F3           = 0x3c, /**< \brief F3 key */
+    KBD_KEY_F4           = 0x3d, /**< \brief F4 key */
+    KBD_KEY_F5           = 0x3e, /**< \brief F5 key */
+    KBD_KEY_F6           = 0x3f, /**< \brief F6 key */
+    KBD_KEY_F7           = 0x40, /**< \brief F7 key */
+    KBD_KEY_F8           = 0x41, /**< \brief F8 key */
+    KBD_KEY_F9           = 0x42, /**< \brief F9 key */
+    KBD_KEY_F10          = 0x43, /**< \brief F10 key */
+    KBD_KEY_F11          = 0x44, /**< \brief F11 key */
+    KBD_KEY_F12          = 0x45, /**< \brief F12 key */
+    KBD_KEY_PRINT        = 0x46, /**< \brief Print Screen key */
+    KBD_KEY_SCRLOCK      = 0x47, /**< \brief Scroll Lock key */
+    KBD_KEY_PAUSE        = 0x48, /**< \brief Pause key */
+    KBD_KEY_INSERT       = 0x49, /**< \brief Insert key */
+    KBD_KEY_HOME         = 0x4a, /**< \brief Home key */
+    KBD_KEY_PGUP         = 0x4b, /**< \brief Page Up key */
+    KBD_KEY_DEL          = 0x4c, /**< \brief Delete key */
+    KBD_KEY_END          = 0x4d, /**< \brief End key */
+    KBD_KEY_PGDOWN       = 0x4e, /**< \brief Page Down key */
+    KBD_KEY_RIGHT        = 0x4f, /**< \brief Right Arrow key */
+    KBD_KEY_LEFT         = 0x50, /**< \brief Left Arrow key */
+    KBD_KEY_DOWN         = 0x51, /**< \brief Down Arrow key */
+    KBD_KEY_UP           = 0x52, /**< \brief Up Arrow key */
+    KBD_KEY_PAD_NUMLOCK  = 0x53, /**< \brief Keypad Numlock key */
+    KBD_KEY_PAD_DIVIDE   = 0x54, /**< \brief Keypad Divide key */
+    KBD_KEY_PAD_MULTIPLY = 0x55, /**< \brief Keypad Multiply key */
+    KBD_KEY_PAD_MINUS    = 0x56, /**< \brief Keypad Minus key */
+    KBD_KEY_PAD_PLUS     = 0x57, /**< \brief Keypad Plus key */
+    KBD_KEY_PAD_ENTER    = 0x58, /**< \brief Keypad Enter key */
+    KBD_KEY_PAD_1        = 0x59, /**< \brief Keypad 1 key */
+    KBD_KEY_PAD_2        = 0x5a, /**< \brief Keypad 2 key */
+    KBD_KEY_PAD_3        = 0x5b, /**< \brief Keypad 3 key */
+    KBD_KEY_PAD_4        = 0x5c, /**< \brief Keypad 4 key */
+    KBD_KEY_PAD_5        = 0x5d, /**< \brief Keypad 5 key */
+    KBD_KEY_PAD_6        = 0x5e, /**< \brief Keypad 6 key */
+    KBD_KEY_PAD_7        = 0x5f, /**< \brief Keypad 7 key */
+    KBD_KEY_PAD_8        = 0x60, /**< \brief Keypad 8 key */
+    KBD_KEY_PAD_9        = 0x61, /**< \brief Keypad 9 key */
+    KBD_KEY_PAD_0        = 0x62, /**< \brief Keypad 0 key */
+    KBD_KEY_PAD_PERIOD   = 0x63, /**< \brief Keypad Period key */
+    KBD_KEY_S3           = 0x65  /**< \brief S3 key */
+} kbd_key_t;
 
 /** \brief      Region Codes for the Dreamcast keyboard
     \ingroup    kbd


### PR DESCRIPTION
Split from #503 . Like the splits from the irq and pvr overhaul, the aim is to bring the changes in via easily readable atomic commits. Implements a majority of the non-breaking changes from #503 . The full set of changes are detailed in the individual commit comments.

The biggest change here is the removal of various pieces of private data for the keyboard queue out of the public `kbd_state_t` struct and into an internal driver struct. This should not be breaking though as the struct members were both noted to be internal and of no real use outside of the driver.

Edit: had some more time, so was able to find further changes to integrate and tried to fix up the doxygen as well. No further changes expected unless some thing is found wrong.
Edit2: Finally got my keyboard out to test. Had to correct a few errors, but no new content.