### PR TITLE
Correct logical error in snd_stream double init protection.

### DIFF
--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -323,7 +323,7 @@ int snd_stream_init(void) {
 
 int snd_stream_init_ex(int channels, size_t buffer_size) {
 
-    if(!sep_buffer[0]) {
+    if(sep_buffer[0]) {
         dbglog(DBG_ERROR, "snd_stream_init_ex(): already initialized\n");
         return -1;
     }


### PR DESCRIPTION
It was exactly backwards and never could have worked.