### PR TITLE
Isolate toolchain patch from main KOS API.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 KOS_CFLAGS += -Wextra -Wno-deprecated
 
 # Add stuff to SUBDIRS to auto-compile it with the big tree.
-SUBDIRS = utils kernel addons # examples
+SUBDIRS = utils kernel addons build_tests # examples
 
 # Detect a non-working or missing environ.sh file.
 ifndef KOS_BASE

--- a/build_tests/dreamcast/build_tests/toolchain_api_change/Makefile
+++ b/build_tests/dreamcast/build_tests/toolchain_api_change/Makefile
@@ -1,0 +1,22 @@
+#
+# Toolchain/API validator
+# Copyright (C) 2025 Donald Haase
+#
+
+TARGET = test.elf
+OBJS = test.o
+
+all: rm-elf $(TARGET)
+
+KOS_CFLAGS += -I$(KOS_BASE)/utils/dc-chain/patches/gcc/
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $@ $^

--- a/build_tests/dreamcast/build_tests/toolchain_api_change/test.c
+++ b/build_tests/dreamcast/build_tests/toolchain_api_change/test.c
@@ -1,0 +1,29 @@
+/* KallistiOS ##version##
+
+   test.c
+   Copyright (C) 2025 Donald Haase
+
+   This is intended to validate that the API required by the toolchain
+   to build correctly hasn't changed.
+*/
+
+/* For EXIT_SUCCESS */
+#include <stdlib.h>
+
+/* Include the actual headers from KOS */
+#include <kos/thread.h>
+#include <kos/tls.h>
+#include <kos/mutex.h>
+#include <kos/once.h>
+#include <kos/cond.h>
+#include <arch/irq.h>
+
+/* Include the patch header to see if there are conflicts */
+#include <gthr-kos.h>
+
+int main(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+
+    return EXIT_SUCCESS;
+}

--- a/build_tests/dreamcast/build_tests/toolchain_api_change_objc/Makefile
+++ b/build_tests/dreamcast/build_tests/toolchain_api_change_objc/Makefile
@@ -1,0 +1,23 @@
+#
+# Toolchain/API validator (ObjC version)
+# Copyright (C) 2025 Donald Haase
+#
+
+TARGET = test.elf
+OBJS = test.o
+
+all: rm-elf $(TARGET)
+
+#Include the dir with the patch to access it, as well as local for a stub <config.h>
+KOS_CFLAGS += -I$(KOS_BASE)/utils/dc-chain/patches/gcc/ -I.
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS) -lobjc

--- a/build_tests/dreamcast/build_tests/toolchain_api_change_objc/test.m
+++ b/build_tests/dreamcast/build_tests/toolchain_api_change_objc/test.m
@@ -1,0 +1,28 @@
+/* KallistiOS ##version##
+
+   test.c
+   Copyright (C) 2025 Donald Haase
+
+   This is intended to validate that the API required by the toolchain
+   to build correctly hasn't changed.
+*/
+
+#import <objc/objc.h>
+#import <objc/Object.h>
+#import <objc/runtime.h>
+#import <objc/thr.h>
+
+#include <stdlib.h>
+
+/* Ensure we're testing the libobj patch */
+#ifndef _LIBOBJC
+    #define _LIBOBJC
+#endif
+
+/* Include the patch header to see if there are conflicts */
+#include <gthr-kos.h>
+
+int main(int argc, char *argv[]) {
+    (void)argc; (void)argv;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This replaces the includes from KOS headers with forward declarations and definitions for the minimally required functionality. This should help prevent changes in KOS headers from causing toolchain build issues except for the narrow cases where the API is changed for these core functions (which would have been the case before as well).

Additionally have added two 'test' examples which include the actual kos headers then force the inclusion of the patch in order to have a warning system if a mismatch happens that could impact the toolchain.


I'm not sure if this is a good idea, and am looking for feedback. It seems like it might have more negative side effects, but I *think* the tradeoff is just having to keep the core threading primitives in sync (which rarely change) with the patch file if they change in KOS.

EDIT: Something that hadn't occurred to me when writing this up was that we already do exactly this via https://github.com/KallistiOS/KallistiOS/blob/master/utils/dc-chain/patches/gcc/fake-kos.S where we have to provide symbols for all those same functions being provided for threading.