### PR TITLE
libpthread: Add support for pthread_getschedparam() and pthread_setschedparam()

### DIFF
--- a/addons/libpthread/Makefile
+++ b/addons/libpthread/Makefile
@@ -66,6 +66,7 @@ OBJS += pthread_barrierattr_init.o pthread_barrierattr_destroy.o \
 
 # Misc.
 OBJS += pthread_atfork.o pthread_getsetconcurrency.o pthread_yield.o \
-        pthread_setprio.o pthread_getprio.o
+        pthread_setprio.o pthread_getprio.o \
+        pthread_setschedparam.o pthread_getschedparam.o
 
 include $(KOS_BASE)/addons/Makefile.prefab

--- a/addons/libpthread/pthread_getschedparam.c
+++ b/addons/libpthread/pthread_getschedparam.c
@@ -1,0 +1,31 @@
+/* KallistiOS ##version##
+
+   pthread_getschedparam.c
+   Copyright (C) 2025 Eric Fradella
+*/
+
+#include "pthread-internal.h"
+#include <pthread.h>
+#include <sched.h>
+#include <errno.h>
+#include <kos/thread.h>
+
+int pthread_getschedparam(pthread_t thread, int *__RESTRICT policy,
+                          struct sched_param *__RESTRICT param) {
+    kthread_t *thd = (kthread_t *)thread;
+
+    if(!thd)
+        return EINVAL;
+
+    if(!policy)
+        return EINVAL;
+
+    if(!param)
+        return EFAULT;
+
+    *policy = SCHED_RR;
+
+    param->sched_priority = (int)thd_get_prio(thd);
+
+    return 0;
+}

--- a/addons/libpthread/pthread_setschedparam.c
+++ b/addons/libpthread/pthread_setschedparam.c
@@ -1,0 +1,30 @@
+/* KallistiOS ##version##
+
+   pthread_setschedparam.c
+   Copyright (C) 2025 Eric Fradella
+*/
+
+#include "pthread-internal.h"
+#include <pthread.h>
+#include <sched.h>
+#include <errno.h>
+#include <kos/thread.h>
+
+int pthread_setschedparam(pthread_t thread, int policy,
+                          const struct sched_param *param) {
+    kthread_t *thd = (kthread_t *)thread;
+
+    if(!thd)
+        return EINVAL;
+
+    if(policy != SCHED_RR)
+        return EINVAL;
+
+    if(!param)
+        return EFAULT;
+
+    if(thd_set_prio(thd, (prio_t)param->sched_priority))
+        return EINVAL;
+
+    return 0;
+}


### PR DESCRIPTION
This only supports round robin policy getting/setting right now, but it would help things compile that try to use this function (see #1010).