### PR TITLE
Add missing DECLS to pthreads and sys headers.

### DIFF
--- a/addons/libpthread/pthread-internal.h
+++ b/addons/libpthread/pthread-internal.h
@@ -7,6 +7,9 @@
 #ifndef __PTHREAD_INTERNAL_H
 #define __PTHREAD_INTERNAL_H
 
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
 #define __PTHREAD_HAVE_ATTR_TYPE        1
 #define __PTHREAD_HAVE_MUTEX_TYPE       1
 #define __PTHREAD_HAVE_COND_TYPE        1
@@ -80,5 +83,7 @@ STATIC_ASSERT(sizeof(pthread_barrier_t) == __PTHREAD_BARRIER_SIZE)
 STATIC_ASSERT(__PTHREAD_BARRIER_SIZE == THD_BARRIER_SIZE)
 
 #undef STATIC_ASSERT
+
+__END_DECLS
 
 #endif /* !__PTHREAD_INTERNAL_H */

--- a/include/sys/_pthreadtypes.h
+++ b/include/sys/_pthreadtypes.h
@@ -8,6 +8,9 @@
 #ifndef __SYS_PTHREADTYPES_H
 #define __SYS_PTHREADTYPES_H
 
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
 typedef unsigned long int pthread_t;
 
 typedef struct pthread_mutexattr_t {
@@ -99,5 +102,7 @@ typedef union pthread_barrier_t {
 
 #undef __PTHREAD_BARRIER_SIZE
 #endif /* !__PTHREAD_HAVE_BARRIER_TYPE */
+
+__END_DECLS
 
 #endif /* !__SYS_PTHREADTYPES_H */

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -19,6 +19,9 @@
 #ifndef __SYS_LOCK_H__
 #define __SYS_LOCK_H__
 
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
 /** \cond */
 
 typedef struct {
@@ -62,5 +65,7 @@ int __newlib_lock_try_acquire_recursive(__newlib_recursive_lock_t*);
 void __newlib_lock_release_recursive(__newlib_recursive_lock_t*);
 
 /** \endcond */
+
+__END_DECLS
 
 #endif /* __SYS_LOCK_H__ */

--- a/include/sys/stdio.h
+++ b/include/sys/stdio.h
@@ -8,6 +8,9 @@
 #ifndef _NEWLIB_STDIO_H
 #define _NEWLIB_STDIO_H
 
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
 // Cribbed from newlib sys/stdio.h
 
 /* Internal locking macros, used to protect stdio functions.  In the
@@ -30,5 +33,7 @@
 #include <unistd.h>
 #include <stdarg.h>
 #include <kos/fs.h>
+
+__END_DECLS
 
 #endif /* _NEWLIB_STDIO_H */


### PR DESCRIPTION
Some of these may not be needed in their scope, but should have no ill effects in such situations.

Since this touches toolchain-related files, tested rebuilding stable and it seemed to not be impacted. I thought this might help to resolve #1029 but it did not seem to.