### PR TITLE
Clean up `pvr_init_params_t` usage in examples.

### DIFF
--- a/examples/dreamcast/2ndmix/2ndmix.c
+++ b/examples/dreamcast/2ndmix/2ndmix.c
@@ -823,7 +823,10 @@ pvr_init_params_t params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0 },
 
     /* Vertex buffer size 512K */
-    512 * 1024
+    512 * 1024,
+
+    /* Defaults for the rest */
+    0, 0, 0, 0, 0
 };
 
 KOS_INIT_FLAGS(INIT_DEFAULT);

--- a/examples/dreamcast/cpp/clock/clock.cc
+++ b/examples/dreamcast/cpp/clock/clock.cc
@@ -145,7 +145,11 @@ int read_input() {
 }
 
 int main(int argc, char **argv) {
-    pvr_init_params_t pvrInit = { {PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_32, PVR_BINSIZE_0, PVR_BINSIZE_0}, 512 * 1024};
+    pvr_init_params_t pvrInit = {
+        {PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_32, PVR_BINSIZE_0, PVR_BINSIZE_0},
+        512 * 1024, 0, 0, 0, 0, 0
+    };
+
     pvr_init(&pvrInit);
 
     text = new fntRenderer();

--- a/examples/dreamcast/cpp/dcplib/fnt_test.cc
+++ b/examples/dreamcast/cpp/dcplib/fnt_test.cc
@@ -205,7 +205,11 @@ int read_input() {
 }
 
 int main(int argc, char **argv) {
-    pvr_init_params_t pvrInit = { {PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_32, PVR_BINSIZE_0, PVR_BINSIZE_0}, 512 * 1024};
+    pvr_init_params_t pvrInit = {
+        {PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_32, PVR_BINSIZE_0, PVR_BINSIZE_0},
+        512 * 1024, 0, 0, 0, 0, 0
+    };
+
     pvr_init(&pvrInit);
 
     text = new fntRenderer();

--- a/examples/dreamcast/gldc/benchmarks/quadmark/quadmark.c
+++ b/examples/dreamcast/gldc/benchmarks/quadmark/quadmark.c
@@ -16,7 +16,7 @@
 
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 enum { PHASE_HALVE, PHASE_INCR, PHASE_DECR, PHASE_FINAL };

--- a/examples/dreamcast/gldc/benchmarks/trimark/trimark.c
+++ b/examples/dreamcast/gldc/benchmarks/trimark/trimark.c
@@ -16,7 +16,7 @@
 
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 enum { PHASE_HALVE, PHASE_INCR, PHASE_DECR, PHASE_FINAL };

--- a/examples/dreamcast/gldc/benchmarks/tristripmark/tristripmark.c
+++ b/examples/dreamcast/gldc/benchmarks/tristripmark/tristripmark.c
@@ -16,7 +16,7 @@
 
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 enum { PHASE_HALVE, PHASE_INCR, PHASE_DECR, PHASE_FINAL };

--- a/examples/dreamcast/kgl/basic/scissor/scissor.c
+++ b/examples/dreamcast/kgl/basic/scissor/scissor.c
@@ -209,7 +209,10 @@ pvr_init_params_t params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0 },
 
     /* Vertex buffer size 512K */
-    512 * 1024
+    512 * 1024,
+
+    /* Defaults for the rest */
+    0, 0, 0, 0, 0
 };
 
 int main(int argc, char **argv) {

--- a/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
+++ b/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
@@ -16,7 +16,7 @@
 
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 enum { PHASE_HALVE, PHASE_INCR, PHASE_DECR, PHASE_FINAL };

--- a/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
+++ b/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
@@ -16,7 +16,7 @@
 
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 enum { PHASE_HALVE, PHASE_INCR, PHASE_DECR, PHASE_FINAL };

--- a/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
+++ b/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
@@ -16,7 +16,7 @@
 
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 enum { PHASE_HALVE, PHASE_INCR, PHASE_DECR, PHASE_FINAL };

--- a/examples/dreamcast/libdream/ta/ta.c
+++ b/examples/dreamcast/libdream/ta/ta.c
@@ -155,7 +155,7 @@ void draw_frame(void) {
 /* Main program: init and loop drawing polygons */
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    64 * 1024
+    64 * 1024, 0, 0, 0, 0, 0
 };
 int main(int argc, char **argv) {
     pvr_init(&pvr_params);

--- a/examples/dreamcast/parallax/bubbles/bubbles.c
+++ b/examples/dreamcast/parallax/bubbles/bubbles.c
@@ -249,7 +249,10 @@ pvr_init_params_t params = {
     0,
 
     /* Extra OPBs */
-    3
+    3,
+
+    /* Vertex buffer double-buffering enabled */
+    0
 };
 
 int main(int argc, char **argv) {

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -256,11 +256,14 @@ pvr_init_params_t params = {
     /* No FSAA */
     0,
 
-    /* Translucent Autosort enabled. */
+    /* Translucent Autosort enabled */
     0,
 
     /* Extra OPBs */
-    3
+    3,
+
+    /* Vertex buffer double-buffering enabled */
+    0
 };
 
 // DMA buffers. This should ideally be in separate memory banks to take

--- a/examples/dreamcast/pvr/bumpmap/bump.c
+++ b/examples/dreamcast/pvr/bumpmap/bump.c
@@ -207,7 +207,7 @@ static pvr_init_params_t pvr_params = {
         PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0,
         PVR_BINSIZE_16
     },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 int main(int argc, char *argv[]) {

--- a/examples/dreamcast/pvr/cheap_shadow/shadow.c
+++ b/examples/dreamcast/pvr/cheap_shadow/shadow.c
@@ -194,7 +194,7 @@ static pvr_init_params_t pvr_params = {
         PVR_BINSIZE_16, PVR_BINSIZE_16, PVR_BINSIZE_16, PVR_BINSIZE_16,
         PVR_BINSIZE_0
     },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 int main(int argc, char *argv[]) {

--- a/examples/dreamcast/pvr/modifier_volume/modifier.c
+++ b/examples/dreamcast/pvr/modifier_volume/modifier.c
@@ -179,7 +179,7 @@ static pvr_init_params_t pvr_params = {
         PVR_BINSIZE_16, PVR_BINSIZE_16, PVR_BINSIZE_16, PVR_BINSIZE_16,
         PVR_BINSIZE_0
     },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 int main(int argc, char *argv[]) {

--- a/examples/dreamcast/pvr/modifier_volume_tex/modifier.c
+++ b/examples/dreamcast/pvr/modifier_volume_tex/modifier.c
@@ -230,7 +230,7 @@ static pvr_init_params_t pvr_params = {
         PVR_BINSIZE_16, PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0,
         PVR_BINSIZE_0
     },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 int main(int argc, char *argv[]) {

--- a/examples/dreamcast/pvr/pvrline/pvrline.c
+++ b/examples/dreamcast/pvr/pvrline/pvrline.c
@@ -23,7 +23,7 @@ KOS_INIT_FLAGS(INIT_DEFAULT);
 
 /* enable OP and TR lists */
 pvr_init_params_t pvr_params = {
-{ PVR_BINSIZE_16, 0, PVR_BINSIZE_16, 0, 0 }, VERTBUF_SIZE, 1, 0, 0, 3
+{ PVR_BINSIZE_16, 0, PVR_BINSIZE_16, 0, 0 }, VERTBUF_SIZE, 1, 0, 0, 3, 0
 };
 
 uint8_t __attribute__((aligned(32))) op_buf[VERTBUF_SIZE];

--- a/examples/dreamcast/pvr/pvrmark/pvrmark.c
+++ b/examples/dreamcast/pvr/pvrmark/pvrmark.c
@@ -10,7 +10,7 @@
 
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    1024 * 1024
+    1024 * 1024, 0, 0, 0, 0, 0
 };
 
 enum { PHASE_HALVE, PHASE_INCR, PHASE_DECR, PHASE_FINAL };

--- a/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
+++ b/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
@@ -10,7 +10,7 @@
 
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 enum { PHASE_HALVE, PHASE_INCR, PHASE_DECR, PHASE_FINAL };

--- a/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
+++ b/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
@@ -19,7 +19,7 @@ enum { PHASE_HALVE, PHASE_INCR, PHASE_DECR, PHASE_FINAL };
 
 static pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    512 * 1024
+    512 * 1024, 0, 0, 0, 0, 0
 };
 
 static int polycnt;

--- a/examples/dreamcast/pvr/texture_render/texture_render.c
+++ b/examples/dreamcast/pvr/texture_render/texture_render.c
@@ -190,7 +190,7 @@ void draw_textured(void) {
 pvr_init_params_t pvr_params = {
     { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0,
       PVR_BINSIZE_0, PVR_BINSIZE_0 },
-    64 * 1024
+    64 * 1024, 0, 0, 0, 0, 0
 };
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
As we've expanded the members of the struct, the new ones are each set to have 0 as the default behavior in order to be able to allow backwards compatibility in most cases. Catching all these up by filling in those implicit 0s with explicit ones as better demonstration of the params available and to clear up warnings as the compatibility behavior generates.