### PR TITLE
Update gitignore to ignore intermediate bin2c file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ kernel/stubs/*.c
 kernel/exports/kernel_exports.c
 kernel/arch/dreamcast/kernel/arch_exports.c
 kernel/arch/dreamcast/kernel/banner.h
+kernel/arch/dreamcast/sound/snd_stream_drv.c
 kernel/arch/dreamcast/sound/arm/stream.drv
 utils/bincnv/bincnv
 utils/genromfs/genromfs


### PR DESCRIPTION
With #977 the ARM firmware is now using bin2c so
an intermediary .c file is created that should
be ignored by git.