### PR TITLE
Fix mismatched types for ubc callback.

### DIFF
--- a/examples/dreamcast/basic/breaking/breaking.c
+++ b/examples/dreamcast/basic/breaking/breaking.c
@@ -48,6 +48,9 @@ static atomic_bool handled = false;
 static bool on_break(const ubc_breakpoint_t *bp,
                      const irq_context_t *ctx,
                      void *ud) {
+    /* Don't warn about unused bp */
+    (void)bp;
+
     /* Signal to the outside that the breakpoint has been handled. */
     handled = true;
 

--- a/kernel/arch/dreamcast/include/dc/ubc.h
+++ b/kernel/arch/dreamcast/include/dc/ubc.h
@@ -26,6 +26,7 @@ __BEGIN_DECLS
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <arch/irq.h>
 
 /** \defgroup ubc   User Break Controller
     \brief          Driver for the SH4's UBC
@@ -54,10 +55,6 @@ __BEGIN_DECLS
 
     @{
 */
-
-/** \cond Forward declarations */
-struct irq_context;
-/** \endcond */
 
 /** \brief UBC address mask specifier
 
@@ -298,7 +295,7 @@ typedef struct ubc_breakpoint {
     \sa ubc_add_breakpoint()
 */
 typedef bool (*ubc_break_func_t)(const ubc_breakpoint_t   *bp, 
-                                 const struct irq_context *ctx, 
+                                 const irq_context_t *ctx,
                                  void                     *user_data);
 
 /** \brief Enables a breakpoint


### PR DESCRIPTION
`ubc.h` is using the irq_context type but for
some reason wasn't using the typedef'd name
for it, and wasn't including `irq.h` either.

This fixes the use of it in gcc14+.

Threw in the void cast to clean up unused param warning in the example as well.