### PR TITLE
Fixes for doxygen warnings

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -27,10 +27,10 @@
     \author Lawrence Sebald
 */
 
-/** \cond **/
-
 #ifndef __PTHREAD_H
 #define __PTHREAD_H
+
+/** \cond **/
 
 #include <sys/cdefs.h>
 #include <sys/features.h>

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -451,16 +451,18 @@ typedef struct kbd_state {
     /** \brief  The latest raw condition of the keyboard. */
     kbd_cond_t cond;
 
-    /** \brief Current (and previous) state of all keys in kbd_keys_t */
     union {
+        /* \cond */
         uint8_t matrix[KBD_MAX_KEYS] __depr("Please see key_state_t and use key_states to access this.");
-        key_state_t key_states[KBD_MAX_KEYS];
+        /* \endcond */
+        key_state_t key_states[KBD_MAX_KEYS];   /** \brief Current (and previous) state of all keys in kbd_keys_t */
     };
 
-    /** \brief  Modifier key status. Stored to track changes. */
     union {
+        /* \cond */
         int shift_keys __depr("Please see kbd_mods_t and use last_modifiers.raw to access this.");
-        kbd_mods_t last_modifiers;
+        /* \endcond */
+        kbd_mods_t last_modifiers;  /** \brief  Modifier key status. Stored to track changes. */
     };
 
     /** \brief  Keyboard type/region. */

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -189,12 +189,12 @@ int vmu_get_custom_color(maple_device_t *dev, uint8_t *red, uint8_t *green, uint
     icon by providing custom icons for both the DC BIOS menu and the VMU's LCD screen.
 
     \param  dev             The device to change the icon shape of.
-    \param  icon_shape      One of the values found in \ref vmu_icons.
+    \param  icon_shape      One of the values found in \ref bfont_vmu_icon_t.
 
     \retval 0               On success
     \retval -1              On failure
 
-    \sa vmu_icons, vmu_get_icon_shape
+    \sa bfont_vmu_icon_t, vmu_get_icon_shape
 */
 int vmu_set_icon_shape(maple_device_t *dev, uint8_t icon_shape);
 
@@ -211,12 +211,12 @@ int vmu_set_icon_shape(maple_device_t *dev, uint8_t icon_shape);
     icon by providing custom icons for both the DC BIOS menu and the VMU's LCD screen.
 
     \param  dev             The device to change the icon shape of.
-    \param  icon_shape      One of the values found in \ref vmu_icons.
+    \param  icon_shape      One of the values found in \ref bfont_vmu_icon_t.
 
     \retval 0               On success
     \retval -1              On failure
 
-    \sa vmu_icons, vmu_set_icon_shape
+    \sa bfont_vmu_icon_t, vmu_set_icon_shape
 */
 int vmu_get_icon_shape(maple_device_t *dev, uint8_t *icon_shape);
 


### PR DESCRIPTION
pthread.h - endcond was inside the header ifdef guards and cond was
 on the outside, so doxygen couldn't see them both.

vmu.h - wrong ref name was being used for bfont icons.

keyboard.h - There may be a better fix for this, but it seems that
 doxygen is choking on the depr inside a union.

These are the majority of what was left from #1031 with only one error left.