### PR TITLE
Added flag for disabling TLS for individual threads.

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -4,7 +4,7 @@
    Copyright (C) 2000, 2001, 2002, 2003 Megan Potter
    Copyright (C) 2009, 2010, 2016, 2023 Lawrence Sebald
    Copyright (C) 2023 Colton Pawielski
-   Copyright (C) 2023, 2024 Falco Girgis
+   Copyright (C) 2023, 2024, 2025 Falco Girgis
 
 */
 
@@ -128,11 +128,12 @@ LIST_HEAD(ktlist, kthread);
 
     @{
 */
-#define THD_DEFAULTS    0  /**< \brief Defaults: no flags */
-#define THD_USER        1  /**< \brief Thread runs in user mode */
-#define THD_QUEUED      2  /**< \brief Thread is in the run queue */
-#define THD_DETACHED    4  /**< \brief Thread is detached */
-#define THD_OWNS_STACK  8  /**< \brief Thread manages stack lifetime */
+#define THD_DEFAULTS    0x0  /**< \brief Defaults: no flags */
+#define THD_USER        0x1  /**< \brief Thread runs in user mode */
+#define THD_QUEUED      0x2  /**< \brief Thread is in the run queue */
+#define THD_DETACHED    0x4  /**< \brief Thread is detached */
+#define THD_OWNS_STACK  0x8  /**< \brief Thread manages stack lifetime */
+#define THD_DISABLE_TLS 0x10 /**< \brief Thread does not use TLS variables */
 /** @} */
 
 /** \brief Kernel thread flags type */
@@ -149,8 +150,6 @@ typedef enum kthread_state {
     STATE_WAIT     = 0x0003,  /**< \brief Blocked on a genwait */
     STATE_FINISHED = 0x0004   /**< \brief Finished execution */
 } kthread_state_t;
-
-
 
 /** \brief   Structure describing one running thread.
 
@@ -289,6 +288,9 @@ typedef struct kthread_attr {
 
     /** \brief  Thread label. */
     const char *label;
+
+    /** \brief 1 if the thread doesn't use thread_local variables. */
+    bool disable_tls;
 } kthread_attr_t;
 
 /** \brief  kthread mode values

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -4,7 +4,7 @@
    Copyright (C) 2000, 2001, 2002, 2003 Megan Potter
    Copyright (C) 2010, 2016, 2023 Lawrence Sebald
    Copyright (C) 2023 Colton Pawielski
-   Copyright (C) 2023, 2024 Falco Girgis
+   Copyright (C) 2023, 2024, 2025 Falco Girgis
 */
 
 #include <assert.h>

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -368,7 +368,7 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
     kthread_t *nt = NULL;
     tid_t tid;
     uint32_t params[4];
-    kthread_attr_t real_attr = { false, THD_STACK_SIZE, NULL, PRIO_DEFAULT, NULL };
+    kthread_attr_t real_attr = { false, THD_STACK_SIZE, NULL, PRIO_DEFAULT, NULL, false };
 
     if(attr)
         real_attr = *attr;
@@ -429,8 +429,10 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
                                ((uint32_t)nt->stack) + nt->stack_size,
                                (uint32_t)thd_birth, params, 0);
 
-            /* Create static TLS data */
-            if(!arch_tls_setup_data(nt)) {
+            /* Create static TLS data if the thread hasn't disabled it. */
+            if(real_attr.disable_tls) {
+                nt->flags |= THD_DISABLE_TLS;
+            } else if(!arch_tls_setup_data(nt)) {
                 if(nt->flags & THD_OWNS_STACK)
                     free(nt->stack);
                 free(nt);
@@ -525,8 +527,9 @@ int thd_destroy(kthread_t *thd) {
     if(thd->flags & THD_OWNS_STACK)
         free(thd->stack);
 
-    /* Free static TLS segment */
-    arch_tls_destroy_data(thd);
+    /* Free static TLS segment (if it hasn't been disabled for the thread). */
+    if(!(thd->flags & THD_DISABLE_TLS))
+        arch_tls_destroy_data(thd);
 
     /* Free the thread */
     free(thd);
@@ -1008,17 +1011,19 @@ int thd_init(void) {
     };
 
     const kthread_attr_t reaper_attr = {
-        .stack_size = sizeof(thd_reaper_stack),
-        .stack_ptr  = thd_reaper_stack,
-        .prio       = 1,
-        .label      = "[reaper]"
+        .stack_size  = sizeof(thd_reaper_stack),
+        .stack_ptr   = thd_reaper_stack,
+        .prio        = 1,
+        .label       = "[reaper]"
+        .disable_tls = true
     };
 
     const kthread_attr_t idle_attr = {
-        .stack_size = sizeof(thd_idle_stack),
-        .stack_ptr  = thd_idle_stack,
-        .prio       = PRIO_MAX,
-        .label      = "[idle]"
+        .stack_size  = sizeof(thd_idle_stack),
+        .stack_ptr   = thd_idle_stack,
+        .prio        = PRIO_MAX,
+        .label       = "[idle]"
+        .disable_tls = true
     };
 
     kthread_t *kern;


### PR DESCRIPTION
I thought of a potential optimization the other day for how we handle TLS that could lead to some RAM savings... Say that we KNOW a thread is just some little simple task that is never accessing any TLS variables. If we were able to tell the kernel this is the case, we could avoid allocating a TLS segment that will never be used for that particular thread.

...and we already have two very good use-cases immediately within the kernel: the reaper and idle threads are not going to be accessing any TLS variables, yet they're getting their own copies of them allocated upon their creation.

1) Added THD_DISABLE_TLS to kthread_flags_t for signaling to the kernel
   that we're not using TLS for a particular thread.
2) Added kthread_attr_t::disable_tls flag for telling the kernel we
   don't want TLS when spawning a thread and passing its attributes.
    - notice it's the last member of the struct, so I don't break backwards compat, also it's the NEGATIVE so a 0 default value keeps the old functionality
3) Added checks to thread.c when creating and destroying threads to see
   whether THD_DISABLE_TLS is used, and if so, skip TLS segment
processing.
4) Made the [reaper] and [idle] threads, by default, disable TLS.

I validated these changes by rerunning my TLS test located in: examples/dreamcast/basic/threading/compiler_tls. Everything looks good!