### PR TITLE
Fix printf format types for pvr_stats members in GL examples.

### DIFF
--- a/examples/dreamcast/gldc/basic/gl/gltest.c
+++ b/examples/dreamcast/gldc/basic/gl/gltest.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
     }
 
     pvr_get_stats(&stats);
-    printf("VBL Count: %ld, last_time: %d, frame rate: %f fps\n",
+    printf("VBL Count: %d, last_time: %lld, frame rate: %f fps\n",
            stats.vbl_count, stats.frame_last_time, stats.frame_rate);
 
     return 0;

--- a/examples/dreamcast/gldc/benchmarks/quadmark/quadmark.c
+++ b/examples/dreamcast/gldc/benchmarks/quadmark/quadmark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, stats.frame_rate);
 }
 

--- a/examples/dreamcast/gldc/benchmarks/trimark/trimark.c
+++ b/examples/dreamcast/gldc/benchmarks/trimark/trimark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, stats.frame_rate);
 }
 

--- a/examples/dreamcast/gldc/benchmarks/tristripmark/tristripmark.c
+++ b/examples/dreamcast/gldc/benchmarks/tristripmark/tristripmark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %ld VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, stats.frame_rate);
 }
 


### PR DESCRIPTION
These were changed in #471 and the examples hadn't been updated to reflect the new sizes.