### PR TITLE
Reduce usage of `<arch/types.h>`

### DIFF
--- a/include/kos/cond.h
+++ b/include/kos/cond.h
@@ -48,7 +48,6 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <kos/thread.h>
 #include <kos/mutex.h>
 
@@ -82,7 +81,7 @@ typedef struct condvar {
     \par    Error Conditions:
     \em     ENOMEM - out of memory
 */
-condvar_t *cond_create() __depr("Use cond_init or COND_INITIALIZER.");
+condvar_t *cond_create(void) __depr("Use cond_init or COND_INITIALIZER.");
 
 /** \brief  Initialize a condition variable.
 

--- a/include/kos/fs_pty.h
+++ b/include/kos/fs_pty.h
@@ -26,7 +26,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <kos/fs.h>
 
 /** \defgroup vfs_pty   PTY

--- a/include/kos/fs_ramdisk.h
+++ b/include/kos/fs_ramdisk.h
@@ -26,7 +26,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <kos/fs.h>
 
 /** \defgroup vfs_ramdisk   Ramdisk

--- a/include/kos/nmmgr.h
+++ b/include/kos/nmmgr.h
@@ -22,7 +22,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
+#include <stdint.h>
 #include <kos/limits.h>
 #include <sys/queue.h>
 
@@ -60,10 +60,10 @@ typedef LIST_HEAD(nmmgr_list, nmmgr_handler) nmmgr_list_t;
 */
 typedef struct nmmgr_handler {
     char    pathname[NAME_MAX];   /* Path name */
-    int pid;                /* Process table ID for handler (0 == static) */
-    uint32  version;        /* Version code */
-    uint32  flags;          /* Bitmask of flags */
-    uint32  type;           /* Type of handler */
+    int pid;                  /* Process table ID for handler (0 == static) */
+    uint32_t  version;        /* Version code */
+    uint32_t  flags;          /* Bitmask of flags */
+    uint32_t  type;           /* Type of handler */
     LIST_ENTRY(nmmgr_handler)   list_ent;   /* Linked list entry */
 } nmmgr_handler_t;
 

--- a/include/malloc.h
+++ b/include/malloc.h
@@ -22,8 +22,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
-
 /** \defgroup system_allocator  Allocator
     \brief                      Dynamic memory heap management and allocation
     \ingroup                    system

--- a/kernel/arch/dreamcast/hardware/sci.c
+++ b/kernel/arch/dreamcast/hardware/sci.c
@@ -9,7 +9,7 @@
 #include <arch/cache.h>
 #include <arch/dmac.h>
 #include <arch/timer.h>
-#include <arch/types.h>
+
 #include <kos/dbglog.h>
 #include <kos/regfield.h>
 #include <kos/thread.h>

--- a/kernel/arch/dreamcast/hardware/ubc.c
+++ b/kernel/arch/dreamcast/hardware/ubc.c
@@ -6,7 +6,6 @@
 
 #include <dc/ubc.h>
 
-#include <arch/types.h>
 #include <arch/memory.h>
 #include <arch/irq.h>
 

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -26,7 +26,6 @@
 __BEGIN_DECLS
 
 #include <stdint.h>
-#include <arch/types.h>
 
 /** \defgroup system_cache Cache
     \brief                 Driver and API for managing the SH4's cache

--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -32,8 +32,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
-
 /** \defgroup irqs  Interrupts
     \brief          IRQs and ISRs for the SH4's CPU
     \ingroup        system

--- a/kernel/arch/dreamcast/include/arch/mmu.h
+++ b/kernel/arch/dreamcast/include/arch/mmu.h
@@ -50,7 +50,6 @@ __BEGIN_DECLS
 
 #include <stdbool.h>
 
-#include <arch/types.h>
 #include <sys/uio.h>
 
 /** \defgroup mmu   MMU

--- a/kernel/arch/dreamcast/include/dc/biosfont.h
+++ b/kernel/arch/dreamcast/include/dc/biosfont.h
@@ -36,8 +36,6 @@ __BEGIN_DECLS
 #include <stdbool.h>
 #include <stdarg.h>
 
-#include <arch/types.h>
-
 /** \defgroup bfont     BIOS
     \brief              API for the Dreamcast's built-in BIOS font
     \ingroup            video_fonts

--- a/kernel/arch/dreamcast/include/dc/fmath.h
+++ b/kernel/arch/dreamcast/include/dc/fmath.h
@@ -21,7 +21,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
+#include <stdint.h>
 #include <dc/fmath_base.h>
 
 /** \defgroup math_intrinsics Intrinsics
@@ -178,12 +178,12 @@ __FMINLINE void fsincosr(float f, float *s, float *c) {
     \note   Thanks to Fredrik Ehnbom for figuring this stuff out and posting it
             to the mailing list back in 2005!
 */
-__FMINLINE uint32 pvr_pack_bump(float h, float t, float q) {
-    uint8 hp = (uint8)(h * 255.0f);
-    uint8 k1 = ~hp;
-    uint8 k2 = (uint8)(hp * __fsin(t));
-    uint8 k3 = (uint8)(hp * __fcos(t));
-    uint8 qp = (uint8)((q / (2 * F_PI)) * 255.0f);
+__FMINLINE uint32_t pvr_pack_bump(float h, float t, float q) {
+    uint8_t hp = (uint8_t)(h * 255.0f);
+    uint8_t k1 = ~hp;
+    uint8_t k2 = (uint8_t)(hp * __fsin(t));
+    uint8_t k3 = (uint8_t)(hp * __fcos(t));
+    uint8_t qp = (uint8_t)((q / (2 * F_PI)) * 255.0f);
 
 
     return (k1 << 24) | (k2 << 16) | (k3 << 8) | qp;

--- a/kernel/arch/dreamcast/include/dc/fs_iso9660.h
+++ b/kernel/arch/dreamcast/include/dc/fs_iso9660.h
@@ -29,7 +29,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <kos/limits.h>
 #include <kos/fs.h>
 

--- a/kernel/arch/dreamcast/include/dc/g2bus.h
+++ b/kernel/arch/dreamcast/include/dc/g2bus.h
@@ -37,7 +37,6 @@ __BEGIN_DECLS
 
 #include <stdint.h>
 #include <arch/irq.h>
-#include <arch/types.h>
 
 #include <dc/fifo.h>
 

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -27,7 +27,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <stdint.h>
 
 /** \defgroup controller Controller

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -27,7 +27,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <dc/maple.h>
 #include <kos/regfield.h>
 

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -30,7 +30,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <dc/maple.h>
 #include <kos/regfield.h>
 

--- a/kernel/arch/dreamcast/include/dc/sci.h
+++ b/kernel/arch/dreamcast/include/dc/sci.h
@@ -21,7 +21,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <arch/dmac.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -29,7 +29,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <kos/fs.h>
 #include <stdint.h>
 

--- a/kernel/arch/dreamcast/include/dc/spu.h
+++ b/kernel/arch/dreamcast/include/dc/spu.h
@@ -22,7 +22,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <arch/memory.h>
 #include <dc/g2bus.h>
 

--- a/kernel/arch/dreamcast/include/dc/sq.h
+++ b/kernel/arch/dreamcast/include/dc/sq.h
@@ -42,7 +42,6 @@
 __BEGIN_DECLS
 
 #include <stdint.h>
-#include <arch/types.h>
 #include <arch/memory.h>
 #include <arch/cache.h>
 

--- a/kernel/arch/dreamcast/kernel/perfctr.c
+++ b/kernel/arch/dreamcast/kernel/perfctr.c
@@ -7,6 +7,7 @@
 
 #include <dc/perfctr.h>
 #include <arch/timer.h>
+#include <kos/cdefs.h>
 
 /* Control Registers */
 #define PMCR_CTRL(o)  ( *((volatile uint16_t *)(0xff000084) + (o << 1)) )

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -28,7 +28,8 @@ or space present.
 #include <kos/mutex.h>
 #include <kos/cond.h>
 #include <kos/fs_pty.h>
-#include <sys/queue.h>
+
+#include <arch/types.h>
 
 #include <string.h>
 #include <stdlib.h>
@@ -36,7 +37,9 @@ or space present.
 #include <unistd.h>
 #include <assert.h>
 #include <errno.h>
+
 #include <sys/ioctl.h>
+#include <sys/queue.h>
 
 /* pty buffer size */
 #define PTY_BUFFER_SIZE 1024

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -36,6 +36,8 @@ cache data from disk rather than as a general purpose file system.
 #include <kos/fs_ramdisk.h>
 #include <kos/opts.h>
 
+#include <arch/types.h>
+
 #include <string.h>
 #include <strings.h>
 #include <stdio.h>


### PR DESCRIPTION
Furthering #840 and our general move to stdint types, removing a bunch of extraneous usages of `<arch/types.h>` as well as transitioning nmmgr to stdint, as it was such a minor change. For all but `fs_ramdisk` and `fs_pty` (where the include was moved to the .c), it wasn't actually doing anything. Seemingly they just got left in after the code was changed to use stdint types.