### PR TITLE
dc-chain: Change source URL for config.guess and config.sub to more reliable mirror

### DIFF
--- a/utils/dc-chain/scripts/host-detect.mk
+++ b/utils/dc-chain/scripts/host-detect.mk
@@ -8,9 +8,9 @@
 # Download ./config.guess if necessary
 # This will help a lot to execute conditional steps depending on the host.
 config_guess = config.guess
-config_guess_url = http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=${config_guess};hb=HEAD
+config_guess_url = https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;a=blob_plain;f=${config_guess};hb=HEAD
 config_sub = config.sub
-config_sub_url = http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=${config_sub};hb=HEAD
+config_sub_url = https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;a=blob_plain;f=${config_sub};hb=HEAD
 
 is_clean_target=$(findstring clean,$(MAKECMDGOALS))
 config_guess_check=$(shell test -f ./config.guess || echo 0)


### PR DESCRIPTION
The server we grab `config.guess` and `config.sub` frequently has issues connecting over the last few months. When `config.guess` and `config.sub` aren't downloaded, it also causes issues during the patch stage, so it's important that a working mirror is chosen. We should probably create a better fallback mechanism though.