### PR TITLE
Keep network examples connected to dcload console.

### DIFF
--- a/examples/dreamcast/network/basic/Makefile
+++ b/examples/dreamcast/network/basic/Makefile
@@ -1,7 +1,7 @@
 #
 # Basic KallistiOS skeleton / test program
 # (c)2001 Megan Potter
-#   
+#
 
 # Put the filename of the output binary here
 TARGET = basic.elf
@@ -26,7 +26,7 @@ $(TARGET): $(OBJS)
 	kos-cc -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
-	$(KOS_LOADER) $(TARGET) -n
+	$(KOS_LOADER) $(TARGET)
 
 dist: $(TARGET)
 	-rm -f $(OBJS)

--- a/examples/dreamcast/network/dns-client/Makefile
+++ b/examples/dreamcast/network/dns-client/Makefile
@@ -21,7 +21,7 @@ $(TARGET): $(OBJS)
 	kos-cc -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
-	$(KOS_LOADER) $(TARGET) -n
+	$(KOS_LOADER) $(TARGET)
 
 dist: $(TARGET)
 	-rm -f $(OBJS)

--- a/examples/dreamcast/network/httpd/Makefile
+++ b/examples/dreamcast/network/httpd/Makefile
@@ -28,7 +28,7 @@ $(TARGET): $(OBJS)
 	kos-cc -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
-	$(KOS_LOADER) $(TARGET) -n
+	$(KOS_LOADER) $(TARGET)
 
 dist: $(TARGET)
 	-rm -f $(OBJS) romdisk.img

--- a/examples/dreamcast/network/ntp/Makefile
+++ b/examples/dreamcast/network/ntp/Makefile
@@ -27,7 +27,7 @@ $(TARGET): $(OBJS)
 	kos-cc -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
-	$(KOS_LOADER) $(TARGET) -n
+	$(KOS_LOADER) $(TARGET)
 
 dist: $(TARGET)
 	-rm -f $(OBJS)

--- a/examples/dreamcast/network/ping/Makefile
+++ b/examples/dreamcast/network/ping/Makefile
@@ -1,7 +1,7 @@
 #
 # Basic KallistiOS skeleton / test program
 # (c)2001 Megan Potter
-#   
+#
 
 # Put the filename of the output binary here
 TARGET = ping.elf
@@ -26,7 +26,7 @@ $(TARGET): $(OBJS)
 	kos-cc -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
-	$(KOS_LOADER) $(TARGET) -n
+	$(KOS_LOADER) $(TARGET)
 
 dist: $(TARGET)
 	-rm -f $(OBJS)

--- a/examples/dreamcast/network/ping6/Makefile
+++ b/examples/dreamcast/network/ping6/Makefile
@@ -1,7 +1,7 @@
 #
 # Basic KallistiOS skeleton / test program
 # (c)2001 Megan Potter
-#   
+#
 
 # Put the filename of the output binary here
 TARGET = ping.elf
@@ -26,7 +26,7 @@ $(TARGET): $(OBJS)
 	kos-cc -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
-	$(KOS_LOADER) $(TARGET) -n
+	$(KOS_LOADER) $(TARGET)
 
 dist: $(TARGET)
 	-rm -f $(OBJS)

--- a/examples/dreamcast/network/speedtest/Makefile
+++ b/examples/dreamcast/network/speedtest/Makefile
@@ -1,6 +1,6 @@
 #
 # KallistiOS network/speedtest example
-# 
+#
 # Copyright (C) 2024 Andress Barajas
 #
 
@@ -23,7 +23,7 @@ $(TARGET): $(OBJS)
 	kos-cc -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
-	$(KOS_LOADER) $(TARGET) -n
+	$(KOS_LOADER) $(TARGET)
 
 dist: $(TARGET)
 	-rm -f $(OBJS) romdisk.img

--- a/examples/dreamcast/network/udpecho6/Makefile
+++ b/examples/dreamcast/network/udpecho6/Makefile
@@ -1,7 +1,7 @@
 #
 # Basic KallistiOS skeleton / test program
 # (c)2001 Megan Potter
-#   
+#
 
 # Put the filename of the output binary here
 TARGET = echo.elf
@@ -26,7 +26,7 @@ $(TARGET): $(OBJS)
 	kos-cc -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
-	$(KOS_LOADER) $(TARGET) -n
+	$(KOS_LOADER) $(TARGET)
 
 dist: $(TARGET)
 	-rm -f $(OBJS)


### PR DESCRIPTION
By default most network examples were set to call dctool with `-n` to disconnect the debug console. The idea behind it seems to have been to prevent dcload-ip from interferring with the network traffic, but that's not needed. We have a system in place just for this and it relies on the dcload console being active in order to request the already assigned IP.

Will be opening a separate issue for supporting reconnecting to the network properly while using dcload-ip to load but disconnecting the console.