### PR TITLE
Fix various warnings in examples.

### DIFF
--- a/examples/dreamcast/2ndmix/2ndmix.c
+++ b/examples/dreamcast/2ndmix/2ndmix.c
@@ -731,7 +731,7 @@ void font_one_frame(void) {
 }
 
 void font_init(void) {
-    int x, y, c;
+    size_t x, y, c;
     uint8 pcxpall[768];
     volatile uint16 *vtex;
     uint16 val;

--- a/examples/dreamcast/basic/breaking/breaking.c
+++ b/examples/dreamcast/basic/breaking/breaking.c
@@ -251,7 +251,7 @@ static bool break_on_sized_operand_region_access_value_range(void) {
     VERIFY(!handled);
 
     /* Read from the region-of-interest as the wrong data size. */
-    volatile uint16_t tmp16; (void)tmp16;
+    volatile uint16_t tmp16 = 0; (void)tmp16;
     tmp16 = ((uint16_t *)vars)[1023 / sizeof(uint16_t)];
     VERIFY(!handled);
 

--- a/examples/dreamcast/basic/mmu/nullptr/nullptr.c
+++ b/examples/dreamcast/basic/mmu/nullptr/nullptr.c
@@ -14,7 +14,7 @@
 
 KOS_INIT_FLAGS(INIT_DEFAULT | INIT_MALLOCSTATS);
 
-mmupage_t * catchnull(mmucontext_t * c, int vp) {
+mmupage_t * catchnull(mmucontext_t *, int vp) {
     printf("Caught us trying to use a bad pointer!\n");
     printf("The pointer page was %08x\n", vp << PAGESIZE_BITS);
     printf("The address of the attempt was %08lx\n",

--- a/examples/dreamcast/cdrom/stream/cd-stream-test.c
+++ b/examples/dreamcast/cdrom/stream/cd-stream-test.c
@@ -116,8 +116,8 @@ static int cd_stream_test(uint32_t lba, uint8_t *buffer, size_t size, int mode) 
     return 0;
 }
 
-int print_diff(uint8_t *pio_buf, uint8_t *dma_buf, size_t size) {
-    int i, j, rv = 0;
+size_t print_diff(uint8_t *pio_buf, uint8_t *dma_buf, size_t size) {
+    size_t i, j, rv = 0;
 
     for(i = 0; i < size; ++i) {
         if (dma_buf[i] != pio_buf[i]) {
@@ -143,7 +143,8 @@ int print_diff(uint8_t *pio_buf, uint8_t *dma_buf, size_t size) {
 }
 
 int main(int argc, char *argv[]) {
-    int rs, i;
+    int rs;
+    size_t i;
     uint32_t lba;
     CDROM_TOC toc;
 

--- a/examples/dreamcast/cpp/concurrency/concurrency.cpp
+++ b/examples/dreamcast/cpp/concurrency/concurrency.cpp
@@ -147,7 +147,7 @@ static void test_semaphore() {
 struct LatchJob {
     const std::string name;
     std::string product{"not worked"};
-    std::thread action;
+    std::thread action{std::thread()};
 };
  
 static void test_latch() {

--- a/examples/dreamcast/gldc/basic/vq/vq-example.c
+++ b/examples/dreamcast/gldc/basic/vq/vq-example.c
@@ -42,7 +42,7 @@ static int loadtxr(void) {
                            512,           /* Texture Width */
                            512,           /* Texture Height */
                            0,             /* This bit must be set to 0 */
-                           fruit_end - fruit, /* Compressed Texture Size*/
+                           (uintptr_t)fruit_end - (uintptr_t)fruit, /* Compressed Texture Size*/
                            fruit);       /* Address of texture data in RAM: OpenGL will load the texture into VRAM for you.
                                             Because of this, make sure to call glDeleteTextures() as needed, as that will
                                             free the VRAM allocated for the texture. */

--- a/examples/dreamcast/sound/ghettoplay-vorbis/songmenu.c
+++ b/examples/dreamcast/sound/ghettoplay-vorbis/songmenu.c
@@ -53,6 +53,7 @@ static int curpos = 0;
 static int filtinitted = 0;
 
 static void snd_hook(int strm, void * obj, int freq, int chn, void ** buf, int *req) {
+    (void)strm; (void)obj, (void)freq, (void)chn;
     int actual;
     uint64 t;
 
@@ -115,6 +116,7 @@ static void draw_wave(void) {
 
 
 static void *load_song_list(void * p) {
+    (void)p;
     file_t d;
 
     d = fs_open(curdir, O_RDONLY | O_DIR);


### PR DESCRIPTION
Uninitialized variables, unused args, and signedness mismatches.nehe26 got a bit deeper of a cleanup in order to address unchecked allocations.