### PR TITLE
Use THD_STACK_ALIGNMENT to adjust arch's stack alignment requirements

### DIFF
--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -79,6 +79,11 @@ extern char _etext;
 static const
 unsigned HZ __depr("Please use the new THD_SCHED_HZ macro.") = THD_SCHED_HZ;
 
+#ifndef THD_STACK_ALIGNMENT
+/** \brief  Required alignment for stack. */
+#define THD_STACK_ALIGNMENT 4
+#endif
+
 #ifndef THD_STACK_SIZE
 /** \brief  Default thread stack size. */
 #define THD_STACK_SIZE  32768

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -404,7 +404,8 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
 
             /* Create a new thread stack */
             if(!real_attr.stack_ptr) {
-                nt->stack = (uint32_t*)malloc(real_attr.stack_size);
+                nt->stack = (uint32_t*)aligned_alloc(THD_STACK_ALIGNMENT,
+                                                     real_attr.stack_size);
 
                 if(!nt->stack) {
                     free(nt);


### PR DESCRIPTION
SH4 only requires 4-byte alignment for the stack, but other platforms (like PowerPC) may require alignment >4 bytes.