### PR TITLE
Fix built object file not added to the KOS library

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -12,7 +12,7 @@ STUBS = stubs/kernel_export_stubs.o stubs/arch_export_stubs.o
 # Everything from here up should be plain old C.
 KOS_CFLAGS += $(KOS_CSTD)
 
-all: subdirs $(STUBS) $(OBJS)
+all: defaultall $(STUBS)
 	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a
 	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libromdiskbase.a romdisk/*.o
 	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a build/*.o


### PR DESCRIPTION
The source files inside the kernel/ subdirectory (which is just version.c for now) were compiled, but the object files were not added to the KallistiOS library.

Address this by adding a Makefile dependency on the "defaultall" rule, which will copy the object files to the build folder, so that they are subsequently compiled inside the KallistiOS library.