### PR TITLE
cdrom: Introduced IRQ handling for DMA and command polling. 

### DIFF
--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -136,8 +136,17 @@ bfont_draw_str_vram_fmt
 
 # CD-Rom
 cdrom_reinit
+cdrom_reinit_ex
+cdrom_set_sector_size
+cdrom_change_datatype
+cdrom_exec_cmd
+cdrom_exec_cmd_timed
+cdrom_abort_cmd
+cdrom_get_status
+cdrom_get_subcode
 cdrom_read_toc
 cdrom_read_sectors
+cdrom_read_sectors_ex
 cdrom_locate_data_track
 cdrom_cdda_play
 cdrom_cdda_pause

--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -182,6 +182,7 @@ static size_t dma_nb_sectors = 0;
 static uint64_t dma_sector = 0;
 static semaphore_t dma_done = SEM_INITIALIZER(0);
 static kthread_t *dma_thd = NULL;
+static asic_evt_handler_entry_t old_dma_irq;
 
 /* From cdrom.c */
 extern mutex_t _g1_ata_mutex;
@@ -259,7 +260,6 @@ static void g1_dma_irq_hnd(uint32 code, void *data) {
     uint8_t status;
 
     /* XXXX: Probably should look at the code to make sure it isn't an error. */
-    (void)code;
     (void)data;
 
     if(dma_in_progress && !can_lba48 && dma_nb_sectors > ATA_MAX_SECTORS_LBA28) {
@@ -297,6 +297,11 @@ static void g1_dma_irq_hnd(uint32 code, void *data) {
     }
     else if(dma_in_progress) {
         g1_dma_done();
+    }
+    else {
+        if(old_dma_irq.hdl) {
+            old_dma_irq.hdl(code, old_dma_irq.data);
+        }
     }
 }
 
@@ -1416,12 +1421,15 @@ int g1_ata_init(void) {
     }
 
     /* Hook all the DMA related events. */
-    asic_evt_set_handler(ASIC_EVT_GD_DMA, g1_dma_irq_hnd, NULL);
-    asic_evt_enable(ASIC_EVT_GD_DMA, ASIC_IRQB);
+    old_dma_irq = asic_evt_set_handler(ASIC_EVT_GD_DMA, g1_dma_irq_hnd, NULL);
     asic_evt_set_handler(ASIC_EVT_GD_DMA_OVERRUN, g1_dma_irq_hnd, NULL);
-    asic_evt_enable(ASIC_EVT_GD_DMA_OVERRUN, ASIC_IRQB);
     asic_evt_set_handler(ASIC_EVT_GD_DMA_ILLADDR, g1_dma_irq_hnd, NULL);
-    asic_evt_enable(ASIC_EVT_GD_DMA_ILLADDR, ASIC_IRQB);
+
+    if(old_dma_irq.hdl == NULL) {
+        asic_evt_enable(ASIC_EVT_GD_DMA, ASIC_IRQB);
+        asic_evt_enable(ASIC_EVT_GD_DMA_OVERRUN, ASIC_IRQB);
+        asic_evt_enable(ASIC_EVT_GD_DMA_ILLADDR, ASIC_IRQB);
+    }
 
     initted = 1;
 
@@ -1442,10 +1450,24 @@ void g1_ata_shutdown(void) {
     memset(&device, 0, sizeof(device));
 
     /* Unhook the events and disable the IRQs. */
-    asic_evt_disable(ASIC_EVT_GD_DMA, ASIC_IRQB);
-    asic_evt_remove_handler(ASIC_EVT_GD_DMA);
-    asic_evt_disable(ASIC_EVT_GD_DMA_OVERRUN, ASIC_IRQB);
-    asic_evt_remove_handler(ASIC_EVT_GD_DMA_OVERRUN);
-    asic_evt_disable(ASIC_EVT_GD_DMA_ILLADDR, ASIC_IRQB);
-    asic_evt_remove_handler(ASIC_EVT_GD_DMA_ILLADDR);
+    if(old_dma_irq.hdl) {
+        /* CDROM driver uses the same handler for 3 events. */
+        asic_evt_set_handler(ASIC_EVT_GD_DMA,
+            old_dma_irq.hdl, old_dma_irq.data);
+        asic_evt_set_handler(ASIC_EVT_GD_DMA_OVERRUN,
+            old_dma_irq.hdl, old_dma_irq.data);
+        asic_evt_set_handler(ASIC_EVT_GD_DMA_ILLADDR,
+            old_dma_irq.hdl, old_dma_irq.data);
+
+        old_dma_irq.hdl = NULL;
+    }
+    else {
+        asic_evt_disable(ASIC_EVT_GD_DMA, ASIC_IRQB);
+        asic_evt_remove_handler(ASIC_EVT_GD_DMA);
+        asic_evt_disable(ASIC_EVT_GD_DMA_OVERRUN, ASIC_IRQB);
+        asic_evt_remove_handler(ASIC_EVT_GD_DMA_OVERRUN);
+        asic_evt_disable(ASIC_EVT_GD_DMA_ILLADDR, ASIC_IRQB);
+        asic_evt_remove_handler(ASIC_EVT_GD_DMA_ILLADDR);
+    }
+
 }

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -14,6 +14,7 @@ __BEGIN_DECLS
 
 #include <arch/types.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 /** \file    dc/cdrom.h
     \brief   CD access to the GD-ROM drive.
@@ -316,6 +317,19 @@ int cdrom_exec_cmd(int cmd, void *param);
     \return                 \ref cd_cmd_response
 */
 int cdrom_exec_cmd_timed(int cmd, void *param, uint32_t timeout);
+
+/** \brief    Abort a CD-ROM command with timeout.
+    \ingroup  gdrom
+
+    This function aborts current command using the BIOS syscall for
+    aborting GD-ROM commands. They can also abort DMA transfers.
+
+    \param  timeout         Timeout in milliseconds.
+    \param  abort_dma       Whether to abort the DMA transfer.
+
+    \return                 \ref cd_cmd_response
+*/
+int cdrom_abort_cmd(uint32_t timeout, bool abort_dma);
 
 /** \brief    Get the status of the GD-ROM drive.
     \ingroup  gdrom

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -3,7 +3,7 @@
    dc/cdrom.h
    Copyright (C) 2000-2001 Megan Potter
    Copyright (C) 2014 Donald Haase
-   Copyright (C) 2023, 2024 Ruslan Rostovtsev
+   Copyright (C) 2023, 2024, 2025 Ruslan Rostovtsev
 */
 
 #ifndef __DC_CDROM_H
@@ -13,6 +13,7 @@
 __BEGIN_DECLS
 
 #include <arch/types.h>
+#include <stdint.h>
 
 /** \file    dc/cdrom.h
     \brief   CD access to the GD-ROM drive.
@@ -314,7 +315,7 @@ int cdrom_exec_cmd(int cmd, void *param);
 
     \return                 \ref cd_cmd_response
 */
-int cdrom_exec_cmd_timed(int cmd, void *param, int timeout);
+int cdrom_exec_cmd_timed(int cmd, void *param, uint32_t timeout);
 
 /** \brief    Get the status of the GD-ROM drive.
     \ingroup  gdrom


### PR DESCRIPTION
This is a part of code from a larger PR #736, slightly modified and improved.
Here is introduced the processing of interrupts of DMA and polling of commands in vblank. This is what original games do, but I improve this algorithm and adapted it for modern devices with flash memory and fast access.
The next PR will contain the streaming API.