### PR TITLE
pvr: Move + improve PVR poly headers and types into their own file

### DIFF
--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -53,6 +53,7 @@ __BEGIN_DECLS
     at the bottom of the file to be able to use types defined throughout. */
 
 #include "pvr/pvr_mem.h"
+#include "pvr/pvr_header.h"
 
 /** \defgroup pvr   PowerVR API
     \brief          Low-level PowerVR GPU Driver.
@@ -287,22 +288,6 @@ typedef struct {
 
 /* Constants for the above structure; thanks to Benoit Miller for these */
 
-/** \defgroup pvr_lists_types Types
-    \brief                    Values of various PVR polygon list types
-    \ingroup                  pvr_lists
-
-    Each primitive submitted to the PVR must be placed in one of these lists,
-    depending on its characteristics.
-
-    @{
-*/
-#define PVR_LIST_OP_POLY        0   /**< \brief Opaque polygon list */
-#define PVR_LIST_OP_MOD         1   /**< \brief Opaque modifier list */
-#define PVR_LIST_TR_POLY        2   /**< \brief Translucent polygon list */
-#define PVR_LIST_TR_MOD         3   /**< \brief Translucent modifier list*/
-#define PVR_LIST_PT_POLY        4   /**< \brief Punch-thru polygon list */
-/** @} */
-
 /** \defgroup pvr_ctx_attrib Attributes
     \brief                   PVR primitive context attributes
     \ingroup                 pvr_ctx
@@ -326,40 +311,6 @@ typedef struct {
     \brief                      Depth attributes for PVR polygon contexts
     \ingroup                    pvr_ctx_attrib
 */
-
-/** \defgroup pvr_depth_modes   Comparison Modes
-    \brief                      PowerVR depth comparison modes
-    \ingroup                    pvr_ctx_depth
-
-    These set the depth function used for comparisons.
-
-    @{
-*/
-#define PVR_DEPTHCMP_NEVER      0   /**< \brief Never pass */
-#define PVR_DEPTHCMP_LESS       1   /**< \brief Less than */
-#define PVR_DEPTHCMP_EQUAL      2   /**< \brief Equal to */
-#define PVR_DEPTHCMP_LEQUAL     3   /**< \brief Less than or equal to */
-#define PVR_DEPTHCMP_GREATER    4   /**< \brief Greater than */
-#define PVR_DEPTHCMP_NOTEQUAL   5   /**< \brief Not equal to */
-#define PVR_DEPTHCMP_GEQUAL     6   /**< \brief Greater than or equal to */
-#define PVR_DEPTHCMP_ALWAYS     7   /**< \brief Always pass */
-/** @} */
-
-/** \defgroup pvr_cull_modes        Culling Modes
-    \brief                          PowerVR primitive context culling modes
-    \ingroup                        pvr_ctx_attrib
-
-    These culling modes can be set by polygons to determine when they are
-    culled. They work pretty much as you'd expect them to if you've ever used
-    any 3D hardware before.
-
-    @{
-*/
-#define PVR_CULLING_NONE        0   /**< \brief Disable culling */
-#define PVR_CULLING_SMALL       1   /**< \brief Cull if small */
-#define PVR_CULLING_CCW         2   /**< \brief Cull if counterclockwise */
-#define PVR_CULLING_CW          3   /**< \brief Cull if clockwise */
-/** @} */
 
 /** \defgroup pvr_depth_switch      Write Toggle
     \brief                          Enable or Disable Depth Writes.
@@ -390,25 +341,6 @@ typedef struct {
     \ingroup                        pvr_ctx_attrib
 */
 
-/** \defgroup pvr_blend_modes       Blending Modes
-    \brief                          Blending modes for PowerVR primitive contexts
-    \ingroup                        pvr_blend
-
-    These are all the blending modes that can be done with regard to alpha
-    blending on the PVR.
-
-    @{
-*/
-#define PVR_BLEND_ZERO          0   /**< \brief None of this color */
-#define PVR_BLEND_ONE           1   /**< \brief All of this color */
-#define PVR_BLEND_DESTCOLOR     2   /**< \brief Destination color */
-#define PVR_BLEND_INVDESTCOLOR  3   /**< \brief Inverse of destination color */
-#define PVR_BLEND_SRCALPHA      4   /**< \brief Blend with source alpha */
-#define PVR_BLEND_INVSRCALPHA   5   /**< \brief Blend with inverse source alpha */
-#define PVR_BLEND_DESTALPHA     6   /**< \brief Blend with destination alpha */
-#define PVR_BLEND_INVDESTALPHA  7   /**< \brief Blend with inverse destination alpha */
-/** @} */
-
 /** \defgroup pvr_blend_switch      Blending Toggle
     \brief                          Enable or Disable Blending.
     \ingroup                        pvr_blend
@@ -417,34 +349,6 @@ typedef struct {
 */
 #define PVR_BLEND_DISABLE       0   /**< \brief Disable blending */
 #define PVR_BLEND_ENABLE        1   /**< \brief Enable blending */
-/** @} */
-
-/** \defgroup pvr_fog_types         Fog Modes
-    \brief                          PowerVR primitive context fog modes
-    \ingroup                        pvr_ctx_attrib
-
-    Each polygon can decide what fog type is used with regard to it using these
-    constants in its pvr_poly_cxt_t.
-
-    @{
-*/
-#define PVR_FOG_TABLE           0   /**< \brief Table fog */
-#define PVR_FOG_VERTEX          1   /**< \brief Vertex fog */
-#define PVR_FOG_DISABLE         2   /**< \brief Disable fog */
-#define PVR_FOG_TABLE2          3   /**< \brief Table fog mode 2 */
-/** @} */
-
-/** \defgroup pvr_clip_modes        Clipping Modes
-    \brief                          PowerVR primitive context clipping modes
-    \ingroup                        pvr_ctx_attrib
-
-    These control how primitives are clipped against the user clipping area.
-
-    @{
-*/
-#define PVR_USERCLIP_DISABLE    0   /**< \brief Disable clipping */
-#define PVR_USERCLIP_INSIDE     2   /**< \brief Enable clipping inside area */
-#define PVR_USERCLIP_OUTSIDE    3   /**< \brief Enable clipping outside area */
 /** @} */
 
 /** \defgroup pvr_ctx_color     Color
@@ -549,19 +453,6 @@ typedef struct {
 #define PVR_UVCLAMP_UV          3   /**< \brief Clamp U and V */
 /** @} */
 
-/** \defgroup pvr_filter_modes      Sampling Modes
-    \brief                          PowerVR texture sampling modes
-    \ingroup                        pvr_ctx_texture
-
-    @{
-*/
-#define PVR_FILTER_NONE         0   /**< \brief No filtering (point sample) */
-#define PVR_FILTER_NEAREST      0   /**< \brief No filtering (point sample) */
-#define PVR_FILTER_BILINEAR     2   /**< \brief Bilinear interpolation */
-#define PVR_FILTER_TRILINEAR1   4   /**< \brief Trilinear interpolation pass 1 */
-#define PVR_FILTER_TRILINEAR2   6   /**< \brief Trilinear interpolation pass 2 */
-/** @} */
-
 /** \defgroup pvr_mip_bias          Mipmap Bias Modes
     \brief                          Mipmap bias modes for PowerVR primitive contexts
     \ingroup                        pvr_ctx_texture
@@ -584,18 +475,6 @@ typedef struct {
 #define PVR_MIPBIAS_3_25        13
 #define PVR_MIPBIAS_3_50        14
 #define PVR_MIPBIAS_3_75        15
-/** @} */
-
-/** \defgroup pvr_txrenv_modes      Color Calculation Modes
-    \brief                          PowerVR texture color calculation modes
-    \ingroup                        pvr_ctx_texture
-
-    @{
-*/
-#define PVR_TXRENV_REPLACE          0   /**< \brief C = Ct, A = At */
-#define PVR_TXRENV_MODULATE         1   /**< \brief  C = Cs * Ct, A = At */
-#define PVR_TXRENV_DECAL            2   /**< \brief C = (Cs * At) + (Cs * (1-At)), A = As */
-#define PVR_TXRENV_MODULATEALPHA    3   /**< \brief C = Cs * Ct, A = As * At */
 /** @} */
 
 /** \defgroup pvr_mip_switch        Mipmap Toggle
@@ -715,42 +594,14 @@ typedef struct {
     @{
 */
 
-/** \brief   PVR polygon header.
-
-    This is the hardware equivalent of a rendering context; you'll create one of
-    these from your pvr_poly_cxt_t and use it for submission to the hardware.
-
-    \headerfile dc/pvr.h
-*/
-typedef struct pvr_poly_hdr {
-    alignas(32)
-    uint32_t cmd;                /**< \brief TA command */
-    uint32_t mode1;              /**< \brief Parameter word 1 */
-    uint32_t mode2;              /**< \brief Parameter word 2 */
-    uint32_t mode3;              /**< \brief Parameter word 3 */
-    uint32_t d1;                 /**< \brief Dummy value */
-    uint32_t d2;                 /**< \brief Dummy value */
-    uint32_t d3;                 /**< \brief Dummy value */
-    uint32_t d4;                 /**< \brief Dummy value */
-} pvr_poly_hdr_t;
-
 /** \brief   PVR polygon header with intensity color.
 
     This is the equivalent of pvr_poly_hdr_t, but for use with intensity color.
 
     \headerfile dc/pvr.h
 */
-typedef struct pvr_poly_ic_hdr {
-    alignas(32)
-    uint32_t cmd;                /**< \brief TA command */
-    uint32_t mode1;              /**< \brief Parameter word 1 */
-    uint32_t mode2;              /**< \brief Parameter word 2 */
-    uint32_t mode3;              /**< \brief Parameter word 3 */
-    float   a;                   /**< \brief Face color alpha component */
-    float   r;                   /**< \brief Face color red component */
-    float   g;                   /**< \brief Face color green component */
-    float   b;                   /**< \brief Face color blue component */
-} pvr_poly_ic_hdr_t;
+#define pvr_poly_ic_hdr pvr_poly_hdr
+typedef pvr_poly_hdr_t pvr_poly_ic_hdr_t;
 
 /** \brief   PVR polygon header to be used with modifier volumes.
 
@@ -759,17 +610,8 @@ typedef struct pvr_poly_ic_hdr {
 
     \headerfile dc/pvr.h
 */
-typedef struct pvr_poly_mod_hdr {
-    alignas(32)
-    uint32_t cmd;                /**< \brief TA command */
-    uint32_t mode1;              /**< \brief Parameter word 1 */
-    uint32_t mode2_0;            /**< \brief Parameter word 2 (outside volume) */
-    uint32_t mode3_0;            /**< \brief Parameter word 3 (outside volume) */
-    uint32_t mode2_1;            /**< \brief Parameter word 2 (inside volume) */
-    uint32_t mode3_1;            /**< \brief Parameter word 3 (inside volume) */
-    uint32_t d1;                 /**< \brief Dummy value */
-    uint32_t d2;                 /**< \brief Dummy value */
-} pvr_poly_mod_hdr_t;
+#define pvr_poly_mod_hdr pvr_poly_hdr
+typedef pvr_poly_hdr_t pvr_poly_mod_hdr_t;
 
 /** \brief   PVR polygon header specifically for sprites.
 
@@ -778,17 +620,8 @@ typedef struct pvr_poly_mod_hdr {
 
     \headerfile dc/pvr.h
 */
-typedef struct pvr_sprite_hdr {
-    alignas(32)
-    uint32_t cmd;                /**< \brief TA command */
-    uint32_t mode1;              /**< \brief Parameter word 1 */
-    uint32_t mode2;              /**< \brief Parameter word 2 */
-    uint32_t mode3;              /**< \brief Parameter word 3 */
-    uint32_t argb;               /**< \brief Sprite face color */
-    uint32_t oargb;              /**< \brief Sprite offset color */
-    uint32_t d1;                 /**< \brief Dummy value */
-    uint32_t d2;                 /**< \brief Dummy value */
-} pvr_sprite_hdr_t;
+#define pvr_sprite_hdr pvr_poly_hdr
+typedef pvr_poly_hdr_t pvr_sprite_hdr_t;
 
 /** \brief   Modifier volume header.
 
@@ -797,18 +630,8 @@ typedef struct pvr_sprite_hdr {
 
     \headerfile dc/pvr.h
 */
-typedef struct pvr_mod_hdr {
-    alignas(32)
-    uint32_t cmd;                /**< \brief TA command */
-    uint32_t mode1;              /**< \brief Parameter word 1 */
-    uint32_t d1;                 /**< \brief Dummy value */
-    uint32_t d2;                 /**< \brief Dummy value */
-    uint32_t d3;                 /**< \brief Dummy value */
-    uint32_t d4;                 /**< \brief Dummy value */
-    uint32_t d5;                 /**< \brief Dummy value */
-    uint32_t d6;                 /**< \brief Dummy value */
-} pvr_mod_hdr_t;
-
+#define pvr_mod_hdr pvr_poly_hdr
+typedef pvr_poly_hdr_t pvr_mod_hdr_t;
 /** @} */
 
 /** \defgroup pvr_vertex_types  Vertices
@@ -1115,7 +938,7 @@ Striplength set to 2 */
 #define PVR_TA_PM2_TXRALPHA        BIT(19)
 #define PVR_TA_PM2_UVFLIP          GENMASK(18, 17)
 #define PVR_TA_PM2_UVCLAMP         GENMASK(16, 15)
-#define PVR_TA_PM2_FILTER          GENMASK(14, 12)
+#define PVR_TA_PM2_FILTER          GENMASK(14, 13)
 #define PVR_TA_PM2_MIPBIAS         GENMASK(11, 8)
 #define PVR_TA_PM2_TXRENV          GENMASK(7, 6)
 #define PVR_TA_PM2_USIZE           GENMASK(5, 3)

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
@@ -1,0 +1,351 @@
+/* KallistiOS ##version##
+
+   dc/pvr/pvr_header.h
+   Copyright (C) 2025 Paul Cercueil
+*/
+
+/** \file       dc/pvr/pvr_header.h
+    \brief      Polygon/Sprite header definitions
+    \ingroup    pvr
+
+  \author Paul Cercueil
+*/
+
+#ifndef __DC_PVR_PVR_HEADER_H
+#define __DC_PVR_PVR_HEADER_H
+
+#include <stdalign.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+/** \defgroup pvr_primitives_headers Headers
+    \brief                           Structs relative to PVR headers
+    \ingroup pvr_primitives
+    \headerfile dc/pvr/pvr_header.h
+
+    @{
+*/
+
+/** \brief   Vertex color formats
+
+    These control how colors are represented in polygon data.
+*/
+enum pvr_color_fmts {
+    PVR_CLRFMT_ARGBPACKED,      /**< 32-bit integer ARGB */
+    PVR_CLRFMT_4FLOATS,         /**< 4 floating point values */
+    PVR_CLRFMT_INTENSITY,       /**< Intensity color */
+    PVR_CLRFMT_INTENSITY_PREV,  /**< Use last intensity */
+};
+
+/** \brief   Primitive clipping modes
+
+    These control how primitives are clipped against the user clipping area.
+*/
+enum pvr_clip_mode {
+    PVR_USERCLIP_DISABLE = 0,   /**< Disable clipping */
+    PVR_USERCLIP_INSIDE = 2,    /**< Enable clipping inside area */
+    PVR_USERCLIP_OUTSIDE = 3,   /**< Enable clipping outside area */
+};
+
+/** \brief   PVR rendering lists
+
+    Each primitive submitted to the PVR must be placed in one of these lists,
+    depending on its characteristics.
+*/
+enum pvr_list_type {
+    PVR_LIST_OP_POLY,           /**< Opaque polygon list */
+    PVR_LIST_OP_MOD,            /**< Opaque modifier list */
+    PVR_LIST_TR_POLY,           /**< Translucent polygon list */
+    PVR_LIST_TR_MOD,            /**< Translucent modifier list*/
+    PVR_LIST_PT_POLY,           /**< Punch-thru polygon list */
+};
+
+/** \brief   Primitive culling modes
+
+    These culling modes can be set by polygons to determine when they are
+    culled. They work pretty much as you'd expect them to if you've ever used
+    any 3D hardware before.
+*/
+enum pvr_cull_mode {
+    PVR_CULLING_NONE,           /**< Disable culling */
+    PVR_CULLING_SMALL,          /**< Cull if small */
+    PVR_CULLING_CCW,            /**< Cull if counterclockwise */
+    PVR_CULLING_CW,             /**< Cull if clockwise */
+};
+
+/** \brief   Depth comparison modes
+
+    These set the depth function used for comparisons.
+*/
+enum pvr_depthcmp_mode {
+    PVR_DEPTHCMP_NEVER,         /**< Never pass */
+    PVR_DEPTHCMP_LESS,          /**< Less than */
+    PVR_DEPTHCMP_EQUAL,         /**< Equal to */
+    PVR_DEPTHCMP_LEQUAL,        /**< Less than or equal to */
+    PVR_DEPTHCMP_GREATER,       /**< Greater than */
+    PVR_DEPTHCMP_NOTEQUAL,      /**< Not equal to */
+    PVR_DEPTHCMP_GEQUAL,        /**< Greater than or equal to */
+    PVR_DEPTHCMP_ALWAYS,        /**< Always pass */
+};
+
+/** \brief   Texture U/V size */
+enum pvr_uv_size {
+    PVR_UV_SIZE_8,
+    PVR_UV_SIZE_16,
+    PVR_UV_SIZE_32,
+    PVR_UV_SIZE_64,
+    PVR_UV_SIZE_128,
+    PVR_UV_SIZE_256,
+    PVR_UV_SIZE_512,
+    PVR_UV_SIZE_1024,
+};
+
+/** \brief   Texture color calculation modes */
+enum pvr_txr_shading_mode {
+    PVR_TXRENV_REPLACE,         /**< C = Ct, A = At */
+    PVR_TXRENV_MODULATE,        /**< C = Cs * Ct, A = At */
+    PVR_TXRENV_DECAL,           /**< C = (Cs * At) + (Cs * (1-At)), A = As */
+    PVR_TXRENV_MODULATEALPHA,   /**< C = Cs * Ct, A = As * At */
+};
+
+/** \brief   Texture sampling modes */
+enum pvr_filter_mode {
+    PVR_FILTER_NEAREST,         /**< No filtering (point sample) */
+    PVR_FILTER_BILINEAR,        /**< Bilinear interpolation */
+    PVR_FILTER_TRILINEAR1,      /**< Trilinear interpolation pass 1 */
+    PVR_FILTER_TRILINEAR2,      /**< Trilinear interpolation pass 2 */
+    PVR_FILTER_NONE = PVR_FILTER_NEAREST,
+};
+
+/** \brief   Fog modes
+
+    Each polygon can decide what fog type is used by specifying the fog mode
+    in its header.
+*/
+enum pvr_fog_type {
+    PVR_FOG_TABLE,              /**< Table fog */
+    PVR_FOG_VERTEX,             /**< Vertex fog */
+    PVR_FOG_DISABLE,            /**< Disable fog */
+    PVR_FOG_TABLE2,             /**< Table fog mode 2 */
+};
+
+/** \brief   Blending modes
+
+    These are all the blending modes that can be done with regard to alpha
+    blending on the PVR.
+*/
+enum pvr_blend_mode {
+    PVR_BLEND_ZERO,             /**< None of this color */
+    PVR_BLEND_ONE,              /**< All of this color */
+    PVR_BLEND_DESTCOLOR,        /**< Destination color */
+    PVR_BLEND_INVDESTCOLOR,     /**< Inverse of destination color */
+    PVR_BLEND_SRCALPHA,         /**< Blend with source alpha */
+    PVR_BLEND_INVSRCALPHA,      /**< Blend with inverse source alpha */
+    PVR_BLEND_DESTALPHA,        /**< Blend with destination alpha */
+    PVR_BLEND_INVDESTALPHA,     /**< Blend with inverse destination alpha */
+};
+
+/** \brief   Texture formats
+
+    These are the texture formats that the PVR supports.
+*/
+enum pvr_pixel_mode {
+    PVR_PIXEL_MODE_ARGB1555,    /**< 16-bit ARGB1555 */
+    PVR_PIXEL_MODE_RGB565,      /**< 16-bit RGB565 */
+    PVR_PIXEL_MODE_ARGB4444,    /**< 16-bit ARGB4444 */
+    PVR_PIXEL_MODE_YUV422,      /**< YUV422 format */
+    PVR_PIXEL_MODE_BUMP,        /**< Bumpmap format */
+    PVR_PIXEL_MODE_PAL_4BPP,    /**< 4BPP paletted format */
+    PVR_PIXEL_MODE_PAL_8BPP,    /**< 8BPP paletted format */
+};
+
+/** \brief   Triangle strip length
+
+    This sets the maximum length of a triangle strip, if not
+    configured in auto mode.
+*/
+enum pvr_strip_len {
+    PVR_STRIP_LEN_1,
+    PVR_STRIP_LEN_2,
+    PVR_STRIP_LEN_4,
+    PVR_STRIP_LEN_6,
+};
+
+/** \brief   Polygon header type
+
+    This enum contains the possible PVR header types.
+*/
+enum pvr_hdr_type {
+    PVR_HDR_EOL = 0,
+    PVR_HDR_USERCLIP = 1,
+    PVR_HDR_OBJECT_LIST_SET = 2,
+    PVR_HDR_POLY = 4,
+    PVR_HDR_SPRITE = 5,
+};
+
+/** \brief   Texture address
+
+    This type represents an address of a texture in VRAM,
+    pre-processed to be used in headers.
+*/
+typedef uint32_t pvr_txr_ptr_t;
+
+/** \brief   Get texture address from VRAM address
+
+    This function can be used to get a texture address that can be used
+    in a PVR header from the texture's VRAM address.
+
+    \param  addr            The texture's address in VRAM
+    \return                 The pre-processed texture address
+*/
+static inline pvr_txr_ptr_t to_pvr_txr_ptr(pvr_ptr_t addr) {
+    return ((uint32_t)addr & 0x00fffff8) >> 3;
+}
+
+/** \brief   PVR header command
+
+    This structure contains all the fields for the command of PVR headers.
+*/
+struct pvr_poly_hdr_cmd {
+    bool uvfmt_f16                      :1; /* 0 */     /**< Use 16-bit floating-point U/Vs */
+    bool gouraud                        :1; /* 1 */     /**< Enable gouraud shading */
+    bool oargb_en                       :1; /* 2 */     /**< Enable specular lighting */
+    bool txr_en                         :1; /* 3 */     /**< Enable texturing */
+    enum pvr_color_fmts color_fmt       :2; /* 5-4 */   /**< Select color encoding */
+    bool mod_normal                     :1; /* 6 */     /**< true: normal, false: cheap shadow */
+    bool modifier_en                    :1; /* 7 */     /**< Enable modifier effects */
+    uint32_t __pad0                     :8; /* 15-8 */
+    enum pvr_clip_mode clip_mode        :2; /* 17-16 */ /**< Clipping mode */
+    enum pvr_strip_len strip_len        :2; /* 19-18 */ /**< Triangle strips length (if non-auto) */
+    uint32_t __pad1                     :3; /* 22-20 */
+    bool auto_strip_len                 :1; /* 23 */    /**< Auto select triangle strips length */
+
+    enum pvr_list_type list_type        :3; /* 26-24 */ /**< Render list to use */
+    uint32_t __pad2                     :1; /* 27 */
+    bool strip_end                      :1; /* 28 */    /**< Mark an end-of-strip */
+    enum pvr_hdr_type hdr_type          :3; /* 31-29 */ /**< Header type */
+};
+
+/** \brief   PVR header mode1
+
+    This structure contains all the fields for the mode1 parameter of
+    PVR headers.
+*/
+struct pvr_poly_hdr_mode1 {
+    uint32_t __pad3                     :25; /* 24-0 */
+    bool txr_en                         :1; /* 25 */    /**< Enable texturing (2nd bit) */
+    bool depth_write_dis                :1; /* 26 */    /**< Disable depth writes */
+    enum pvr_cull_mode culling          :2; /* 28-27 */ /**< Culling mode */
+    enum pvr_depthcmp_mode depth_cmp    :3; /* 31-29 */ /**< Depth comparison mode */
+};
+
+/** \brief   PVR header mode2
+
+    This structure contains all the fields for the mode2 parameter of
+    PVR headers.
+*/
+struct pvr_poly_hdr_mode2 {
+    enum pvr_uv_size v_size             :3; /* 2-0 */   /**< Texture height */
+    enum pvr_uv_size u_size             :3; /* 5-3 */   /**< Texture width */
+    enum pvr_txr_shading_mode shading   :2; /* 7-6 */   /**< Shading mode */
+    uint32_t mip_bias                   :4; /* 11-8 */  /**< Bias for mipmaps */
+    bool supersampling                  :1; /* 12 */    /**< Enable texture supersampling */
+    enum pvr_filter_mode filter_mode    :2; /* 14-13 */ /**< Texture filtering mode */
+    bool v_clamp                        :1; /* 15 */    /**< Clamp V to 1.0 */
+    bool u_clamp                        :1; /* 16 */    /**< Clamp U to 1.0 */
+    bool v_flip                         :1; /* 17 */    /**< Flip V after 1.0 */
+    bool u_flip                         :1; /* 18 */    /**< Flip U after 1.0 */
+    bool txralpha_dis                   :1; /* 19 */    /**< Disable alpha channel in textures */
+    bool alpha                          :1; /* 20 */    /**< Enable alpha channel in vertex colors */
+    bool fog_clamp                      :1; /* 21 */    /**< Enable fog clamping */
+    enum pvr_fog_type fog_type          :2; /* 23-22 */ /**< Select fog type */
+    bool blend_dst_acc2                 :1; /* 24 */    /**< Blend to the 2nd accumulation buffer */
+    bool blend_src_acc2                 :1; /* 25 */    /**< Blend from the 2nd accumulation buffer */
+    enum pvr_blend_mode blend_dst       :3; /* 28-26 */ /**< Blend mode for the background */
+    enum pvr_blend_mode blend_src       :3; /* 31-29 */ /**< Blend mode for the foreground */
+};
+
+/** \brief   PVR header mode3
+
+    This structure contains all the fields for the mode3 parameter of
+    PVR headers.
+*/
+struct pvr_poly_hdr_mode3 {
+    pvr_txr_ptr_t txr_base              :25; /* 24-0 */ /**< Pre-processed texture address */
+    bool x32stride                      :1; /* 25 */    /**< Set if texture stride is multiple of 32 */
+    bool nontwiddled                    :1; /* 26 */    /**< Set if texture is not twiddled */
+    enum pvr_pixel_mode pixel_mode      :3; /* 29-27 */ /**< Select the texture's pixel format */
+    bool vq_en                          :1; /* 30 */    /**< Set if the texture is VQ encoded */
+    bool mipmap_en                      :1; /* 31 */    /**< Enable mipmaps */
+};
+
+/** \brief   PVR polygon header.
+
+    This structure contains information about how the following polygons should
+    be rendered.
+*/
+typedef __attribute__((aligned(32))) struct pvr_poly_hdr {
+    union {
+        uint32_t cmd;                                   /**< Raw access to cmd param */
+        struct pvr_poly_hdr_cmd m0;                     /**< command parameters */
+    };
+    union {
+        uint32_t mode1;                                 /**< Raw access to mode1 param */
+        struct pvr_poly_hdr_mode1 m1;                   /**< mode1 parameters */
+    };
+    union {
+        uint32_t mode2;                                 /**< Raw access to mode2 param */
+        uint32_t mode2_0;                               /**< Legacy name */
+        uint32_t d5;                                    /**< Dummy value 5 */
+        struct pvr_poly_hdr_mode2 m2;                   /**< mode2 parameters (modifiers: outside volume) */
+    };
+    union {
+        uint32_t mode3;                                 /**< Raw access to mode3 param */
+        uint32_t mode3_0;                               /**< Legacy name */
+        uint32_t d6;                                    /**< Dummy value 6 */
+        struct pvr_poly_hdr_mode3 m3;                   /**< mode3 parameters (modifiers: outside volume) */
+    };
+    union {
+        struct {
+            uint32_t d1;                                /**< Dummy value 1 */
+            uint32_t d2;                                /**< Dummy value 2 */
+            uint32_t d3;                                /**< Dummy value 3 */
+            uint32_t d4;                                /**< Dummy value 4 */
+        };
+        struct {
+            /* Intensity color */
+            float a;                                    /**< Intensity color alpha */
+            float r;                                    /**< Intensity color red */
+            float g;                                    /**< Intensity color green */
+            float b;                                    /**< Intensity color blue */
+        };
+        struct {
+            /* Modifier volume */
+            union {
+                struct {
+                    uint32_t mode2_1;                   /**< Legacy name */
+                    uint32_t mode3_1;                   /**< Legacy name */
+                };
+                struct {
+                    struct pvr_poly_hdr_mode2 m2;       /**< mode2 parameters (modifiers: inside volume) */
+                    struct pvr_poly_hdr_mode3 m3;       /**< mode3 parameters (modifiers: inside volume) */
+                } modifier;
+            };
+            uint64_t __pad4;
+        };
+        struct {
+            /* Sprite */
+            uint32_t argb;                              /**< 32-bit ARGB vertex color for sprites */
+            uint32_t oargb;                             /**< 32-bit ARGB specular color for sprites */
+            uint64_t __pad5;
+        };
+    };
+} pvr_poly_hdr_t;
+
+_Static_assert(sizeof(pvr_poly_hdr_t) == 32, "Invalid header size");
+
+__END_DECLS
+#endif /* __DC_PVR_PVR_HEADER_H */

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
@@ -103,12 +103,24 @@ enum pvr_uv_size {
     PVR_UV_SIZE_1024,
 };
 
-/** \brief   Texture color calculation modes */
+/** \brief   Texture color calculation modes.
+
+    The shading mode specifies how the pixel value used as the "foreground" or
+    "source" for blending is computed.
+
+    Here, "tex" represents the pixel value from the texture, and "col"
+    represents the pixel value from the polygon's color.  RGB() represents the
+    color channels, A() represents the alpha channel, and ARGB() represents the
+    whole pixel (color + alpha).
+
+    Note that the offset color (aka. oargb), if specular lighting is enabled,
+    is added to the result. Its alpha channel is ignored.
+*/
 enum pvr_txr_shading_mode {
-    PVR_TXRENV_REPLACE,         /**< C = Ct, A = At */
-    PVR_TXRENV_MODULATE,        /**< C = Cs * Ct, A = At */
-    PVR_TXRENV_DECAL,           /**< C = (Cs * At) + (Cs * (1-At)), A = As */
-    PVR_TXRENV_MODULATEALPHA,   /**< C = Cs * Ct, A = As * At */
+    PVR_TXRENV_REPLACE,         /**< px = ARGB(tex) */
+    PVR_TXRENV_MODULATE,        /**< px = A(tex) + RGB(col) * RGB(tex) */
+    PVR_TXRENV_DECAL,           /**< px = A(col) + RGB(tex) * A(tex) + RGB(col) * (1 - A(tex)) */
+    PVR_TXRENV_MODULATEALPHA,   /**< px = ARGB(col) * ARGB(tex) */
 };
 
 /** \brief   Texture sampling modes */


### PR DESCRIPTION
Create enums and types for the various macros relative to the PVR headers and polygon contexts.
Note the change with PVR_FILTER_* values - which does not break API since the register field was moved as well.

Create types for the cmd, mode1, mode2, mode3 fields of a PVR header. Redefine pvr_poly_hdr_t to use these new types, in a fully backwards-compatible manner.

This allows applications to create poly headers directly, without having to go through creating a poly context that is later "compiled". It also greatly improves documentation, if only because of the type system.