### PR TITLE
Keyboard Cleanup Part 2 + Event Driven API

### DIFF
--- a/examples/dreamcast/libdream/keyboard/keyboard.c
+++ b/examples/dreamcast/libdream/keyboard/keyboard.c
@@ -4,11 +4,24 @@
 /* Display constants */
 #define SCREEN_WIDTH        640
 #define SCREEN_HEIGHT       480
+#define MARGIN_HORIZONTAL   20
+#define MARGIN_VERTICAL     20
+#define PATTERN_OFFSET      64
 
-void kb_test(void) {
+/* Structure holding cursor state */
+typedef struct {
+    int x;
+    int y;
+    mutex_t m;
+} cursor_t;
+
+/* Function for performing textual input style polling logic by
+   popping keys off of the pending keyboard queue to process.
+*/
+static void kb_test(cursor_t *cursor) {
     maple_device_t *cont, *kbd;
     cont_state_t *state;
-    int k, x = 20, y = 20 + BFONT_HEIGHT;
+    int k;
 
     printf("Now doing keyboard test\n");
 
@@ -29,14 +42,6 @@ void kb_test(void) {
 
         if(!kbd) continue;
 
-        thd_sleep(10);
-
-        /* Check for keyboard input */
-        /* if (kbd_poll(mkb)) {
-            printf("Error checking keyboard status\n");
-            return;
-        } */
-
         /* Keep popping keys while there are more enqueued. */
         while((k = kbd_queue_pop(kbd, true)) != KBD_QUEUE_END) {
             /* Quit if ESC key is pressed. */
@@ -50,35 +55,83 @@ void kb_test(void) {
                 printf("Special key %04x\n", k);
 
             /* Handle every key that isn't the RETURN key. */
-            if(k != '\r') {
+            else if(k != '\r') {
+                mutex_lock(&cursor->m);
                 /* Draw the key we just pressed. */
-                bfont_draw(vram_s + y * SCREEN_WIDTH + x, SCREEN_WIDTH, 0, k);
+                bfont_draw(vram_s + cursor->y * SCREEN_WIDTH + cursor->x,
+                           SCREEN_WIDTH, 0, k);
 
                 /* Advance the cursor horizontally. */
-                x += BFONT_THIN_WIDTH;
-            }
-            else {
-                x = 20;
-                y += BFONT_HEIGHT;
+                cursor->x += BFONT_THIN_WIDTH;
+
+                /* Implement wrapping if we're at the end of the line. */
+                if(cursor->x >= (SCREEN_WIDTH - MARGIN_HORIZONTAL)) {
+                    cursor->x = MARGIN_HORIZONTAL;
+                    cursor->y += BFONT_HEIGHT;
+                }
+
+                mutex_unlock(&cursor->m);
             }
         }
+    }
+}
 
-        thd_sleep(10);
+/* Asynchronous callback function which is invoked by the keyboard
+   driver any time a key's state changes. This is what you want to
+   use when using the keyboard as a traditional controller-like input-
+   device.
+*/
+static void on_key_event(maple_device_t *dev, kbd_key_t key,
+                         key_state_t state, kbd_mods_t mods,
+                         kbd_leds_t leds, void *user_data) {
+    /* Retrieve keyboard state from maple device. */
+    kbd_state_t *kbd_state = kbd_get_state(dev);
+    /* Fetch cursor from generic userdata pointer. */
+    cursor_t *cursor = user_data;
+
+    /* Print keyboard address + key ID and state change type. */
+    printf("[%c%u] %c: %s\n",
+           'A' + dev->port, dev->unit,
+           kbd_key_to_ascii(key, 1, mods, leds),
+           state.value == KEY_STATE_CHANGED_DOWN? "PRESSED" : "RELEASED");
+
+    /* Check whether the RETURN key was pressed (but not held): */
+    if(key == KBD_KEY_ENTER && state.value == KEY_STATE_CHANGED_DOWN) {
+        if(mutex_trylock(&cursor->m)) return;
+        /* Advance cursor to the next line. */
+        cursor->x = MARGIN_HORIZONTAL;
+        cursor->y += BFONT_HEIGHT;
+        mutex_unlock(&cursor->m);
     }
 }
 
 int main(int argc, char **argv) {
     int x, y;
 
+    /* Initialize our cursor in the top-left. */
+    cursor_t cursor = {
+        .x = MARGIN_HORIZONTAL,
+        .y = MARGIN_VERTICAL + BFONT_HEIGHT,
+        .m = ERRORCHECK_MUTEX_INITIALIZER
+    };
+
     for(y = 0; y < SCREEN_HEIGHT; y++)
         for(x = 0; x < SCREEN_WIDTH; x++) {
-            int c = (x ^ y) & 255;
+            int c = ((x % PATTERN_OFFSET) ^
+                     (y % PATTERN_OFFSET)) & 0xff;
             vram_s[y * SCREEN_WIDTH + x] = ((c >> 3) << 12)
                                          | ((c >> 2) << 5)
                                          | ((c >> 3) << 0);
         }
 
-    kb_test();
+    /* Install a custom keyboard event handler which will listen for
+       key state changes, passing it our cursor. This drives the keyboard
+       as a controller-like input device.
+    */
+    kbd_set_event_handler(on_key_event, &cursor);
+
+    /* Run our main logic which drives the keyboard as a text-input device. */
+    kb_test(&cursor);
 
     return EXIT_SUCCESS;
 }

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -581,7 +581,7 @@ static void kbd_check_poll(maple_frame_t *frm) {
     state->last_modifiers = cond->modifiers;
 
     /* Process all pressed keys */
-    for(i = 0; i < MAX_PRESSED_KEYS; i++) {
+    for(i = 0; i < KBD_MAX_PRESSED_KEYS; i++) {
 
         /* Once we get to a 'none', the rest will be 'none' */
         if(cond->keys[i] == KBD_KEY_NONE) {

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -333,7 +333,10 @@ char kbd_key_to_ascii(kbd_key_t key, kbd_region_t region,
 
     This is a hardware constant. The define prevents the magic number '6' from appearing.
 **/
-#define MAX_PRESSED_KEYS 6
+#define KBD_MAX_PRESSED_KEYS 6
+
+/* Short-term compatibility helper. */
+static const int MAX_PRESSED_KEYS   __depr("Please use KBD_MAX_PRESSED_KEYS.") = KBD_MAX_PRESSED_KEYS;
 
 /** \brief   Maximum number of keys a DC keyboard can have.
 
@@ -355,7 +358,7 @@ typedef void kbd_keymap_t __depr("Please open an issue, there should be no reaso
 typedef struct {
     kbd_mods_t modifiers;    /**< \brief Bitmask of set modifiers. */
     kbd_leds_t leds;         /**< \brief Bitmask of set LEDs */
-    kbd_key_t keys[MAX_PRESSED_KEYS];      /**< \brief Key codes for currently pressed keys. */
+    kbd_key_t keys[KBD_MAX_PRESSED_KEYS];      /**< \brief Key codes for currently pressed keys. */
 } kbd_cond_t;
 
 /** \brief   Keyboard status structure.


### PR DESCRIPTION
Second split from #503 . Recreates the changes with more atomic commits while integrating additional changes and backwards compatibility.

Includes:
- `kbd_state_t'`s "key matrix" has been modified to store both the current frame and previous frame's key states, which allows for the driver to check for state changes and emit events accordingly. This added zero extra space overhead, since we were storing key states within a byte anyway, and I'm only using two bits of it. This also optimized the key state tracking by setting it up to be a mere bitshift.
- Added an event-driven callback mechanism for registering a callback to be invoked whenever a key changes states (similar to how Qt, GTk, and high-level widgeting frameworks process key events).
- Adjusted libDream's keyboard example to show off event-driven handler mechanism.
- Rename `MAX_PRESSED_KEYS` to be in line with our naming scheme, but leaving deprecated compatibility helper.
- Clean up some internal typing and remove a duplicated set of keymaps for the global queue.