### PR TITLE
timer: Fine-tune timer rate

### DIFF
--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -65,8 +65,11 @@ typedef enum PCK_DIV {
 #define TIMER_TPSC      PCK_DIV_4
 /* Timer IRQ priority levels (0-15) */
 #define TIMER_PRIO      15
-/* Peripheral clock rate (50Mhz) */
-#define TIMER_PCK       50000000
+
+/* Peripheral clock rate (~49.9 Mhz).
+ * The main clock is not exactly 200 MHz, and has been measured at
+ * 199499520 Hz. The peripheral clock is a quarter of that. */
+#define TIMER_PCK       (199499520 / 4)
 
 /* Timer registers, indexed by Timer ID. */
 static const unsigned tcors[] = { TCOR0, TCOR1, TCOR2 };


### PR DESCRIPTION
The seconds counter has been reported to drift quite significantly vs. a wall clock. This is most likely because until now we considered that the peripheral clock was a perfect 50.0 MHz, while in practice it is closer to 49.9 MHz.

Before merging, somebody should test it against https://github.com/CSword123/Dreamclock-DC-/ and see if the new value works better there. I could do it myself but for the time being I can't find a way to compile Raylib, I get ICEs with many different toolchains.