### PR TITLE
cdrom: Fixed confusion between sessions and areas.

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -343,7 +343,7 @@ static int init_percd(void) {
         return -1;
     }
 
-    if((i = cdrom_read_toc(&toc, 0)) != 0)
+    if((i = cdrom_read_toc(&toc, false)) != 0)
         return i;
 
     if(!(session_base = cdrom_locate_data_track(&toc)))

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -332,14 +332,14 @@ int cdrom_reinit_ex(int sector_part, int cdxa, int sector_size) {
 }
 
 /* Read the table of contents */
-int cdrom_read_toc(CDROM_TOC *toc_buffer, int session) {
+int cdrom_read_toc(CDROM_TOC *toc_buffer, bool high_density) {
     struct {
-        int session;
+        int area;
         void *buffer;
     } params;
     int rv;
 
-    params.session = session;
+    params.area = high_density ? 1 : 0;
     params.buffer = toc_buffer;
 
     rv = cdrom_exec_cmd(CMD_GETTOC2, &params);

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -406,13 +406,14 @@ int cdrom_reinit_ex(int sector_part, int cdxa, int sector_size);
 /** \brief    Read the table of contents from the disc.
     \ingroup  gdrom
 
-    This function reads the TOC from the specified session of the disc.
+    This function reads the TOC from the specified area of the disc.
+    On regular CD-ROMs, there are only low density area.
 
     \param  toc_buffer      Space to store the returned TOC in.
-    \param  session         The session of the disc to read.
+    \param  high_density    Whether to read from the high density area.
     \return                 \ref cd_cmd_response
 */
-int cdrom_read_toc(CDROM_TOC *toc_buffer, int session);
+int cdrom_read_toc(CDROM_TOC *toc_buffer, bool high_density);
 
 /** \brief    Read one or more sector from a CD-ROM.
     \ingroup  gdrom


### PR DESCRIPTION
GD-ROM drive does not differentiate sessions at all. This TOC is always divided into two, for the low-density area and the high-density area, which is only on the GD-ROM disc.
And in fact, this is one and the same TOC, it’s just that for non-requested area the tracks are erased (and first/last changed) in this common TOC, because the tracks numbering remains the same.
There may be multiple sessions in one area, but there is no division between them.