### PR TITLE
Fix type errors in dc/fifo.h and dc/g2bus.h

### DIFF
--- a/kernel/arch/dreamcast/include/dc/fifo.h
+++ b/kernel/arch/dreamcast/include/dc/fifo.h
@@ -32,7 +32,7 @@ __BEGIN_DECLS
     Accessing this value provides the current status of all FIFOs.
 
 */
-#define FIFO_STATUS     (*(vuint32 const *)0xa05f688c)
+#define FIFO_STATUS     (*(volatile uint32_t const *)0xa05f688c)
 
 /** \name        FIFO Status Indicators
  

--- a/kernel/arch/dreamcast/include/dc/g2bus.h
+++ b/kernel/arch/dreamcast/include/dc/g2bus.h
@@ -146,9 +146,9 @@ typedef struct {
 /* Internal constants to access suspend registers for G2 DMA. They are not meant for
    user-code use. */
 /** \cond */ 
-#define G2_DMA_SUSPEND_SPU     (*((vuint32 *)0xa05f781C))
-#define G2_DMA_SUSPEND_BBA     (*((vuint32 *)0xa05f783C))
-#define G2_DMA_SUSPEND_CH2     (*((vuint32 *)0xa05f785C))
+#define G2_DMA_SUSPEND_SPU     (*((volatile uint32_t *)0xa05f781C))
+#define G2_DMA_SUSPEND_BBA     (*((volatile uint32_t *)0xa05f783C))
+#define G2_DMA_SUSPEND_CH2     (*((volatile uint32_t *)0xa05f785C))
 /** \endcond */
 
 /** \brief  Disable IRQs and G2 DMA
@@ -223,7 +223,7 @@ void g2_write_8(uintptr_t address, uint8_t value);
     \param  address         The address in memory to read.
     \return                 The word read from the address specified.
 */
-uint16 g2_read_16(uintptr_t address);
+uint16_t g2_read_16(uintptr_t address);
 
 /** \brief  Write a 16-bit word to G2.
 


### PR DESCRIPTION
I'm getting compilation errors when building the Rust examples due to missing types. Sure enough, these particular headers need `arch/types.h` included. Rather than making a PR to add the `arch/types.h` include, however, I just switched the types in these headers to standard types.