### PR TITLE
Correct and apply the `__pure` attribute

### DIFF
--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -47,12 +47,6 @@
 #define __noreturn  __attribute__((__noreturn__))
 #endif
 
-#ifndef __pure
-/** \brief  Identify a function that has no side effects other than its return,
-            and only uses its arguments for any work. */
-#define __pure      __attribute__((__const__))
-#endif
-
 #ifndef __unused
 /** \brief  Identify a function or variable that may be unused. */
 #define __unused    __attribute__((__unused__))
@@ -76,11 +70,6 @@
 #ifndef __dead2
 /** \brief  Alias for \ref __noreturn. For BSD compatibility. */
 #define __dead2     __noreturn  /* BSD compat */
-#endif
-
-#ifndef __pure2
-/** \brief  Alias for \ref __pure. For BSD compatibility. */
-#define __pure2     __pure      /* ditto */
 #endif
 
 #ifndef __likely

--- a/include/kos/net.h
+++ b/include/kos/net.h
@@ -299,7 +299,7 @@ void net_arp_shutdown(void);
     \param  timestamp       The entry's timestamp. Set to 0 for a permanent
                             entry, otherwise set to the current number of
                             milliseconds since boot (i.e, timer_ms_gettime64()).
-    
+
     \retval 0               On success.
     \retval -1              Error allocating memory.
 */
@@ -320,7 +320,7 @@ int net_arp_insert(netif_t *nif, const uint8_t mac[6], const uint8_t ip[4],
                             response comes in (if not found immediately).
     \param  data            Packet data to go with the header.
     \param  data_size       The size of data.
-    
+
     \retval 0               On success.
     \retval -1              A query is outstanding for that address.
     \retval -2              Address not found, query generated.
@@ -338,7 +338,7 @@ int net_arp_lookup(netif_t *nif, const uint8_t ip_in[4], uint8_t mac_out[6],
     \param  nif             The network device in use.
     \param  ip_out          Storage for the IPv4 address.
     \param  mac_in          The MAC address to look up.
-    
+
     \retval 0               On success.
     \retval -1              On failure.
 */
@@ -350,7 +350,7 @@ int net_arp_revlookup(netif_t *nif, uint8_t ip_out[4], const uint8_t mac_in[6]);
     \param  nif             The network device in use.
     \param  pkt             The packet received.
     \param  len             The length of the packet.
-    
+
     \retval 0               On success (no error conditions defined).
 */
 int net_arp_input(netif_t *nif, const uint8_t *pkt, int len);
@@ -360,7 +360,7 @@ int net_arp_input(netif_t *nif, const uint8_t *pkt, int len);
 
     \param  nif             The network device to use.
     \param  ip              The IP to query.
-    
+
     \retval 0               On success (no error conditions defined).
 */
 int net_arp_query(netif_t *nif, const uint8_t ip[4]);
@@ -374,12 +374,12 @@ int net_arp_query(netif_t *nif, const uint8_t ip[4]);
     \param  nif             The network device in use.
     \param  pkt             The packet received.
     \param  len             The length of the packet, in bytes.
-    
+
     \return                 0 on success, <0 on failure.
 */
 typedef int (*net_input_func)(netif_t *nif, const uint8_t *pkt, int len);
 
-/** \brief   Where will input packets be routed? 
+/** \brief   Where will input packets be routed?
     \ingroup networking_drivers
  */
 extern net_input_func net_input_target;
@@ -394,7 +394,7 @@ extern net_input_func net_input_target;
     \param  device          The network device submitting packets.
     \param  data            The packet to submit.
     \param  len             The length of the packet, in bytes.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_input(netif_t *device, const uint8_t *data, int len);
@@ -403,7 +403,7 @@ int net_input(netif_t *device, const uint8_t *data, int len);
     \ingroup networking_drivers
 
     \param  t               The new target callback.
-    
+
     \return                 The old target.
 */
 net_input_func net_input_set_target(net_input_func t);
@@ -448,13 +448,13 @@ extern net_echo_cb net_icmp_echo_cb;
     \param  seq             A packet sequence number.
     \param  data            Data to send with the packet.
     \param  size            The size of the data to send.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp_send_echo(netif_t *net, const uint8_t ipaddr[4], uint16_t ident,
                        uint16_t seq, const uint8_t *data, size_t size);
 
-/** \defgroup networking_icmp_unreach Unreachable Values 
+/** \defgroup networking_icmp_unreach Unreachable Values
     \brief    Valid values for net_icmp_send_dest_unreach().
     \ingroup  networking_icmpv4
     @{
@@ -470,7 +470,7 @@ int net_icmp_send_echo(netif_t *net, const uint8_t ipaddr[4], uint16_t ident,
     \param  net             The network device to use.
     \param  code            The type of message this is.
     \param  msg             The message that caused this error.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp_send_dest_unreach(netif_t *net, uint8_t code, const uint8_t *msg);
@@ -483,11 +483,11 @@ int net_icmp_send_dest_unreach(netif_t *net, uint8_t code, const uint8_t *msg);
 
 /** \brief   Send an ICMP Time Exceeded packet in reply to the given message.
     \ingroup networking_icmp
-    
+
     \param  net             The network device to use.
     \param  code            The type of message this is.
     \param  msg             The message that caused this error.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp_send_time_exceeded(netif_t *net, uint8_t code, const uint8_t *msg);
@@ -523,15 +523,15 @@ net_ipv4_stats_t net_ipv4_get_stats(void);
     \ingroup networking_ipv4
 
     \param  addr            Array of IP address octets.
-    
+
     \return                 The address, in host byte order.
 */
-uint32_t net_ipv4_address(const uint8_t addr[4]);
+uint32_t __pure net_ipv4_address(const uint8_t addr[4]);
 
 /** \brief   Parse an IP address that is packet into a uint32 into an array of
              the individual bytes.
     \ingroup networking_ipv4
-    
+
     \param  addr            The full address, in host byte order.
     \param  out             The output buffer.
 */
@@ -547,7 +547,7 @@ void net_ipv4_parse_address(uint32_t addr, uint8_t out[4]);
 
 /** \brief   ICMPv6 echo reply callback type.
     \ingroup networking_icmpv6
-    
+
     \param  ip              The IPv6 address the reply is from.
     \param  seq             The sequence number of the packet.
     \param  delta_us        The time difference, in microseconds.
@@ -566,14 +566,14 @@ extern net6_echo_cb net_icmp6_echo_cb;
 
 /** \brief   Send an ICMPv6 Echo (PING6) packet to the specified device.
     \ingroup networking_icmpv6
-    
+
     \param  net             The network device to use.
     \param  dst             The address to send to.
     \param  ident           A packet identifier.
     \param  seq             A packet sequence number.
     \param  data            Data to send with the packet.
     \param  size            Length of the data, in bytes.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp6_send_echo(netif_t *net, const struct in6_addr *dst, uint16_t ident,
@@ -581,12 +581,12 @@ int net_icmp6_send_echo(netif_t *net, const struct in6_addr *dst, uint16_t ident
 
 /** \brief   Send a Neighbor Solicitation packet on the specified device.
     \ingroup networking_icmpv6
-    
+
     \param  net             The network device to use.
     \param  dst             The destination address.
     \param  target          The target address.
     \param  dupdet          1 if this is for duplicate detection.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp6_send_nsol(netif_t *net, const struct in6_addr *dst,
@@ -594,12 +594,12 @@ int net_icmp6_send_nsol(netif_t *net, const struct in6_addr *dst,
 
 /** \brief   Send a Neighbor Advertisement packet on the specified device.
     \ingroup networking_icmpv6
-    
+
     \param  net             The network device to use.
     \param  dst             The destination address.
     \param  target          The target address.
     \param  sol             1 if solicited, 0 otherwise.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp6_send_nadv(netif_t *net, const struct in6_addr *dst,
@@ -607,9 +607,9 @@ int net_icmp6_send_nadv(netif_t *net, const struct in6_addr *dst,
 
 /** \brief   Send a Router Solicitation request on the specified interface.
     \ingroup networking_icmpv6
-    
+
     \param  net             The network device to use.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp6_send_rsol(netif_t *net);
@@ -638,7 +638,7 @@ int net_icmp6_send_rsol(netif_t *net);
     \param  code            The type of message this is.
     \param  ppkt            The message that caused this error.
     \param  psz             Size of the original message.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp6_send_dest_unreach(netif_t *net, uint8_t code, const uint8_t *ppkt,
@@ -648,7 +648,7 @@ int net_icmp6_send_dest_unreach(netif_t *net, uint8_t code, const uint8_t *ppkt,
     \brief                                    Time exceeded codes for ICMPv6
     \ingroup                                  networking_icmpv6
 
-    Only fragment reassembly time exceeded makes sense 
+    Only fragment reassembly time exceeded makes sense
 
     @{
 */
@@ -658,12 +658,12 @@ int net_icmp6_send_dest_unreach(netif_t *net, uint8_t code, const uint8_t *ppkt,
 
 /** \brief   Send a time exceeded message on the specified interface.
     \ingroup networking_icmpv6
-    
+
     \param  net             The network device to use.
     \param  code            The error code.
     \param  ppkt            The message that caused this error.
     \param  psz             Size of the original packet.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp6_send_time_exceeded(netif_t *net, uint8_t code, const uint8_t *ppkt,
@@ -681,13 +681,13 @@ int net_icmp6_send_time_exceeded(netif_t *net, uint8_t code, const uint8_t *ppkt
 
 /** \brief   Send an ICMPv6 Parameter Problem about the given packet.
     \ingroup networking_icmpv6
-    
+
     \param  net             The network device to use.
     \param  code            The error code.
     \param  ptr             Where in the packet is the error?
     \param  ppkt            The message that caused the error.
     \param  psz             Size of the original packet.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_icmp6_send_param_prob(netif_t *net, uint8_t code, uint32_t ptr,
@@ -795,13 +795,13 @@ typedef struct net_udp_stats {
 } net_udp_stats_t;
 
 /** \brief  Retrieve statistics from the UDP layer.
-    
+
     \return                 The global UDP stats struct.
 */
 net_udp_stats_t net_udp_get_stats(void);
 
 /** \brief  Init UDP.
-    
+
     \retval 0               On success (no error conditions defined).
 */
 int net_udp_init(void);
@@ -838,25 +838,25 @@ void net_tcp_shutdown(void);
 */
 
 /** \brief  Calculate a "little-endian" CRC-32 over a block of data.
-    
+
     \param  data            The data to calculate over.
     \param  size            The size of the data, in bytes.
-    
+
     \return                 The calculated CRC-32.
 */
-uint32_t net_crc32le(const uint8_t *data, int size);
+uint32_t __pure net_crc32le(const uint8_t *data, int size);
 
 /** \brief  Calculate a "big-endian" CRC-32 over a block of data.
-    
+
     \param  data            The data to calculate over.
     \param  size            The size of the data, in bytes.
-    
+
     \return                 The calculated CRC-32.
 */
-uint32_t net_crc32be(const uint8_t *data, int size);
+uint32_t __pure net_crc32be(const uint8_t *data, int size);
 
 /** \brief  Calculate a CRC16-CCITT over a block of data.
-    
+
     \note                   Based on code found online at
                             http://www.ccsinfo.com/forum/viewtopic.php?t=24977
 
@@ -866,10 +866,10 @@ uint32_t net_crc32be(const uint8_t *data, int size);
                             return value from this function (if continuing a
                             previous calculation) or some initial seed value
                             (typically 0xFFFF or 0x0000).
-    
+
     \return                 The calculated CRC16-CCITT.
 */
-uint16_t net_crc16ccitt(const uint8_t *data, int size, uint16_t start);
+uint16_t __pure net_crc16ccitt(const uint8_t *data, int size, uint16_t start);
 
 /** @} */
 
@@ -921,14 +921,14 @@ void net_multicast_shutdown(void);
 
 /***** net_core.c *********************************************************/
 
-/** \brief   Interface list; note: do not manipulate directly! 
+/** \brief   Interface list; note: do not manipulate directly!
     \ingroup networking_drivers
  */
 extern struct netif_list net_if_list;
 
 /** \brief   Function to retrieve the interface list.
     \ingroup networking_drivers
-    
+
     \warning
     Do not manipulate what this returns to you!
 
@@ -936,8 +936,8 @@ extern struct netif_list net_if_list;
 */
 struct netif_list * net_get_if_list(void);
 
-/** \brief   The default network device, used with sockets (read-only). 
-    \ingroup networking_drivers    
+/** \brief   The default network device, used with sockets (read-only).
+    \ingroup networking_drivers
 */
 extern netif_t *net_default_dev;
 
@@ -945,7 +945,7 @@ extern netif_t *net_default_dev;
     \ingroup networking_drivers
 
     \param  n               The device to set as default.
-    
+
     \return                 The old default device.
 */
 netif_t *net_set_default(netif_t *n);
@@ -963,14 +963,14 @@ int net_reg_device(netif_t *device);
     \ingroup networking_drivers
 
     \param  device          The device to unregister.
-    
+
     \return                 0 on success, <0 on failure.
 */
 int net_unreg_device(netif_t *device);
 
 /** \brief   Init network support.
     \ingroup networking_drivers
-    
+
     \note                   To auto-detect the IP address to assign to the
                             default device (i.e, over DHCP or from the flashrom
                             on the Dreamcast), pass 0 as the IP parameter.
@@ -982,7 +982,7 @@ int net_unreg_device(netif_t *device);
 */
 int net_init(uint32_t ip);
 
-/** \brief   Shutdown network support. 
+/** \brief   Shutdown network support.
     \ingroup networking_drivers
 */
 void net_shutdown(void);

--- a/kernel/arch/dreamcast/fs/vmufs.c
+++ b/kernel/arch/dreamcast/fs/vmufs.c
@@ -49,7 +49,7 @@ Function comments located in vmufs.h.
 static mutex_t mutex;
 
 /* Convert a decimal number to BCD; max of two digits */
-static uint8 dec_to_bcd(int dec) {
+static uint8 __pure dec_to_bcd(int dec) {
     uint8 rv = 0;
 
     rv = dec % 10;

--- a/kernel/arch/dreamcast/hardware/maple/controller.c
+++ b/kernel/arch/dreamcast/hardware/maple/controller.c
@@ -51,13 +51,13 @@ static TAILQ_HEAD(cont_btn_callback_list, cont_callback_params) btn_cbs;
 static mutex_t btn_cbs_mtx = MUTEX_INITIALIZER;
 
 /* Check whether the controller has EXACTLY the given capabilities. */
-int cont_is_type(const maple_device_t *cont, uint32_t type) {
+int __pure cont_is_type(const maple_device_t *cont, uint32_t type) {
     return cont ? cont->info.function_data[CONT_FUNCTION_DATA_INDEX] == type :
                   -1;
 }
 
 /* Check whether the controller has at LEAST the given capabilities. */
-int cont_has_capabilities(const maple_device_t *cont, uint32_t capabilities) {
+int __pure cont_has_capabilities(const maple_device_t *cont, uint32_t capabilities) {
     return cont ? ((cont->info.function_data[CONT_FUNCTION_DATA_INDEX] 
                    & capabilities) == capabilities) : -1;
 }

--- a/kernel/arch/dreamcast/hardware/ubc.c
+++ b/kernel/arch/dreamcast/hardware/ubc.c
@@ -76,7 +76,7 @@ static struct ubc_channel_state {
 } channel_state[ubc_channel_count] = { 0 };
 
 /* Translates ubc_access_t to BBR.ID field format. */
-inline static uint8_t get_access_mask(ubc_access_t access) {
+inline static uint8_t __pure get_access_mask(ubc_access_t access) {
     switch(access) {
     case ubc_access_either:
         return 0x3;
@@ -86,7 +86,7 @@ inline static uint8_t get_access_mask(ubc_access_t access) {
 }
 
 /* Translates ubc_rw_t to BBR.RW field format. */
-inline static uint8_t get_rw_mask(ubc_rw_t rw) {
+inline static uint8_t __pure get_rw_mask(ubc_rw_t rw) {
     switch(rw) {
     case ubc_rw_either:
         return 0x3;
@@ -96,7 +96,7 @@ inline static uint8_t get_rw_mask(ubc_rw_t rw) {
 }
 
 /* Translates ubc_address_mask_t to BASR.BAM field format. */
-inline static uint8_t get_address_mask(ubc_address_mask_t addr_mask) {
+inline static uint8_t __pure get_address_mask(ubc_address_mask_t addr_mask) {
     switch(addr_mask) {
         case ubc_address_mask_all:
             return 3;

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -340,7 +340,7 @@ int hardware_sys_mode(int *region);
 
     \return                 A pointer to the banner string.
 */
-const char *kos_get_banner(void);
+const char * __pure kos_get_banner(void);
 
 /** \brief   Retrieve the license information for the compiled copy of KOS.
     \ingroup attribution
@@ -351,7 +351,7 @@ const char *kos_get_banner(void);
 
     \return                 A pointer to the license terms.
 */
-const char *kos_get_license(void);
+const char * __pure kos_get_license(void);
 
 /** \brief   Retrieve a list of authors and the dates of their contributions.
     \ingroup attribution
@@ -367,7 +367,7 @@ const char *kos_get_license(void);
 
     \return                 A pointer to the authors' copyright information.
 */
-const char *kos_get_authors(void);
+const char *__pure kos_get_authors(void);
 
 /** \brief   Dreamcast specific sleep mode function.
     \ingroup arch

--- a/kernel/arch/dreamcast/include/dc/fmath.h
+++ b/kernel/arch/dreamcast/include/dc/fmath.h
@@ -46,7 +46,7 @@ __BEGIN_DECLS
     \brief  Floating point inner product.
     \return v1 dot v2 (inner product)
 */
-__FMINLINE float fipr(float x, float y, float z, float w,
+__FMINLINE float __pure fipr(float x, float y, float z, float w,
                       float a, float b, float c, float d) {
     return __fipr(x, y, z, w, a, b, c, d);
 }
@@ -55,7 +55,7 @@ __FMINLINE float fipr(float x, float y, float z, float w,
     \brief  Floating point inner product w/self (square of vector magnitude)
     \return v1 dot v1 (square of magnitude)
 */
-__FMINLINE float fipr_magnitude_sqr(float x, float y, float z, float w) {
+__FMINLINE float __pure fipr_magnitude_sqr(float x, float y, float z, float w) {
     return __fipr_magnitude_sqr(x, y, z, w);
 }
 
@@ -64,7 +64,7 @@ __FMINLINE float fipr_magnitude_sqr(float x, float y, float z, float w) {
     \param r a floating point number between 0 and 2*PI
     \return sin(r), where r is [0..2*PI]
 */
-__FMINLINE float fsin(float r) {
+__FMINLINE float __pure fsin(float r) {
     return __fsin(r);
 }
 
@@ -73,7 +73,7 @@ __FMINLINE float fsin(float r) {
     \param r a floating point number between 0 and 2*PI
     \return cos(r), where r is [0..2*PI]
 */
-__FMINLINE float fcos(float r) {
+__FMINLINE __pure float fcos(float r) {
     return __fcos(r);
 }
 
@@ -82,7 +82,7 @@ __FMINLINE float fcos(float r) {
     \param r a floating point number between 0 and 2*PI
     \return tan(r), where r is [0..2*PI]
 */
-__FMINLINE float ftan(float r) {
+__FMINLINE __pure float ftan(float r) {
     return __ftan(r);
 }
 
@@ -91,7 +91,7 @@ __FMINLINE float ftan(float r) {
     \param d an integer between 0 and 65535
     \return sin(d), where d is [0..65535]
 */
-__FMINLINE float fisin(int d) {
+__FMINLINE __pure float fisin(int d) {
     return __fisin(d);
 }
 
@@ -100,7 +100,7 @@ __FMINLINE float fisin(int d) {
     \param d an integer between 0 and 65535
     \return cos(d), where d is [0..65535]
 */
-__FMINLINE float ficos(int d) {
+__FMINLINE __pure float ficos(int d) {
     return __ficos(d);
 }
 
@@ -109,7 +109,7 @@ __FMINLINE float ficos(int d) {
     \param d an integer between 0 and 65535
     \return tan(d), where d is [0..65535]
 */
-__FMINLINE float fitan(int d) {
+__FMINLINE float __pure fitan(int d) {
     return __fitan(d);
 }
 
@@ -117,14 +117,14 @@ __FMINLINE float fitan(int d) {
     \brief Floating point square root
     \return sqrt(f)
 */
-__FMINLINE float fsqrt(float f) {
+__FMINLINE float __pure fsqrt(float f) {
     return __fsqrt(f);
 }
 
 /**
     \return 1.0f / sqrt(f)
 */
-__FMINLINE float frsqrt(float f) {
+__FMINLINE float __pure frsqrt(float f) {
     return __frsqrt(f);
 }
 
@@ -178,13 +178,12 @@ __FMINLINE void fsincosr(float f, float *s, float *c) {
     \note   Thanks to Fredrik Ehnbom for figuring this stuff out and posting it
             to the mailing list back in 2005!
 */
-__FMINLINE uint32_t pvr_pack_bump(float h, float t, float q) {
+__FMINLINE uint32_t __pure pvr_pack_bump(float h, float t, float q) {
     uint8_t hp = (uint8_t)(h * 255.0f);
     uint8_t k1 = ~hp;
     uint8_t k2 = (uint8_t)(hp * __fsin(t));
     uint8_t k3 = (uint8_t)(hp * __fcos(t));
     uint8_t qp = (uint8_t)((q / (2 * F_PI)) * 255.0f);
-
 
     return (k1 << 24) | (k2 << 16) | (k3 << 8) | qp;
 }

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -343,7 +343,7 @@ struct maple_device;
 
     \sa cont_is_type
 */
-int cont_has_capabilities(const struct maple_device *cont, uint32_t capabilities);
+int __pure cont_has_capabilities(const struct maple_device *cont, uint32_t capabilities);
 /** @} */
 
 /** \defgroup controller_query_types Querying Types
@@ -507,7 +507,7 @@ int cont_has_capabilities(const struct maple_device *cont, uint32_t capabilities
 
     \sa cont_has_capabilities
 */
-int cont_is_type(const struct maple_device *cont, uint32_t type);
+int __pure cont_is_type(const struct maple_device *cont, uint32_t type);
 
 /* \cond */
 /* Init / Shutdown */

--- a/kernel/arch/dreamcast/kernel/banner.c
+++ b/kernel/arch/dreamcast/kernel/banner.c
@@ -4,6 +4,7 @@
    Copyright (C) 2013 Lawrence Sebald
 */
 
+#include <kos/cdefs.h>
 #include "banner.h"
 #include "authors.h"
 
@@ -34,15 +35,15 @@ static const char license[] =
 "OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF\n"
 "SUCH DAMAGE.";
 
-const char *kos_get_banner(void) {
+const char * __pure kos_get_banner(void) {
     __asm__ __volatile__("nop" : : "r"(license), "r"(authors));
     return banner;
 }
 
-const char *kos_get_license(void) {
+const char * __pure kos_get_license(void) {
     return license;
 }
 
-const char *kos_get_authors(void) {
+const char * __pure kos_get_authors(void) {
     return authors;
 }

--- a/kernel/arch/dreamcast/kernel/gdb_stub.c
+++ b/kernel/arch/dreamcast/kernel/gdb_stub.c
@@ -273,11 +273,11 @@ static char remcomInBuffer[BUFMAX], remcomOutBuffer[BUFMAX];
 static char in_dcl_buf[BUFMAX], out_dcl_buf[BUFMAX];
 static int using_dcl = 0, in_dcl_pos = 0, out_dcl_pos = 0, in_dcl_size = 0;
 
-static char highhex(int  x) {
+static char __pure highhex(int  x) {
     return hexchars[(x >> 4) & 0xf];
 }
 
-static char lowhex(int  x) {
+static char __pure lowhex(int  x) {
     return hexchars[x & 0xf];
 }
 
@@ -292,7 +292,7 @@ static char lowhex(int  x) {
  * Routines to handle hex data
  */
 
-static int hex(char ch) {
+static int __pure hex(char ch) {
     if((ch >= 'a') && (ch <= 'f'))
         return (ch - 'a' + 10);
 
@@ -486,7 +486,7 @@ static void putpacket(register char *buffer) {
  * this function takes the SH-1 exception number and attempts to
  * translate this number into a unix compatible signal value
  */
-static int computeSignal(int exceptionVector) {
+static int __pure computeSignal(int exceptionVector) {
     int sigval;
 
     switch(exceptionVector) {

--- a/kernel/arch/dreamcast/math/fmath.c
+++ b/kernel/arch/dreamcast/math/fmath.c
@@ -8,53 +8,53 @@
 #include <dc/fmath_base.h>
 
 /* v1 dot v2 (inner product) */
-float fipr(float x, float y, float z, float w, float a, float b, float c,
+float __pure fipr(float x, float y, float z, float w, float a, float b, float c,
            float d) {
     return __fipr(x, y, z, w, a, b, c, d);
 }
 
 /* v1 dot v1 (square of magnitude) */
-float fipr_magnitude_sqr(float x, float y, float z, float w) {
+float __pure fipr_magnitude_sqr(float x, float y, float z, float w) {
     return __fipr_magnitude_sqr(x, y, z, w);
 }
 
 /* Returns sin(r), where r is [0..2*PI] */
-float fsin(float r) {
+float __pure fsin(float r) {
     return __fsin(r);
 }
 
 /* Returns cos(r), where r is [0..2*PI] */
-float fcos(float r) {
+float __pure fcos(float r) {
     return __fcos(r);
 }
 
 /* Returns tan(r), where r is [0..2*PI] */
-float ftan(float r) {
+float __pure ftan(float r) {
     return __ftan(r);
 }
 
 /* Returns sin(d), where d is [0..65535] */
-float fisin(int d) {
+float __pure fisin(int d) {
     return __fisin(d);
 }
 
 /* Returns cos(d), where d is [0..65535] */
-float ficos(int d) {
+float __pure ficos(int d) {
     return __ficos(d);
 }
 
 /* Returns tan(d), where d is [0..65535] */
-float fitan(int d) {
+float __pure fitan(int d) {
     return __fitan(d);
 }
 
 /* Returns sqrt(f) */
-float fsqrt(float f) {
+float __pure fsqrt(float f) {
     return __fsqrt(f);
 }
 
 /* Returns 1.0f / sqrt(f) */
-float frsqrt(float f) {
+float __pure frsqrt(float f) {
     return __frsqrt(f);
 }
 
@@ -66,7 +66,7 @@ void fsincosr(float f, float *s, float *c) {
     __fsincosr(f, *s, *c);
 }
 
-uint32 pvr_pack_bump(float h, float t, float q) {
+uint32 __pure pvr_pack_bump(float h, float t, float q) {
     uint8 hp = (uint8)(h * 255.0f);
     uint8 k1 = ~hp;
     uint8 k2 = (uint8)(hp * __fsin(t));

--- a/kernel/arch/dreamcast/util/vmu_fb.c
+++ b/kernel/arch/dreamcast/util/vmu_fb.c
@@ -130,7 +130,7 @@ static const vmufb_font_t vmufb_font4x6 = {
 
 static const vmufb_font_t *default_font = &vmufb_font4x6;
 
-static uint64_t extract_bits(const uint8_t *data,
+static uint64_t __pure extract_bits(const uint8_t *data,
                              unsigned int offt, unsigned int w) {
     uint32_t tmp, lsb, nb_bits;
     uint64_t bits = 0;

--- a/kernel/arch/dreamcast/util/vmu_pkg.c
+++ b/kernel/arch/dreamcast/util/vmu_pkg.c
@@ -55,7 +55,7 @@ struct bmp_dib_header {
 };
 
 /* CRC calculation: calculates the CRC on a VMU file to be written out */
-static uint16_t vmu_pkg_crc(const uint8_t *buf, size_t size) {
+static uint16_t __pure vmu_pkg_crc(const uint8_t *buf, size_t size) {
     size_t i;
     uint16_t c, n;
 
@@ -73,7 +73,7 @@ static uint16_t vmu_pkg_crc(const uint8_t *buf, size_t size) {
     return n;
 }
 
-static int vmu_eyecatch_size(int eyecatch_type) {
+static int __pure vmu_eyecatch_size(int eyecatch_type) {
     switch(eyecatch_type) {
         case VMUPKG_EC_NONE:
             return 0;
@@ -240,7 +240,7 @@ static unsigned int pal_get_map(uint32_t *pal, const uint32_t *curr_pal,
     return nb_colors;
 }
 
-static uint16_t argb8888_to_argb4444(uint32_t px) {
+static uint16_t __pure argb8888_to_argb4444(uint32_t px) {
     return 0xf000 |
         ((px >> 12) & 0x0f00) |
         ((px >> 8) & 0x00f0) |

--- a/kernel/net/net_crc.c
+++ b/kernel/net/net_crc.c
@@ -9,7 +9,7 @@
 
 /* Calculate a CRC-32 checksum over a given block of data. Somewhat inspired by
    the CRC32 function in Figure 14-6 of http://www.hackersdelight.org/crc.pdf */
-uint32_t net_crc32le(const uint8_t *data, int size) {
+uint32_t __pure net_crc32le(const uint8_t *data, int size) {
     int i;
     uint32_t rv = 0xFFFFFFFF;
 
@@ -29,7 +29,7 @@ uint32_t net_crc32le(const uint8_t *data, int size) {
 }
 
 /* This one isn't quite as nice as the one above for little-endian... */
-uint32_t net_crc32be(const uint8_t *data, int size) {
+uint32_t __pure net_crc32be(const uint8_t *data, int size) {
     int i, j;
     uint32_t rv = 0xFFFFFFFF, b, c;
 
@@ -49,7 +49,7 @@ uint32_t net_crc32be(const uint8_t *data, int size) {
 }
 
 /* Based on code found at: http://www.ccsinfo.com/forum/viewtopic.php?t=24977 */
-uint16_t net_crc16ccitt(const uint8_t *data, int size, uint16_t start) {
+uint16_t __pure net_crc16ccitt(const uint8_t *data, int size, uint16_t start) {
     uint16_t rv = start, tmp;
 
     while(size--) {

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -130,7 +130,7 @@ static int net_dhcp_fill_options(netif_t *net, dhcp_pkt_t *req, uint8_t msgtype,
     return (pos < DHCP_MIN_OPTIONS_SIZE) ? DHCP_MIN_OPTIONS_SIZE : pos;
 }
 
-static int net_dhcp_get_message_type(dhcp_pkt_t *pkt, int len) {
+static int __pure net_dhcp_get_message_type(dhcp_pkt_t *pkt, int len) {
     int i;
 
     len -= sizeof(dhcp_pkt_t);
@@ -153,7 +153,7 @@ static int net_dhcp_get_message_type(dhcp_pkt_t *pkt, int len) {
     return -1;
 }
 
-static uint32_t net_dhcp_get_32bit(dhcp_pkt_t *pkt, uint8_t opt, int len) {
+static uint32_t __pure net_dhcp_get_32bit(dhcp_pkt_t *pkt, uint8_t opt, int len) {
     int i;
 
     len -= sizeof(dhcp_pkt_t);
@@ -179,7 +179,7 @@ static uint32_t net_dhcp_get_32bit(dhcp_pkt_t *pkt, uint8_t opt, int len) {
     return 0;
 }
 
-static uint16_t net_dhcp_get_16bit(dhcp_pkt_t *pkt, uint8_t opt, int len) {
+static uint16_t __pure net_dhcp_get_16bit(dhcp_pkt_t *pkt, uint8_t opt, int len) {
     int i;
 
     len -= sizeof(dhcp_pkt_t);

--- a/kernel/net/net_ipv4.c
+++ b/kernel/net/net_ipv4.c
@@ -26,7 +26,7 @@
 static net_ipv4_stats_t ipv4_stats = { 0 };
 
 /* Perform an IP-style checksum on a block of data */
-uint16_t net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t start) {
+uint16_t __pure net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t start) {
     uint32_t sum = start;
     size_t i = bytes;
 
@@ -67,7 +67,7 @@ uint16_t net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t start) {
 }
 
 /* Determine if a given IP is in the current network */
-static int is_in_network(const uint8_t src[4], const uint8_t dest[4],
+static int __pure is_in_network(const uint8_t src[4], const uint8_t dest[4],
                          const uint8_t netmask[4]) {
     int i;
 
@@ -80,7 +80,7 @@ static int is_in_network(const uint8_t src[4], const uint8_t dest[4],
 }
 
 /* Determine if a given IP is the adapter's broadcast address. */
-static int is_broadcast(const uint8_t dest[4], const uint8_t bc[4]) {
+static int __pure is_broadcast(const uint8_t dest[4], const uint8_t bc[4]) {
     int i;
 
     for(i = 0; i < 4; ++i) {
@@ -281,7 +281,7 @@ int net_ipv4_input_proto(netif_t *src, const ip_hdr_t *ip, const uint8_t *data) 
     return -1;
 }
 
-uint32_t net_ipv4_address(const uint8_t addr[4]) {
+uint32_t __pure net_ipv4_address(const uint8_t addr[4]) {
     return (addr[0] << 24) | (addr[1] << 16) | (addr[2] << 8) | (addr[3]);
 }
 
@@ -292,7 +292,7 @@ void net_ipv4_parse_address(uint32_t addr, uint8_t out[4]) {
     out[3] = (uint8_t)(addr & 0xFF);
 }
 
-uint16_t net_ipv4_checksum_pseudo(in_addr_t src, in_addr_t dst, uint8_t proto,
+uint16_t __pure net_ipv4_checksum_pseudo(in_addr_t src, in_addr_t dst, uint8_t proto,
                                 uint16_t len) {
     ipv4_pseudo_hdr_t ps = { src, dst, 0, proto, htons(len) };
 

--- a/kernel/net/net_ipv4.h
+++ b/kernel/net/net_ipv4.h
@@ -25,7 +25,7 @@ typedef struct {
     uint16_t length;
 } __packed ipv4_pseudo_hdr_t;
 
-uint16_t net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t start);
+uint16_t __pure net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t start);
 int net_ipv4_send_packet(netif_t *net, ip_hdr_t *hdr, const uint8_t *data,
                          size_t size);
 int net_ipv4_send(netif_t *net, const uint8_t *data, size_t size, int id, int ttl,
@@ -34,7 +34,7 @@ int net_ipv4_input(netif_t *src, const uint8_t *pkt, size_t pktsize,
                    const eth_hdr_t *eth);
 int net_ipv4_input_proto(netif_t *net, const ip_hdr_t *ip, const uint8_t *data);
 
-uint16_t net_ipv4_checksum_pseudo(in_addr_t src, in_addr_t dst, uint8_t proto,
+uint16_t __pure net_ipv4_checksum_pseudo(in_addr_t src, in_addr_t dst, uint8_t proto,
                                 uint16_t len);
 
 /* In net_ipv4_frag.c */

--- a/kernel/net/net_ipv4_frag.c
+++ b/kernel/net/net_ipv4_frag.c
@@ -105,7 +105,7 @@ static inline void set_bits(uint8_t *bitfield, int start, int end) {
 }
 
 /* Check if all bits in the bitfield that should be set are set. */
-static inline int all_bits_set(const uint8_t *bitfield, int end) {
+static inline int __pure all_bits_set(const uint8_t *bitfield, int end) {
     int i;
 
     /* Make sure each of the beginning bytes are fully set. */

--- a/kernel/net/net_ipv6.c
+++ b/kernel/net/net_ipv6.c
@@ -42,7 +42,7 @@ const struct in6_addr in6addr_linklocal_allrouters = {
     }
 };
 
-static int is_in_network(netif_t *net, const struct in6_addr *ip) {
+static int __pure is_in_network(netif_t *net, const struct in6_addr *ip) {
     int i;
 
     /* Make sure its not trivially link-local */

--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -152,7 +152,7 @@ int mutex_lock_timed(mutex_t *m, int timeout) {
     return rv;
 }
 
-int mutex_is_locked(const mutex_t *m) {
+int __pure mutex_is_locked(const mutex_t *m) {
     return !!m->count;
 }
 


### PR DESCRIPTION
Switching the `__pure` define to use [the `pure` attribute](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-pure-function-attribute) to use  rather than [`__const__`](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-const-function-attribute) . This seems more in-line with the documentation and should generally be more useful. It'll also be backwards compatible as `__const__` is just a stricter `pure`.

Both generally allow flagging gcc to know that a function's output is entirely dependent on its input and will never vary if the input is the same. This is meant to allow it to better optimize cases where there's multiple calls with the same inputs.

Then went and applied it to everything in the main codebase that seemed to fit the attribute. As a side effect, searching for `__pure` will lead you to functions that are likely targets for further optimization (if they haven't already). A few seemed like they could take advantage of bitop builtins.

EDIT: Rather than fixing our definition of `__pure` I've just dumped it entirely. Its existence predates our newlib integration, which provide this (as well as `__pure2`) in its own `cdefs.h`.