### PR TITLE
SD Card: Multi-interface support with CRC options

### DIFF
--- a/examples/dreamcast/filesystem/sd/speedtest/sd-speedtest.c
+++ b/examples/dreamcast/filesystem/sd/speedtest/sd-speedtest.c
@@ -1,10 +1,11 @@
 /* KallistiOS ##version##
 
-   speedtest.c
-   Copyright (C) 2023 Ruslan Rostovtsev (SWAT)
+   sd-speedtest.c
+   Copyright (C) 2023, 2025 Ruslan Rostovtsev
 
-   This example program simply attempts to read some sectors from the first
-   partition of an SD device attached to SCIF and then show the timing information.
+   This example program performs speed tests for reading sectors from the first
+   partition of an SD device using both SCI-SPI and SCIF-SPI interfaces with
+   CRC checking enabled and disabled, and then shows the timing information.
 */
 
 #include <stdio.h>
@@ -12,6 +13,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <errno.h>
 
 #include <dc/sd.h>
@@ -27,7 +29,9 @@
 
 KOS_INIT_FLAGS(INIT_DEFAULT);
 
-static uint8_t tbuf[1024 * 512] __attribute__((aligned(32)));
+#define TEST_BLOCK_COUNT 1024
+
+static uint8_t tbuf[TEST_BLOCK_COUNT * 512] __attribute__((aligned(32)));
 
 static void __attribute__((__noreturn__)) wait_exit(void) {
     maple_device_t *dev;
@@ -49,36 +53,38 @@ static void __attribute__((__noreturn__)) wait_exit(void) {
     }
 }
 
-int main(int argc, char *argv[]) {
+static int run_speed_test(sd_interface_t interface, bool check_crc) {
+    sd_init_params_t params = {
+        .interface = interface,
+        .check_crc = check_crc
+    };
     kos_blockdev_t sd_dev;
     uint64_t begin, end, timer, average;
     uint64_t sum = 0;
     uint8_t pt;
     int i;
 
-    dbgio_dev_select("fb");
-    dbglog(DBG_DEBUG, "Initializing SD card.\n");
+    const char *interface_name = (interface == SD_IF_SCI) ? "SCI-SPI" : "SCIF-SPI";
 
-    if(sd_init()) {
-        dbglog(DBG_DEBUG, "Could not initialize the SD card. Please make sure that you "
-               "have an SD card adapter plugged in and an SD card inserted.\n");
-        wait_exit();
+    while(sd_init_ex(&params)) {
+        dbglog(DBG_DEBUG, "Could not initialize the SD card on %s interface.\n", interface_name);
+        return -1;
     }
 
     /* Grab the block device for the first partition on the SD card. Note that
        you must have the SD card formatted with an MBR partitioning scheme. */
     if(sd_blockdev_for_partition(0, &sd_dev, &pt)) {
         dbglog(DBG_DEBUG, "Could not find the first partition on the SD card!\n");
-        wait_exit();
+        sd_shutdown();
+        return -1;
     }
-
-    dbglog(DBG_DEBUG, "Calculating average speed for reading 1024 blocks.\n");
 
     for(i = 0; i < 10; i++) {
         begin = timer_ms_gettime64();
 
-        if(sd_dev.read_blocks(&sd_dev, 0, 1024, tbuf)) {
+        if(sd_dev.read_blocks(&sd_dev, 0, TEST_BLOCK_COUNT, tbuf)) {
             dbglog(DBG_DEBUG, "couldn't read block: %s\n", strerror(errno));
+            sd_shutdown();
             return -1;
         }
 
@@ -89,10 +95,38 @@ int main(int argc, char *argv[]) {
 
     average = sum / 10;
 
-    dbglog(DBG_DEBUG, "SD card read average took %llu ms (%.3f KB/sec)\n",
-           average, (512 * 1024) / ((double)average));
+    dbglog(DBG_DEBUG, "%s: read average took %llu ms (%.3f KB/sec)\n",
+           interface_name, average, (512 * TEST_BLOCK_COUNT) / ((double)average));
 
     sd_shutdown();
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    // dbgio_dev_select("fb");
+
+    dbglog(DBG_DEBUG, "Starting SD card speed tests\n");
+
+    dbglog(DBG_DEBUG, "Testing SCI-SPI interface with CRC disabled\n");
+    if (run_speed_test(SD_IF_SCI, false) == 0) {
+        dbglog(DBG_DEBUG, "Testing SCI-SPI interface with CRC enabled\n");
+        run_speed_test(SD_IF_SCI, true);
+    }
+    else {
+        dbglog(DBG_DEBUG, "Skipping SCI-SPI interface with CRC enabled\n");
+    }
+
+    dbglog(DBG_DEBUG, "Testing SCIF-SPI interface with CRC disabled\n");
+    if (run_speed_test(SD_IF_SCIF, false) == 0) {
+        dbglog(DBG_DEBUG, "Testing SCIF-SPI interface with CRC enabled\n");
+        run_speed_test(SD_IF_SCIF, true);
+    }
+    else {
+        dbglog(DBG_DEBUG, "Skipping SCIF-SPI interface with CRC enabled\n");
+    }
+
+    dbglog(DBG_DEBUG, "All tests completed\n");
+
     wait_exit();
     return 0;
 }

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -77,6 +77,15 @@ sci_spi_read_data
 sci_spi_dma_write_data
 sci_spi_dma_read_data
 
+# SD Card
+sd_init
+sd_init_ex
+sd_shutdown
+sd_read_blocks
+sd_write_blocks
+sd_get_size
+sd_blockdev_for_partition
+
 # Timers
 timer_prime
 timer_start

--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -85,6 +85,7 @@ sd_read_blocks
 sd_write_blocks
 sd_get_size
 sd_blockdev_for_partition
+sd_blockdev_for_device
 
 # Timers
 timer_prime

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -103,6 +103,7 @@ sd_read_blocks
 sd_write_blocks
 sd_get_size
 sd_blockdev_for_partition
+sd_blockdev_for_device
 
 # Timers
 timer_prime

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -95,6 +95,15 @@ sci_spi_read_data
 sci_spi_dma_write_data
 sci_spi_dma_read_data
 
+# SD Card
+sd_init
+sd_init_ex
+sd_shutdown
+sd_read_blocks
+sd_write_blocks
+sd_get_size
+sd_blockdev_for_partition
+
 # Timers
 timer_prime
 timer_start

--- a/kernel/arch/dreamcast/hardware/sd.c
+++ b/kernel/arch/dreamcast/hardware/sd.c
@@ -134,7 +134,10 @@ static void sci_write_byte_wrapper(uint8_t data) {
 }
 
 static void sci_read_data_wrapper(uint8_t *data, size_t len) {
-    sci_spi_dma_read_data(data, len, NULL, NULL);
+    if(len & 31)
+        sci_spi_read_data(data, len);
+    else
+        sci_spi_dma_read_data(data, len, NULL, NULL);
 }
 
 static void sci_write_data_wrapper(const uint8_t *data, size_t len) {

--- a/kernel/arch/dreamcast/include/dc/sd.h
+++ b/kernel/arch/dreamcast/include/dc/sd.h
@@ -202,6 +202,22 @@ uint64 sd_get_size(void);
 int sd_blockdev_for_partition(int partition, kos_blockdev_t *rv,
                               uint8 *partition_type);
 
+/** \brief  Get a block device for the SD card.
+
+    This function creates a block device descriptor for the attached SD card.
+    This block device is used to interface with various filesystems on the device.
+
+    \param  rv              Used to return the block device. Must be non-NULL.
+    \retval 0               On success.
+    \retval -1              On error, errno will be set as appropriate.
+
+    \par    Error Conditions:
+    \em     ENXIO - SD card support was not initialized
+    \em     EFAULT - rv was NULL
+    \em     ENOMEM - out of memory
+*/
+int sd_blockdev_for_device(kos_blockdev_t *rv);
+
 /** @} */
 
 __END_DECLS


### PR DESCRIPTION
This PR enhances the SD card functionality by expanding interface support and configuration options:

- Support for old SCIF-SPI and new SCI-SPI interfaces
- Configurable CRC checking options for each interface
- Improved speed test example to support all features.

```
Testing SCI-SPI interface with CRC disabled
SCI-SPI: read average took 357 ms (1468.594 KB/sec)

Testing SCI-SPI interface with CRC enabled
SCI-SPI: read average took 415 ms (1263.345 KB/sec)

Testing SCIF-SPI interface with CRC disabled
SCIF-SPI: read average took 697 ms (752.207 KB/sec)

Testing SCIF-SPI interface with CRC enabled
SCIF-SPI: read average took 756 ms (693.503 KB/sec)
```

**Do not merge until #978**

**Guide for SCI mod on the Sega Dreamcast and NAOMI**
http://www.dc-swat.ru/blog/hardware/1143.html