### PR TITLE
Vmu pkg example fixup

### DIFF
--- a/examples/dreamcast/vmu/vmu_pkg/vmu.c
+++ b/examples/dreamcast/vmu/vmu_pkg/vmu.c
@@ -15,6 +15,9 @@
 
 #define NB_ICONS_MAX 3
 
+/* How many bytes of data to write */
+#define DATA_LEN 4096
+
 #define SCREEN_W 640
 #define SCREEN_H 480
 
@@ -110,7 +113,7 @@ static unsigned char vmu_icon[ICON_SIZE * NB_ICONS_MAX];
 /* Here's the actual meat of it */
 void write_entry(void) {
     vmu_pkg_t   pkg;
-    uint8_t       data[4096], *pkg_out;
+    uint8_t       data[DATA_LEN], *pkg_out;
     int     pkg_size;
     int     i;
     file_t      f;
@@ -122,8 +125,10 @@ void write_entry(void) {
     pkg.icon_data = vmu_icon;
     pkg.icon_anim_speed = 8;
     pkg.eyecatch_type = VMUPKG_EC_NONE;
+    pkg.data_len = DATA_LEN;
+    pkg.data = data;
 
-    for(i = 0; i < 4096; i++)
+    for(i = 0; i < DATA_LEN; i++)
         data[i] = i & 255;
 
     vmu_pkg_load_icon(&pkg, "/rd/ebook.ico");

--- a/examples/dreamcast/vmu/vmu_pkg/vmu.c
+++ b/examples/dreamcast/vmu/vmu_pkg/vmu.c
@@ -13,24 +13,33 @@
 /* An icon is always 32x32 4bpp */
 #define ICON_SIZE (32 * 32 / 2)
 
+#define SCREEN_W 640
+#define SCREEN_H 480
+
+/* The Y indentation for the VMU Info text on screen */
+#define INFO_Y 88
+
+/* The amount of space from the top of one row of text to the next */
+#define ROW_SPACER 24
+
 #define NB_ICONS_MAX 3
 
 void draw_dir(void) {
     file_t      d;
-    int     y = 88;
+    int     y = INFO_Y;
     dirent_t    *de;
 
     d = fs_open("/vmu/a1", O_RDONLY | O_DIR);
 
     if(!d) {
-        bfont_draw_str(vram_s + y * 640 + 10, 640, 0, "Can't read VMU");
+        bfont_draw_str(vram_s + y * SCREEN_W + 10, SCREEN_W, 0, "Can't read VMU");
     }
     else {
         while((de = fs_readdir(d))) {
-            bfont_draw_str(vram_s + y * 640 + 10, 640, 0, de->name);
-            y += 24;
+            bfont_draw_str(vram_s + y * SCREEN_W + 10, SCREEN_W, 0, de->name);
+            y += ROW_SPACER;
 
-            if(y >= (480 - 24))
+            if(y >= (SCREEN_H - ROW_SPACER))
                 break;
         }
 
@@ -46,15 +55,15 @@ void new_vmu(void) {
 
     if(dev == NULL) {
         if(dev_checked) {
-            memset(vram_s + 88 * 640, 0, 640 * (480 - 64) * 2);
-            bfont_draw_str(vram_s + 88 * 640 + 10, 640, 0, "No VMU");
+            memset(vram_s + INFO_Y * SCREEN_W, 0, SCREEN_W * (SCREEN_H - 64) * 2);
+            bfont_draw_str(vram_s + INFO_Y * SCREEN_W + 10, SCREEN_W, 0, "No VMU");
             dev_checked = 0;
         }
     }
     else if(dev_checked) {
     }
     else {
-        memset(vram_s + 88 * 640, 0, 640 * (480 - 88));
+        memset(vram_s + INFO_Y * SCREEN_W, 0, SCREEN_W * (SCREEN_H - INFO_Y));
         draw_dir();
         dev_checked = 1;
     }
@@ -119,11 +128,11 @@ void write_entry(void) {
 }
 
 int main(int argc, char **argv) {
-    bfont_draw_str(vram_s + 20 * 640 + 20, 640, 0,
+    bfont_draw_str(vram_s + 20 * SCREEN_W + 20, SCREEN_W, 0,
                    "Put a VMU you don't care too much about");
-    bfont_draw_str(vram_s + 42 * 640 + 20, 640, 0,
+    bfont_draw_str(vram_s + 42 * SCREEN_W + 20, SCREEN_W, 0,
                    "in slot A1 and press START");
-    bfont_draw_str(vram_s + 88 * 640 + 10, 640, 0, "No VMU");
+    bfont_draw_str(vram_s + INFO_Y * SCREEN_W + 10, SCREEN_W, 0, "No VMU");
 
     if(wait_start() < 0) return 0;
 

--- a/kernel/arch/dreamcast/util/vmu_pkg.c
+++ b/kernel/arch/dreamcast/util/vmu_pkg.c
@@ -97,6 +97,8 @@ int vmu_pkg_build(vmu_pkg_t *src, uint8_t **dst, int *dst_size) {
 
     assert(src && dst);
 
+    if(src->data_len < 0) return -2;
+
     /* First off, figure out how big it will be */
     out_size = sizeof(vmu_hdr_t) + 512 * src->icon_cnt + src->data_len;
     ec_size = vmu_eyecatch_size(src->eyecatch_type);
@@ -138,7 +140,9 @@ int vmu_pkg_build(vmu_pkg_t *src, uint8_t **dst, int *dst_size) {
     memcpy(out, src->eyecatch_data, ec_size);
     out += ec_size;
 
-    memcpy(out, src->data, src->data_len);
+    if(src->data)
+        memcpy(out, src->data, src->data_len);
+
     out += src->data_len;
 
     /* Verify the size */


### PR DESCRIPTION
It seems it could freeze when going into `vmu_pkg_build` and the cause was that `data_len` and `data` were no longer being set and the `pkg` was otherwise uninitialized. While they do get updated in the final header before being written out to the vmu, they need to still be initialized to not allow random bad behavior.

I additionally added some safety checks in `vmu_pkg_build` to help guard against similar issues.

It might be merited to further update this to also include reading back the written data and validating it's identical.