### PR TITLE
Added -fno-PIC to default KOS_CFLAGS.

### DIFF
--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -24,7 +24,7 @@ if [ -z "${KOS_SH4_PRECISION}" ] || [ "${KOS_SH4_PRECISION}" = "-m4-single" ]; t
     fi
 fi
 
-export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_SH4_PRECISION} -ml -mfsrra -mfsca -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec"
+export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_SH4_PRECISION} -ml -mfsrra -mfsca -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec -fno-PIC"
 export KOS_AFLAGS="${KOS_AFLAGS} -little"
 export KOS_LDFLAGS="${KOS_LDFLAGS} ${KOS_SH4_PRECISION} -ml -Wl,--gc-sections"
 export KOS_LD_SCRIPT="-T${KOS_BASE}/utils/ldscripts/shlelf.xc"


### PR DESCRIPTION
By default, it appears that our SH GCC toolchain is building with position independent code enabled. This is both bloating the code with a bunch of constants that get added to the `.text` segment for relative offsetting, plus apparently it also reserves 1 GP register for hold some relative offset information.

The first thing I did in GTA3 for gainz was add `-fno-PIC` to disable this behavior. Really, it should just be the default for our toolchain, as the only time you do NOT want this is in the rare case that you're building a shared library or doing something like DreamShell is... In such a case, you just add `-fPIC` to your flags to override our default. :)