### PR TITLE
Correct `mutex_trylock` errno.

### DIFF
--- a/include/kos/mutex.h
+++ b/include/kos/mutex.h
@@ -239,7 +239,7 @@ int mutex_is_locked(mutex_t *m);
     \retval -1              If the mutex cannot be acquired without blocking
 
     \par    Error Conditions:
-    \em     EAGAIN - the mutex is already locked (mutex_lock() would block) \n
+    \em     EBUSY  - the mutex is already locked (mutex_lock() would block) \n
     \em     EINVAL - the mutex has not been initialized properly \n
     \em     EAGAIN - lock has been acquired too many times (recursive) \n
     \em     EDEADLK - would deadlock (error-checking)

--- a/kernel/libc/c11/mtx_trylock.c
+++ b/kernel/libc/c11/mtx_trylock.c
@@ -9,7 +9,7 @@
 
 int mtx_trylock(mtx_t *mtx) {
     if(mutex_trylock(mtx)) {
-        if(errno == EAGAIN)
+        if(errno == EBUSY)
             return thrd_busy;
 
         return thrd_error;

--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -198,7 +198,7 @@ int mutex_trylock(mutex_t *m) {
 
     /* Check if the lock is held by some other thread already */
     if(m->count && m->holder != thd) {
-        errno = EAGAIN;
+        errno = EBUSY;
         return -1;
     }
 


### PR DESCRIPTION
According to [POSIX spec](https://pubs.opengroup.org/onlinepubs/9799919799/) `EBUSY` should be returned for trylock when the mutex couldn't be locked. `EAGAIN` is instead used if the max number of recursive locks for the mutex has been exceeded. Since we pass our mutex errnos straight out for pthread mutexes, they should match.

