### PR TITLE
pvr: Get rid of dummy fields in prim headers

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -264,10 +264,6 @@ void pvr_blank_polyhdr_buf(int type, pvr_poly_hdr_t * poly) {
 
     /* Put in the list type */
     poly->cmd = FIELD_PREP(PVR_TA_CMD_TYPE, type) | 0x80840012;
-
-    /* Fill in dummy values */
-    poly->d1 = poly->d2 = poly->d3 = poly->d4 = 0xffffffff;
-
 }
 
 pvr_ptr_t pvr_get_front_buffer(void) {

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
@@ -96,16 +96,9 @@ void pvr_poly_compile(pvr_poly_hdr_t *dst, const pvr_poly_cxt_t *src) {
     if(src->fmt.modifier && src->gen.modifier_mode) {
         /* If we're affected by a modifier volume, silently promote the header
            to the one that is affected by a modifier volume. */
-        dst->d1 = mode2;
-        dst->d2 = mode3;
+        dst->mode2_1 = mode2;
+        dst->mode3_1 = mode3;
     }
-    else {
-        dst->d1 = 0xffffffff;
-        dst->d2 = 0xffffffff;
-    }
-
-    dst->d3 = 0xffffffff;
-    dst->d4 = 0xffffffff;
 }
 
 /* Create a colored polygon context with parameters similar to
@@ -353,8 +346,6 @@ void pvr_mod_compile(pvr_mod_hdr_t *dst, pvr_list_t list, uint32 mode,
 
     dst->mode1 = FIELD_PREP(PVR_TA_PM1_MODIFIERINST, mode)
         | FIELD_PREP(PVR_TA_PM1_CULLING, cull);
-
-    dst->d1 = dst->d2 = dst->d3 = dst->d4 = dst->d5 = dst->d6 = 0;
 }
 
 /* Compile a polygon context into a polygon header that is affected by
@@ -467,9 +458,6 @@ void pvr_poly_mod_compile(pvr_poly_mod_hdr_t *dst, const pvr_poly_cxt_t *src) {
 
     dst->mode2_1 = mode2;
     dst->mode3_1 = mode3;
-
-    dst->d1 = 0xffffffff;
-    dst->d2 = 0xffffffff;
 }
 
 /* Create a colored polygon context for polygons affected by modifier volumes */

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
@@ -311,22 +311,14 @@ typedef __attribute__((aligned(32))) struct pvr_poly_hdr {
     union {
         uint32_t mode2;                                 /**< Raw access to mode2 param */
         uint32_t mode2_0;                               /**< Legacy name */
-        uint32_t d5;                                    /**< Dummy value 5 */
         struct pvr_poly_hdr_mode2 m2;                   /**< mode2 parameters (modifiers: outside volume) */
     };
     union {
         uint32_t mode3;                                 /**< Raw access to mode3 param */
         uint32_t mode3_0;                               /**< Legacy name */
-        uint32_t d6;                                    /**< Dummy value 6 */
         struct pvr_poly_hdr_mode3 m3;                   /**< mode3 parameters (modifiers: outside volume) */
     };
     union {
-        struct {
-            uint32_t d1;                                /**< Dummy value 1 */
-            uint32_t d2;                                /**< Dummy value 2 */
-            uint32_t d3;                                /**< Dummy value 3 */
-            uint32_t d4;                                /**< Dummy value 4 */
-        };
         struct {
             /* Intensity color */
             float a;                                    /**< Intensity color alpha */


### PR DESCRIPTION
Those dummy fields were added to the various primitive headers to make sure that they had the correct size.

Now that all primitive headers use the same pvr_poly_hdr_t type, which has the correct size even with the dummy fields removed, all the dummy fields can be removed.

Note that the driver code was setting them either to 0 or 0xffff'ffff, for some reason. Given that this was written almost 25 years ago and everything seems to work just fine without writing those fields, it seems safe to drop them.

Dropping them also fixes #1034, which happened since the switch to the common pvr_poly_hdr_t type, and was caused by the dummy fields moving around (as prior to that, the d1/d2 fields in a pvr_poly_mod_hdr were at different offsets than the d1/d2 fields in a pvr_poly_hdr, for instance).