### PR TITLE
Include arch/types.h in thread.h to fix toolchain building

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -42,6 +42,7 @@ __BEGIN_DECLS
 #include <kos/cdefs.h>
 #include <kos/tls.h>
 #include <arch/irq.h>
+#include <arch/types.h>
 #include <sys/queue.h>
 #include <sys/reent.h>
 


### PR DESCRIPTION
Otherwise the toolchain fails to build not knowing what `tid_t` or `prio_t` are.