### PR TITLE
Makefile: Make romdisk depend on bin2c target

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -80,7 +80,7 @@ ifdef KOS_ROMDISK_DIR
 romdisk.img:
 	$(KOS_GENROMFS) -f romdisk.img -d $(KOS_ROMDISK_DIR) -v -x .keepme -x .DS_Store -x Thumbs.db
 
-romdisk.o: romdisk.img
+romdisk.o: romdisk.img $(KOS_BASE)/utils/bin2c/bin2c
 	$(KOS_BASE)/utils/bin2c/bin2c romdisk.img romdisk_tmp.c romdisk
 	$(KOS_CC) $(KOS_CFLAGS) -o romdisk_tmp.o -c romdisk_tmp.c
 	$(KOS_CC) -o romdisk.o -r romdisk_tmp.o $(KOS_LIB_PATHS) -Wl,--whole-archive -lromdiskbase


### PR DESCRIPTION
We use bin2c to create romdisks, and bin2c is a build target; therefore we have to make sure that it is built before using it.

Fixes #1025.