### PR TITLE
scif: disable MCE by default

### DIFF
--- a/kernel/arch/dreamcast/hardware/scif.c
+++ b/kernel/arch/dreamcast/hardware/scif.c
@@ -242,8 +242,8 @@ int scif_init(void) {
     for(i = 0; i < 800000; i++)
         __asm__("nop");
 
-    /* Unreset, enable hardware flow control, triggers on 8 bytes */
-    SCFCR2 = 0x48;
+    /* Unreset, disable hardware flow control, triggers on 8 bytes */
+    SCFCR2 = 0x40;
 
     /* Disable manual pin control */
     SCSPTR2 = 0;


### PR DESCRIPTION
Enabling MCE is not a reasonable library default because the typical USB-UARTs that are connected to the Dreamcast have large ~1024 byte TX/RX buffers and the maximum Dreamcast SCIF baud rate is slow compared to the capabilities of these chips.

Given the use-case for scif.c appears to be to allow for synchronously-blocking debug prints over scif, from a library/policy perspective MCE should be considered a "specialized" configuration.

For KallistiOS users, the behavior prior to this commit was:

- serial transmission may be silently permanently disabled due to the SCIF CTS pin being disconnected or tied high

- it is not possible to use RTS/CTS as GPIO pins while also using scif.c