### PR TITLE
vmulcd: Correct data types of vmu fb.

### DIFF
--- a/examples/dreamcast/vmu/vmu_lcd/lcd.c
+++ b/examples/dreamcast/vmu/vmu_lcd/lcd.c
@@ -30,7 +30,7 @@
 
 #include <arch/arch.h>
 
-static const char smiley[] = {
+static const uint8_t smiley[] = {
     0b00111100,
     0b01000010,
     0b10100101,

--- a/kernel/arch/dreamcast/include/dc/vmu_fb.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_fb.h
@@ -50,11 +50,11 @@ typedef struct vmufb {
     layout, and a pointer to the raw font data.
  */
 typedef struct vmufb_font {
-    unsigned int id;        /**< Font id */
-    unsigned int w;         /**< Character width in pixels */
-    unsigned int h;         /**< Character height in pixels */
-    size_t       stride;    /**< Size of one character in bytes */
-    const char  *fontdata;  /**< Pointer to the font data */
+    unsigned int    id;        /**< Font id */
+    unsigned int    w;         /**< Character width in pixels */
+    unsigned int    h;         /**< Character height in pixels */
+    size_t          stride;    /**< Size of one character in bytes */
+    const uint8_t  *fontdata;  /**< Pointer to the font data */
 } vmufb_font_t;
 
 /** \brief  Render into the VMU framebuffer
@@ -75,7 +75,7 @@ typedef struct vmufb_font {
 void vmufb_paint_area(vmufb_t *fb,
                       unsigned int x, unsigned int y,
                       unsigned int w, unsigned int h,
-                      const char *data);
+                      const uint8_t *data);
 
 /** \brief  Clear a specific area of the VMU framebuffer
 

--- a/kernel/arch/dreamcast/util/vmu_fb.c
+++ b/kernel/arch/dreamcast/util/vmu_fb.c
@@ -21,7 +21,7 @@
  * Created by Kenneth Albanowski.
  * No rights reserved, released to the public domain.
  */
-static const char fontdata_4x6[] = {
+static const uint8_t fontdata_4x6[] = {
     0xee, 0xee, 0xe0, 0xee, 0xee, 0xe0, 0xee, 0xee,
     0xe0, 0xee, 0xee, 0xe0, 0xee, 0xee, 0xe0, 0xee,
     0xee, 0xe0, 0xee, 0xee, 0xe0, 0xee, 0xee, 0xe0,
@@ -204,8 +204,8 @@ static void vmufb_paint_area_strided(vmufb_t *fb,
 void vmufb_paint_area(vmufb_t *fb,
                       unsigned int x, unsigned int y,
                       unsigned int w, unsigned int h,
-                      const char *data) {
-    vmufb_paint_area_strided(fb, x, y, w, h, w, (const uint8_t *)data);
+                      const uint8_t *data) {
+    vmufb_paint_area_strided(fb, x, y, w, h, w, data);
 }
 
 void vmufb_paint_xbm(vmufb_t *fb,
@@ -230,7 +230,7 @@ void vmufb_clear_area(vmufb_t *fb,
                       unsigned int w, unsigned int h) {
     uint32_t tmp[VMU_SCREEN_WIDTH] = {};
 
-    vmufb_paint_area(fb, x, y, w, h, (const char *) tmp);
+    vmufb_paint_area(fb, x, y, w, h, (const uint8_t *) tmp);
 }
 
 void vmufb_present(const vmufb_t *fb, maple_device_t *dev) {


### PR DESCRIPTION
There was, for some reason, a mix of the signed `char` and unsigned `uint8_t` as the types for the vmu fb. This caused possible unsigned conversion warning/errors when manipulating the data.

Switched to `uint8_t` universally as the usage is for data we need to have specified by the width of it.