### PR TITLE
Restrict SourceForge sync to main repo

### DIFF
--- a/.github/workflows/sourceforge.yml
+++ b/.github/workflows/sourceforge.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository == 'KallistiOS/KallistiOS'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Without this restriction, forks will take the same action and attempt to sync to sourceforge as well. I am unfortunately though unaware of how to test these changes prior to merging them.