### PR TITLE
Macros expansion

### DIFF
--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -9,12 +9,11 @@
 */
 
 /** \file    kos/cdefs.h
-    \brief   Definitions for builtin attributes and compiler directives
-    \ingroup system_macros
+    \brief   Various common macros used throughout the codebase
+    \ingroup system
 
-    This file contains definitions of various __attribute__ directives in
-    shorter forms for use in programs. These typically aid  in optimizations
-    or provide the compiler with extra information about a symbol.
+    This file contains various convenience macros. Mostly compiler
+    __attribute__ directives, as well as other language defines.
 
     \author Megan Potter
     \author Lawrence Sebald
@@ -26,19 +25,21 @@
 
 #include <sys/cdefs.h>
 
-/** \defgroup system_macros     Macros
-    \brief                      Various common macros used throughout the codebase
-    \ingroup                    system
-    
-    @{
-*/
-
 /* Check GCC version */
 #if __GNUC__ <= 3
 #   warning Your GCC is too old. This will probably not work right.
 #endif
 
-/* Special function/variable attributes */
+/** \defgroup system_attributes
+    \brief                      Definitions for builtin attributes and compiler directives
+    \ingroup                    system
+
+    This group contains definitions of various __attribute__ directives in
+    shorter forms for use in programs. These typically aid  in optimizations
+    or provide the compiler with extra information about a symbol.
+
+    @{
+*/
 
 #ifndef __noreturn
 /** \brief  Identify a function that will never return. */
@@ -169,6 +170,18 @@
 #define __no_inline __attribute__((__noinline__))
 #endif
 
+/** @} */
+
+/** \defgroup system_compat
+    \brief                      Definitions for language features
+    \ingroup                    system
+
+    This group contains definitions to help retain some older language
+    backwards compatibility for external software linking into KOS.
+
+    @{
+*/
+
 /* GCC macros for special cases */
 /* #if __GNUC__ ==  */
 
@@ -191,5 +204,6 @@
 #endif
 
 /** @} */
+
 
 #endif  /* __KOS_CDEFS_H */

--- a/include/kos/dbgio.h
+++ b/include/kos/dbgio.h
@@ -107,7 +107,7 @@ typedef struct dbgio_handler {
 /** \cond */
 /* These two should be initialized in arch. */
 extern dbgio_handler_t * dbgio_handlers[];
-extern int dbgio_handler_cnt;
+extern const size_t dbgio_handler_cnt;
 
 /* This is defined by the shared code, in case there's no valid handler. */
 extern dbgio_handler_t dbgio_null;

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -80,7 +80,7 @@ typedef struct kbd_keymap {
 } kbd_keymap_internal_t;
 
 /* Built-in keymaps. */
-#define KBD_NUM_KEYMAPS (sizeof(keymaps) / sizeof(keymaps[0]))
+#define KBD_NUM_KEYMAPS __array_size(keymaps)
 static const kbd_keymap_internal_t keymaps[] = {
     {
         /* Japanese keyboard */

--- a/kernel/arch/dreamcast/hardware/maple/maple_utils.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_utils.c
@@ -93,7 +93,6 @@ static const char *maple_cap_names[] = {
     "Mouse",
     "JumpPack"
 };
-#define maple_cap_name_cnt (sizeof(maple_cap_names)/sizeof(char *))
 
 /* Print the capabilities of a given driver to dbglog; NOT THREAD SAFE */
 static char caps_buffer[64];
@@ -102,7 +101,7 @@ const char * maple_pcaps(uint32 functions) {
 
     for(o = 0, i = 0; i < 32; i++) {
         if(functions & (0x80000000 >> i)) {
-            if(i > maple_cap_name_cnt || maple_cap_names[i] == NULL) {
+            if(i > __array_size(maple_cap_names) || maple_cap_names[i] == NULL) {
                 sprintf(caps_buffer + o, "UNKNOWN(%08x), ", (0x80000000 >> i));
                 o += strlen(caps_buffer + o);
             }
@@ -133,13 +132,12 @@ static const char *maple_resp_names[] = {
     "OK",
     "DATATRF"
 };
-#define maple_resp_name_cnt ((int)(sizeof(maple_resp_names)/sizeof(char *)))
 
 /* Return a string representing the maple response code */
 const char * maple_perror(int response) {
     response += 5;
 
-    if(response < 0 || response >= maple_resp_name_cnt)
+    if(response < 0 || (size_t)response >= __array_size(maple_resp_names))
         return "UNKNOWN";
     else
         return maple_resp_names[response];

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -53,7 +53,7 @@ dbgio_handler_t * dbgio_handlers[] = {
     &dbgio_null,
     &dbgio_fb
 };
-int dbgio_handler_cnt = sizeof(dbgio_handlers) / sizeof(dbgio_handler_t *);
+const size_t dbgio_handler_cnt = __array_size(dbgio_handlers);
 
 void arch_init_net_dcload_ip(void) {
     union {

--- a/kernel/debug/dbgio.c
+++ b/kernel/debug/dbgio.c
@@ -25,7 +25,7 @@
 static dbgio_handler_t * dbgio = NULL;
 
 int dbgio_dev_select(const char * name) {
-    int i;
+    size_t i;
 
     for(i = 0; i < dbgio_handler_cnt; i++) {
         if(!strcmp(dbgio_handlers[i]->name, name)) {
@@ -60,7 +60,7 @@ void dbgio_disable(void) {
 }
 
 int dbgio_init(void) {
-    int i;
+    size_t i;
 
     // Look for a valid interface.
     for(i = 0; i < dbgio_handler_cnt; i++) {


### PR DESCRIPTION
Wanted to toss this up quickly to get some feedback on the naming and goal before putting them in place. The names should possibly instead be something like `__ARRAY_SIZE` or `KOS_ARRAY_SIZE`. It seemed inappropriate to use the plainest `ARRAY_SIZE` due to how easily that could clash with external software.

The macros were taken from public domain implementations from here: https://ccodearchive.net/info/array_size.html and https://ccodearchive.net/info/build_assert.html . 

This PR is going to be the response to this PR comment: https://github.com/KallistiOS/KallistiOS/pull/966#discussion_r2034001652