### PR TITLE
Shrink <kos/dbglog.h> includes

### DIFF
--- a/addons/libkosext2fs/inode.c
+++ b/addons/libkosext2fs/inode.c
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <errno.h>
 #include <limits.h>
+#include <kos/limits.h>
 #include <assert.h>
 #include <sys/queue.h>
 #include <inttypes.h>

--- a/addons/libkosutils/netcfg.c
+++ b/addons/libkosutils/netcfg.c
@@ -8,7 +8,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <assert.h>
+#include <kos/fs.h>
 #include <kos/netcfg.h>
 #include <dc/flashrom.h>
 #include <dc/vmu_pkg.h>

--- a/examples/dreamcast/libdream/vmu/vmu.c
+++ b/examples/dreamcast/libdream/vmu/vmu.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <kos/thread.h>
+
 #include <dc/biosfont.h>
 #include <dc/video.h>
 

--- a/examples/dreamcast/network/httpd/httpd.c
+++ b/examples/dreamcast/network/httpd/httpd.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+
 #include <sys/queue.h>
 #include <sys/stat.h>
 
@@ -14,6 +16,7 @@
 #include <sys/select.h>
 #include <netinet/in.h>
 
+#include <kos/fs.h>
 #include <kos/thread.h>
 #include <kos/mutex.h>
 

--- a/examples/dreamcast/network/ntp/ntp.c
+++ b/examples/dreamcast/network/ntp/ntp.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <netdb.h>
 
@@ -18,6 +19,7 @@
 #include <arch/rtc.h>
 #include <kos/dbgio.h>
 #include <kos/net.h>
+#include <kos/thread.h>
 
 #define NTP_PORT    "123"
 #define NTP_SERVER  "us.pool.ntp.org"

--- a/examples/dreamcast/network/speedtest/handle_request.c
+++ b/examples/dreamcast/network/speedtest/handle_request.c
@@ -2,6 +2,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
+
+#include <kos/fs.h>
 
 #include "speedtest.h"
 

--- a/examples/dreamcast/network/speedtest/server.c
+++ b/examples/dreamcast/network/speedtest/server.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <kos/thread.h>
 

--- a/examples/dreamcast/network/udpecho6/echo.c
+++ b/examples/dreamcast/network/udpecho6/echo.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/examples/dreamcast/rumble/rumble.c
+++ b/examples/dreamcast/rumble/rumble.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <unistd.h>
 
 #include <kos/init.h>
 

--- a/include/kos/dbglog.h
+++ b/include/kos/dbglog.h
@@ -22,10 +22,6 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
-#include <unistd.h>
-#include <stdarg.h>
-#include <kos/fs.h>
-
 /** \defgroup logging   Logging
     \brief              KOS's Logging API 
     \ingroup            debugging

--- a/kernel/arch/dreamcast/include/arch/stack.h
+++ b/kernel/arch/dreamcast/include/arch/stack.h
@@ -23,7 +23,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
+#include <stdint.h>
 
 /** \defgroup debugging_stacktrace  Stack Traces
     \brief                          API for managing stack backtracing

--- a/kernel/arch/dreamcast/util/vmu_pkg.c
+++ b/kernel/arch/dreamcast/util/vmu_pkg.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <dc/vmu_pkg.h>
+#include <kos/fs.h>
 #include <kos/regfield.h>
 
 /*

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -33,6 +33,7 @@ or space present.
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 #include <assert.h>
 #include <errno.h>
 #include <sys/ioctl.h>

--- a/kernel/fs/fs_utils.c
+++ b/kernel/fs/fs_utils.c
@@ -18,6 +18,7 @@ XXX This probably belongs in something like libc...
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
+#include <unistd.h>
 #include <errno.h>
 
 /* Copies a file from 'src' to 'dst'. The amount of the file

--- a/kernel/libc/koslib/dbglog.c
+++ b/kernel/libc/koslib/dbglog.c
@@ -12,6 +12,7 @@
 #include <kos/dbglog.h>
 #include <kos/thread.h>
 #include <kos/dbgio.h>
+#include <kos/fs.h>
 #include <arch/spinlock.h>
 
 /* Not re-entrant */

--- a/kernel/libc/koslib/getaddrinfo.c
+++ b/kernel/libc/koslib/getaddrinfo.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <errno.h>
 #include <poll.h>
 

--- a/kernel/libc/koslib/realpath.c
+++ b/kernel/libc/koslib/realpath.c
@@ -15,7 +15,9 @@
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
+#include <unistd.h>
 #include <sys/stat.h>
+#include <kos/limits.h>
 
 char *realpath(const char *__restrict path, char *__restrict resolved) {
     char temp_path[PATH_MAX];

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
+#include <unistd.h>
 
 #include <kos/net.h>
 #include <kos/genwait.h>

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <unistd.h>
 #include <poll.h>
 #include <sys/socket.h>
 #include <netinet/tcp.h>


### PR DESCRIPTION
It was including <unistd.h> and <kos/fs.h> which were being used in a bunch of other places implicitly from having dbglog (or something including it). Added all those in, then removed the extra includes from dbglog. Might, but is unlikely, to impact users.

Additionally added <kos/thread.h> in two places that were missing it after #991 .