### PR TITLE
Fixed maple crash when unknown device attached.

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -116,6 +116,9 @@ int maple_driver_attach(maple_frame_t *det) {
         }
     }
 
+    if(!dev)
+        return -1;
+
     /* Did we get any hits? */
     if(!attached) {
         free(dev->status);


### PR DESCRIPTION
Currently, the Maple driver crashes due to NULL pointer dereference in "maple_driver.c" on line 121. When the user manually disables certain Maple drivers via explicitly providing a custom KOS_INIT_FLAGS() list, and such a device is plugged into the controller, the "dev" pointer never gets allocated, since a driver for it is never found.

1) Check to see if dev is NULL and error out early before dereferencing it.