### PR TITLE
Add pthread include to fix 9.5.0-winxp profile.

### DIFF
--- a/utils/dc-chain/patches/gcc/gthr-kos.h
+++ b/utils/dc-chain/patches/gcc/gthr-kos.h
@@ -45,6 +45,9 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include <arch/irq.h>
 #include <time.h>
 
+/* 9.5.0 somehow requires this. Remove when no longer supported */
+#include <pthread.h>
+
 /* These should work just fine. */
 typedef kthread_key_t __gthread_key_t;
 typedef kthread_once_t __gthread_once_t;


### PR DESCRIPTION
Split out from #1026 . Resolves #1029 