### PR TITLE
Fix net_init crash when there are 0 detected network devices

### DIFF
--- a/kernel/net/net_core.c
+++ b/kernel/net/net_core.c
@@ -138,7 +138,10 @@ int net_dev_init(void) {
 
     dbglog(DBG_DEBUG, "net_dev_init: detected %d usable network device(s)\n", detected);
 
-    return 0;
+    if(detected)
+        return 0;
+    else
+        return -1;
 }
 
 /* Init */


### PR DESCRIPTION
When `net_init()` is called...
https://github.com/KallistiOS/KallistiOS/blob/5d2b7a432487ba8cf06cf68a8ec76ff02c8815e7/kernel/net/net_core.c#L145-L154

it calls `net_dev_init()`...
https://github.com/KallistiOS/KallistiOS/blob/5d2b7a432487ba8cf06cf68a8ec76ff02c8815e7/kernel/net/net_core.c#L113-L142

and if `net_dev_init()` returns `< 0`, `net_init()` returns `-1`. 

But `net_dev_init()` always returns `0`, and if `net_dev_init()` is zero then that means `net_default_dev` is `NULL`. Down the line, when `net_init()` calls `net_ipv6_init()`, `net_default_dev` gets dereferenced:

https://github.com/KallistiOS/KallistiOS/blob/5d2b7a432487ba8cf06cf68a8ec76ff02c8815e7/kernel/net/net_ipv6.c#L280-L295

Resulting in a crash.

This PR adjusts `net_dev_init()` so that it returns `-1` if no devices were detected.