### PR TITLE
Add __is_defined() macro and use it across code

### DIFF
--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -277,6 +277,12 @@
 #define _array_size_chk(arr) 0
 #endif
 
+/** \brief Create a string from the argument.
+
+    \param arg      The text to stringify.
+ */
+#define __stringify(arg) ""#arg
+
 /** @} */
 
 #endif  /* __KOS_CDEFS_H */

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -283,6 +283,13 @@
  */
 #define __stringify(arg) ""#arg
 
+/** \brief Check if a macro is defined to 1.
+
+    \param macro    The macro to check
+    \return         1 if the macro is defined to 1, 0 otherwise.
+ */
+#define __is_defined(macro) !__builtin_strcmp(__stringify(macro), "1")
+
 /** @} */
 
 #endif  /* __KOS_CDEFS_H */

--- a/include/kos/version.h
+++ b/include/kos/version.h
@@ -263,9 +263,9 @@
                     `major.minor.patch`
 */
 #define KOS_VERSION_MAKE_STRING(major, minor, patch) \
-    KOS_STRINGIFY(major) "." \
-    KOS_STRINGIFY(minor) "." \
-    KOS_STRINGIFY(patch)
+    __stringify(major) "." \
+    __stringify(minor) "." \
+    __stringify(patch)
 /** @} */
 
 /** \name  Version Checking
@@ -380,10 +380,6 @@
 #define KOS_VERSION_MAKE_BELOW(major, minor, patch, version) \
     (KOS_VERSION_MAKE_COMPARISON(major, minor, patch, >, version))
 /** @} */
-
-/** \cond INTERNAL */
-#define KOS_STRINGIFY(str) #str
-/** \endcond */
 
 /** @} */
 

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -166,16 +166,17 @@ static vmu_fh_t *vmu_open_vmu_dir(void) {
                 names[num][0] = p + 'a';
                 names[num][1] = u + '0';
                 num++;
-#ifdef VMUFS_DEBUG
-                dbglog(DBG_KDEBUG, "vmu_open_vmu_dir: found memcard (%c%d)\n", 'a' + p, u);
-#endif
+
+                if(__is_defined(VMUFS_DEBUG)) {
+                    dbglog(DBG_KDEBUG, "vmu_open_vmu_dir: found memcard (%c%d)\n",
+                           'a' + p, u);
+                }
             }
         }
     }
 
-#ifdef VMUFS_DEBUG
-    dbglog(DBG_KDEBUG, "# of memcards found: %d\n", num);
-#endif
+    if(__is_defined(VMUFS_DEBUG))
+        dbglog(DBG_KDEBUG, "# of memcards found: %d\n", num);
 
     if(!(dh = malloc(sizeof(vmu_dh_t))))
         return NULL;
@@ -500,9 +501,8 @@ static ssize_t vmu_write(void * hnd, const void *buffer, size_t cnt) {
 
         n = n / 512;
 
-#ifdef VMUFS_DEBUG
-        dbglog(DBG_KDEBUG, "VMUFS: extending file's filesize by %d\n", n);
-#endif
+        if(__is_defined(VMUFS_DEBUG))
+            dbglog(DBG_KDEBUG, "VMUFS: extending file's filesize by %d\n", n);
 
         /* We alloc another 512*n bytes for the file */
         tmp = realloc(fh->data, (fh->filesize + n) * 512);
@@ -519,10 +519,11 @@ static ssize_t vmu_write(void * hnd, const void *buffer, size_t cnt) {
     }
 
     /* insert the data in buffer into fh->data at fh->loc */
-#ifdef VMUFS_DEBUG
-    dbglog(DBG_KDEBUG, "VMUFS: adding %d bytes of data at loc %d (%d avail)\n",
-           cnt, fh->loc, fh->filesize * 512);
-#endif
+    if(__is_defined(VMUFS_DEBUG)) {
+        dbglog(DBG_KDEBUG, "VMUFS: adding %d bytes of data at loc %d (%d avail)\n",
+               cnt, fh->loc, fh->filesize * 512);
+    }
+
     memcpy(fh->data + fh->loc + fh->start, buffer, cnt);
     fh->loc += cnt;
 

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -58,20 +58,22 @@ static void maple_hw_init(void) {
     }
 
     /* Allocate the DMA send buffer */
-#if MAPLE_DMA_DEBUG
-    maple_state.dma_buffer = aligned_alloc(32, MAPLE_DMA_SIZE + 1024);
-#else
-    maple_state.dma_buffer = aligned_alloc(32, MAPLE_DMA_SIZE);
-#endif
+    if(__is_defined(MAPLE_DMA_DEBUG))
+        maple_state.dma_buffer = aligned_alloc(32, MAPLE_DMA_SIZE + 1024);
+    else
+        maple_state.dma_buffer = aligned_alloc(32, MAPLE_DMA_SIZE);
+
     assert_msg(maple_state.dma_buffer != NULL, "Couldn't allocate maple DMA buffer");
     assert_msg((((uint32)maple_state.dma_buffer) & 0x1f) == 0, "DMA buffer was unaligned; bug in dlmalloc; please report!");
 
     /* Force it into the P2 area */
     maple_state.dma_buffer = (uint8*)((((uint32)maple_state.dma_buffer) & MEM_AREA_CACHE_MASK) | MEM_AREA_P2_BASE);
-#if MAPLE_DMA_DEBUG
-    maple_state.dma_buffer += 512;
-    maple_sentinel_setup(maple_state.dma_buffer - 512, MAPLE_DMA_SIZE + 1024);
-#endif
+
+    if(__is_defined(MAPLE_DMA_DEBUG)) {
+        maple_state.dma_buffer += 512;
+        maple_sentinel_setup(maple_state.dma_buffer - 512, MAPLE_DMA_SIZE + 1024);
+    }
+
     maple_state.dma_in_progress = 0;
     dbglog(DBG_INFO, "  DMA Buffer at %08lx\n", (uint32)maple_state.dma_buffer);
 
@@ -117,9 +119,10 @@ void maple_hw_shutdown(void) {
     /* We must cast this back to P1 or cache issues will arise */
     if(maple_state.dma_buffer != NULL) {
         ptr = (uint32)maple_state.dma_buffer;
-#if MAPLE_DMA_DEBUG
-        ptr -= 512;
-#endif
+
+        if(__is_defined(MAPLE_DMA_DEBUG))
+            ptr -= 512;
+
         ptr = (ptr & MEM_AREA_CACHE_MASK) | MEM_AREA_P1_BASE;
         free((void *)ptr);
         maple_state.dma_buffer = NULL;

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -49,10 +49,11 @@ static void vbl_chk_disconnect(maple_state_t *state, int p, int u) {
     (void)state;
 
     if(maple_dev_valid(p, u)) {
-#if MAPLE_IRQ_DEBUG
-        dbglog(DBG_KDEBUG, "maple: detach on device %c%c\n",
-               'A' + p, '0' + u);
-#endif
+        if(__is_defined(MAPLE_IRQ_DEBUG)) {
+            dbglog(DBG_KDEBUG, "maple: detach on device %c%c\n",
+                   'A' + p, '0' + u);
+        }
+
         if(maple_driver_detach(p, u) >= 0) {
             assert(!maple_dev_valid(p, u));
         }
@@ -151,10 +152,11 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     else if(resp->response == MAPLE_RESPONSE_DEVINFO) {
         /* Device is present, check for connections */
         if(!dev) {
-#if MAPLE_IRQ_DEBUG
-            dbglog(DBG_KDEBUG, "maple: attach on device %c%c\n",
-                   'A' + p, '0' + u);
-#endif
+            if(__is_defined(MAPLE_IRQ_DEBUG)) {
+                dbglog(DBG_KDEBUG, "maple: attach on device %c%c\n",
+                       'A' + p, '0' + u);
+            }
+
             if(maple_driver_attach(frm) == 0) {
                 assert(maple_dev_valid(p, u));
             }
@@ -254,9 +256,10 @@ void maple_dma_irq_hnd(uint32 code, void *data) {
     /* ACK the receipt */
     state->dma_in_progress = 0;
 
-#if MAPLE_DMA_DEBUG
-    maple_sentinel_verify("state->dma_buffer", state->dma_buffer, MAPLE_DMA_SIZE);
-#endif
+    if(__is_defined(MAPLE_DMA_DEBUG)) {
+        maple_sentinel_verify("state->dma_buffer", state->dma_buffer,
+                              MAPLE_DMA_SIZE);
+    }
 
     /* For each queued frame, call its callback if it's done */
     TAILQ_FOREACH_SAFE(i, &state->frame_queue, frameq, tmp) {
@@ -273,9 +276,8 @@ void maple_dma_irq_hnd(uint32 code, void *data) {
             continue;
         }
 
-#if MAPLE_DMA_DEBUG
-        maple_sentinel_verify("i->recv_buf", i->recv_buf, 1024);
-#endif
+        if(__is_defined(MAPLE_DMA_DEBUG))
+            maple_sentinel_verify("i->recv_buf", i->recv_buf, 1024);
 
         /* Mark it as responded to */
         i->state = MAPLE_FRAME_RESPONDED;

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -14,6 +14,7 @@
 #include <dc/maple.h>
 #include <dc/asic.h>
 #include <dc/pvr.h>
+#include <kos/dbglog.h>
 #include <kos/thread.h>
 
 /*********************************************************************/

--- a/kernel/arch/dreamcast/hardware/maple/maple_queue.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_queue.c
@@ -155,18 +155,17 @@ void maple_frame_init(maple_frame_t *frame) {
     if(buf_ptr & 0x1f)
         buf_ptr = (buf_ptr & ~0x1f) + 0x20;
 
-#if MAPLE_DMA_DEBUG
-    buf_ptr += 512;
-#endif
+    if(__is_defined(MAPLE_DMA_DEBUG))
+        buf_ptr += 512;
+
     buf_ptr = (buf_ptr & MEM_AREA_CACHE_MASK) | MEM_AREA_P2_BASE;
     frame->recv_buf = (uint8*)buf_ptr;
 
     /* Clear out the receive buffer */
-#if MAPLE_DMA_DEBUG
-    maple_sentinel_setup(frame->recv_buf - 512, 1024 + 1024);
-#else
-    memset(frame->recv_buf, 0, 1024);
-#endif
+    if(__is_defined(MAPLE_DMA_DEBUG))
+        maple_sentinel_setup(frame->recv_buf - 512, 1024 + 1024);
+    else
+        memset(frame->recv_buf, 0, 1024);
 
     /* Initialize other state stuff */
     frame->cmd = -1;

--- a/kernel/arch/dreamcast/hardware/maple/maple_utils.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_utils.c
@@ -167,9 +167,9 @@ void maple_gun_read_pos(int *x, int *y) {
     *y = maple_state.gun_y;
 }
 
-#if MAPLE_DMA_DEBUG
 /* Debugging help */
 void maple_sentinel_setup(void * buffer, int bufsize) {
+    assert(__is_defined(MAPLE_DMA_DEBUG));
     assert(bufsize % 4 == 0);
     memset(buffer, 0xdeadbeef, bufsize);
 }
@@ -178,6 +178,7 @@ void maple_sentinel_verify(const char * bufname, void * buffer, int bufsize) {
     int i;
     uint32 *b32;
 
+    assert(__is_defined(MAPLE_DMA_DEBUG));
     assert(bufsize % 4 == 0);
 
     b32 = ((uint32 *)buffer) - 512 / 4;
@@ -200,4 +201,3 @@ void maple_sentinel_verify(const char * bufname, void * buffer, int bufsize) {
         }
     }
 }
-#endif

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -161,19 +161,19 @@ int pvr_init(const pvr_init_params_t *params) {
     asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE_TSP, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_RENDERDONE_TSP, ASIC_IRQ_DEFAULT);
 
-#ifdef PVR_RENDER_DBG
-    /* Hook up interrupt handlers for error events */
-    asic_evt_set_handler(ASIC_EVT_PVR_ISP_OUTOFMEM, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_ISP_OUTOFMEM, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_STRIP_HALT, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_STRIP_HALT, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_OPB_OUTOFMEM, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_OPB_OUTOFMEM, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_ERR, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_TA_INPUT_ERR, ASIC_IRQ_DEFAULT);
-    asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_OVERFLOW, pvr_int_handler, NULL);
-    asic_evt_enable(ASIC_EVT_PVR_TA_INPUT_OVERFLOW, ASIC_IRQ_DEFAULT);
-#endif
+    if(__is_defined(PVR_RENDER_DBG)) {
+        /* Hook up interrupt handlers for error events */
+        asic_evt_set_handler(ASIC_EVT_PVR_ISP_OUTOFMEM, pvr_int_handler, NULL);
+        asic_evt_enable(ASIC_EVT_PVR_ISP_OUTOFMEM, ASIC_IRQ_DEFAULT);
+        asic_evt_set_handler(ASIC_EVT_PVR_STRIP_HALT, pvr_int_handler, NULL);
+        asic_evt_enable(ASIC_EVT_PVR_STRIP_HALT, ASIC_IRQ_DEFAULT);
+        asic_evt_set_handler(ASIC_EVT_PVR_OPB_OUTOFMEM, pvr_int_handler, NULL);
+        asic_evt_enable(ASIC_EVT_PVR_OPB_OUTOFMEM, ASIC_IRQ_DEFAULT);
+        asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_ERR, pvr_int_handler, NULL);
+        asic_evt_enable(ASIC_EVT_PVR_TA_INPUT_ERR, ASIC_IRQ_DEFAULT);
+        asic_evt_set_handler(ASIC_EVT_PVR_TA_INPUT_OVERFLOW, pvr_int_handler, NULL);
+        asic_evt_enable(ASIC_EVT_PVR_TA_INPUT_OVERFLOW, ASIC_IRQ_DEFAULT);
+    }
 
     /* 3d-specific parameters; these are all about rendering and
        nothing to do with setting up the video; some stuff in here

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -14,9 +14,7 @@
 #include <kos/genwait.h>
 #include <kos/regfield.h>
 
-#ifdef PVR_RENDER_DBG
 #include <stdio.h>
-#endif
 
 /*
    PVR interrupt handler; the way things are setup, we're gonna get
@@ -176,34 +174,34 @@ void pvr_int_handler(uint32 code, void *data) {
             break;
     }
 
-#ifdef PVR_RENDER_DBG
-    /* Show register values on each interrupt */
-    switch (code) {
-        case ASIC_EVT_PVR_ISP_OUTOFMEM:
-            DBG(("[ERROR]: ASIC_EVT_PVR_ISP_OUTOFMEM\n"));
-            break;
+    if(__is_defined(PVR_RENDER_DBG)) {
+        /* Show register values on each interrupt */
+        switch (code) {
+            case ASIC_EVT_PVR_ISP_OUTOFMEM:
+                DBG(("[ERROR]: ASIC_EVT_PVR_ISP_OUTOFMEM\n"));
+                break;
 
-        case ASIC_EVT_PVR_STRIP_HALT:
-            DBG(("[ERROR]: ASIC_EVT_PVR_STRIP_HALT\n"));
-            break;
+            case ASIC_EVT_PVR_STRIP_HALT:
+                DBG(("[ERROR]: ASIC_EVT_PVR_STRIP_HALT\n"));
+                break;
 
-        case ASIC_EVT_PVR_OPB_OUTOFMEM:
-            DBG(("[ERROR]: ASIC_EVT_PVR_OPB_OUTOFMEM\n"));
-            DBG(("PVR_TA_OPB_START: %08lx\nPVR_TA_OPB_END: %08lx\nPVR_TA_OPB_POS: %08lx\n",
-                PVR_GET(PVR_TA_OPB_START),
-                PVR_GET(PVR_TA_OPB_END),
-                PVR_GET(PVR_TA_OPB_POS) << 2));
-            break;
+            case ASIC_EVT_PVR_OPB_OUTOFMEM:
+                DBG(("[ERROR]: ASIC_EVT_PVR_OPB_OUTOFMEM\n"));
+                DBG(("PVR_TA_OPB_START: %08lx\nPVR_TA_OPB_END: %08lx\nPVR_TA_OPB_POS: %08lx\n",
+                    PVR_GET(PVR_TA_OPB_START),
+                    PVR_GET(PVR_TA_OPB_END),
+                    PVR_GET(PVR_TA_OPB_POS) << 2));
+                break;
 
-        case ASIC_EVT_PVR_TA_INPUT_ERR:
-            DBG(("[ERROR]: ASIC_EVT_PVR_TA_INPUT_ERR\n"));
-            break;
+            case ASIC_EVT_PVR_TA_INPUT_ERR:
+                DBG(("[ERROR]: ASIC_EVT_PVR_TA_INPUT_ERR\n"));
+                break;
 
-        case ASIC_EVT_PVR_TA_INPUT_OVERFLOW:
-            DBG(("[ERROR]: ASIC_EVT_PVR_TA_INPUT_OVERFLOW\n"));
-            break;
+            case ASIC_EVT_PVR_TA_INPUT_OVERFLOW:
+                DBG(("[ERROR]: ASIC_EVT_PVR_TA_INPUT_OVERFLOW\n"));
+                break;
+        }
     }
-#endif
 
     /* Update our stats if we finished all registration */
     switch(code) {

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -13,6 +13,7 @@
 #include <malloc.h> /* For the struct mallinfo defs */
 
 #include <kos/opts.h>
+#include <kos/dbglog.h>
 
 /*
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -18,6 +18,13 @@
 #include <dc/sq.h>
 #include "pvr_internal.h"
 
+/* FIXME: NDEBUG is a reserved C macro, we shouldn't use it like that... */
+#ifdef NDEBUG
+#  define PVR_DEBUG 0
+#else
+#  define PVR_DEBUG 1
+#endif
+
 /*
 
    Scene rendering
@@ -176,13 +183,10 @@ inline static bool pvr_list_uses_dma(pvr_list_t list) {
    error (-1) is returned. */
 int pvr_list_begin(pvr_list_t list) {
     /* Check to make sure we can do this */
-#ifndef NDEBUG
-    if(!pvr_state.dma_mode && pvr_state.lists_closed & BIT(list)) {
+    if(PVR_DEBUG && !pvr_state.dma_mode && pvr_state.lists_closed & BIT(list)) {
         dbglog(DBG_WARNING, "pvr_list_begin: attempt to open already closed list\n");
         return -1;
     }
-
-#endif  /* !NDEBUG */
 
     /* If we already had a list open, close it first */
     if(pvr_state.list_reg_open != -1 && pvr_state.list_reg_open != (int)list)
@@ -209,13 +213,10 @@ int pvr_list_begin(pvr_list_t list) {
    simplicity we just always submit a blank primitive. */
 int pvr_list_finish(void) {
     /* Check to make sure we can do this */
-#ifndef NDEBUG
-    if(!pvr_state.dma_mode && pvr_state.list_reg_open == -1) {
+    if(PVR_DEBUG && !pvr_state.dma_mode && pvr_state.list_reg_open == -1) {
         dbglog(DBG_WARNING, "pvr_list_finish: attempt to close unopened list\n");
         return -1;
     }
-
-#endif  /* !NDEBUG */
 
     /* Check for immediate submission:
        A. If we are not in DMA mode, we must be submitting polygons
@@ -248,21 +249,17 @@ int pvr_list_finish(void) {
 
 int pvr_prim(const void *data, size_t size) {
     /* Check to make sure we can do this */
-#ifndef NDEBUG
-    if(pvr_state.list_reg_open == -1) {
+    if(PVR_DEBUG && pvr_state.list_reg_open == -1) {
         dbglog(DBG_WARNING, "pvr_prim: attempt to submit to unopened list\n");
         return -1;
     }
-#endif  /* !NDEBUG */
 
     if(!pvr_list_dma) {
-#ifndef NDEBUG
-        if((uintptr_t)data & 0x7) {
+        if(PVR_DEBUG && ((uintptr_t)data & 0x7)) {
             dbglog(DBG_WARNING, "pvr_prim: attempt to submit data unaligned "
                                 "to 8 bytes.\n");
             return -1;
         }
-#endif  /* !NDEBUG */
 
         /* Immediately send data via SQs. */
         sq_fast_cpy(SQ_MASK_DEST(PVR_TA_INPUT), data, size >> 5);

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -609,7 +609,6 @@ void maple_gun_disable(void);
 */
 void maple_gun_read_pos(int *x, int *y);
 
-#if MAPLE_DMA_DEBUG
 /* Debugging help */
 
 /** \brief   Setup a sentinel for debugging DMA issues.
@@ -628,7 +627,6 @@ void maple_sentinel_setup(void * buffer, int bufsize);
     \param  bufsize         The size of the buffer.
 */
 void maple_sentinel_verify(const char * bufname, void * buffer, int bufsize);
-#endif
 
 /**************************************************************************/
 /* maple_queue.c */

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -174,8 +174,7 @@ static void irq_dump_regs(int code, irq_t evt) {
             if(valid_pr)
                 dbglog(DBG_DEAD, " %08lx", irq_srt_addr->pr);
 
-#ifdef FRAME_POINTERS
-            while(fp != 0xffffffff) {
+            while(__is_defined(FRAME_POINTERS) && fp != 0xffffffff) {
                 /* Validate the function pointer (fp) */
                 if((fp & 3) || (fp < 0x8c000000) || (fp > _arch_mem_top))
                     break;
@@ -190,7 +189,6 @@ static void irq_dump_regs(int code, irq_t evt) {
                 dbglog(DBG_DEAD, " %08lx", fp);
                 fp = arch_fptr_next(fp);
             }
-#endif
         }
 
         dbglog(DBG_DEAD, "\n");

--- a/kernel/arch/dreamcast/kernel/stack.c
+++ b/kernel/arch/dreamcast/kernel/stack.c
@@ -32,7 +32,11 @@ void arch_stk_trace(int n) {
 /* Do a stack trace from the given frame pointer (useful for things like
    tracing from an ISR); leave off the first n frames. */
 void arch_stk_trace_at(uint32_t fp, size_t n) {
-#ifdef FRAME_POINTERS
+    if(!__is_defined(FRAME_POINTERS)) {
+        dbgio_printf("Stack Trace: frame pointers not enabled!\n");
+        return;
+    }
+
     dbgio_printf("-------- Stack Trace (innermost first) ---------\n");
 
     while(fp != 0xffffffff) {
@@ -59,10 +63,5 @@ void arch_stk_trace_at(uint32_t fp, size_t n) {
     }
 
     dbgio_printf("-------------- End Stack Trace -----------------\n");
-#else
-    (void)fp;
-    (void)n;
-    dbgio_printf("Stack Trace: frame pointers not enabled!\n");
-#endif
 }
 

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -393,7 +393,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
     }
 
     free(img);
-    DBG(("elf_load final ELF stats: memory image at %p, size %08lx\n\tentry pt %p\n", out->data, out->size, out->start));
+    DBG(("elf_load final ELF stats: memory image at %p, size %08lx\n", out->data, out->size));
 
     /* Flush the icache for that zone */
     icache_flush_range((uint32)out->data, out->size);

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -30,11 +30,10 @@
 
 #define ELF_DEBUG 0
 
-#if ELF_DEBUG
-#   define DBG(x) printf x
-#else
-#   define DBG(x)
-#endif
+#define DBG(x) do { \
+    if(__is_defined(ELF_DEBUG)) \
+        printf x; \
+} while(0)
 
 /* Finds a given symbol in a relocated ELF symbol table */
 static int find_sym(char *name, struct elf_sym_t* table, int tablelen) {

--- a/kernel/libc/koslib/assert.c
+++ b/kernel/libc/koslib/assert.c
@@ -13,10 +13,7 @@
 #include <stdlib.h>
 
 #include <kos/dbglog.h>
-
-#ifdef FRAME_POINTERS
 #include <arch/stack.h>
-#endif
 
 /* The default assert handler */
 static void __noreturn assert_handler_default(const char *file, int line,
@@ -30,9 +27,9 @@ static void __noreturn assert_handler_default(const char *file, int line,
         dbglog(DBG_CRITICAL, "Assertion \"%s\" failed at %s:%d in `%s': %s\n\n",
                expr, file, line, func, msg);
 
-#ifdef FRAME_POINTERS
-    arch_stk_trace(2);
-#endif
+    if(__is_defined(FRAME_POINTERS))
+        arch_stk_trace(2);
+
     abort();
     /* NOT REACHED */
 }


### PR DESCRIPTION
Add a `__is_defined()` macro which resolves to 1 if the argument is a macro that resolves to 1, and resolves to 0 otherwise.

This allows to switch away from using #ifdef guards to protect code, which has the nasty drawback of causing the protected code to become stale after a while.

This was already the case in the maple code, whose conditionally-compiled code would not build anymore.