### PR TITLE
environ_base.sh: Source environ_dreamcast.sh later

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -14,9 +14,6 @@ fi
 # Arch kernel folder.
 export KOS_ARCH_DIR="${KOS_BASE}/kernel/arch/${KOS_ARCH}"
 
-# Pull in the arch environ file.
-. ${KOS_BASE}/environ_${KOS_ARCH}.sh
-
 # Add the compiler bins dir to the path if it is not already.
 if ! expr ":$PATH:" : ".*:${KOS_CC_BASE}/bin:.*" > /dev/null ; then
   export PATH="${PATH}:${KOS_CC_BASE}/bin"
@@ -48,6 +45,10 @@ export KOS_LD="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-ld"
 export KOS_RANLIB="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-gcc-ranlib"
 export KOS_STRIP="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-strip"
 export KOS_SIZE="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-size"
+
+# Pull in the arch environ file.
+. ${KOS_BASE}/environ_${KOS_ARCH}.sh
+
 export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_INC_PATHS} -D_arch_${KOS_ARCH} -D_arch_sub_${KOS_SUBARCH} -Wall -g"
 export KOS_CPPFLAGS="${KOS_CPPFLAGS} ${KOS_INC_PATHS_CPP}"
 


### PR DESCRIPTION
The `$KOS_SH4_PRECISION` check is dependent on `$KOS_CC` being established, so move the sourcing of `environ_dreamcast.sh` after compiler paths are set.