### PR TITLE
`libkosext2fs`: Ensure buffer can store uint32s.

### DIFF
--- a/addons/libkosext2fs/inode.c
+++ b/addons/libkosext2fs/inode.c
@@ -989,9 +989,11 @@ static ext2_dirent_t *search_indir_23(ext2_fs_t *fs, const uint32_t *iblock,
     uint32_t *buf;
     int i, block_ents;
     ext2_dirent_t *rv;
+    /* Ensure the buffer will hold uint32_ts */
+    size_t bufsize = __align_up(block_size, sizeof(buf[0]));
 
     /* We're going to need this buffer... */
-    if(!(buf = (uint32_t *)malloc(block_size))) {
+    if(!(buf = (uint32_t *)malloc(bufsize))) {
         *err = -ENOMEM;
         return NULL;
     }


### PR DESCRIPTION
As the malloc'd returned buffer is accessed as `uint32_t *` we should ensure that the size of it is a multiple of 4 otherwise we could read into unallocated memory.

gcc complains of this with `-fanalyzer` on and it's set to `-Werror`. There's likely a cleaner way to do this, or perhaps to let gcc see better that the buffer would already be appropriately sized.

EDIT: found the macro preexisting in newlib's `<sys/cdefs.h>`. Turns out we actually have a lot of these. In this case it's backed by a builtin from gcc ( `__builtin_align_up(x, y)` ) that's been there since ~v9.