### PR TITLE
Fix toolchain compilation on Darwin 24.4.0+ using Apple Clang 17

### DIFF
--- a/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/binutils-2.43-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/binutils-2.43-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN binutils-2.43/zlib/zutil.h binutils-2.43/zlib/zutil-apple-clang17-fix.h
+--- binutils-2.43/zlib/zutil.h	2024-08-04 08:00:00
++++ binutils-2.43/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:19:11
+@@ -139,15 +139,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/binutils-2.44-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/binutils-2.44-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN binutils-2.44/zlib/zutil.h binutils-2.44/zlib/zutil-apple-clang17-fix.h
+--- binutils-2.44/zlib/zutil.h	2025-02-02 09:00:00
++++ binutils-2.44/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:19:21
+@@ -139,15 +139,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/gcc-13.2.0-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/gcc-13.2.0-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN gcc-13.2.0/zlib/zutil.h gcc-13.2.0/zlib/zutil-apple-clang17-fix.h
+--- gcc-13.2.0/zlib/zutil.h	2023-07-27 17:13:08
++++ gcc-13.2.0/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:21:37
+@@ -132,15 +132,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/gcc-13.4.0-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/gcc-13.4.0-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN gcc-13.4.0/zlib/zutil.h gcc-13.4.0/zlib/zutil-apple-clang17-fix.h
+--- gcc-13.4.0/zlib/zutil.h	2023-07-27 17:13:08
++++ gcc-13.4.0/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:21:37
+@@ -132,15 +132,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/gcc-14.3.0-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/gcc-14.3.0-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN gcc-14.3.0/zlib/zutil.h gcc-14.3.0/zlib/zutil-apple-clang17-fix.h
+--- gcc-14.3.0/zlib/zutil.h	2023-07-27 17:13:08
++++ gcc-14.3.0/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:21:37
+@@ -132,15 +132,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/gcc-15.1.0-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.4.0/gcc-15.1.0-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN gcc-15.1.0/zlib/zutil.h gcc-15.1.0/zlib/zutil-apple-clang17-fix.h
+--- gcc-15.1.0/zlib/zutil.h	2023-07-27 17:13:08
++++ gcc-15.1.0/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:21:37
+@@ -132,15 +132,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/binutils-2.43-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/binutils-2.43-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN binutils-2.43/zlib/zutil.h binutils-2.43/zlib/zutil-apple-clang17-fix.h
+--- binutils-2.43/zlib/zutil.h	2024-08-04 08:00:00
++++ binutils-2.43/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:19:11
+@@ -139,15 +139,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/binutils-2.44-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/binutils-2.44-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN binutils-2.44/zlib/zutil.h binutils-2.44/zlib/zutil-apple-clang17-fix.h
+--- binutils-2.44/zlib/zutil.h	2025-02-02 09:00:00
++++ binutils-2.44/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:19:21
+@@ -139,15 +139,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/gcc-13.2.0-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/gcc-13.2.0-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN gcc-13.2.0/zlib/zutil.h gcc-13.2.0/zlib/zutil-apple-clang17-fix.h
+--- gcc-13.2.0/zlib/zutil.h	2023-07-27 17:13:08
++++ gcc-13.2.0/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:21:37
+@@ -132,15 +132,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/gcc-13.4.0-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/gcc-13.4.0-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN gcc-13.4.0/zlib/zutil.h gcc-13.4.0/zlib/zutil-apple-clang17-fix.h
+--- gcc-13.4.0/zlib/zutil.h	2023-07-27 17:13:08
++++ gcc-13.4.0/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:21:37
+@@ -132,15 +132,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/gcc-14.3.0-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/gcc-14.3.0-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN gcc-14.3.0/zlib/zutil.h gcc-14.3.0/zlib/zutil-apple-clang17-fix.h
+--- gcc-14.3.0/zlib/zutil.h	2023-07-27 17:13:08
++++ gcc-14.3.0/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:21:37
+@@ -132,15 +132,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn

--- a/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/gcc-15.1.0-zlibfix.diff
+++ b/utils/dc-chain/patches/aarch64-apple-darwin24.5.0/gcc-15.1.0-zlibfix.diff
@@ -1,0 +1,24 @@
+diff --color -ruN gcc-15.1.0/zlib/zutil.h gcc-15.1.0/zlib/zutil-apple-clang17-fix.h
+--- gcc-15.1.0/zlib/zutil.h	2023-07-27 17:13:08
++++ gcc-15.1.0/zlib/zutil-apple-clang17-fix.h	2025-06-14 21:21:37
+@@ -132,15 +132,11 @@
+ 
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
++/*
++ * Backport fix from zlib 1.3.1 where these lines
++ * redefining fdopen were removed. In Apple Clang 17
++ * these will cause errors when building zlib.
++ */
+ #endif
+ 
+ #ifdef __acorn


### PR DESCRIPTION
### Toolchain compilation is broken on recent macOS versions.

## Background

Starting with Xcode 16.3 (Darwin 24.4.0, Sequoia 15.4) the compiler was updated to Apple Clang 17. 
Same goes for Xcode 16.4 (Darwin 24.5.0, Sequoia 15.5)

## Problem
Old versions of zlib break under Apple Clang 17 because of some lines in `zutil.h` redefining `fdopen` to `NULL` which causes compilation to error out when it reaches zlib when building binutils (and gcc).

The latest zlib versions [seem to have fixed this ](https://github.com/madler/zlib/blob/develop/zutil.h#L144) some time ago by simply removing those lines redefining the symbol.

However, binutils and gcc bundle in their own copy of copy of zlib under `binutils-x.y/zlib/` and `gcc-x.y.z/zlib/` which appears to be old enough that it doesn't have the latest upstream fixes for macOS.

## Solution
I backported the zlib changes as patches in `aarch64-apple-darwin24.4.0/` and `aarch64-apple-darwin24.5.0/` under `dc-chain/patches/`

The patches are for all the stable versions of the toolchain, being:
- binutils-2.43
- binutils-2.44
- gcc-13.2.0
- gcc-13.4.0
- gcc-14.3.0
- gcc-15.1.0

## Conclusion
With these patches the toolchain builds without issue. 🚀

## Other
Googling around this seems to be an overall issue with Clang 17 which also affects Intel platforms as people elsewhere were encountering issues with zlib on their Intel Macs, so patches should probably exist for the Intel target as well, but I only have an Apple Silicon Mac so I can't confirm. 

Though considering those lines were removed from upstream zlib entirely, the patches could probably just be copy pasted into a directory for the Intel target too.

This should probably be added to the KOS 2.2.x branch if possible if they are to be the new stable version going forward.