### PR TITLE
Restore struct packing to network structs that were removed

### DIFF
--- a/include/kos/net.h
+++ b/include/kos/net.h
@@ -247,7 +247,7 @@ typedef struct ip_hdr_s {
     uint16  checksum;           /**< \brief IP checksum */
     uint32  src;                /**< \brief Source IP address */
     uint32  dest;               /**< \brief Destination IP address */
-} ip_hdr_t;
+} __packed ip_hdr_t;
 
 /** \defgroup networking_ipv6   IPv6
     \brief                      IPv6 Network Stack
@@ -269,7 +269,7 @@ typedef struct ipv6_hdr_s {
     uint8           hop_limit;      /**< \brief Hop limit */
     struct in6_addr src_addr;       /**< \brief Source IP address */
     struct in6_addr dst_addr;       /**< \brief Destination IP address */
-} ipv6_hdr_t;
+} __packed ipv6_hdr_t;
 
 /***** net_arp.c **********************************************************/
 

--- a/kernel/net/net_arp.c
+++ b/kernel/net/net_arp.c
@@ -33,7 +33,7 @@ typedef struct {
     uint8 pr_send[4];
     uint8 hw_recv[6];
     uint8 pr_recv[6];
-} arp_pkt_t;
+} __packed arp_pkt_t;
 
 /* Structure describing an ARP entry; each entry contains a MAC address,
    an IP address, and a timestamp from 'jiffies'. The timestamp allows

--- a/kernel/net/net_dhcp.h
+++ b/kernel/net/net_dhcp.h
@@ -141,7 +141,7 @@ typedef struct dhcp_pkt {
     char    sname[64];
     char    file[128];
     uint8   options[];
-} dhcp_pkt_t;
+} __packed dhcp_pkt_t;
 
 int net_dhcp_init(void);
 

--- a/kernel/net/net_icmp.h
+++ b/kernel/net/net_icmp.h
@@ -24,7 +24,7 @@ typedef struct {
         uint16 m16[2];
         uint32 m32;
     } misc;
-} icmp_hdr_t;
+} __packed icmp_hdr_t;
 
 #define ICMP_MESSAGE_ECHO_REPLY         0
 #define ICMP_MESSAGE_DEST_UNREACHABLE   3

--- a/kernel/net/net_icmp6.h
+++ b/kernel/net/net_icmp6.h
@@ -15,7 +15,7 @@ typedef struct icmp6_hdr_s {
     uint8   type;
     uint8   code;
     uint16  checksum;
-} icmp6_hdr_t;
+} __packed icmp6_hdr_t;
 
 /* Header for Destination Unreachable packets (type 1) */
 typedef struct icmp6_dest_unreach_s {
@@ -23,7 +23,7 @@ typedef struct icmp6_dest_unreach_s {
     uint8   code;
     uint16  checksum;
     uint32  unused;
-} icmp6_dest_unreach_t;
+} __packed icmp6_dest_unreach_t;
 
 /* Header for Packet Too Big packets (type 2) */
 typedef struct icmp6_pkt_too_big_s {
@@ -31,7 +31,7 @@ typedef struct icmp6_pkt_too_big_s {
     uint8   code;
     uint16  checksum;
     uint32  mtu;
-} icmp6_pkt_too_big_t;
+} __packed icmp6_pkt_too_big_t;
 
 /* Header for Time Exceeded packets (type 3) */
 typedef struct icmp6_time_exceeded_s {
@@ -39,7 +39,7 @@ typedef struct icmp6_time_exceeded_s {
     uint8   code;
     uint16  checksum;
     uint32  unused;
-} icmp6_time_exceeded_t;
+} __packed icmp6_time_exceeded_t;
 
 /* Header for Parameter Problem packets (type 4) */
 typedef struct icmp6_param_problem_s {
@@ -47,7 +47,7 @@ typedef struct icmp6_param_problem_s {
     uint8   code;
     uint16  checksum;
     uint32  ptr;
-} icmp6_param_problem_t;
+} __packed icmp6_param_problem_t;
 
 /* Header for Echo/Echo Reply packets (types 128/129) */
 typedef struct icmp6_echo_hdr_s {
@@ -56,7 +56,7 @@ typedef struct icmp6_echo_hdr_s {
     uint16  checksum;
     uint16  ident;
     uint16  seq;
-} icmp6_echo_hdr_t;
+} __packed icmp6_echo_hdr_t;
 
 /* Format for Router Solicitation packets (type 133) - RFC 4861 */
 typedef struct icmp6_router_sol_s {
@@ -65,7 +65,7 @@ typedef struct icmp6_router_sol_s {
     uint16  checksum;
     uint32  reserved;
     uint8   options[];
-} icmp6_router_sol_t;
+} __packed icmp6_router_sol_t;
 
 /* Format for Router Advertisement packets (type 134) - RFC 4861 */
 typedef struct icmp6_router_adv_s {
@@ -78,7 +78,7 @@ typedef struct icmp6_router_adv_s {
     uint32  reachable_time;
     uint32  retrans_timer;
     uint8   options[];
-} icmp6_router_adv_t;
+} __packed icmp6_router_adv_t;
 
 /* Format for Neighbor Solicitation packets (type 135) - RFC 4861 */
 typedef struct icmp6_neighbor_sol_s {
@@ -88,7 +88,7 @@ typedef struct icmp6_neighbor_sol_s {
     uint32          reserved;
     struct in6_addr target;
     uint8           options[];
-} icmp6_neighbor_sol_t;
+} __packed icmp6_neighbor_sol_t;
 
 /* Format for Neighbor Advertisement packets (type 136) - RFC 4861 */
 typedef struct icmp6_neighbor_adv_s {
@@ -99,7 +99,7 @@ typedef struct icmp6_neighbor_adv_s {
     uint8           reserved[3];
     struct in6_addr target;
     uint8           options[];
-} icmp6_neighbor_adv_t;
+} __packed icmp6_neighbor_adv_t;
 
 /* Link-layer address option for neighbor advertisement/solictation packets for
    ethernet. */
@@ -107,7 +107,7 @@ typedef struct icmp6_nsol_lladdr_s {
     uint8           type;
     uint8           length;
     uint8           mac[6];
-} icmp6_nsol_lladdr_t;
+} __packed icmp6_nsol_lladdr_t;
 
 /* Redirect packet (type 137) - RFC 4861 */
 typedef struct icmp6_redirect_s {
@@ -118,7 +118,7 @@ typedef struct icmp6_redirect_s {
     struct in6_addr target;
     struct in6_addr dest;
     uint8           options[];
-} icmp6_redirect_t;
+} __packed icmp6_redirect_t;
 
 /* Prefix information for router advertisement packets */
 typedef struct icmp6_ndp_prefix_s {
@@ -130,7 +130,7 @@ typedef struct icmp6_ndp_prefix_s {
     uint32          preferred_time;
     uint32          reserved;
     struct in6_addr prefix;
-} icmp6_ndp_prefix_t;
+} __packed icmp6_ndp_prefix_t;
 
 /* ICMPv6 Message types */
 /* Error messages (type < 127) */

--- a/kernel/net/net_ipv4.h
+++ b/kernel/net/net_ipv4.h
@@ -15,7 +15,7 @@ typedef struct {
     uint8   dest[6];
     uint8   src[6];
     uint8   type[2];
-} eth_hdr_t;
+} __packed eth_hdr_t;
 
 typedef struct {
     uint32 src_addr;
@@ -23,7 +23,7 @@ typedef struct {
     uint8 zero;
     uint8 proto;
     uint16 length;
-} ipv4_pseudo_hdr_t;
+} __packed ipv4_pseudo_hdr_t;
 
 uint16 net_ipv4_checksum(const uint8 *data, size_t bytes, uint16 start);
 int net_ipv4_send_packet(netif_t *net, ip_hdr_t *hdr, const uint8 *data,

--- a/kernel/net/net_ipv6.h
+++ b/kernel/net/net_ipv6.h
@@ -16,7 +16,7 @@ typedef struct ipv6_ext_hdr_s {
     uint8       next_header;
     uint8       ext_length;
     uint8       data[];
-} ipv6_ext_hdr_t;
+} __packed ipv6_ext_hdr_t;
 
 typedef struct ipv6_pseudo_hdr_s {
     struct in6_addr src_addr;
@@ -24,7 +24,7 @@ typedef struct ipv6_pseudo_hdr_s {
     uint32          upper_layer_len;
     uint8           zero[3];
     uint8           next_header;
-} ipv6_pseudo_hdr_t;
+} __packed ipv6_pseudo_hdr_t;
 
 #define IPV6_HDR_EXT_HOP_BY_HOP     0
 #define IPV6_HDR_EXT_ROUTING        43

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -101,7 +101,7 @@ typedef struct tcp_hdr {
     uint16_t checksum;
     uint16_t urg;
     uint8_t options[];
-} tcp_hdr_t;
+} __packed tcp_hdr_t;
 
 /* Listening socket. Each one of these is an incoming connection from a socket
    that is in the listen state */

--- a/kernel/net/net_udp.c
+++ b/kernel/net/net_udp.c
@@ -34,10 +34,10 @@
 #define UDP_DEFAULT_HOPS    64
 
 typedef struct {
-    uint16 src_port;
-    uint16 dst_port;
-    uint16 length;
-    uint16 checksum;
+    uint16 src_port __packed;
+    uint16 dst_port __packed;
+    uint16 length __packed;
+    uint16 checksum __packed;
 } udp_hdr_t;
 
 struct udp_pkt {


### PR DESCRIPTION
In commit 02c99c9, the packed attribute was removed from various structs in the network stack. This caused networking to crash. This commit restores the packed attributes to all structs it was applied to previously.

It seemed to work once I only packed `ip_hdr_t` and `tcp_hdr_t`, but since I cannot thoroughly test all of the networking modes, IPv4/IPv6, etc., I'm restoring the attributes across the whole network stack.