### PR TITLE
Snd stream dbl init

### DIFF
--- a/examples/dreamcast/sound/multi-stream/main.c
+++ b/examples/dreamcast/sound/multi-stream/main.c
@@ -28,7 +28,6 @@ int main(int argc, char **argv) {
 
     vid_set_mode(DM_640x480, PM_RGB555);
     // Initialize sound system and WAV
-    snd_stream_init();
     wav_init();
 
     wav_stream_hnd_t faucet = wav_create("/rd/faucet.wav", LOOP);

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -322,6 +322,12 @@ int snd_stream_init(void) {
 }
 
 int snd_stream_init_ex(int channels, size_t buffer_size) {
+
+    if(!sep_buffer[0]) {
+        dbglog(DBG_ERROR, "snd_stream_init_ex(): already initialized\n");
+        return -1;
+    }
+
     max_channels = channels;
 
     if(buffer_size > 0) {


### PR DESCRIPTION
Without this protection, there would be a memory leak caused by separation buffers being allocated multiple times.

Additionally removed the double init in the wav example as libwav bails if it fails to init snd_stream.

Closes #955 