### PR TITLE
Deprecate `snd_stream_prefill`

### DIFF
--- a/kernel/arch/dreamcast/exports-naomi.txt
+++ b/kernel/arch/dreamcast/exports-naomi.txt
@@ -174,7 +174,6 @@ snd_stream_pan
 snd_stream_alloc
 snd_stream_destroy
 snd_stream_reinit
-snd_stream_prefill
 snd_pcm16_split
 snd_pcm16_split_sq
 snd_pcm8_split

--- a/kernel/arch/dreamcast/exports-pristine.txt
+++ b/kernel/arch/dreamcast/exports-pristine.txt
@@ -239,7 +239,6 @@ snd_stream_pan
 snd_stream_alloc
 snd_stream_destroy
 snd_stream_reinit
-snd_stream_prefill
 snd_pcm16_split
 snd_pcm16_split_sq
 snd_pcm8_split

--- a/kernel/arch/dreamcast/include/dc/sound/stream.h
+++ b/kernel/arch/dreamcast/include/dc/sound/stream.h
@@ -191,13 +191,13 @@ void snd_stream_filter_remove(snd_stream_hnd_t hnd,
 
 /** \brief  Prefill the stream buffers.
 
-    This function prefills the stream buffers before starting it. This is
-    implicitly called by snd_stream_start(), so there's probably no good reason
-    to call this yourself.
+    This function has no effect. The stream is prefilled on start.
+    This is deprecated and should be removed if used.
 
-    \param  hnd             The stream to prefill buffers on.
+    \param  hnd             Param.
 */
-void snd_stream_prefill(snd_stream_hnd_t hnd);
+static const int __snd_stream_prefill   __depr("snd_stream_prefill has no effect and should be removed") = 0;
+#define snd_stream_prefill(x)  ((void)__snd_stream_prefill)
 
 /** \brief  Initialize the stream system.
 

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -315,27 +315,6 @@ void snd_pcm16_split_sq(uint32_t *data, uintptr_t left, uintptr_t right, size_t 
     g2_unlock(ctx);
 }
 
-
-/* Prefill buffers -- implicitly called by snd_stream_start() */
-void snd_stream_prefill(snd_stream_hnd_t hnd) {
-    strchan_t *stream;
-
-    CHECK_HND(hnd);
-    stream = &streams[hnd];
-
-    /* No way to request data, or not yet allocated. */
-    if((!stream->get_data && !stream->req_data) ||
-                            (!stream->channels)) {
-        return;
-    }
-
-    snd_stream_fill(hnd, 0, stream->buffer_size / 2);
-    snd_stream_fill(hnd, stream->buffer_size / 2, stream->buffer_size / 2);
-
-    /* Start playing from the beginning */
-    stream->last_write_pos = 0;
-}
-
 /* Initialize stream system */
 int snd_stream_init(void) {
     return snd_stream_init_ex(2, SND_STREAM_BUFFER_MAX);
@@ -536,8 +515,12 @@ static void snd_stream_start_type(snd_stream_hnd_t hnd, uint32_t type, uint32_t 
         }
     }
 
-    /* Prefill buffers */
-    snd_stream_prefill(hnd);
+    /* As long as there's a way to get/request data, prefill buffers */
+    snd_stream_fill(hnd, 0, streams[hnd].buffer_size / 2);
+    snd_stream_fill(hnd, streams[hnd].buffer_size / 2, streams[hnd].buffer_size / 2);
+
+    /* Start playing from the beginning */
+    streams[hnd].last_write_pos = 0;
 
     /* Make sure these are sync'd (and/or delayed) */
     snd_sh4_to_aica_stop();

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -323,7 +323,9 @@ void snd_stream_prefill(snd_stream_hnd_t hnd) {
     CHECK_HND(hnd);
     stream = &streams[hnd];
 
-    if(!stream->get_data && !stream->req_data) {
+    /* No way to request data, or not yet allocated. */
+    if((!stream->get_data && !stream->req_data) ||
+                            (!stream->channels)) {
         return;
     }
 
@@ -688,6 +690,12 @@ static size_t snd_stream_fill(snd_stream_hnd_t hnd, uint32_t offset, size_t size
     const int needed_bytes = size * chans;
     int got_bytes = 0;
     void *data = NULL;
+
+    /* The stream hasn't been initted or is invalid. */
+    CHECK_HND(hnd);
+
+    /* The stream has been initted but not allocated. */
+    assert(chans != 0);
 
     if(stream->req_data) {
         got_bytes = stream->req_data(hnd,


### PR DESCRIPTION
`snd_stream_fill` (and thus prefill) is currently not able to be run before the first call to `snd_stream_start` as the number of channels is undefined at the time. This behavior worked partially prior to #346 as the logic for most of the code was `if(channels == 2) ... else{}` so channels being zero didn't cause issues.

What I've done is deprecate `snd_stream_prefill` leaving a warning stub in its place and folding its operation into `snd_stream_start`. Additionally added minor error checking to prevent potential crashes

Found while debugging [vcdc](https://gitlab.completext.com/Dreamcast/vcdc) which did:
`snd_stream_init();
shnd = snd_stream_alloc(mpv_callback, sbsize);
snd_stream_prefill(shnd);
`