### PR TITLE
Update version number for current master.

### DIFF
--- a/include/kos/version.h
+++ b/include/kos/version.h
@@ -72,7 +72,7 @@
 
     ## App Versioning
     The same \ref version_utils used to implement the KOS versioning
-    API are available as part of the public API so that they may be used to 
+    API are available as part of the public API so that they may be used to
     implement your own similar versioning scheme at the app-level.
 
     @{
@@ -99,7 +99,7 @@
 
 #define KOS_VERSION_MAJOR   2   /**< KOS's current major revision number. */
 #define KOS_VERSION_MINOR   2   /**< KOS's current minor revision number. */
-#define KOS_VERSION_PATCH   0   /**< KOS's current patch revision number. */
+#define KOS_VERSION_PATCH   1   /**< KOS's current patch revision number. */
 
 /** KOS's current version as an integer ID. */
 #define KOS_VERSION \


### PR DESCRIPTION
Moving forward I believe this should be the way we operate. After a version is cut, we set master to
the next version patch version. This should allow
for more consistent ability to test with the
presumption that master is a higher version than
the most recent one.

The only drawback I can think of is the accidental creation of 
some 'phantom versions'. For instance if we end up going 
directly to v2.3.0 from v2.2.0 there could be tests set up 
against v2.2.1 which never existed. But that shouldn't be 
any sort of functional problem.