### PR TITLE
libc: Fix thrd_join()

### DIFF
--- a/kernel/libc/c11/thrd_join.c
+++ b/kernel/libc/c11/thrd_join.c
@@ -12,6 +12,8 @@ int thrd_join(thrd_t thr, int *res) {
     if(thd_join(thr, &rv))
         return thrd_error;
 
-    *res = (int)rv;
+    if (res)
+        *res = (int)rv;
+
     return thrd_success;
 }


### PR DESCRIPTION
thrd_join() did not handle the case where the second parameter passed is NULL, which is permitted by the standard.