### PR TITLE
Fix missing include in speedtest.

### DIFF
--- a/examples/dreamcast/filesystem/sd/speedtest/sd-speedtest.c
+++ b/examples/dreamcast/filesystem/sd/speedtest/sd-speedtest.c
@@ -25,6 +25,7 @@
 
 #include <kos/init.h>
 #include <kos/dbgio.h>
+#include <kos/dbglog.h>
 #include <kos/blockdev.h>
 
 KOS_INIT_FLAGS(INIT_DEFAULT);


### PR DESCRIPTION
Add dbglog.h after removal from stdio in #1000