### PR TITLE
dc-chain: Make GDB CPATH and LIBRARY_PATH exports for macOS conditional

### DIFF
--- a/utils/dc-chain/scripts/gdb.mk
+++ b/utils/dc-chain/scripts/gdb.mk
@@ -26,13 +26,13 @@ build_gdb: $(stamp_gdb_build)
 ifeq ($(MACOS), 1)
   ifeq ($(uname_m),arm64)
     $(info Fixing up MacOS arm64 environment variables)
-    $(stamp_gdb_build): export CPATH := /opt/homebrew/include
-    $(stamp_gdb_build): export LIBRARY_PATH := /opt/homebrew/lib
+    $(stamp_gdb_build): export CPATH ?= /opt/homebrew/include
+    $(stamp_gdb_build): export LIBRARY_PATH ?= /opt/homebrew/lib
   endif
   ifeq ($(uname_m),x86_64)
     $(info Fixing up MacOS x86_64 environment variables)
-    $(stamp_gdb_build): export CPATH := /usr/local/include
-    $(stamp_gdb_build): export LIBRARY_PATH := /usr/local/lib
+    $(stamp_gdb_build): export CPATH ?= /usr/local/include
+    $(stamp_gdb_build): export LIBRARY_PATH ?= /usr/local/lib
   endif
 endif
 


### PR DESCRIPTION
In the default case, we specify the CPATH and LIBRARY_PATH environment variables for users using the Homebrew package manager, which is the most common case. By making these variables conditional, we allow users of other package managers to specify their own environment variables here.

Fixes #1081 