### PR TITLE
Update gitignore to ignore generated `authors.h`

### DIFF
--- a/kernel/arch/dreamcast/kernel/.gitignore
+++ b/kernel/arch/dreamcast/kernel/.gitignore
@@ -1,2 +1,3 @@
 arch_exports.c
+authors.h
 banner.h


### PR DESCRIPTION
Was missed likely because it's only an issue if building stops unexpectedly and otherwise it gets cleaned up.