### PR TITLE
maple: Support multiple hotplug callbacks

### DIFF
--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -354,6 +354,28 @@ typedef struct maple_driver {
         \param  dev         The device that was detached.
     */
     void (*detach)(struct maple_driver *drv, maple_device_t *dev);
+
+    /** \brief  User-specified device attached callback.
+
+        This callback will be called when a new device of this driver is
+        connected to the system. It should be set by applications using
+        maple_attach_callback().
+
+        \param  dev         The device that was connected.
+        \return             0 on success, <0 on error.
+    */
+    void (*user_attach)(maple_device_t *dev);
+
+    /** \brief  User-specified device detached callback.
+
+        This callback will be called when a new device of this driver is
+        connected to the system. It should be set by applications using
+        maple_detach_callback().
+
+        \param  dev         The device that was connected.
+        \return             0 on success, <0 on error.
+    */
+    void (*user_detach)(maple_device_t *dev);
 } maple_driver_t;
 
 /** \brief   Maple state structure.


### PR DESCRIPTION
Previously, maple_attach_callback() would register a callback function to be called when a device featuring one or more of the specified functions was plugged.

The problem is that there could only be a single callback function registered at any given time; it was therefore impossible to register a callback e.g. for a controller and a different one for a VMU.

Address this issue by adding callback pointers inside the maple_driver structure itself, and update maple_attach_callback and maple_detach_callback to update the fields of the drivers that match the specified functions.

With this new setup, there can be one attach / detach callback couple registered for each single function, or any combination of them, that KallistiOS supports.