### PR TITLE
Add dummy char in pthread_barrierattr_t and pthread_rwlockattr_t

### DIFF
--- a/include/sys/_pthreadtypes.h
+++ b/include/sys/_pthreadtypes.h
@@ -17,6 +17,7 @@ typedef struct pthread_mutexattr_t {
 
 typedef struct pthread_rwlockattr_t {
     /* Empty */
+    char _unused;
 } pthread_rwlockattr_t;
 
 #ifndef __PTHREAD_HAVE_CONDATTR_TYPE
@@ -33,6 +34,7 @@ typedef union pthread_condattr_t {
 
 typedef struct pthread_barrierattr_t {
     /* Empty */
+    char _unused;
 } pthread_barrierattr_t;
 
 /* The following types have no public elements. Their implementation is hidden


### PR DESCRIPTION
An empty struct is undefined in C, and causes a mismatch in sizes with C++ code. We add a dummy char here to define the struct (not to mention suppress warnings).