### PR TITLE
Add GCC 16.0.0-dev profile

### DIFF
--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -15,6 +15,7 @@
 # - 13.3.1-dev    Bleeding edge GCC 13 series from git.
 # - 14.2.1-dev    Bleeding edge GCC 14 series from git.
 # - 15.0.1-dev    Bleeding edge GCC 15 series from git.
+# - 16.0.0-dev    Bleeding edge GCC 16 series from git.
 # If unsure, select stable. See README.md for more detailed descriptions.
 toolchain_profile=stable
 

--- a/utils/dc-chain/README.md
+++ b/utils/dc-chain/README.md
@@ -105,6 +105,7 @@ The following toolchain profiles are available for users to select in
 | 13.3.1-dev | 13.3.1 (git) | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | Bleeding edge GCC 13 series from git |
 | 14.2.1-dev | 14.2.1 (git) | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | Bleeding edge GCC 14 series from git |
 | 15.0.1-dev | 15.0.1 (git) | 4.5.0 | 2.43.1 | 8.5.0 | 2.43.1 | Bleeding edge GCC 15 series from git |
+| 16.0.0-dev | 16.0.0 (git) | 4.5.0 | 2.44 | 8.5.0 | 2.44 | Bleeding edge GCC 16 series from git |
 
 The **stable** profile is the primary, widely tested target for KallistiOS, and
 is the most recent toolchain profile known to work with all example programs.

--- a/utils/dc-chain/doc/CHANGELOG.md
+++ b/utils/dc-chain/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Date<br/>_____________ | Author(s)<br/>_____________ | Changes<br/>_____________ |
 |:-----------------------|:----------------------------|---------------------------|
+| 2025-04-17 | Eric Fradella | Add 16.0.0 profile with Binutils 2.44 and GDB 16.2. |
 | 2025-02-19 | Eric Fradella | Remove profiles and patches for older toolchains (9.3.0, 10.5.0, 11.5.0, 12.4.0) and Rust dev toolchains. Support for Newlib versions prior to 4.x now deprecated. |
 | 2025-01-26 | Mickaël Cardoso | Update documentations. |
 | 2025-01-05 | Eric Fradella | Add support and update toolchain profiles for Newlib 4.5.0, Binutils 2.43.1, and GDB 15.2. |

--- a/utils/dc-chain/patches/gcc-16.0.0-kos.diff
+++ b/utils/dc-chain/patches/gcc-16.0.0-kos.diff
@@ -1,0 +1,162 @@
+diff -ruN gcc-16.0.0/gcc/config/sh/sh-c.cc gcc-16.0.0-kos/gcc/config/sh/sh-c.cc
+--- gcc-16.0.0/gcc/config/sh/sh-c.cc	2025-04-17 16:01:33.790051712 -0600
++++ gcc-16.0.0-kos/gcc/config/sh/sh-c.cc	2025-04-17 16:01:42.910094466 -0600
+@@ -141,4 +141,11 @@
+ 
+   cpp_define_formatted (pfile, "__SH_ATOMIC_MODEL_%s__",
+ 			selected_atomic_model ().cdef_name);
++
++  /* Custom built-in defines for KallistiOS */
++  builtin_define ("__KOS_GCC_PATCHED__");
++  cpp_define_formatted (pfile, "__KOS_GCC_PATCHLEVEL__=%d",
++			2023010200);
++  /* Toolchain supports setting up stack for 32MB */
++  builtin_define ("__KOS_GCC_32MB__");
+ }
+diff -ruN gcc-16.0.0/gcc/configure gcc-16.0.0-kos/gcc/configure
+--- gcc-16.0.0/gcc/configure	2025-04-17 16:01:33.801051764 -0600
++++ gcc-16.0.0-kos/gcc/configure	2025-04-17 16:01:42.913094480 -0600
+@@ -13165,7 +13165,7 @@
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32 | mcf)
++  single | tpf | vxworks | win32 | kos | mcf)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff -ruN gcc-16.0.0/libgcc/config/sh/t-sh gcc-16.0.0-kos/libgcc/config/sh/t-sh
+--- gcc-16.0.0/libgcc/config/sh/t-sh	2025-04-17 16:01:37.134067388 -0600
++++ gcc-16.0.0-kos/libgcc/config/sh/t-sh	2025-04-17 16:01:42.914094485 -0600
+@@ -23,6 +23,8 @@
+   $(LIB1ASMFUNCS_CACHE)
+ LIB1ASMFUNCS_CACHE = _ic_invalidate _ic_invalidate_array
+ 
++LIB2ADD = $(srcdir)/config/sh/fake-kos.S
++
+ crt1.o: $(srcdir)/config/sh/crt1.S
+ 	$(gcc_compile) -c $<
+ 
+diff -ruN gcc-16.0.0/libgcc/configure gcc-16.0.0-kos/libgcc/configure
+--- gcc-16.0.0/libgcc/configure	2025-04-17 16:01:37.139067412 -0600
++++ gcc-16.0.0-kos/libgcc/configure	2025-04-17 16:01:42.914094485 -0600
+@@ -5733,6 +5733,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 
+diff -ruN gcc-16.0.0/libobjc/configure gcc-16.0.0-kos/libobjc/configure
+--- gcc-16.0.0/libobjc/configure	2025-04-17 16:01:37.499069099 -0600
++++ gcc-16.0.0-kos/libobjc/configure	2025-04-17 16:01:42.915094489 -0600
+@@ -2924,11 +2924,9 @@
+ 
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#include <stdio.h>
+ int
+ main ()
+ {
+-printf ("hello world\n");
+   ;
+   return 0;
+ }
+diff -ruN gcc-16.0.0/libobjc/Makefile.in gcc-16.0.0-kos/libobjc/Makefile.in
+--- gcc-16.0.0/libobjc/Makefile.in	2025-04-17 16:01:37.499069099 -0600
++++ gcc-16.0.0-kos/libobjc/Makefile.in	2025-04-17 16:01:42.915094489 -0600
+@@ -308,14 +308,16 @@
+ $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
+ 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+ 
+-install: install-libs install-headers
++install-strip: INSTALL_STRIP_FLAG = -s
++install install-strip: install-libs install-headers
+ 
+ install-libs: installdirs
+ 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
+-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
++	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+ 	if [ "$(OBJC_BOEHM_GC)" ]; then \
+-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
+-				$(DESTDIR)$(toolexeclibdir);\
++	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
++	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
+ 	fi
+ 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
+ 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
+@@ -328,7 +330,7 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
+diff -ruN gcc-16.0.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-16.0.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-16.0.0/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-17 16:01:37.608069611 -0600
++++ gcc-16.0.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-17 16:01:42.916094494 -0600
+@@ -22,14 +22,40 @@
+ // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ // <http://www.gnu.org/licenses/>.
+ 
+-// Use the default atomicity stuff, which will use __atomic* builtins
+-// if threads are available, or the *_single functions on single-thread
+-// configurations.
+-// Actually we wouldn't need this header at all, but because of PR 53579
+-// libstdc++'s configury will not pickup the -matomic-model= option when
+-// set in the environment.  This makes it impossible to enable the proper
+-// atomic model on SH without modifying GCC itself, because libstdc++ always
+-// thinks the target doesn't do any atomics and uses the default mutex based
+-// implementation from cpu/generic/atomicity_mutex.
++/* This is generic/atomicity.h */
+ 
+ #include <ext/atomicity.h>
++#include <ext/concurrence.h>
++
++namespace 
++{
++  __gnu_cxx::__mutex&
++  get_atomic_mutex()
++  {
++    static __gnu_cxx::__mutex atomic_mutex;
++    return atomic_mutex;
++  }
++} // anonymous namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val) throw ()
++  {
++    __gnu_cxx::__scoped_lock sentry(get_atomic_mutex());
++    _Atomic_word __result;
++    __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word* __mem, int __val) throw ()
++  { __exchange_and_add(__mem, __val); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff -ruN gcc-16.0.0/libstdc++-v3/configure gcc-16.0.0-kos/libstdc++-v3/configure
+--- gcc-16.0.0/libstdc++-v3/configure	2025-04-17 16:01:37.616069648 -0600
++++ gcc-16.0.0-kos/libstdc++-v3/configure	2025-04-17 16:01:42.919094508 -0600
+@@ -15974,6 +15974,7 @@
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    kos)	thread_header=config/sh/gthr-kos.h ;;
+     mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 

--- a/utils/dc-chain/profiles/profile.16.0.0-dev.mk
+++ b/utils/dc-chain/profiles/profile.16.0.0-dev.mk
@@ -1,0 +1,47 @@
+# Sega Dreamcast Toolchains Maker (dc-chain)
+# This file is part of KallistiOS.
+
+###############################################################################
+###############################################################################
+### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2025-04-17.
+###############################################################################
+###############################################################################
+
+# Toolchain versions for SH
+sh_binutils_ver=2.44
+sh_gcc_ver=16.0.0
+newlib_ver=4.5.0.20241231
+gdb_ver=16.2
+
+# Overide SH toolchain download type
+sh_gcc_download_type=git
+sh_gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+sh_gcc_git_branch=master
+
+# Toolchain for ARM
+# The ARM version of gcc/binutils is separated as support for the ARM7DI core
+# used in the Dreamcast's AICA is not available in versions of GCC beyond 8.5.0.
+arm_binutils_ver=2.44
+arm_gcc_ver=8.5.0
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'sh_isl_ver' and 'arm_isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies for SH
+sh_gmp_ver=6.2.1
+sh_mpfr_ver=4.1.0
+sh_mpc_ver=1.2.1
+sh_isl_ver=0.24
+
+# GCC dependencies for ARM
+arm_gmp_ver=6.1.0
+arm_mpfr_ver=3.1.4
+arm_mpc_ver=1.0.3
+arm_isl_ver=0.18


### PR DESCRIPTION
The GCC 15 dev branch has hit zero P1 (highest priority) regressions, meaning release candidates will be coming in the next couple of weeks. Therefore GCC 15 branch is frozen for commits without managerial signoff, and meanwhile, the GCC 16 branch has been created today for the rest of new GCC development.

This PR creates a new profile (`16.0.0-dev`) which uses the new GCC 16 branch with additional upgrades to Binutils (`2.43.1` -> `2.44`) and GDB (`15.2` -> `16.2`). 

A PR with GCC 15.1.0 will come later once the release candidates hit.