### PR TITLE
Deprecate custom `ptr_t` type.

### DIFF
--- a/addons/libkosext2fs/fs_ext2.c
+++ b/addons/libkosext2fs/fs_ext2.c
@@ -1703,7 +1703,7 @@ int fs_ext2_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     /* Root directory ext2 device */
     if(len == 0 || (len == 1 && *path == '/')) {
         memset(st, 0, sizeof(struct stat));
-        st->st_dev = (dev_t)((ptr_t)vfs);
+        st->st_dev = (dev_t)((uintptr_t)vfs);
         st->st_mode = S_IFDIR | S_IRUSR | S_IRGRP | S_IROTH | S_IXUSR |
             S_IXGRP | S_IXOTH | S_IWUSR | S_IWGRP | S_IWOTH;
         st->st_size = -1;
@@ -1723,7 +1723,7 @@ int fs_ext2_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
 
     /* Fill in the structure */
     memset(st, 0, sizeof(struct stat));
-    st->st_dev = (dev_t)((ptr_t)vfs);
+    st->st_dev = (dev_t)((uintptr_t)vfs);
     st->st_ino = inode_num;
     st->st_mode = inode->i_mode & 0x0FFF;
     st->st_nlink = inode->i_links_count;
@@ -1823,7 +1823,7 @@ static int fs_ext2_fstat(void *h, struct stat *st) {
 
     /* Fill in the structure */
     memset(st, 0, sizeof(struct stat));
-    st->st_dev = (dev_t)((ptr_t)fs->vfsh);
+    st->st_dev = (dev_t)((uintptr_t)fs->vfsh);
     st->st_ino = fh[fd].inode_num;
     st->st_mode = inode->i_mode & 0x0FFF;
     st->st_nlink = inode->i_links_count;

--- a/addons/libkosfat/fs_fat.c
+++ b/addons/libkosfat/fs_fat.c
@@ -1052,7 +1052,7 @@ static int fs_fat_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     /* Root directory fat device */
     if(len == 0 || (len == 1 && *path == '/')) {
         memset(st, 0, sizeof(struct stat));
-        st->st_dev = (dev_t)((ptr_t)fs->vfsh);
+        st->st_dev = (dev_t)((uintptr_t)fs->vfsh);
         st->st_mode = S_IFDIR | S_IRUSR | S_IRGRP | S_IROTH | S_IXUSR |
             S_IXGRP | S_IXOTH | S_IWUSR | S_IWGRP | S_IWOTH;
         st->st_size = -1;
@@ -1074,7 +1074,7 @@ static int fs_fat_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     /* Fill in the structure */
     memset(st, 0, sizeof(struct stat));
     irv = 0;
-    st->st_dev = (dev_t)((ptr_t)fs->vfsh);
+    st->st_dev = (dev_t)((uintptr_t)fs->vfsh);
     st->st_ino = ent.cluster_low | (ent.cluster_high << 16);
     st->st_nlink = 1;
     st->st_uid = 0;
@@ -1266,7 +1266,7 @@ static int fs_fat_fstat(void *h, struct stat *buf) {
 
     /* Fill in the structure */
     memset(buf, 0, sizeof(struct stat));
-    buf->st_dev = (dev_t)((ptr_t)fs->vfsh);
+    buf->st_dev = (dev_t)((uintptr_t)fs->vfsh);
     buf->st_ino = ent->cluster_low | (ent->cluster_high << 16);
     buf->st_nlink = 1;
     buf->st_uid = 0;

--- a/addons/libpthread/pthread_attr_setstack.c
+++ b/addons/libpthread/pthread_attr_setstack.c
@@ -7,10 +7,11 @@
 #include "pthread-internal.h"
 #include <pthread.h>
 #include <errno.h>
+#include <stdint.h>
 
 int pthread_attr_setstack(pthread_attr_t *restrict attr,
                           void *restrict stackaddr, size_t stacksize) {
-    ptr_t addr = (ptr_t)stackaddr;
+    uintptr_t addr = (uintptr_t)stackaddr;
 
     if(!attr)
         return EINVAL;

--- a/include/kos/elf.h
+++ b/include/kos/elf.h
@@ -24,6 +24,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
+#include <stdint.h>
 #include <arch/types.h>
 #include <sys/queue.h>
 
@@ -306,10 +307,10 @@ typedef struct elf_prog {
     uint32 size;            /**< \brief Memory image size (rounded up to page size) */
 
     /* Library exports */
-    ptr_t lib_get_name;     /**< \brief Pointer to get_name() function */
-    ptr_t lib_get_version;  /**< \brief Pointer to get_version() function */
-    ptr_t lib_open;         /**< \brief Pointer to library's open function */
-    ptr_t lib_close;        /**< \brief Pointer to library's close function */
+    uintptr_t lib_get_name;     /**< \brief Pointer to get_name() function */
+    uintptr_t lib_get_version;  /**< \brief Pointer to get_version() function */
+    uintptr_t lib_open;         /**< \brief Pointer to library's open function */
+    uintptr_t lib_close;        /**< \brief Pointer to library's close function */
 
     char fn[256];           /**< \brief Filename of library */
 } elf_prog_t;

--- a/include/kos/genwait.h
+++ b/include/kos/genwait.h
@@ -27,6 +27,7 @@
 __BEGIN_DECLS
 
 #include <kos/thread.h>
+#include <stdint.h>
 
 /** \brief  Sleep on an object.
 
@@ -132,7 +133,7 @@ int genwait_wake_thd(void *obj, kthread_t *thd, int err);
 
     \param  now             The current system time, in milliseconds since boot
 */
-void genwait_check_timeouts(uint64 now);
+void genwait_check_timeouts(uint64_t now);
 
 /** \brief  Look for the next timeout event time.
 
@@ -143,7 +144,7 @@ void genwait_check_timeouts(uint64 now);
     \return                 The next timeout time in milliseconds since boot, or
                             0 if there are no pending genwait_wait() calls
 */
-uint64 genwait_next_timeout(void);
+uint64_t genwait_next_timeout(void);
 
 /** \cond */
 /* Initialize the genwait system */

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -26,6 +26,7 @@ printf goes to the dc-tool console
 #include <kos/init.h>
 
 #include <errno.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -351,7 +352,7 @@ static int dcload_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     /* Root directory '/pc' */
     if(len == 0 || (len == 1 && *path == '/')) {
         memset(st, 0, sizeof(struct stat));
-        st->st_dev = (dev_t)((ptr_t)vfs);
+        st->st_dev = (dev_t)((uintptr_t)vfs);
         st->st_mode = S_IFDIR | S_IRWXU | S_IRWXG | S_IRWXO;
         st->st_size = -1;
         st->st_nlink = 2;
@@ -365,7 +366,7 @@ static int dcload_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
 
     if(!retval) {
         memset(st, 0, sizeof(struct stat));
-        st->st_dev = (dev_t)((ptr_t)vfs);
+        st->st_dev = (dev_t)((uintptr_t)vfs);
         st->st_ino = filestat.st_ino;
         st->st_mode = filestat.st_mode;
         st->st_nlink = filestat.st_nlink;

--- a/kernel/arch/dreamcast/fs/fs_dclsocket.c
+++ b/kernel/arch/dreamcast/fs/fs_dclsocket.c
@@ -24,6 +24,7 @@
 #include <arpa/inet.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <unistd.h>
 #include <errno.h>
 #include <dirent.h>
@@ -528,7 +529,7 @@ static int dcls_stat(vfs_handler_t *vfs, const char *fn, struct stat *rv,
 
     if(!retval) {
         memset(rv, 0, sizeof(struct stat));
-        rv->st_dev = (dev_t)((ptr_t)vfs);
+        rv->st_dev = (dev_t)((uintptr_t)vfs);
         rv->st_ino = filestat.st_ino;
         rv->st_mode = filestat.st_mode;
         rv->st_nlink = filestat.st_nlink;

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -6,6 +6,7 @@
 
 */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -729,7 +730,7 @@ static int vmu_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
 
     /* Get the number of free blocks */
     memset(st, 0, sizeof(struct stat));
-    st->st_dev = (dev_t)((ptr_t)dev);
+    st->st_dev = (dev_t)((uintptr_t)dev);
     st->st_mode = S_IFDIR | S_IRUSR | S_IXUSR | S_IRGRP | 
         S_IXGRP | S_IROTH | S_IXOTH;
     st->st_size = vmufs_free_blocks(dev);
@@ -806,7 +807,7 @@ static int vmu_fstat(void *fd, struct stat *st) {
 
     fh = (vmu_fh_t *)fd;
     memset(st, 0, sizeof(struct stat));
-    st->st_dev = (dev_t)((ptr_t)fh->dev);
+    st->st_dev = (dev_t)((uintptr_t)fh->dev);
     st->st_mode =  S_IRWXU | S_IRWXG | S_IRWXO;
     st->st_mode |= (fh->strtype == VMU_DIR) ? S_IFDIR : S_IFREG;
     st->st_size = (fh->strtype == VMU_DIR) ? 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -7,6 +7,7 @@
  */
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <kos/genwait.h>
@@ -39,7 +40,7 @@ void *pvr_set_vertbuf(pvr_list_t list, void *buffer, size_t len) {
     assert(pvr_state.lists_enabled & BIT(list));
 
     // Make sure the buffer parameters are valid.
-    assert(!(((ptr_t)buffer) & 31));
+    assert(!(((uintptr_t)buffer) & 31));
     assert(!(len & 63));
 
     // Save the old value.

--- a/kernel/arch/dreamcast/include/arch/types.h
+++ b/kernel/arch/dreamcast/include/arch/types.h
@@ -48,9 +48,6 @@ typedef volatile int32 vint32;      /**< \brief 32-bit volatile signed type */
 typedef volatile int16 vint16;      /**< \brief 16-bit volatile signed type */
 typedef volatile int8 vint8;        /**< \brief 8-bit volatile signed type */
 
-/* Pointer arithmetic types */
-typedef uint32 ptr_t;               /**< \brief Pointer arithmetic type */
-
 /* This type may be used for any generic handle type that is allowed
    to be negative (for errors) and has no specific bit count
    restraints. */

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -23,6 +23,7 @@ on sunsite.unc.edu in /pub/Linux/system/recovery/, or as a package under Debian 
 #include <kos/opts.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 #include <strings.h>
 #include <stdio.h>
@@ -462,7 +463,7 @@ static int romdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     /* Root directory of romdisk */
     if(len == 0 || (len == 1 && *path == '/')) {
         memset(st, 0, sizeof(struct stat));
-        st->st_dev = (dev_t)((ptr_t)mnt);
+        st->st_dev = (dev_t)((uintptr_t)mnt);
         st->st_mode = S_IFDIR | S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP |
             S_IROTH | S_IXOTH;
         st->st_size = -1;
@@ -488,7 +489,7 @@ static int romdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     }
        
     memset(st, 0, sizeof(struct stat));
-    st->st_dev = (dev_t)((ptr_t)mnt);
+    st->st_dev = (dev_t)((uintptr_t)mnt);
     st->st_mode = md | S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
     st->st_size = -1;
     st->st_nlink = 2;
@@ -562,7 +563,7 @@ static int romdisk_fstat(void *h, struct stat *st) {
     }
 
     memset(st, 0, sizeof(struct stat));
-    st->st_dev = (dev_t)((ptr_t)fh[fd].mnt);
+    st->st_dev = (dev_t)((uintptr_t)fh[fd].mnt);
     st->st_mode = S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
     st->st_mode |= (fh[fd].dir) ? S_IFDIR : S_IFREG;
     st->st_size = fh[fd].size;

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -16,6 +16,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <assert.h>
 #include <errno.h>
 
@@ -28,7 +29,7 @@
    on to something. :) */
 #define TABLESIZE   128
 static TAILQ_HEAD(slpquehead, kthread) slpque[TABLESIZE];
-#define LOOKUP(x)   (((ptr_t)(x) >> 8) & (TABLESIZE - 1))
+#define LOOKUP(x)   (((uintptr_t)(x) >> 8) & (TABLESIZE - 1))
 
 /* Timed event queue. Anything that isn't ready to run yet, but will be
    ready to run at a later time will be placed here. Note that this doesn't
@@ -218,7 +219,7 @@ int genwait_wake_thd(void *obj, kthread_t *thd, int err) {
     return 0;
 }
 
-void genwait_check_timeouts(uint64 tm) {
+void genwait_check_timeouts(uint64_t tm) {
     kthread_t   *t;
 
     t = tq_next();
@@ -245,7 +246,7 @@ void genwait_check_timeouts(uint64 tm) {
     }
 }
 
-uint64 genwait_next_timeout(void) {
+uint64_t genwait_next_timeout(void) {
     kthread_t * t;
 
     t = tq_next();

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -7,10 +7,10 @@
    Copyright (C) 2023, 2024 Falco Girgis
 */
 
-#include <stdlib.h>
 #include <assert.h>
 #include <string.h>
 #include <malloc.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -591,7 +591,7 @@ static inline void thd_schedule_inner(kthread_t *thd) {
 
     /* Make sure the thread hasn't underrun its stack */
     if(thd_current->stack && thd_current->stack_size) {
-        if(CONTEXT_SP(thd_current->context) < (ptr_t)(thd_current->stack)) {
+        if(CONTEXT_SP(thd_current->context) < (uintptr_t)(thd_current->stack)) {
             thd_pslist(printf);
             thd_pslist_queue(printf);
             assert_msg(0, "Thread stack underrun");


### PR DESCRIPTION
`ptr_t` is one of our custom types from <arch/types> and is obsoleted by the standard `uintptr_t` which has the same definition and usage.

Replace its use where found with `uintptr_t`, ensure each use has <stdint> included, and do one extra minor stdint cleanup along the way in genwait.

Working towards #840 

edit: force-pushed to fix a mistake in the commit message.