### PR TITLE
Fixed -Wfree-nonheap-object warnings with LTO.

### DIFF
--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -55,7 +55,7 @@ int mutex_init(mutex_t *m, int mtype) {
     return 0;
 }
 
-int mutex_destroy(mutex_t *m) {
+__no_inline int mutex_destroy(mutex_t *m) {
     irq_disable_scoped();
 
     if(m->type < MUTEX_TYPE_NORMAL || m->type > MUTEX_TYPE_RECURSIVE) {

--- a/kernel/thread/rwsem.c
+++ b/kernel/thread/rwsem.c
@@ -44,7 +44,7 @@ int rwsem_init(rw_semaphore_t *s) {
 }
 
 /* Destroy a reader/writer semaphore */
-int rwsem_destroy(rw_semaphore_t *s) {
+__no_inline int rwsem_destroy(rw_semaphore_t *s) {
     int rv = 0;
 
     irq_disable_scoped();

--- a/kernel/thread/sem.c
+++ b/kernel/thread/sem.c
@@ -65,7 +65,7 @@ int sem_init(semaphore_t *sm, int count) {
 }
 
 /* Take care of destroying a semaphore */
-int sem_destroy(semaphore_t *sm) {
+__no_inline int sem_destroy(semaphore_t *sm) {
     /* Wake up any queued threads with an error */
     genwait_wake_all_err(sm, ENOTRECOVERABLE);
 


### PR DESCRIPTION
It's apparently a commonly-known issue that this particular GCC warning is prone to false-positives on any routine that only frees a pointer conditionally, such as with reference counting:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54202.

Unfortuantely our kernel's synchronization primitives utilize such a pattern to only conditionally free() instances that have been heap-allocated via a "_create()" variant constructor.

After many, many painstaking hours of trying to figure out the best way to fix this without introducing any real changes into the code, I arrived at the following changes, which are as non-intrusive as I think is humanly possible to the "offending" lines of code.

1) Marked the following destructor routines as __no_inline to prevent  LTO from looking deeply enough into the body of the routines to produce these warnings:
    a. `mutex_destroy()`
    b. `sem_destroy()`
    c. `rwsem_destroy()`