### PR TITLE
Fix use-after-free in `fs_close`.

### DIFF
--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -340,10 +340,6 @@ int fs_close(file_t fd) {
     /* Deref it and remove it from our table */
     retval = fs_hnd_unref(h);
 
-    /* Reset our position */
-    if(h->refcnt == 0)
-        h->idx = 0;
-
     fd_table[fd] = NULL;
     return retval ? -1 : 0;
 }


### PR DESCRIPTION
Seems this was added in #634 with the notion of resetting the readdir index tracking on file close. The problem is that the only time it would apply is when there are 0 references, which means the file handle has already been freed based on the behavior of `fs_hnd_unref`.