### PR TITLE
Faster IRQ enable/disable/restore + SR fetch.

### DIFF
--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -1,9 +1,9 @@
 /* KallistiOS ##version##
 
    arch/dreamcast/include/arch/irq.h
-   Copyright (C) 2000-2001 Megan Potter
+   Copyright (C) 2000, 2001 Megan Potter
    Copyright (C) 2024 Paul Cercueil
-   Copyright (C) 2024 Falco Girgis
+   Copyright (C) 2024, 2025 Falco Girgis
 
 */
 
@@ -329,7 +329,25 @@ typedef uint32_t irq_mask_t;
     \retval                 Status register word
     \sa irq_disable()
 */
-irq_mask_t irq_get_sr(void);
+static inline irq_mask_t irq_get_sr(void) {
+    irq_mask_t value;
+    __asm__ volatile("stc sr, %0" : "=r" (value));
+    return value;
+}
+
+/** Restore IRQ state.
+
+    This function will restore the interrupt state to the value specified. This
+    should correspond to a value returned by irq_disable().
+
+    \param  v               The IRQ state to restore. This should be a value
+                            returned by irq_disable().
+
+    \sa irq_disable()
+*/
+inline static void irq_restore(irq_mask_t old) {
+    __asm__ volatile("ldc %0, sr" : : "r" (old));
+}
 
 /** Disable interrupts.
 
@@ -342,7 +360,11 @@ irq_mask_t irq_get_sr(void);
 
     \sa irq_restore(), irq_enable()
 */
-irq_mask_t irq_disable(void);
+inline static irq_mask_t irq_disable(void) {
+    uint32_t mask = (uint32_t)irq_get_sr();
+    irq_restore((mask & 0xefffff0f) | 0x000000f0);
+    return mask;
+}
 
 /** Enable all interrupts.
 
@@ -350,19 +372,10 @@ irq_mask_t irq_disable(void);
 
     \sa irq_disable()
 */
-void irq_enable(void);
-
-/** Restore IRQ state.
-
-    This function will restore the interrupt state to the value specified. This
-    should correspond to a value returned by irq_disable().
-
-    \param  v               The IRQ state to restore. This should be a value
-                            returned by irq_disable().
-
-    \sa irq_disable()
-*/
-void irq_restore(irq_mask_t v);
+inline static void irq_enable(void) {
+    uint32_t mask = ((uint32_t)irq_get_sr() & 0xefffff0f);
+    irq_restore(mask);
+}
 
 /** \brief  Disable interrupts with scope management.
 

--- a/kernel/arch/dreamcast/kernel/thdswitch.s
+++ b/kernel/arch/dreamcast/kernel/thdswitch.s
@@ -1,8 +1,9 @@
 ! KallistiOS ##version##
 !
 !   arch/dreamcast/kernel/thdswitch.s
-!   Copyright (c)2003 Megan Potter
+!   Copyright (C) 2003 Megan Potter
 !   Copyright (C) 2023 Paul Cercueil <paul@crapouillou.net>
+!   Copyright (C) 2025 Falco Girgis
 !
 ! Assembler code for swapping out running threads
 !
@@ -33,12 +34,13 @@ _thd_block_now:
 	! and start at R8.
 
 	! Save SR and disable interrupts
-	sts.l		pr,@-r15
-	mov.l		idaddr,r0
-	jsr		@r0
-	nop
+	mov.l	irqd_and,r1
+	mov.l	irqd_or,r2
+	stc	sr,r0
+	and	r0,r1
+	or	r2,r1
+	ldc	r1,sr
 
-	lds.l		@r15+,pr
 	add		#0x72,r4
 
 	mov		r0,r1
@@ -122,9 +124,13 @@ _thd_block_now:
 	jmp		@r1
 	mov		r0,r4
 
+	.align 2
+irqd_and:
+	.long	0xefffff0f
+irqd_or:
+	.long	0x000000f0
+
 	.balign	4
-idaddr:
-	.long	_irq_disable
 ifraddr:
 	.long	_irq_force_return
 tcnaddr:


### PR DESCRIPTION
Despite being tiny little routines that clobber either just one register or nothing at all, the following routines were being implemented in pure out-of-line ASM, which meant the compiler could never inline them even with LTO:
    a. irq_get_sr()
    b. irq_restore()
    c. irq_disable()
    d. irq_enable()

This PR moves them into inline functions as inline ASM where the compiler should definitely be inlining them at even low optimization levels for pretty high perf gainz, since these are very hot throughout the codebase.

1) Removed all out-of-line implementations of theses routines from
  entry.s.
2) Rewrote them as inlined functions in inline ASM within irq.h 3) Had to tweak the following ASM routines to no longer call into the
   removed routines, since ASM cannot call inline C functions:
    a. irq_save_regs() [entry.s]
    b. thd_block_now() [thdswitch.s]