### PR TITLE
Add missing include in sci

### DIFF
--- a/kernel/arch/dreamcast/hardware/sci.c
+++ b/kernel/arch/dreamcast/hardware/sci.c
@@ -12,6 +12,7 @@
 #include <arch/types.h>
 #include <kos/dbglog.h>
 #include <kos/regfield.h>
+#include <kos/thread.h>
 #include <stdint.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
The new pthreads implementation that was merged
directly before the sci work changed some
dependencies so it's needed to explicitly include
thread.h now. Otherwise it's a warning in gcc13
and an error in newer.