### PR TITLE
Extended but backwards compatible purupuru_effect_t definition

### DIFF
--- a/examples/dreamcast/rumble/rumble.c
+++ b/examples/dreamcast/rumble/rumble.c
@@ -37,105 +37,8 @@ KOS_INIT_FLAGS(INIT_DEFAULT);
 
 plx_fcxt_t *cxt;
 
-
-typedef union rumble_fields {
-  uint32_t raw;
-  struct {
-    /* Special Effects and motor select. The normal purupuru packs will
-only have one motor. Selecting MOTOR2 for these is probably not
-a good idea. The PULSE setting here supposably creates a sharp
-pulse effect, when ORed with the special field. */
-
-    /** \brief  Yet another pulse effect.
-        This supposedly creates a sharp pulse effect.
-    */
-    uint32_t special_pulse : 1;
-    uint32_t : 3; // unused
-
-    /** \brief  Select motor #1.
-
-        Most jump packs only have one motor, but on things that do have more
-       than one motor (like PS1->Dreamcast controller adapters that support
-       rumble), this selects the first motor.
-    */
-    uint32_t special_motor1 : 1;
-    uint32_t : 2; // unused
-
-    /** \brief  Select motor #2.
-
-        Most jump packs only have one motor, but on things that do have more
-       than one motor (like PS1->Dreamcast controller adapters that support
-       rumble), this selects the second motor.
-    */
-    uint32_t special_motor2 : 1;
-
-    /** \brief  Ignore this command.
-
-        Valid value 15 (0xF).
-
-        Most jump packs will ignore commands with this set in effect1,
-       apparently.
-    */
-    uint32_t fx1_powersave : 4;
-
-    /** \brief  Upper nibble of effect1.
-
-        This value works with the lower nibble of the effect2 field to
-        increase the intensity of the rumble effect.
-        Valid values are 0-7.
-
-        \see    rumble_fields_t.fx2_lintensity
-    */
-    uint32_t fx1_intensity : 3;
-
-    /** \brief  Give a pulse effect to the rumble.
-
-        This probably should be used with rumble_fields_t.fx1_pulse as well.
-
-        \see    rumble_fields_t.fx2_pulse
-    */
-    uint32_t fx1_pulse : 1;
-
-    /** \brief  Lower-nibble of effect2.
-
-        This value works with the upper nibble of the effect1
-        field to increase the intensity of the rumble effect.
-        Valid values are 0-7.
-
-        \see    rumble_fields_t.fx1_intensity
-    */
-    uint32_t fx2_lintensity : 3;
-
-    /** \brief  Give a pulse effect to the rumble.
-
-        This probably should be used with rumble_fields_t.fx1_pulse as well.
-
-        \see    rumble_fields_t.fx1_intensity
-    */
-    uint32_t fx2_pulse : 1;
-
-    /** \brief  Upper-nibble of effect2.
-
-        This apparently lowers the rumble's intensity somewhat.
-        Valid values are 0-7.
-    */
-    uint32_t fx2_uintensity : 3;
-
-    /* OR these in with your effect2 value if you feel so inclined.
-       if you or the PULSE effect in here, you probably should also
-       do so with the effect1 one below. */
-
-    /** \brief  Give a decay effect to the rumble on some packs. */
-    uint32_t fx2_decay : 1;
-
-    /** \brief  The duration of the effect. No idea on units... */
-    uint32_t duration : 8;
-  };
-} rumble_fields_t;
-
-
 void print_rumble_fields(uint32_t raw) {
-  rumble_fields_t fields = {.raw = raw};
+  purupuru_effect_t fields = {.raw = raw};
   printf("Rumble Fields:\n");
   printf("  .special_pulse   =  %u,\n", fields.special_pulse);
   printf("  .special_motor1  =  %u,\n", fields.special_motor1);
@@ -187,7 +90,6 @@ void wait_for_dev_attach(maple_device_t **dev_ptr, unsigned int func) {
     }
 }
 
-
 typedef struct {
   uint32_t pattern;
   const char *description;
@@ -210,7 +112,6 @@ static inline void word2hexbytes(uint32_t word, uint8_t *bytes) {
 }
 
 int main(int argc, char *argv[]) {
-
     cont_state_t *state;
     maple_device_t *contdev = NULL, *purudev = NULL;
 

--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -61,17 +61,9 @@ int purupuru_rumble_raw(maple_device_t *dev, uint32 effect) {
 }
 
 int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect) {
-    uint32 comp_effect;
-
     assert(dev != NULL);
-
-    /* "Compile" the effect */
-    comp_effect = (effect->duration << 24) | (effect->effect2 << 16) |
-                  (effect->effect1 << 8) | (effect->special);
-
-    return purupuru_rumble_raw(dev, comp_effect);
+    return purupuru_rumble_raw(dev, effect->raw);
 }
-
 
 /* Device Driver Struct */
 static maple_driver_t purupuru_drv = {

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -174,9 +174,9 @@ pulse effect, when ORed with the special field. */
     /** \brief  Give a decay effect to the rumble on some packs. */
     uint32_t fx2_decay : 1;
 
-    // /** \brief  The duration of the effect. No idea on units...  valid values
-    //  * 0-255*/
-    uint32_t :8;  /* this is covered by duration in the first anonymous struct, so not named here */
+    /* these last bits are covered by duration in the first anonymous struct,
+       so not named here */
+    uint32_t :8;  
   };
 } purupuru_effect_t;
 


### PR DESCRIPTION
- Changed purupuru_effect_t to a union of a uint32_t .raw, the previous 4 uint8_t fields in an unnamed struct and a struct with more specific bitfields.
- Moved documentation on old macros to the corresponding new bitfields
- Changed purupuru_rumble to take advantage of this simpler approach
- Updated rumble example to use the expanded purupuru_effect_t type instead of defining a similar bitfield type in the example code