### PR TITLE
sound: Fix loading of ARM firmware

### DIFF
--- a/kernel/arch/dreamcast/sound/Makefile
+++ b/kernel/arch/dreamcast/sound/Makefile
@@ -20,5 +20,10 @@ include $(KOS_BASE)/Makefile.prefab
 
 arm/stream.drv: subdirs
 
-snd_stream_drv.o: arm/stream.drv
-	$(KOS_BASE)/utils/bin2o/bin2o arm/stream.drv snd_stream_drv snd_stream_drv.o
+snd_iface.c: snd_stream_drv.c
+
+snd_stream_drv.c: arm/stream.drv $(KOS_BASE)/utils/bin2c/bin2c
+	$(KOS_BASE)/utils/bin2c/bin2c $< $@ snd_stream_drv
+
+clean:
+	-rm -f snd_stream_drv.c

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -20,12 +20,11 @@
 
 #include "arm/aica_cmd_iface.h"
 
+/* Include the default firmware blob */
+#include "snd_stream_drv.c"
+
 /* Are we initted? */
 static int initted = 0;
-
-/* This will come from a separately linked object file */
-extern uintptr_t snd_stream_drv;
-extern uintptr_t snd_stream_drv_end;
 
 /* The queue processing mutex for snd_sh4_to_aica_start and snd_sh4_to_aica_stop.
    There are some cases like stereo stream control + stereo sfx control
@@ -41,13 +40,13 @@ int snd_init(void) {
     if(!initted) {
         spu_disable();
         spu_memset_sq(0, 0, AICA_RAM_START);
-        amt = snd_stream_drv_end - snd_stream_drv;
+        amt = snd_stream_drv_size;
 
         if(amt % 4)
             amt = (amt + 4) & ~3;
 
-        dbglog(DBG_DEBUG, "snd_init(): loading %u bytes into SPU RAM\n", amt);
-        spu_memload_sq(0, (void* )snd_stream_drv, amt);
+        dbglog(DBG_DEBUG, "snd_init(): loading %zu bytes into SPU RAM\n", amt);
+        spu_memload_sq(0, (void *)snd_stream_drv_data, amt);
 
         /* Enable the AICA and give it a few ms to start up */
         spu_enable();


### PR DESCRIPTION
The offending commit 1d507167d ("Use proper typing for pointer math.") had the following change:

-extern uint8_t snd_stream_drv[];
-extern uint8_t snd_stream_drv_end[];
+extern uintptr_t snd_stream_drv;
+extern uintptr_t snd_stream_drv_end;

and was later computing the size of the firmware by doing the difference (snd_stream_drv_end - snd_stream_drv).

However, the behaviour was changed; before, it computed the difference between two addresses, and now computed the difference between the two uintptr_t values located at these addresses.
Therefore the difference should have been changed to (&snd_stream_drv_end - &snd_stream_drv).

Instead of just reverting the commit, update the code to use a blob generated by bin2c instead of bin2o, since we already moved to bin2c for romdisks.

The source blob generated by bin2c can be included directly, which means that the symbols can be used directly without having to use "extern".