### PR TITLE
Fix toolchain compilation on recent macOS using Apple Clang 17

### DIFF
--- a/utils/dc-chain/scripts/init.mk
+++ b/utils/dc-chain/scripts/init.mk
@@ -68,6 +68,18 @@ ifdef MACOS
     SH_CXX_FOR_TARGET += $(macos_extra_args)
     macos_gcc_configure_args = --with-sysroot --with-native-system-header=/usr/include
     macos_gdb_configure_args = --with-sysroot=$(sdkroot)
+    # Detect if CC is Apple Clang and get major version, skip if using gcc.
+    APPLE_CLANG_MAJOR := $(shell $(CC) --version 2>&1 | \
+      grep -i "Apple clang" | cut -f 4 -d " " | cut -f 1 -d ".")
+    ifdef APPLE_CLANG_MAJOR
+      # When using Apple Clang 17 or above, use system zlib.
+      ifeq ($(shell [ "$(APPLE_CLANG_MAJOR)" -gt 16 ] && echo "yes"), yes)
+        $(info Apple clang $(APPLE_CLANG_MAJOR) detected, using system zlib)
+        macos_gcc_configure_args += --with-system-zlib
+        macos_gdb_configure_args += --with-system-zlib
+        binutils_extra_configure_args += --with-system-zlib
+      endif
+    endif
   endif
 endif
 


### PR DESCRIPTION
### Toolchain compilation is broken on recent macOS versions.

## Background

Starting with Xcode 16.3 (Darwin 24.4.0, Sequoia 15.4) the compiler was updated to Apple Clang 17. 
Same goes for Xcode 16.4 (Darwin 24.5.0, Sequoia 15.5)

## Problem
Old versions of zlib break under Apple Clang 17 because of some lines in `zutil.h` redefining `fdopen` to `NULL` which causes compilation to error out when it reaches zlib when building binutils (and gcc).

The latest zlib versions [seem to have fixed this ](https://github.com/madler/zlib/blob/develop/zutil.h#L144) some time ago by simply removing those lines redefining the symbol.

However, binutils and gcc bundle in their own copy of copy of zlib under `binutils-x.y/zlib/` and `gcc-x.y.z/zlib/` which appears to be old enough that it doesn't have the latest upstream fixes for macOS.

## Solution
Detect if the user is building with Apple Clang, and then check its major version number.
If Apple Clang 17+ is detected then specify `--with-system-zlib` to build against the system version of zlib and avoid compiling the problematic dependency.
Users building with gcc or older clang will be unaffected.

## Conclusion
With these patches the toolchain builds without issue. 🚀 Tested on M3 Macbook Pro.

## Other
Googling around this seems to be an overall issue with Clang 17 which also affects Intel platforms as people elsewhere were encountering issues with building zlib on their Intel Macs, so this is a universal fix for both architectures.

This should probably be added to the KOS 2.2.x branch if possible if they are to be the new stable version going forward.