### PR TITLE
Stop dbglog from being included in stdio

### DIFF
--- a/addons/libkosext2fs/ext2internal.h
+++ b/addons/libkosext2fs/ext2internal.h
@@ -45,13 +45,15 @@ struct ext2fs_struct {
 #define EXT2_FS_FLAG_SB_DIRTY   1
 
 #ifdef EXT2_NOT_IN_KOS
-#include <stdio.h>
-#define DBG_DEBUG 0
-#define DBG_KDEBUG 0
-#define DBG_WARNING 0
-#define DBG_ERROR 0
+    #include <stdio.h>
+    #define DBG_DEBUG 0
+    #define DBG_KDEBUG 0
+    #define DBG_WARNING 0
+    #define DBG_ERROR 0
 
-#define dbglog(lvl, ...) printf(__VA_ARGS__)
+    #define dbglog(lvl, ...) printf(__VA_ARGS__)
+#else
+    #include <kos/dbglog.h>
 #endif
 
 #endif /* !__EXT2_EXT2INTERNAL_H */

--- a/addons/libkosfat/fatinternal.h
+++ b/addons/libkosfat/fatinternal.h
@@ -39,13 +39,15 @@ struct fatfs_struct {
 #define FAT_FS_FLAG_SB_DIRTY   1
 
 #ifdef FAT_NOT_IN_KOS
-#include <stdio.h>
-#define DBG_DEBUG 0
-#define DBG_KDEBUG 0
-#define DBG_WARNING 0
-#define DBG_ERROR 0
+    #include <stdio.h>
+    #define DBG_DEBUG 0
+    #define DBG_KDEBUG 0
+    #define DBG_WARNING 0
+    #define DBG_ERROR 0
 
-#define dbglog(lvl, ...) printf(__VA_ARGS__)
+    #define dbglog(lvl, ...) printf(__VA_ARGS__)
+#else
+    #include <kos/dbglog.h>
 #endif
 
 #endif /* !__FAT_FATINTERNAL_H */

--- a/addons/libnavi/navi_flash.c
+++ b/addons/libnavi/navi_flash.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <navi/flash.h>
+#include <kos/dbglog.h>
 #include <kos/thread.h>
 
 /*

--- a/addons/libnavi/navi_ide.c
+++ b/addons/libnavi/navi_ide.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <navi/ide.h>
 #include <dc/g2bus.h>
+#include <kos/dbglog.h>
 #include <kos/thread.h>
 
 /*

--- a/include/sys/stdio.h
+++ b/include/sys/stdio.h
@@ -26,7 +26,9 @@
 #  define _funlockfile(fp)
 #endif
 
-// Added for old KOS source compatibility
-#include <kos/dbglog.h>
+/* Keep compat with old dbglog.h inclusion */
+#include <unistd.h>
+#include <stdarg.h>
+#include <kos/fs.h>
 
 #endif /* _NEWLIB_STDIO_H */

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -22,6 +22,7 @@ printf goes to the dc-tool console
 #include <dc/fs_dcload.h>
 #include <arch/spinlock.h>
 #include <kos/dbgio.h>
+#include <kos/dbglog.h>
 #include <kos/fs.h>
 #include <kos/init.h>
 

--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -36,6 +36,7 @@ ISO9660 systems, as these were used as references as well.
 #include <kos/mutex.h>
 #include <kos/fs.h>
 #include <kos/opts.h>
+#include <kos/dbglog.h>
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -14,6 +14,7 @@
 
 #include <arch/types.h>
 #include <kos/mutex.h>
+#include <kos/dbglog.h>
 #include <dc/fs_vmu.h>
 #include <dc/vmufs.h>
 #include <dc/maple.h>

--- a/kernel/arch/dreamcast/fs/vmufs.c
+++ b/kernel/arch/dreamcast/fs/vmufs.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <time.h>
 
+#include <kos/dbglog.h>
 #include <kos/mutex.h>
 #include <dc/vmufs.h>
 #include <dc/maple.h>

--- a/kernel/arch/dreamcast/hardware/flashrom.c
+++ b/kernel/arch/dreamcast/hardware/flashrom.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <dc/flashrom.h>
 #include <dc/syscalls.h>
+#include <kos/dbglog.h>
 #include <arch/irq.h>
 
 static void strcpy_no_term(char *dest, const char *src, size_t destsize) {

--- a/kernel/arch/dreamcast/hardware/g2dma.c
+++ b/kernel/arch/dreamcast/hardware/g2dma.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <dc/asic.h>
 #include <dc/g2bus.h>
+#include <kos/dbglog.h>
 #include <kos/sem.h>
 #include <kos/thread.h>
 

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -14,6 +14,7 @@
 #include <dc/vblank.h>
 #include <kos/thread.h>
 #include <kos/init.h>
+#include <kos/dbglog.h>
 
 #include <dc/maple/controller.h>
 #include <dc/maple/keyboard.h>

--- a/kernel/arch/dreamcast/hardware/maple/maple_utils.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_utils.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <arch/memory.h>
 #include <dc/maple.h>
+#include <kos/dbglog.h>
 
 /* Enable / Disable the bus */
 void maple_bus_enable(void) {

--- a/kernel/arch/dreamcast/hardware/maple/sip.c
+++ b/kernel/arch/dreamcast/hardware/maple/sip.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <arch/irq.h>
+#include <kos/dbglog.h>
 #include <kos/genwait.h>
 #include <dc/maple.h>
 #include <dc/maple/sip.h>

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -19,6 +19,7 @@
 #include <kos/thread.h>
 #include <kos/genwait.h>
 #include <kos/platform.h>
+#include <kos/dbglog.h>
 #include <dc/maple.h>
 #include <dc/maple/vmu.h>
 #include <dc/math.h>

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -19,6 +19,7 @@
 #include <arch/irq.h>
 #include <arch/cache.h>
 #include <arch/memory.h>
+#include <kos/dbglog.h>
 #include <kos/net.h>
 #include <kos/thread.h>
 #include <kos/sem.h>

--- a/kernel/arch/dreamcast/hardware/network/lan_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/lan_adapter.c
@@ -15,6 +15,7 @@
 #include <dc/flashrom.h>
 #include <dc/net/lan_adapter.h>
 #include <arch/irq.h>
+#include <kos/dbglog.h>
 #include <kos/net.h>
 #include <kos/thread.h>
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
@@ -17,6 +17,7 @@
 #include <dc/sq.h>
 #include <kos/thread.h>
 #include <kos/sem.h>
+#include <kos/dbglog.h>
 
 #include "pvr_internal.h"
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_fog.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_fog.c
@@ -8,6 +8,8 @@
 #include <assert.h>
 #include <stdio.h>
 #include <dc/pvr.h>
+#include <kos/dbglog.h>
+
 #include "pvr_internal.h"
 #include "pvr_fog_tables.h"
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -12,6 +12,7 @@
 #include <dc/video.h>
 #include <dc/asic.h>
 #include <dc/vblank.h>
+#include <kos/dbglog.h>
 #include "pvr_internal.h"
 
 /*

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
@@ -33,6 +33,7 @@
 
 #include "pvr_mem_core.h"
 
+#include <kos/dbglog.h>
 #include <kos/opts.h>
 
 #undef DEBUG

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include <kos/dbglog.h>
 #include <kos/genwait.h>
 #include <kos/regfield.h>
 #include <kos/thread.h>

--- a/kernel/arch/dreamcast/hardware/video.c
+++ b/kernel/arch/dreamcast/hardware/video.c
@@ -10,6 +10,7 @@
 #include <dc/video.h>
 #include <dc/pvr.h>
 #include <dc/sq.h>
+#include <kos/dbglog.h>
 #include <kos/platform.h>
 #include <string.h>
 #include <stdio.h>

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <kos/dbgio.h>
+#include <kos/dbglog.h>
 #include <kos/init.h>
 #include <kos/platform.h>
 #include <arch/arch.h>

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -18,6 +18,7 @@
 #include <arch/timer.h>
 #include <arch/stack.h>
 #include <kos/dbgio.h>
+#include <kos/dbglog.h>
 #include <kos/thread.h>
 #include <kos/library.h>
 #include <kos/regfield.h>

--- a/kernel/arch/dreamcast/kernel/mm.c
+++ b/kernel/arch/dreamcast/kernel/mm.c
@@ -17,6 +17,7 @@
 #include <arch/types.h>
 #include <arch/arch.h>
 #include <arch/irq.h>
+#include <kos/dbglog.h>
 #include <errno.h>
 #include <stdio.h>
 

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <stdio.h>
 
+#include <kos/dbglog.h>
 #include <kos/mutex.h>
 #include <arch/timer.h>
 #include <dc/g2bus.h>

--- a/kernel/arch/dreamcast/sound/snd_mem.c
+++ b/kernel/arch/dreamcast/sound/snd_mem.c
@@ -14,6 +14,7 @@
 #include <sys/queue.h>
 #include <dc/sound/sound.h>
 #include <arch/spinlock.h>
+#include <kos/dbglog.h>
 
 /*
 

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -17,6 +17,7 @@
 
 #include <sys/queue.h>
 #include <sys/ioctl.h>
+#include <kos/dbglog.h>
 #include <kos/fs.h>
 #include <arch/irq.h>
 #include <dc/spu.h>

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <sys/queue.h>
 
+#include <kos/dbglog.h>
 #include <kos/mutex.h>
 #include <arch/cache.h>
 #include <arch/timer.h>

--- a/kernel/arch/dreamcast/util/screenshot.c
+++ b/kernel/arch/dreamcast/util/screenshot.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dc/video.h>
+#include <kos/dbglog.h>
 #include <kos/fs.h>
 #include <arch/irq.h>
 

--- a/kernel/arch/dreamcast/util/vmu_pkg.c
+++ b/kernel/arch/dreamcast/util/vmu_pkg.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <dc/vmu_pkg.h>
+#include <kos/dbglog.h>
 #include <kos/fs.h>
 #include <kos/regfield.h>
 

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -15,6 +15,7 @@
 #include <kos/exports.h>
 #include <kos/thread.h>
 #include <kos/library.h>
+#include <kos/dbglog.h>
 
 /* What's our architecture code we're expecting? */
 #if defined(_arch_dreamcast)

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -39,6 +39,7 @@ something like this:
 #include <kos/mutex.h>
 #include <kos/nmmgr.h>
 #include <kos/dbgio.h>
+#include <kos/dbglog.h>
 
 /* File handle structure; this is an entirely internal structure so it does
    not go in a header file. */

--- a/kernel/fs/fs_dev.c
+++ b/kernel/fs/fs_dev.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 
 #include <arch/types.h>
+#include <kos/dbglog.h>
 #include <kos/fs_dev.h>
 #include <sys/queue.h>
 

--- a/kernel/fs/fs_random.c
+++ b/kernel/fs/fs_random.c
@@ -14,6 +14,7 @@
 #include <arch/types.h>
 #include <kos/mutex.h>
 #include <kos/fs_random.h>
+#include <kos/dbglog.h>
 #include <sys/queue.h>
 #include <sys/time.h>
 

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -21,6 +21,7 @@ on sunsite.unc.edu in /pub/Linux/system/recovery/, or as a package under Debian 
 #include <kos/mutex.h>
 #include <kos/fs_romdisk.h>
 #include <kos/opts.h>
+#include <kos/dbglog.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>

--- a/kernel/libc/koslib/assert.c
+++ b/kernel/libc/koslib/assert.c
@@ -12,6 +12,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <kos/dbglog.h>
+
 #ifdef FRAME_POINTERS
 #include <arch/stack.h>
 #endif

--- a/kernel/libc/koslib/malloc.c
+++ b/kernel/libc/koslib/malloc.c
@@ -23,6 +23,7 @@
 #include <arch/spinlock.h>
 #include <arch/arch.h>
 
+#include <kos/dbglog.h>
 #include <kos/opts.h>
 
 #undef DEBUG

--- a/kernel/net/net_arp.c
+++ b/kernel/net/net_arp.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include <kos/dbglog.h>
 #include <kos/net.h>
 #include <kos/thread.h>
 #include <arch/timer.h>

--- a/kernel/net/net_core.c
+++ b/kernel/net/net_core.c
@@ -12,6 +12,7 @@
 
 #include <kos/net.h>
 #include <kos/fs_socket.h>
+#include <kos/dbglog.h>
 
 #include "net_dhcp.h"
 #include "net_thd.h"

--- a/kernel/net/net_icmp.c
+++ b/kernel/net/net_icmp.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 
 #include <sys/queue.h>
+#include <kos/dbglog.h>
 #include <kos/net.h>
 #include <kos/thread.h>
 #include <arch/timer.h>

--- a/kernel/net/net_icmp6.c
+++ b/kernel/net/net_icmp6.c
@@ -11,6 +11,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arch/timer.h>
+#include <kos/dbglog.h>
 
 #include "net_icmp6.h"
 #include "net_ipv6.h"

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 
 #include <arch/timer.h>
+#include <kos/dbglog.h>
 #include <kos/genwait.h>
 #include <kos/sem.h>
 

--- a/kernel/thread/rwsem.c
+++ b/kernel/thread/rwsem.c
@@ -12,6 +12,7 @@
 
 #include <kos/rwsem.h>
 #include <kos/genwait.h>
+#include <kos/dbglog.h>
 
 /* Allocate a new reader/writer semaphore */
 rw_semaphore_t *rwsem_create(void) {

--- a/kernel/thread/sem.c
+++ b/kernel/thread/sem.c
@@ -18,6 +18,7 @@
 #include <kos/thread.h>
 #include <kos/sem.h>
 #include <kos/genwait.h>
+#include <kos/dbglog.h>
 
 /**************************************/
 

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -20,6 +20,7 @@
 
 #include <kos/thread.h>
 #include <kos/dbgio.h>
+#include <kos/dbglog.h>
 #include <kos/sem.h>
 #include <kos/rwsem.h>
 #include <kos/cond.h>


### PR DESCRIPTION
Following #995 I found that dbglog.h was being exposed in `<stdio.h>` and so many internal headers were being accidentally automatically provided indirectly through dbglog.h out to anything needing stdio. So this PR ensures all uses of dbglog include the header explicitly, then removes it from stdio.h. In it's place, two of the removed includes from #995 in order to reduce the breakage to `kos-ports` (and likely user software) as it seems some types and internal functions were only being exposed through that.