### PR TITLE
Add special events for controller callback

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -8,6 +8,7 @@
  */
 
 #include <arch/arch.h>
+#include <arch/timer.h>
 #include <dc/maple.h>
 #include <dc/maple/controller.h>
 #include <kos/mutex.h>
@@ -180,6 +181,10 @@ static void cont_reply(maple_state_t *st, maple_frame_t *frm) {
     cooked->joy2x = ((int)raw->joy2x) - 128;
     cooked->joy2y = ((int)raw->joy2y) - 128;
 
+    /* If any button pressed, reset the last pressed timer */
+    if(cooked->buttons)
+       cooked->last_press = timer_ms_gettime64();
+
     /* If someone is in the middle of modifying the list, don't process callbacks */
     if(mutex_trylock(&btn_cbs_mtx))
         return;
@@ -189,7 +194,18 @@ static void cont_reply(maple_state_t *st, maple_frame_t *frm) {
         if(!c->addr ||
                 (c->addr &&
                  c->addr == maple_addr(frm->dev->port, frm->dev->unit))) {
-            if(((cooked->buttons & c->btns) == c->btns) ||
+            /* Check for timeout trigger */
+            if(((c->btns) & CONT_CB_TIMEOUT(0)) &&
+            ((timer_ms_gettime64() - cooked->last_press) >= ((c->btns) & CONT_CB_ANY))) {
+                /* Reset last_press timeout after trigger */
+                cooked->last_press = timer_ms_gettime64();
+
+                c->cur_btns = 0;
+                c->cur_addr = maple_addr(frm->dev->port, frm->dev->unit);
+                thd_worker_wakeup(c->worker);
+            }
+            /* Check for specific button combo OR press of a subset of buttons */
+            else if(((cooked->buttons & c->btns) == c->btns) ||
                ((cooked->buttons & c->btns) && ((c->btns) & CONT_CB_ANY)))
             {
                 c->cur_btns = cooked->buttons;
@@ -222,12 +238,21 @@ static void cont_periodic(maple_driver_t *drv) {
     maple_driver_foreach(drv, cont_poll);
 }
 
+static int cont_attach(maple_driver_t *drv, maple_device_t *dev) {
+    (void)drv;
+
+    cont_state_t *state = (cont_state_t *)(dev->status);
+    state->last_press = timer_ms_gettime64();
+    return 0;
+}
+
 /* Device Driver Struct */
 static maple_driver_t controller_drv = {
     .functions = MAPLE_FUNC_CONTROLLER,
     .name = "Controller Driver",
     .periodic = cont_periodic,
-    .status_size = sizeof(cont_state_t)
+    .status_size = sizeof(cont_state_t),
+    .attach = cont_attach
 };
 
 /* Add the controller to the driver chain */

--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -189,7 +189,9 @@ static void cont_reply(maple_state_t *st, maple_frame_t *frm) {
         if(!c->addr ||
                 (c->addr &&
                  c->addr == maple_addr(frm->dev->port, frm->dev->unit))) {
-            if((cooked->buttons & c->btns) == c->btns) {
+            if(((cooked->buttons & c->btns) == c->btns) ||
+               ((cooked->buttons & c->btns) && ((c->btns) & CONT_CB_ANY)))
+            {
                 c->cur_btns = cooked->buttons;
                 c->cur_addr = maple_addr(frm->dev->port, frm->dev->unit);
                 thd_worker_wakeup(c->worker);

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -185,6 +185,8 @@ typedef struct cont_state {
     int joyy;     /**< \brief Main joystick y-axis value. */
     int joy2x;    /**< \brief Secondary joystick x-axis value. */
     int joy2y;    /**< \brief Secondary joystick y-axis value. */
+
+    uint64_t last_press;    /**< \brief Timestamp of last button press in ms. */
 } cont_state_t;
 
 /** \brief   Controller automatic callback type.
@@ -240,7 +242,8 @@ int cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb);
 
     @{
 */
-#define CONT_CB_ANY BIT(16)      /**< \brief Match if any passed button pressed. */
+#define CONT_CB_ANY         BIT(16)      /**< \brief Match if any passed button pressed. */
+#define CONT_CB_TIMEOUT(x)  ((CONT_ALL & x) | BIT(17))  /**< \brief Match if no button pressed in x ms. */
 /** @} */
 
 /** \defgroup controller_query_caps Querying Capabilities

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -127,6 +127,15 @@ __BEGIN_DECLS
 */
 #define CONT_RESET_BUTTONS  (CONT_A | CONT_B | CONT_X | CONT_Y | CONT_START)
 
+/** \brief   All controller buttons at once
+    \ingroup controller_inputs
+
+    Convenience macro providing all buttons pressed at once.
+    This can be used in conjunction with CONT_CB_ANY to match
+    any button press.
+*/
+#define CONT_ALL            (GENMASK(15,0))
+
 /** \brief   Controller state structure.
     \ingroup controller_inputs
 
@@ -199,7 +208,7 @@ typedef void (*cont_btn_callback_t)(uint8_t addr, uint32_t btns);
     \ingroup controller_inputs
 
     This function sets a callback function to be called when the specified
-    controller has the set of buttons given pressed.
+    controller has the set of buttons given pressed or special events.
 
     \note 
     The callback gets invoked for the given maple port; however, providing
@@ -212,12 +221,27 @@ typedef void (*cont_btn_callback_t)(uint8_t addr, uint32_t btns);
 
     \param  addr            The controller to listen on (or 0 for all ports). 
                             This value can be obtained by using maple_addr().
-    \param  btns            The buttons bitmask to match.
+    \param  btns            The buttons bitmask to match. May also be a special
+                            event code.
     \param  cb              The callback to call when the buttons are pressed.
                             Passing NULL will uninstall all callbacks on the
                             addr/btns combination.
+
+    \sa controller_cb_events
 */
 int cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb);
+
+/** \defgroup controller_cb_events Events
+    \brief    Controller Callback Events
+    \ingroup  controller_inputs
+
+    A set of special event codes sent in the top 16 bits of the btns
+    param of cont_btn_callback.
+
+    @{
+*/
+#define CONT_CB_ANY BIT(16)      /**< \brief Match if any passed button pressed. */
+/** @} */
 
 /** \defgroup controller_query_caps Querying Capabilities
     \brief    API used to query for a controller's capabilities

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -27,6 +27,7 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
+#include <kos/regfield.h>
 #include <stdint.h>
 #include <kos/regfield.h>
 


### PR DESCRIPTION
Adding two 'special events' that can be used with the controller callbacks. 
- `CONT_CB_ANY` when OR'd in with buttons will cause the callback to trigger if any of the buttons is pressed rather than all.
- `CONT_ALL` all buttons pressed. This should be impossible with regular usage as it would require a fictional controller with all 16 possible buttons and for them to all be pressed. But it's quite useful in combination with `CONT_CB_ANY` to trigger based on any button press.
- `CONT_CB_TIMEOUT(x)` trigger if there has been no button pressed for at least `x` ms. When the 0 option is chosen for address, indicating 'any controller' this checks the same condition per-controller (rather than checking if no controller had input).

Still pondering factorization and any other possible ones to add in. Also need to test, as it was written cold. May create an example to pair with it.