### PR TITLE
Fixed unresolved linker errors with LTO+atomics.

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -31,7 +31,7 @@ export KOS_INC_PATHS="${KOS_INC_PATHS} -I${KOS_BASE}/include \
 
 # "System" libraries.
 export KOS_LIB_PATHS="-L${KOS_BASE}/lib/${KOS_ARCH} -L${KOS_BASE}/addons/lib/${KOS_ARCH} -L${KOS_PORTS}/lib"
-export KOS_LIBS="-Wl,--start-group -lkallisti -lm -lc -lgcc -Wl,--end-group"
+export KOS_LIBS="-Wl,--start-group -lkallisti -lm -lc -lgcc -latomic -Wl,--end-group"
 
 # Main arch compiler paths.
 export KOS_CC="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-gcc"

--- a/kernel/libc/Makefile
+++ b/kernel/libc/Makefile
@@ -4,7 +4,7 @@
 # Copyright (C) 2004 Megan Potter
 #
 
-SUBDIRS = koslib newlib c11 posix
+SUBDIRS = koslib newlib c11 posix atomics
 
 all: subdirs
 clean: clean_subdirs

--- a/kernel/libc/atomics/Makefile
+++ b/kernel/libc/atomics/Makefile
@@ -1,0 +1,13 @@
+# KallistiOS ##version##
+#
+# kernel/libc/atomics/Makefile
+# Copyright (C) 2025 Falco Girgis
+#
+
+TARGET = libatomic.a
+SUBDIRS =
+KOS_CFLAGS += -fno-lto
+
+OBJS = atomics.o
+
+include $(KOS_BASE)/addons/Makefile.prefab

--- a/kernel/libc/atomics/atomics.c
+++ b/kernel/libc/atomics/atomics.c
@@ -16,13 +16,14 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+//#include <stdatomic.h>
 
 /* Create a set of macros to codegen atomic symbols for primitive types.
    For these types, we simply disable interrupts then re-enable them
    around accesses to our atomics to ensure their atomicity.
 */
 #define ATOMIC_LOAD_N_(type, n) \
-    type \
+    __used type \
     __atomic_load_##n(const volatile void *ptr, int model) { \
         (void)model; \
         irq_disable_scoped(); \
@@ -30,7 +31,7 @@
     }
 
 #define ATOMIC_STORE_N_(type, n) \
-    void \
+    __used void \
     __atomic_store_##n(volatile void *ptr, type val, int model) { \
         (void)model; \
         irq_disable_scoped(); \
@@ -38,7 +39,7 @@
     }
 
 #define ATOMIC_EXCHANGE_N_(type, n) \
-    type \
+    __used type \
     __atomic_exchange_##n(volatile void* ptr, type val, int model) { \
         irq_disable_scoped(); \
         const type ret = *(type *)ptr; \
@@ -48,7 +49,7 @@
     }
 
 #define ATOMIC_COMPARE_EXCHANGE_N_(type, n) \
-    bool \
+    __used bool \
     __atomic_compare_exchange_##n(volatile void *ptr, \
                                   void *expected, \
                                   type desired, \
@@ -69,7 +70,7 @@
     }
 
 #define ATOMIC_FETCH_N_(type, n, opname, op) \
-    type \
+    __used type \
     __atomic_fetch_##opname##_##n(volatile void* ptr, \
                                   type val, \
                                   int memorder) { \
@@ -81,7 +82,7 @@
     }
 
 #define ATOMIC_FETCH_NAND_N_(type, n) \
-    type \
+    __used type \
     __atomic_fetch_nand_##n(volatile void* ptr, \
                             type val, \
                             int memorder) { \

--- a/kernel/libc/c11/Makefile
+++ b/kernel/libc/c11/Makefile
@@ -11,6 +11,6 @@ OBJS = call_once.o cnd_broadcast.o cnd_destroy.o cnd_init.o cnd_signal.o \
     mtx_timedlock.o mtx_trylock.o mtx_unlock.o thrd_create.o thrd_current.o \
     thrd_detach.o thrd_equal.o thrd_exit.o thrd_join.o thrd_sleep.o \
     thrd_yield.o tss_create.o tss_delete.o tss_get.o tss_set.o \
-    timespec_get.o timegm.o atomics.o
+    timespec_get.o timegm.o
 
 include $(KOS_BASE)/Makefile.prefab


### PR DESCRIPTION
LTO and our atomics have never worked together correctly, ever since their implementation. 1, 2, and 4-byte atomics are fine, as they are built into the compiler and are provided via the
-matomic-model=soft-imask mechanism built into the compiler, leaving KOS to implement just the 8-byte and N-byte cases.

Our implementation works fine for those, but ONLY with LTO disabled. As soon as LTO becomes enabled, the symbols for working with 8 and N-byte atomics will never resolve properly, causing linking to fail.

It turns out that LTO is manging the symbol names within the atomics.o object file, so that they no longer match the expected special built-in symbol names emitted by the copiler around atomics usage.

The solution was two-fold. Yes, LTO needs to be disabled for *just* the atomics.o translation unit, but what's the cleanest way to make this distinction bewteen the atomics symbols and the rest of libkallisti.a? A static library, imho, which is exactly how atomics are backed for mainstream platforms with GCC, by using libatomic. So we're technically behaving consistently with the rest of GCC by having a separate libatomic as well.

1) Moved atomics.c to its own subdirectory within libc. 2) Added a new Makefile for building atomics.c into a static lib,
   libatomic.a, which gets installed as a kos add-on.
3) Updated parent Makefile within "libc" to build libatomic. 4) Removed atomics.o from the "c11" subdirectory Makefile. 5) Added "-latomic" to our list of built-in linker flags.
    a. Because this will preserve backwards compat
    b. Because I don't like the idea of the user having to care where
things like atomics are implemented, since it's a GCC-ism, and compilers like Clang don't require "-latomic." Since it's part of libc, which is something that's supposed to "just work" within the KOS environment, I think it should be there automatically, similarly to our decision to auto-link to "libm" for C math.