### PR TITLE
net: Replace `arch/types.h` types with stdint.

### DIFF
--- a/include/kos/net.h
+++ b/include/kos/net.h
@@ -21,9 +21,9 @@
 #define __KOS_NET_H
 
 #include <sys/cdefs.h>
+#include <stdint.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <sys/queue.h>
 #include <netinet/in.h>
 
@@ -65,28 +65,28 @@ typedef struct knetif {
     int                 index;
 
     /** \brief  Internal device ID (for whatever the driver wants) */
-    uint32              dev_id;
+    uint32_t            dev_id;
 
     /** \brief  Interface flags */
-    uint32              flags;
+    uint32_t            flags;
 
     /** \brief  The device's MAC address */
-    uint8               mac_addr[6];
+    uint8_t             mac_addr[6];
 
     /** \brief  The device's IP address (if any) */
-    uint8               ip_addr[4];
+    uint8_t             ip_addr[4];
 
     /** \brief  The device's netmask */
-    uint8               netmask[4];
+    uint8_t             netmask[4];
 
     /** \brief  The device's gateway's IP address */
-    uint8               gateway[4];
+    uint8_t             gateway[4];
 
     /** \brief  The device's broadcast address */
-    uint8               broadcast[4];
+    uint8_t             broadcast[4];
 
     /** \brief  The device's DNS server address */
-    uint8               dns[4];
+    uint8_t             dns[4];
 
     /** \brief  The device's MTU */
     int                 mtu;
@@ -104,7 +104,7 @@ typedef struct knetif {
     struct in6_addr     ip6_gateway;
 
     /** \brief  Default MTU over IPv6 */
-    uint32              mtu6;
+    uint32_t            mtu6;
 
     /** \brief  Default hop limit over IPv6 */
     int                 hop_limit;
@@ -117,31 +117,31 @@ typedef struct knetif {
         \param  self        The network device in question.
         \return             0 on success, <0 on failure.
     */
-    int (*if_detect)(struct knetif * self);
+    int (*if_detect)(struct knetif *self);
 
     /** \brief  Initialize the device.
         \param  self        The network device in question.
         \return             0 on success, <0 on failure.
     */
-    int (*if_init)(struct knetif * self);
+    int (*if_init)(struct knetif *self);
 
     /** \brief  Shutdown the device.
         \param  self        The network device in question.
         \return             0 on success, <0 on failure.
     */
-    int (*if_shutdown)(struct knetif * self);
+    int (*if_shutdown)(struct knetif *self);
 
     /** \brief  Start the device (after init or stop).
         \param  self        The network device in question.
         \return             0 on success, <0 on failure.
     */
-    int (*if_start)(struct knetif * self);
+    int (*if_start)(struct knetif *self);
 
     /** \brief  Stop (hibernate) the device.
         \param  self        The network device in question.
         \return             0 on success, <0 on failure
     */
-    int (*if_stop)(struct knetif * self);
+    int (*if_stop)(struct knetif *self);
 
     /** \brief  Queue a packet for transmission.
         \param  self        The network device in question.
@@ -152,20 +152,20 @@ typedef struct knetif {
         \retval NETIF_TX_ERROR  On general failure.
         \retval NETIF_TX_AGAIN  If non-blocking and we must block to send.
     */
-    int (*if_tx)(struct knetif * self, const uint8 * data, int len,
+    int (*if_tx)(struct knetif *self, const uint8_t *data, int len,
                  int blocking);
 
     /** \brief  Commit any queued output packets.
         \param  self        The network device in question.
         \return             0 on success, <0 on failure.
     */
-    int (*if_tx_commit)(struct knetif * self);
+    int (*if_tx_commit)(struct knetif *self);
 
     /** \brief  Poll for queued receive packets, if necessary.
         \param  self        The network device in question.
         \return             0 on success, <0 on failure.
     */
-    int (*if_rx_poll)(struct knetif * self);
+    int (*if_rx_poll)(struct knetif *self);
 
     /** \brief  Set flags; you should generally manipulate flags through here so
                 that the driver gets a chance to act on the info.
@@ -173,14 +173,14 @@ typedef struct knetif {
         \param  flags_and   Bitmask to and with the flags.
         \param  flags_or    Bitmask to or with the flags.
     */
-    int (*if_set_flags)(struct knetif * self, uint32 flags_and, uint32 flags_or);
+    int (*if_set_flags)(struct knetif *self, uint32_t flags_and, uint32_t flags_or);
 
     /** \brief  Set the device's multicast list.
         \param  self        The network device in question.
         \param  list        The list of MAC addresses (6 * count bytes).
         \param  count       The number of addresses in list.
     */
-    int (*if_set_mc)(struct knetif *self, const uint8 *list, int count);
+    int (*if_set_mc)(struct knetif *self, const uint8_t *list, int count);
 } netif_t;
 
 /** \defgroup net_drivers_flags netif_t Flags
@@ -237,16 +237,16 @@ LIST_HEAD(netif_list, knetif);
     \ingroup    networking_ipv4
 */
 typedef struct ip_hdr_s {
-    uint8   version_ihl;        /**< \brief IP version and header length */
-    uint8   tos;                /**< \brief Type of Service */
-    uint16  length;             /**< \brief Length */
-    uint16  packet_id;          /**< \brief Packet ID */
-    uint16  flags_frag_offs;    /**< \brief Flags and fragment offset */
-    uint8   ttl;                /**< \brief Time to live */
-    uint8   protocol;           /**< \brief IP protocol */
-    uint16  checksum;           /**< \brief IP checksum */
-    uint32  src;                /**< \brief Source IP address */
-    uint32  dest;               /**< \brief Destination IP address */
+    uint8_t   version_ihl;        /**< \brief IP version and header length */
+    uint8_t   tos;                /**< \brief Type of Service */
+    uint16_t  length;             /**< \brief Length */
+    uint16_t  packet_id;          /**< \brief Packet ID */
+    uint16_t  flags_frag_offs;    /**< \brief Flags and fragment offset */
+    uint8_t   ttl;                /**< \brief Time to live */
+    uint8_t   protocol;           /**< \brief IP protocol */
+    uint16_t  checksum;           /**< \brief IP checksum */
+    uint32_t  src;                /**< \brief Source IP address */
+    uint32_t  dest;               /**< \brief Destination IP address */
 } __packed ip_hdr_t;
 
 /** \defgroup networking_ipv6   IPv6
@@ -259,14 +259,14 @@ typedef struct ip_hdr_s {
     \ingroup    networking_ipv6
 */
 typedef struct ipv6_hdr_s {
-    uint8           version_lclass; /**< \brief Version and low-order class
+    uint8_t         version_lclass; /**< \brief Version and low-order class
                                                 byte */
-    uint8           hclass_lflow;   /**< \brief High-order class byte, low-order
+    uint8_t         hclass_lflow;   /**< \brief High-order class byte, low-order
                                                 flow byte */
-    uint16          lclass;         /**< \brief Low-order class byte */
-    uint16          length;         /**< \brief Length */
-    uint8           next_header;    /**< \brief Next header type */
-    uint8           hop_limit;      /**< \brief Hop limit */
+    uint16_t        lclass;         /**< \brief Low-order class byte */
+    uint16_t        length;         /**< \brief Length */
+    uint8_t         next_header;    /**< \brief Next header type */
+    uint8_t         hop_limit;      /**< \brief Hop limit */
     struct in6_addr src_addr;       /**< \brief Source IP address */
     struct in6_addr dst_addr;       /**< \brief Destination IP address */
 } __packed ipv6_hdr_t;
@@ -303,8 +303,8 @@ void net_arp_shutdown(void);
     \retval 0               On success.
     \retval -1              Error allocating memory.
 */
-int net_arp_insert(netif_t *nif, const uint8 mac[6], const uint8 ip[4],
-                   uint64 timestamp);
+int net_arp_insert(netif_t *nif, const uint8_t mac[6], const uint8_t ip[4],
+                   uint64_t timestamp);
 
 /** \brief   Look up an entry from the ARP cache.
     \ingroup networking_arp
@@ -326,8 +326,8 @@ int net_arp_insert(netif_t *nif, const uint8 mac[6], const uint8 ip[4],
     \retval -2              Address not found, query generated.
     \retval -3              Error allocating memory.
 */
-int net_arp_lookup(netif_t *nif, const uint8 ip_in[4], uint8 mac_out[6],
-                   const ip_hdr_t *pkt, const uint8 *data, int data_size);
+int net_arp_lookup(netif_t *nif, const uint8_t ip_in[4], uint8_t mac_out[6],
+                   const ip_hdr_t *pkt, const uint8_t *data, int data_size);
 
 /** \brief   Do a reverse ARP lookup.
     \ingroup networking_arp
@@ -342,7 +342,7 @@ int net_arp_lookup(netif_t *nif, const uint8 ip_in[4], uint8 mac_out[6],
     \retval 0               On success.
     \retval -1              On failure.
 */
-int net_arp_revlookup(netif_t *nif, uint8 ip_out[4], const uint8 mac_in[6]);
+int net_arp_revlookup(netif_t *nif, uint8_t ip_out[4], const uint8_t mac_in[6]);
 
 /** \brief   Receive an ARP packet and process it (called by net_input).
     \ingroup networking_arp
@@ -353,7 +353,7 @@ int net_arp_revlookup(netif_t *nif, uint8 ip_out[4], const uint8 mac_in[6]);
     
     \retval 0               On success (no error conditions defined).
 */
-int net_arp_input(netif_t *nif, const uint8 *pkt, int len);
+int net_arp_input(netif_t *nif, const uint8_t *pkt, int len);
 
 /** \brief   Generate an ARP who-has query on the given device.
     \ingroup networking_arp
@@ -363,7 +363,7 @@ int net_arp_input(netif_t *nif, const uint8 *pkt, int len);
     
     \retval 0               On success (no error conditions defined).
 */
-int net_arp_query(netif_t *nif, const uint8 ip[4]);
+int net_arp_query(netif_t *nif, const uint8_t ip[4]);
 
 
 /***** net_input.c *********************************************************/
@@ -377,7 +377,7 @@ int net_arp_query(netif_t *nif, const uint8 ip[4]);
     
     \return                 0 on success, <0 on failure.
 */
-typedef int (*net_input_func)(netif_t *nif, const uint8 *pkt, int len);
+typedef int (*net_input_func)(netif_t *nif, const uint8_t *pkt, int len);
 
 /** \brief   Where will input packets be routed? 
     \ingroup networking_drivers
@@ -397,7 +397,7 @@ extern net_input_func net_input_target;
     
     \return                 0 on success, <0 on failure.
 */
-int net_input(netif_t *device, const uint8 *data, int len);
+int net_input(netif_t *device, const uint8_t *data, int len);
 
 /** \brief   Setup a network input target.
     \ingroup networking_drivers
@@ -431,8 +431,8 @@ net_input_func net_input_set_target(net_input_func t);
     \param  data            Any data in the packet.
     \param  len             The length of the data, in bytes.
 */
-typedef void (*net_echo_cb)(const uint8 *ip, uint16 seq, uint64 delta_us,
-                            uint8 ttl, const uint8 *data, size_t len);
+typedef void (*net_echo_cb)(const uint8_t *ip, uint16_t seq, uint64_t delta_us,
+                            uint8_t ttl, const uint8_t *data, size_t len);
 
 /** \brief   Where will we handle possibly notifying the user of ping replies?
     \ingroup networking_icmp
@@ -451,8 +451,8 @@ extern net_echo_cb net_icmp_echo_cb;
     
     \return                 0 on success, <0 on failure.
 */
-int net_icmp_send_echo(netif_t *net, const uint8 ipaddr[4], uint16 ident,
-                       uint16 seq, const uint8 *data, size_t size);
+int net_icmp_send_echo(netif_t *net, const uint8_t ipaddr[4], uint16_t ident,
+                       uint16_t seq, const uint8_t *data, size_t size);
 
 /** \defgroup networking_icmp_unreach Unreachable Values 
     \brief    Valid values for net_icmp_send_dest_unreach().
@@ -473,7 +473,7 @@ int net_icmp_send_echo(netif_t *net, const uint8 ipaddr[4], uint16 ident,
     
     \return                 0 on success, <0 on failure.
 */
-int net_icmp_send_dest_unreach(netif_t *net, uint8 code, const uint8 *msg);
+int net_icmp_send_dest_unreach(netif_t *net, uint8_t code, const uint8_t *msg);
 
 /** \brief   Valid values for the code in the net_icmp_send_time_exceeded()
              function.
@@ -490,7 +490,7 @@ int net_icmp_send_dest_unreach(netif_t *net, uint8 code, const uint8 *msg);
     
     \return                 0 on success, <0 on failure.
 */
-int net_icmp_send_time_exceeded(netif_t *net, uint8 code, const uint8 *msg);
+int net_icmp_send_time_exceeded(netif_t *net, uint8_t code, const uint8_t *msg);
 
 /***** net_ipv4.c *********************************************************/
 
@@ -503,12 +503,12 @@ int net_icmp_send_time_exceeded(netif_t *net, uint8 code, const uint8 *msg);
     \headerfile kos/net.h
 */
 typedef struct net_ipv4_stats {
-    uint32  pkt_sent;               /** \brief Packets sent out successfully */
-    uint32  pkt_send_failed;        /** \brief Packets that failed to send */
-    uint32  pkt_recv;               /** \brief Packets received successfully */
-    uint32  pkt_recv_bad_size;      /** \brief Packets of a bad size */
-    uint32  pkt_recv_bad_chksum;    /** \brief Packets with a bad checksum */
-    uint32  pkt_recv_bad_proto;     /** \brief Packets with an unknown proto */
+    uint32_t  pkt_sent;               /** \brief Packets sent out successfully */
+    uint32_t  pkt_send_failed;        /** \brief Packets that failed to send */
+    uint32_t  pkt_recv;               /** \brief Packets received successfully */
+    uint32_t  pkt_recv_bad_size;      /** \brief Packets of a bad size */
+    uint32_t  pkt_recv_bad_chksum;    /** \brief Packets with a bad checksum */
+    uint32_t  pkt_recv_bad_proto;     /** \brief Packets with an unknown proto */
 } net_ipv4_stats_t;
 
 /** \brief   Retrieve statistics from the IPv4 layer.
@@ -526,7 +526,7 @@ net_ipv4_stats_t net_ipv4_get_stats(void);
     
     \return                 The address, in host byte order.
 */
-uint32 net_ipv4_address(const uint8 addr[4]);
+uint32_t net_ipv4_address(const uint8_t addr[4]);
 
 /** \brief   Parse an IP address that is packet into a uint32 into an array of
              the individual bytes.
@@ -535,7 +535,7 @@ uint32 net_ipv4_address(const uint8 addr[4]);
     \param  addr            The full address, in host byte order.
     \param  out             The output buffer.
 */
-void net_ipv4_parse_address(uint32 addr, uint8 out[4]);
+void net_ipv4_parse_address(uint32_t addr, uint8_t out[4]);
 
 /***** net_icmp6.c ********************************************************/
 
@@ -555,8 +555,8 @@ void net_ipv4_parse_address(uint32 addr, uint8 out[4]);
     \param  data            Any data in the packet.
     \param  len             The length of the data, in bytes.
 */
-typedef void (*net6_echo_cb)(const struct in6_addr *ip, uint16 seq,
-                             uint64 delta_us, uint8 hlim, const uint8 *data,
+typedef void (*net6_echo_cb)(const struct in6_addr *ip, uint16_t seq,
+                             uint64_t delta_us, uint8_t hlim, const uint8_t *data,
                              size_t len);
 
 /** \brief   Where will we handle possibly notifying the user of ping replies?
@@ -576,8 +576,8 @@ extern net6_echo_cb net_icmp6_echo_cb;
     
     \return                 0 on success, <0 on failure.
 */
-int net_icmp6_send_echo(netif_t *net, const struct in6_addr *dst, uint16 ident,
-                        uint16 seq, const uint8 *data, size_t size);
+int net_icmp6_send_echo(netif_t *net, const struct in6_addr *dst, uint16_t ident,
+                        uint16_t seq, const uint8_t *data, size_t size);
 
 /** \brief   Send a Neighbor Solicitation packet on the specified device.
     \ingroup networking_icmpv6
@@ -641,7 +641,7 @@ int net_icmp6_send_rsol(netif_t *net);
     
     \return                 0 on success, <0 on failure.
 */
-int net_icmp6_send_dest_unreach(netif_t *net, uint8 code, const uint8 *ppkt,
+int net_icmp6_send_dest_unreach(netif_t *net, uint8_t code, const uint8_t *ppkt,
                                 size_t psz);
 
 /** \defgroup networking_icmpv6_time_exceeded Time Exceeded Codes
@@ -666,7 +666,7 @@ int net_icmp6_send_dest_unreach(netif_t *net, uint8 code, const uint8 *ppkt,
     
     \return                 0 on success, <0 on failure.
 */
-int net_icmp6_send_time_exceeded(netif_t *net, uint8 code, const uint8 *ppkt,
+int net_icmp6_send_time_exceeded(netif_t *net, uint8_t code, const uint8_t *ppkt,
                                  size_t psz);
 
 /** \defgroup networking_icmpv6_param_problem   Parameter Problem Codes
@@ -690,8 +690,8 @@ int net_icmp6_send_time_exceeded(netif_t *net, uint8 code, const uint8 *ppkt,
     
     \return                 0 on success, <0 on failure.
 */
-int net_icmp6_send_param_prob(netif_t *net, uint8 code, uint32 ptr,
-                              const uint8 *ppkt, size_t psz);
+int net_icmp6_send_param_prob(netif_t *net, uint8_t code, uint32_t ptr,
+                              const uint8_t *ppkt, size_t psz);
 
 /***** net_ipv6.c *********************************************************/
 
@@ -704,12 +704,12 @@ int net_icmp6_send_param_prob(netif_t *net, uint8 code, uint32 ptr,
     \headerfile kos/net.h
 */
 typedef struct net_ipv6_stats {
-    uint32  pkt_sent;               /**< \brief Packets sent out successfully */
-    uint32  pkt_send_failed;        /**< \brief Packets that failed to send */
-    uint32  pkt_recv;               /**< \brief Packets received successfully */
-    uint32  pkt_recv_bad_size;      /**< \brief Packets of a bad size */
-    uint32  pkt_recv_bad_proto;     /**< \brief Packets with an unknown proto */
-    uint32  pkt_recv_bad_ext;       /**< \brief Packets with an unknown hdr */
+    uint32_t  pkt_sent;               /**< \brief Packets sent out successfully */
+    uint32_t  pkt_send_failed;        /**< \brief Packets that failed to send */
+    uint32_t  pkt_recv;               /**< \brief Packets received successfully */
+    uint32_t  pkt_recv_bad_size;      /**< \brief Packets of a bad size */
+    uint32_t  pkt_recv_bad_proto;     /**< \brief Packets with an unknown proto */
+    uint32_t  pkt_recv_bad_ext;       /**< \brief Packets with an unknown hdr */
 } net_ipv6_stats_t;
 
 /** \brief   Retrieve statistics from the IPv6 layer.
@@ -747,7 +747,7 @@ void net_ndp_gc(void);
     \param  unsol           Was this unsolicited?
     \return                 0 on success, <0 on failure.
 */
-int net_ndp_insert(netif_t *nif, const uint8 mac[6], const struct in6_addr *ip,
+int net_ndp_insert(netif_t *nif, const uint8_t mac[6], const struct in6_addr *ip,
                    int unsol);
 
 /** \brief  Look up an entry from the NDP cache.
@@ -765,8 +765,8 @@ int net_ndp_insert(netif_t *nif, const uint8 mac[6], const struct in6_addr *ip,
     \param  data_size       The size of data.
     \return                 0 on success, <0 on failure.
 */
-int net_ndp_lookup(netif_t *net, const struct in6_addr *ip, uint8 mac_out[6],
-                   const ipv6_hdr_t *pkt, const uint8 *data, int data_size);
+int net_ndp_lookup(netif_t *net, const struct in6_addr *ip, uint8_t mac_out[6],
+                   const ipv6_hdr_t *pkt, const uint8_t *data, int data_size);
 
 /** @} */
 
@@ -786,12 +786,12 @@ int net_ndp_lookup(netif_t *net, const struct in6_addr *ip, uint8 mac_out[6],
     \headerfile kos/net.h
 */
 typedef struct net_udp_stats {
-    uint32  pkt_sent;               /**< \brief Packets sent out successfully */
-    uint32  pkt_send_failed;        /**< \brief Packets that failed to send */
-    uint32  pkt_recv;               /**< \brief Packets received successfully */
-    uint32  pkt_recv_bad_size;      /**< \brief Packets of a bad size */
-    uint32  pkt_recv_bad_chksum;    /**< \brief Packets with a bad checksum */
-    uint32  pkt_recv_no_sock;       /**< \brief Packets with to a closed port */
+    uint32_t  pkt_sent;               /**< \brief Packets sent out successfully */
+    uint32_t  pkt_send_failed;        /**< \brief Packets that failed to send */
+    uint32_t  pkt_recv;               /**< \brief Packets received successfully */
+    uint32_t  pkt_recv_bad_size;      /**< \brief Packets of a bad size */
+    uint32_t  pkt_recv_bad_chksum;    /**< \brief Packets with a bad checksum */
+    uint32_t  pkt_recv_no_sock;       /**< \brief Packets with to a closed port */
 } net_udp_stats_t;
 
 /** \brief  Retrieve statistics from the UDP layer.
@@ -844,7 +844,7 @@ void net_tcp_shutdown(void);
     
     \return                 The calculated CRC-32.
 */
-uint32 net_crc32le(const uint8 *data, int size);
+uint32_t net_crc32le(const uint8_t *data, int size);
 
 /** \brief  Calculate a "big-endian" CRC-32 over a block of data.
     
@@ -853,7 +853,7 @@ uint32 net_crc32le(const uint8 *data, int size);
     
     \return                 The calculated CRC-32.
 */
-uint32 net_crc32be(const uint8 *data, int size);
+uint32_t net_crc32be(const uint8_t *data, int size);
 
 /** \brief  Calculate a CRC16-CCITT over a block of data.
     
@@ -869,7 +869,7 @@ uint32 net_crc32be(const uint8 *data, int size);
     
     \return                 The calculated CRC16-CCITT.
 */
-uint16 net_crc16ccitt(const uint8 *data, int size, uint16 start);
+uint16_t net_crc16ccitt(const uint8_t *data, int size, uint16_t start);
 
 /** @} */
 
@@ -889,7 +889,7 @@ uint16 net_crc16ccitt(const uint8 *data, int size, uint16 start);
     \param  mac             The MAC address to add.
     \return                 0 on success, <0 on failure.
 */
-int net_multicast_add(const uint8 mac[6]);
+int net_multicast_add(const uint8_t mac[6]);
 
 /** \brief  Delete a entry from our multicast list.
 
@@ -899,7 +899,7 @@ int net_multicast_add(const uint8 mac[6]);
     \param  mac             The MAC address to add.
     \return                 0 on success, <0 on failure.
 */
-int net_multicast_del(const uint8 mac[6]);
+int net_multicast_del(const uint8_t mac[6]);
 
 /** \brief  Check if an address is on the multicast list.
     \param  mac             The MAC address to check for.
@@ -907,7 +907,7 @@ int net_multicast_del(const uint8 mac[6]);
     \retval 1               The address is in the list.
     \retval -1              On error.
 */
-int net_multicast_check(const uint8 mac[6]);
+int net_multicast_check(const uint8_t mac[6]);
 
 /** \brief  Init multicast support.
     \return                 0 on success, !0 on error.
@@ -980,7 +980,7 @@ int net_unreg_device(netif_t *device);
 
     \return                 0 on success, <0 on failure.
 */
-int net_init(uint32 ip);
+int net_init(uint32_t ip);
 
 /** \brief   Shutdown network support. 
     \ingroup networking_drivers

--- a/kernel/net/net_arp.c
+++ b/kernel/net/net_arp.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include <kos/dbglog.h>
 #include <kos/net.h>
@@ -25,15 +26,15 @@
 
 /* ARP Packet Structure */
 typedef struct {
-    uint8 hw_type[2];
-    uint8 pr_type[2];
-    uint8 hw_size;
-    uint8 pr_size;
-    uint8 opcode[2];
-    uint8 hw_send[6];
-    uint8 pr_send[4];
-    uint8 hw_recv[6];
-    uint8 pr_recv[6];
+    uint8_t hw_type[2];
+    uint8_t pr_type[2];
+    uint8_t hw_size;
+    uint8_t pr_size;
+    uint8_t opcode[2];
+    uint8_t hw_send[6];
+    uint8_t pr_send[4];
+    uint8_t hw_recv[6];
+    uint8_t pr_recv[6];
 } __packed arp_pkt_t;
 
 /* Structure describing an ARP entry; each entry contains a MAC address,
@@ -44,19 +45,19 @@ typedef struct netarp {
     LIST_ENTRY(netarp)  ac_list;
 
     /* Mac address */
-    uint8               mac[6];
+    uint8_t             mac[6];
 
     /* Associated IP address */
-    uint8               ip[4];
+    uint8_t             ip[4];
 
     /* Cache entry time; if zero, this entry won't expire */
-    uint64              timestamp;
+    uint64_t            timestamp;
 
     /* Optional packet to send when the entry is filled in */
     ip_hdr_t            *pkt;
 
     /* Additional data for that packet, if any */
-    uint8               *data;
+    uint8_t             *data;
 
     /* Size of the additional data for the packet */
     int                 data_size;
@@ -77,7 +78,7 @@ struct netarp_list net_arp_cache = LIST_HEAD_INITIALIZER(0);
 /* Garbage collect timed out entries */
 static int net_arp_gc(netif_t *nif) {
     netarp_t *a1, *a2;
-    uint64 now = timer_ms_gettime64();
+    uint64_t now = timer_ms_gettime64();
 
     a1 = LIST_FIRST(&net_arp_cache);
 
@@ -114,8 +115,8 @@ static int net_arp_gc(netif_t *nif) {
 }
 
 /* Add an entry to the ARP cache manually */
-int net_arp_insert(netif_t *nif, const uint8 mac[6], const uint8 ip[4],
-                   uint64 timestamp) {
+int net_arp_insert(netif_t *nif, const uint8_t mac[6], const uint8_t ip[4],
+                   uint64_t timestamp) {
     netarp_t *cur;
 
     /* First make sure the entry isn't already there */
@@ -163,8 +164,8 @@ int net_arp_insert(netif_t *nif, const uint8 mac[6], const uint8 ip[4],
    query will be sent and an error will be returned. Thus your packet send
    should also fail. Later when the transmit retries, hopefully the answer
    will have arrived. */
-int net_arp_lookup(netif_t *nif, const uint8 ip_in[4], uint8 mac_out[6],
-                   const ip_hdr_t *pkt, const uint8 *data, int data_size) {
+int net_arp_lookup(netif_t *nif, const uint8_t ip_in[4], uint8_t mac_out[6],
+                   const ip_hdr_t *pkt, const uint8_t *data, int data_size) {
     netarp_t *cur;
 
     /* Garbage collect expired entries */
@@ -200,7 +201,7 @@ int net_arp_lookup(netif_t *nif, const uint8 ip_in[4], uint8 mac_out[6],
 
     /* Copy our packet if we have one to copy. */
     if(pkt && data && data_size) {
-        cur->data = (uint8 *)malloc(data_size);
+        cur->data = (uint8_t *)malloc(data_size);
 
         if(cur->data) {
             cur->pkt = (ip_hdr_t *)malloc(sizeof(ip_hdr_t));
@@ -229,7 +230,7 @@ int net_arp_lookup(netif_t *nif, const uint8 ip_in[4], uint8 mac_out[6],
 
 /* Do a reverse ARP lookup: look for an IP for a given mac address; note
    that if this fails, you have no recourse. */
-int net_arp_revlookup(netif_t *nif, uint8 ip_out[4], const uint8 mac_in[6]) {
+int net_arp_revlookup(netif_t *nif, uint8_t ip_out[4], const uint8_t mac_in[6]) {
     netarp_t *cur;
 
     (void)nif;
@@ -253,7 +254,7 @@ int net_arp_revlookup(netif_t *nif, uint8 ip_out[4], const uint8 mac_in[6]) {
 static int net_arp_send(netif_t *nif, arp_pkt_t *pkt) {
     arp_pkt_t pkt_out;
     eth_hdr_t eth_hdr;
-    uint8 buf[sizeof(arp_pkt_t) + sizeof(eth_hdr_t)];
+    uint8_t buf[sizeof(arp_pkt_t) + sizeof(eth_hdr_t)];
 
     /* First, fill in the ARP packet. */
     pkt_out.hw_type[0] = 0;
@@ -285,7 +286,7 @@ static int net_arp_send(netif_t *nif, arp_pkt_t *pkt) {
 }
 
 /* Receive an ARP packet and process it (called by net_input) */
-int net_arp_input(netif_t *nif, const uint8 *pkt_in, int len) {
+int net_arp_input(netif_t *nif, const uint8_t *pkt_in, int len) {
     //eth_hdr_t *eth_hdr = (eth_hdr_t *)pkt_in;
     arp_pkt_t *pkt;
 
@@ -314,10 +315,10 @@ int net_arp_input(netif_t *nif, const uint8 *pkt_in, int len) {
 }
 
 /* Generate an ARP who-has query on the given device */
-int net_arp_query(netif_t *nif, const uint8 ip[4]) {
+int net_arp_query(netif_t *nif, const uint8_t ip[4]) {
     arp_pkt_t pkt_out;
     eth_hdr_t eth_hdr;
-    uint8 buf[sizeof(arp_pkt_t) + sizeof(eth_hdr_t)];
+    uint8_t buf[sizeof(arp_pkt_t) + sizeof(eth_hdr_t)];
 
     /* First, fill in the ARP packet. */
     pkt_out.hw_type[0] = 0;

--- a/kernel/net/net_core.c
+++ b/kernel/net/net_core.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include <kos/net.h>
 #include <kos/fs_socket.h>
@@ -145,7 +146,7 @@ int net_dev_init(void) {
 }
 
 /* Init */
-int net_init(uint32 ip) {
+int net_init(uint32_t ip) {
     int rv = 0;
 
     /* Make sure we haven't already done this */

--- a/kernel/net/net_crc.c
+++ b/kernel/net/net_crc.c
@@ -9,9 +9,9 @@
 
 /* Calculate a CRC-32 checksum over a given block of data. Somewhat inspired by
    the CRC32 function in Figure 14-6 of http://www.hackersdelight.org/crc.pdf */
-uint32 net_crc32le(const uint8 *data, int size) {
+uint32_t net_crc32le(const uint8_t *data, int size) {
     int i;
-    uint32 rv = 0xFFFFFFFF;
+    uint32_t rv = 0xFFFFFFFF;
 
     for(i = 0; i < size; ++i) {
         rv ^= data[i];
@@ -29,9 +29,9 @@ uint32 net_crc32le(const uint8 *data, int size) {
 }
 
 /* This one isn't quite as nice as the one above for little-endian... */
-uint32 net_crc32be(const uint8 *data, int size) {
+uint32_t net_crc32be(const uint8_t *data, int size) {
     int i, j;
-    uint32 rv = 0xFFFFFFFF, b, c;
+    uint32_t rv = 0xFFFFFFFF, b, c;
 
     for(i = 0; i < size; ++i) {
         b = data[i];
@@ -49,8 +49,8 @@ uint32 net_crc32be(const uint8 *data, int size) {
 }
 
 /* Based on code found at: http://www.ccsinfo.com/forum/viewtopic.php?t=24977 */
-uint16 net_crc16ccitt(const uint8 *data, int size, uint16 start) {
-    uint16 rv = start, tmp;
+uint16_t net_crc16ccitt(const uint8_t *data, int size, uint16_t start) {
+    uint16_t rv = start, tmp;
 
     while(size--) {
         tmp = (rv >> 8) ^ *data++;

--- a/kernel/net/net_dhcp.h
+++ b/kernel/net/net_dhcp.h
@@ -12,8 +12,6 @@
 
 __BEGIN_DECLS
 
-#include <arch/types.h>
-
 /* Available values for the op fields of dhcp_pkt_t */
 #define DHCP_OP_BOOTREQUEST             1
 #define DHCP_OP_BOOTREPLY               2
@@ -126,28 +124,28 @@ __BEGIN_DECLS
 #define DHCP_STATE_REBOOTING    7
 
 typedef struct dhcp_pkt {
-    uint8   op;
-    uint8   htype;
-    uint8   hlen;
-    uint8   hops;
-    uint32  xid;
-    uint16  secs;
-    uint16  flags;
-    uint32  ciaddr;
-    uint32  yiaddr;
-    uint32  siaddr;
-    uint32  giaddr;
-    uint8   chaddr[16];
-    char    sname[64];
-    char    file[128];
-    uint8   options[];
+    uint8_t   op;
+    uint8_t   htype;
+    uint8_t   hlen;
+    uint8_t   hops;
+    uint32_t  xid;
+    uint16_t  secs;
+    uint16_t  flags;
+    uint32_t  ciaddr;
+    uint32_t  yiaddr;
+    uint32_t  siaddr;
+    uint32_t  giaddr;
+    uint8_t   chaddr[16];
+    char      sname[64];
+    char      file[128];
+    uint8_t   options[];
 } __packed dhcp_pkt_t;
 
 int net_dhcp_init(void);
 
 void net_dhcp_shutdown(void);
 
-int net_dhcp_request(uint32 required_address);
+int net_dhcp_request(uint32_t required_address);
 
 __END_DECLS
 

--- a/kernel/net/net_icmp.h
+++ b/kernel/net/net_icmp.h
@@ -16,13 +16,13 @@ __BEGIN_DECLS
 #include "net_ipv4.h"
 
 typedef struct {
-    uint8 type;
-    uint8 code;
-    uint16 checksum;
+    uint8_t type;
+    uint8_t code;
+    uint16_t checksum;
     union {
-        uint8 m8[4];
-        uint16 m16[2];
-        uint32 m32;
+        uint8_t m8[4];
+        uint16_t m16[2];
+        uint32_t m32;
     } misc;
 } __packed icmp_hdr_t;
 
@@ -31,7 +31,7 @@ typedef struct {
 #define ICMP_MESSAGE_ECHO               8
 #define ICMP_MESSAGE_TIME_EXCEEDED      11
 
-int net_icmp_input(netif_t *src, const ip_hdr_t *ih, const uint8 *data,
+int net_icmp_input(netif_t *src, const ip_hdr_t *ih, const uint8_t *data,
                    size_t size);
 
 __END_DECLS

--- a/kernel/net/net_icmp6.c
+++ b/kernel/net/net_icmp6.c
@@ -5,6 +5,7 @@
 
 */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -42,16 +43,16 @@ Message types that are not implemented yet (if ever):
     Any other numbers not listed in the first list...
 */
 
-static void icmp6_default_echo_cb(const struct in6_addr *ip, uint16 seq,
-                                  uint64 delta_us, uint8 hlim,
-                                  const uint8 *data, size_t data_sz) {
+static void icmp6_default_echo_cb(const struct in6_addr *ip, uint16_t seq,
+                                  uint64_t delta_us, uint8_t hlim,
+                                  const uint8_t *data, size_t data_sz) {
     char ipstr[INET6_ADDRSTRLEN];
 
     (void)data;
 
     inet_ntop(AF_INET6, ip, ipstr, INET6_ADDRSTRLEN);
 
-    if(delta_us != (uint64) - 1) {
+    if(delta_us != (uint64_t) - 1) {
         printf("%d bytes from %s, icmp_seq=%d hlim=%d time=%.3f ms\n", data_sz,
                ipstr, seq, hlim, delta_us / 1000.0);
     }
@@ -66,9 +67,9 @@ net6_echo_cb net_icmp6_echo_cb = icmp6_default_echo_cb;
 
 /* Handle Echo Reply (ICMPv6 type 129) packets */
 static void net_icmp6_input_129(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
-                                const uint8 *d, size_t s) {
-    uint64 tmr, otmr = 0;
-    uint16 seq;
+                                const uint8_t *d, size_t s) {
+    uint64_t tmr, otmr = 0;
+    uint16_t seq;
 
     (void)net;
     (void)icmp;
@@ -78,8 +79,8 @@ static void net_icmp6_input_129(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
 
     /* Read back the time if we have it */
     if(s >= sizeof(icmp6_echo_hdr_t) + 8) {
-        otmr = ((uint64)d[8] << 56) | ((uint64)d[9] << 48) |
-               ((uint64)d[10] << 40) | ((uint64)d[11] << 32) |
+        otmr = ((uint64_t)d[8] << 56) | ((uint64_t)d[9] << 48) |
+               ((uint64_t)d[10] << 40) | ((uint64_t)d[11] << 32) |
                (d[12] << 24) | (d[13] << 16) | (d[14] << 8) | (d[15]);
         net_icmp6_echo_cb(&ip->src_addr, seq, tmr - otmr, ip->hop_limit, d, s);
     }
@@ -90,8 +91,8 @@ static void net_icmp6_input_129(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
 
 /* Handle Echo (ICMPv6 type 128) packets */
 static void net_icmp6_input_128(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
-                                const uint8 *d, size_t s) {
-    uint16 cs;
+                                const uint8_t *d, size_t s) {
+    uint16_t cs;
     struct in6_addr src, dst;
 
     memcpy(&src, &ip->dst_addr, sizeof(struct in6_addr));
@@ -143,10 +144,10 @@ static void dupdet(netif_t *net, const struct in6_addr *ip) {
 
 /* Handle Router Advertisement (ICMPv6 type 134) packets */
 static void net_icmp6_input_134(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
-                                const uint8 *d, size_t s) {
+                                const uint8_t *d, size_t s) {
     icmp6_router_adv_t *pkt = (icmp6_router_adv_t *)icmp;
     struct in6_addr src;
-    uint16 len = ntohs(ip->length);
+    uint16_t len = ntohs(ip->length);
     int pos = 0;
 
     (void)d;
@@ -269,10 +270,10 @@ static void net_icmp6_input_134(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
 
 /* Handle Neighbor Solicitation (ICMPv6 type 135) packets */
 static void net_icmp6_input_135(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
-                                const uint8 *d, size_t s) {
+                                const uint8_t *d, size_t s) {
     icmp6_neighbor_sol_t *pkt = (icmp6_neighbor_sol_t *)icmp;
     icmp6_nsol_lladdr_t *ll;
-    uint16 len = ntohs(ip->length);
+    uint16_t len = ntohs(ip->length);
     struct in6_addr target, src;
     int sol = 1, pos = 0, i;
 
@@ -338,12 +339,12 @@ cont:
 
 /* Handle Neighbor Advertisement (ICMPv6 type 136) packets */
 static void net_icmp6_input_136(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
-                                const uint8 *d, size_t s) {
+                                const uint8_t *d, size_t s) {
     icmp6_neighbor_adv_t *pkt = (icmp6_neighbor_adv_t *)icmp;
     icmp6_nsol_lladdr_t *lladdr = (icmp6_nsol_lladdr_t *)pkt->options;
-    uint16 len = ntohs(ip->length);
+    uint16_t len = ntohs(ip->length);
     struct in6_addr target, dest;
-    uint32 flags;
+    uint32_t flags;
 
     (void)d;
     (void)s;
@@ -382,12 +383,12 @@ static void net_icmp6_input_136(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
 }
 
 static void net_icmp6_input_137(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
-                                const uint8 *d, size_t s) {
+                                const uint8_t *d, size_t s) {
     icmp6_redirect_t *pkt = (icmp6_redirect_t *)icmp;
     icmp6_nsol_lladdr_t *ll = (icmp6_nsol_lladdr_t *)pkt->options;
     struct in6_addr target, dest;
     char str[INET6_ADDRSTRLEN], str2[INET6_ADDRSTRLEN];
-    uint32 len = ntohs(ip->length), pos = 0;
+    uint32_t len = ntohs(ip->length), pos = 0;
 
     (void)d;
     (void)s;
@@ -424,9 +425,9 @@ static void net_icmp6_input_137(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
     }
 }
 
-int net_icmp6_input(netif_t *net, ipv6_hdr_t *ip, const uint8 *d, size_t s) {
+int net_icmp6_input(netif_t *net, ipv6_hdr_t *ip, const uint8_t *d, size_t s) {
     icmp6_hdr_t *icmp;
-    uint16 cs = net_ipv6_checksum_pseudo(&ip->src_addr, &ip->dst_addr,
+    uint16_t cs = net_ipv6_checksum_pseudo(&ip->src_addr, &ip->dst_addr,
                                          ntohs(ip->length), IPV6_HDR_ICMP);
     int i;
 
@@ -475,14 +476,14 @@ int net_icmp6_input(netif_t *net, ipv6_hdr_t *ip, const uint8 *d, size_t s) {
 }
 
 /* Send an ICMPv6 Echo (PING6) packet to the specified device */
-int net_icmp6_send_echo(netif_t *net, const struct in6_addr *dst, uint16 ident,
-                        uint16 seq, const uint8 *data, size_t size) {
+int net_icmp6_send_echo(netif_t *net, const struct in6_addr *dst, uint16_t ident,
+                        uint16_t seq, const uint8_t *data, size_t size) {
     icmp6_echo_hdr_t *echo;
-    uint8 databuf[sizeof(icmp6_echo_hdr_t) + size + 8];
+    uint8_t databuf[sizeof(icmp6_echo_hdr_t) + size + 8];
     struct in6_addr src;
-    uint16 cs;
-    uint64 t;
-    uint16 sz = sizeof(icmp6_echo_hdr_t) + size + 8;
+    uint16_t cs;
+    uint64_t t;
+    uint16_t sz = sizeof(icmp6_echo_hdr_t) + size + 8;
 
     if(!net) {
         if(!(net = net_default_dev)) {
@@ -538,10 +539,10 @@ int net_icmp6_send_nsol(netif_t *net, const struct in6_addr *dst,
                         const struct in6_addr *target, int dupdet) {
     icmp6_neighbor_sol_t *pkt;
     icmp6_nsol_lladdr_t *ll;
-    uint8 databuf[sizeof(icmp6_neighbor_sol_t) + sizeof(icmp6_nsol_lladdr_t)];
+    uint8_t databuf[sizeof(icmp6_neighbor_sol_t) + sizeof(icmp6_nsol_lladdr_t)];
     struct in6_addr src;
     int size = sizeof(icmp6_neighbor_sol_t);
-    uint16 cs;
+    uint16_t cs;
 
     if(!net) {
         if(!(net = net_default_dev)) {
@@ -600,10 +601,10 @@ int net_icmp6_send_nadv(netif_t *net, const struct in6_addr *dst,
                         const struct in6_addr *target, int sol) {
     icmp6_neighbor_adv_t *pkt;
     icmp6_nsol_lladdr_t *ll;
-    uint8 databuf[sizeof(icmp6_neighbor_adv_t) + sizeof(icmp6_nsol_lladdr_t)];
+    uint8_t databuf[sizeof(icmp6_neighbor_adv_t) + sizeof(icmp6_nsol_lladdr_t)];
     struct in6_addr src;
     int size = sizeof(icmp6_neighbor_adv_t) + sizeof(icmp6_nsol_lladdr_t);
-    uint16 cs;
+    uint16_t cs;
 
     if(!net) {
         if(!(net = net_default_dev)) {
@@ -644,10 +645,10 @@ int net_icmp6_send_nadv(netif_t *net, const struct in6_addr *dst,
 int net_icmp6_send_rsol(netif_t *net) {
     icmp6_router_sol_t *pkt;
     icmp6_nsol_lladdr_t *ll;
-    uint8 databuf[sizeof(icmp6_router_sol_t) + sizeof(icmp6_nsol_lladdr_t)];
+    uint8_t databuf[sizeof(icmp6_router_sol_t) + sizeof(icmp6_nsol_lladdr_t)];
     struct in6_addr src;
     int size = sizeof(icmp6_router_sol_t) + sizeof(icmp6_nsol_lladdr_t);
-    uint16 cs;
+    uint16_t cs;
 
     if(!net) {
         if(!(net = net_default_dev)) {
@@ -688,12 +689,12 @@ int net_icmp6_send_rsol(netif_t *net) {
 
 /* Convenience function for handling the parts of error packets that are the
    same no matter what kind we're dealing with. */
-static int send_err_pkt(netif_t *net, uint8 buf[1240], int ptr,
+static int send_err_pkt(netif_t *net, uint8_t buf[1240], int ptr,
                         const uint8 *ppkt, size_t pktsz, int mc_allow) {
     size_t size = 1240 - ptr;
     icmp6_hdr_t *pkt = (icmp6_hdr_t *)buf;
     const ipv6_hdr_t *orig = (const ipv6_hdr_t *)ppkt;
-    uint16 cs;
+    uint16_t cs;
     struct in6_addr osrc, odst, src;
 
     /* Copy out the original source and destination addresses */
@@ -743,9 +744,9 @@ static int send_err_pkt(netif_t *net, uint8 buf[1240], int ptr,
 }
 
 /* Send an ICMPv6 Destination Unreachable about the given packet. */
-int net_icmp6_send_dest_unreach(netif_t *net, uint8 code, const uint8 *ppkt,
+int net_icmp6_send_dest_unreach(netif_t *net, uint8_t code, const uint8_t *ppkt,
                                 size_t psz) {
-    uint8 buf[1240];
+    uint8_t buf[1240];
     icmp6_dest_unreach_t *pkt = (icmp6_dest_unreach_t *)buf;
 
     /* Make sure the given code is sane */
@@ -763,9 +764,9 @@ int net_icmp6_send_dest_unreach(netif_t *net, uint8 code, const uint8 *ppkt,
 }
 
 /* Send an ICMPv6 Time Exceeded about the given packet. */
-int net_icmp6_send_time_exceeded(netif_t *net, uint8 code, const uint8 *ppkt,
+int net_icmp6_send_time_exceeded(netif_t *net, uint8_t code, const uint8_t *ppkt,
                                  size_t psz) {
-    uint8 buf[1240];
+    uint8_t buf[1240];
     icmp6_time_exceeded_t *pkt = (icmp6_time_exceeded_t *)buf;
 
     /* Make sure the given code is sane */
@@ -783,9 +784,9 @@ int net_icmp6_send_time_exceeded(netif_t *net, uint8 code, const uint8 *ppkt,
 }
 
 /* Send an ICMPv6 Parameter Problem about the given packet. */
-int net_icmp6_send_param_prob(netif_t *net, uint8 code, uint32 ptr,
-                              const uint8 *ppkt, size_t psz) {
-    uint8 buf[1240];
+int net_icmp6_send_param_prob(netif_t *net, uint8_t code, uint32_t ptr,
+                              const uint8_t *ppkt, size_t psz) {
+    uint8_t buf[1240];
     icmp6_param_problem_t *pkt = (icmp6_param_problem_t *)buf;
     int mc_allow = 0;
 

--- a/kernel/net/net_icmp6.h
+++ b/kernel/net/net_icmp6.h
@@ -12,124 +12,124 @@
 #include "net_ipv6.h"
 
 typedef struct icmp6_hdr_s {
-    uint8   type;
-    uint8   code;
-    uint16  checksum;
+    uint8_t   type;
+    uint8_t   code;
+    uint16_t  checksum;
 } __packed icmp6_hdr_t;
 
 /* Header for Destination Unreachable packets (type 1) */
 typedef struct icmp6_dest_unreach_s {
-    uint8   type;
-    uint8   code;
-    uint16  checksum;
-    uint32  unused;
+    uint8_t   type;
+    uint8_t   code;
+    uint16_t  checksum;
+    uint32_t  unused;
 } __packed icmp6_dest_unreach_t;
 
 /* Header for Packet Too Big packets (type 2) */
 typedef struct icmp6_pkt_too_big_s {
-    uint8   type;
-    uint8   code;
-    uint16  checksum;
-    uint32  mtu;
+    uint8_t   type;
+    uint8_t   code;
+    uint16_t  checksum;
+    uint32_t  mtu;
 } __packed icmp6_pkt_too_big_t;
 
 /* Header for Time Exceeded packets (type 3) */
 typedef struct icmp6_time_exceeded_s {
-    uint8   type;
-    uint8   code;
-    uint16  checksum;
-    uint32  unused;
+    uint8_t   type;
+    uint8_t   code;
+    uint16_t  checksum;
+    uint32_t  unused;
 } __packed icmp6_time_exceeded_t;
 
 /* Header for Parameter Problem packets (type 4) */
 typedef struct icmp6_param_problem_s {
-    uint8   type;
-    uint8   code;
-    uint16  checksum;
-    uint32  ptr;
+    uint8_t   type;
+    uint8_t   code;
+    uint16_t  checksum;
+    uint32_t  ptr;
 } __packed icmp6_param_problem_t;
 
 /* Header for Echo/Echo Reply packets (types 128/129) */
 typedef struct icmp6_echo_hdr_s {
-    uint8   type;
-    uint8   code;
-    uint16  checksum;
-    uint16  ident;
-    uint16  seq;
+    uint8_t   type;
+    uint8_t   code;
+    uint16_t  checksum;
+    uint16_t  ident;
+    uint16_t  seq;
 } __packed icmp6_echo_hdr_t;
 
 /* Format for Router Solicitation packets (type 133) - RFC 4861 */
 typedef struct icmp6_router_sol_s {
-    uint8   type;
-    uint8   code;
-    uint16  checksum;
-    uint32  reserved;
-    uint8   options[];
+    uint8_t   type;
+    uint8_t   code;
+    uint16_t  checksum;
+    uint32_t  reserved;
+    uint8_t   options[];
 } __packed icmp6_router_sol_t;
 
 /* Format for Router Advertisement packets (type 134) - RFC 4861 */
 typedef struct icmp6_router_adv_s {
-    uint8   type;
-    uint8   code;
-    uint16  checksum;
-    uint8   cur_hop_limit;
-    uint8   flags;
-    uint16  router_lifetime;
-    uint32  reachable_time;
-    uint32  retrans_timer;
-    uint8   options[];
+    uint8_t   type;
+    uint8_t   code;
+    uint16_t  checksum;
+    uint8_t   cur_hop_limit;
+    uint8_t   flags;
+    uint16_t  router_lifetime;
+    uint32_t  reachable_time;
+    uint32_t  retrans_timer;
+    uint8_t   options[];
 } __packed icmp6_router_adv_t;
 
 /* Format for Neighbor Solicitation packets (type 135) - RFC 4861 */
 typedef struct icmp6_neighbor_sol_s {
-    uint8           type;
-    uint8           code;
-    uint16          checksum;
-    uint32          reserved;
-    struct in6_addr target;
-    uint8           options[];
+    uint8_t           type;
+    uint8_t           code;
+    uint16_t          checksum;
+    uint32_t          reserved;
+    struct in6_addr   target;
+    uint8_t           options[];
 } __packed icmp6_neighbor_sol_t;
 
 /* Format for Neighbor Advertisement packets (type 136) - RFC 4861 */
 typedef struct icmp6_neighbor_adv_s {
-    uint8           type;
-    uint8           code;
-    uint16          checksum;
-    uint8           flags;
-    uint8           reserved[3];
-    struct in6_addr target;
-    uint8           options[];
+    uint8_t           type;
+    uint8_t           code;
+    uint16_t          checksum;
+    uint8_t           flags;
+    uint8_t           reserved[3];
+    struct in6_addr   target;
+    uint8_t           options[];
 } __packed icmp6_neighbor_adv_t;
 
 /* Link-layer address option for neighbor advertisement/solictation packets for
    ethernet. */
 typedef struct icmp6_nsol_lladdr_s {
-    uint8           type;
-    uint8           length;
-    uint8           mac[6];
+    uint8_t           type;
+    uint8_t           length;
+    uint8_t           mac[6];
 } __packed icmp6_nsol_lladdr_t;
 
 /* Redirect packet (type 137) - RFC 4861 */
 typedef struct icmp6_redirect_s {
-    uint8           type;
-    uint8           code;
-    uint16          checksum;
-    uint32          reserved;
-    struct in6_addr target;
-    struct in6_addr dest;
-    uint8           options[];
+    uint8_t           type;
+    uint8_t           code;
+    uint16_t          checksum;
+    uint32_t          reserved;
+    struct in6_addr   target;
+    struct in6_addr   dest;
+    uint8_t           options[];
 } __packed icmp6_redirect_t;
 
 /* Prefix information for router advertisement packets */
 typedef struct icmp6_ndp_prefix_s {
-    uint8           type;
-    uint8           length;
-    uint8           prefix_length;
-    uint8           flags;
-    uint32          valid_time;
-    uint32          preferred_time;
-    uint32          reserved;
-    struct in6_addr prefix;
+    uint8_t           type;
+    uint8_t           length;
+    uint8_t           prefix_length;
+    uint8_t           flags;
+    uint32_t          valid_time;
+    uint32_t          preferred_time;
+    uint32_t          reserved;
+    struct in6_addr   prefix;
 } __packed icmp6_ndp_prefix_t;
 
 /* ICMPv6 Message types */
@@ -156,7 +156,7 @@ typedef struct icmp6_ndp_prefix_s {
 #define NDP_OPT_REDIRECTED_HDR          4
 #define NDP_OPT_MTU                     5
 
-int net_icmp6_input(netif_t *src, ipv6_hdr_t *ih, const uint8 *data,
+int net_icmp6_input(netif_t *src, ipv6_hdr_t *ih, const uint8_t *data,
                     size_t size);
 
 #endif /* !__LOCAL_NET_ICMP6_H */

--- a/kernel/net/net_input.c
+++ b/kernel/net/net_input.c
@@ -5,6 +5,7 @@
    Copyright (C) 2005, 2012 Lawrence Sebald
 */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <kos/net.h>
 #include "net_ipv4.h"
@@ -16,8 +17,8 @@
 
 */
 
-static int net_default_input(netif_t *nif, const uint8 *data, int len) {
-    uint16 proto = (uint16)((data[12] << 8) | (data[13]));
+static int net_default_input(netif_t *nif, const uint8_t *data, int len) {
+    uint16_t proto = (uint16_t)((data[12] << 8) | (data[13]));
 
     /* If this is bound for a multicast address, make sure we actually care
        about the one that it gets sent to. */
@@ -51,7 +52,7 @@ static int net_default_input(netif_t *nif, const uint8 *data, int len) {
 net_input_func net_input_target = net_default_input;
 
 /* Process an incoming packet */
-int net_input(netif_t *device, const uint8 *data, int len) {
+int net_input(netif_t *device, const uint8_t *data, int len) {
     if(net_input_target != NULL)
         return net_input_target(device, data, len);
     else

--- a/kernel/net/net_ipv4.h
+++ b/kernel/net/net_ipv4.h
@@ -12,35 +12,35 @@
 
 /* These structs are from AndrewK's dcload-ip. */
 typedef struct {
-    uint8   dest[6];
-    uint8   src[6];
-    uint8   type[2];
+    uint8_t   dest[6];
+    uint8_t   src[6];
+    uint8_t   type[2];
 } __packed eth_hdr_t;
 
 typedef struct {
-    uint32 src_addr;
-    uint32 dst_addr;
-    uint8 zero;
-    uint8 proto;
-    uint16 length;
+    uint32_t src_addr;
+    uint32_t dst_addr;
+    uint8_t zero;
+    uint8_t proto;
+    uint16_t length;
 } __packed ipv4_pseudo_hdr_t;
 
-uint16 net_ipv4_checksum(const uint8 *data, size_t bytes, uint16 start);
-int net_ipv4_send_packet(netif_t *net, ip_hdr_t *hdr, const uint8 *data,
+uint16_t net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t start);
+int net_ipv4_send_packet(netif_t *net, ip_hdr_t *hdr, const uint8_t *data,
                          size_t size);
-int net_ipv4_send(netif_t *net, const uint8 *data, size_t size, int id, int ttl,
-                  int proto, uint32 src, uint32 dst);
-int net_ipv4_input(netif_t *src, const uint8 *pkt, size_t pktsize,
+int net_ipv4_send(netif_t *net, const uint8_t *data, size_t size, int id, int ttl,
+                  int proto, uint32_t src, uint32_t dst);
+int net_ipv4_input(netif_t *src, const uint8_t *pkt, size_t pktsize,
                    const eth_hdr_t *eth);
-int net_ipv4_input_proto(netif_t *net, const ip_hdr_t *ip, const uint8 *data);
+int net_ipv4_input_proto(netif_t *net, const ip_hdr_t *ip, const uint8_t *data);
 
-uint16 net_ipv4_checksum_pseudo(in_addr_t src, in_addr_t dst, uint8 proto,
-                                uint16 len);
+uint16_t net_ipv4_checksum_pseudo(in_addr_t src, in_addr_t dst, uint8_t proto,
+                                uint16_t len);
 
 /* In net_ipv4_frag.c */
-int net_ipv4_frag_send(netif_t *net, ip_hdr_t *hdr, const uint8 *data,
+int net_ipv4_frag_send(netif_t *net, ip_hdr_t *hdr, const uint8_t *data,
                        size_t size);
-int net_ipv4_reassemble(netif_t *net, const ip_hdr_t *hdr, const uint8 *data,
+int net_ipv4_reassemble(netif_t *net, const ip_hdr_t *hdr, const uint8_t *data,
                         size_t size);
 int net_ipv4_frag_init(void);
 void net_ipv4_frag_shutdown(void);

--- a/kernel/net/net_ipv4_frag.c
+++ b/kernel/net/net_ipv4_frag.c
@@ -24,17 +24,17 @@
 struct ip_frag {
     TAILQ_ENTRY(ip_frag) listhnd;
 
-    uint32 src;
-    uint32 dst;
-    uint16 ident;
-    uint8 proto;
+    uint32_t src;
+    uint32_t dst;
+    uint16_t ident;
+    uint8_t proto;
 
     ip_hdr_t hdr;
-    uint8 *data;
-    uint8 bitfield[8192];
+    uint8_t *data;
+    uint8_t bitfield[8192];
     int cur_length;
     int total_length;
-    uint64 death_time;
+    uint64_t death_time;
 };
 
 TAILQ_HEAD(ip_frag_list, ip_frag);
@@ -49,7 +49,7 @@ static int initted = 0;
    seconds (since death_time is always on the order of seconds). */
 static void frag_thd_cb(void *data) {
     struct ip_frag *f, *n;
-    uint64 now = timer_ms_gettime64();
+    uint64_t now = timer_ms_gettime64();
 
     (void)data;
 
@@ -73,7 +73,7 @@ static void frag_thd_cb(void *data) {
 }
 
 /* Set the bits in the bitfield for the given set of fragment blocks. */
-static inline void set_bits(uint8 *bitfield, int start, int end) {
+static inline void set_bits(uint8_t *bitfield, int start, int end) {
     /* Use a slightly more efficient method when dealing with an end that is not
        in the same byte as the start. */
     if((end >> 3) > (start >> 3)) {
@@ -105,7 +105,7 @@ static inline void set_bits(uint8 *bitfield, int start, int end) {
 }
 
 /* Check if all bits in the bitfield that should be set are set. */
-static inline int all_bits_set(const uint8 *bitfield, int end) {
+static inline int all_bits_set(const uint8_t *bitfield, int end) {
     int i;
 
     /* Make sure each of the beginning bytes are fully set. */
@@ -125,8 +125,8 @@ static inline int all_bits_set(const uint8 *bitfield, int end) {
 
 /* Import the data for a fragment, potentially passing it onward in processing,
    if the whole datagram has arrived. */
-static int frag_import(netif_t *src, const ip_hdr_t *hdr, const uint8 *data,
-                       size_t size, uint16 flags, struct ip_frag *frag) {
+static int frag_import(netif_t *src, const ip_hdr_t *hdr, const uint8_t *data,
+                       size_t size, uint16_t flags, struct ip_frag *frag) {
     void *tmp;
     int fo = flags & 0x1FFF;
     int tl = ntohs(hdr->length);
@@ -134,7 +134,7 @@ static int frag_import(netif_t *src, const ip_hdr_t *hdr, const uint8 *data,
     int ihl = (hdr->version_ihl & 0x0F) << 2;
     int end = start + tl - ihl;
     int rv = 0;
-    uint64 now = timer_ms_gettime64();
+    uint64_t now = timer_ms_gettime64();
 
     (void)size;
 
@@ -193,11 +193,11 @@ out:
 
 /* IPv4 fragmentation procedure. This is basically a direct implementation of
    the example IP fragmentation procedure on pages 26-27 of RFC 791. */
-int net_ipv4_frag_send(netif_t *net, ip_hdr_t *hdr, const uint8 *data,
+int net_ipv4_frag_send(netif_t *net, ip_hdr_t *hdr, const uint8_t *data,
                        size_t size) {
     int ihl = (hdr->version_ihl & 0x0f) << 2;
     int total = size + ihl;
-    uint16 flags = ntohs(hdr->flags_frag_offs);
+    uint16_t flags = ntohs(hdr->flags_frag_offs);
     ip_hdr_t newhdr;
     int nfb, ds;
 
@@ -243,9 +243,9 @@ int net_ipv4_frag_send(netif_t *net, ip_hdr_t *hdr, const uint8 *data,
 /* IPv4 fragment reassembly procedure. This (along with the frag_import function
    above are basically a direct implementation of the example IP reassembly
    routine on pages 27-29 of RFC 791. */
-int net_ipv4_reassemble(netif_t *src, const ip_hdr_t *hdr, const uint8 *data,
+int net_ipv4_reassemble(netif_t *src, const ip_hdr_t *hdr, const uint8_t *data,
                         size_t size) {
-    uint16 flags = ntohs(hdr->flags_frag_offs);
+    uint16_t flags = ntohs(hdr->flags_frag_offs);
     struct ip_frag *f;
 
     /* If the fragment offset is zero and the MF flag is 0, this is the whole

--- a/kernel/net/net_ipv6.c
+++ b/kernel/net/net_ipv6.c
@@ -5,6 +5,7 @@
 
 */
 
+#include <stdint.h>
 #include <string.h>
 #include <netinet/in.h>
 #include <kos/net.h>
@@ -60,10 +61,10 @@ static int is_in_network(netif_t *net, const struct in6_addr *ip) {
 }
 
 /* Send a packet on the specified network adapter */
-int net_ipv6_send_packet(netif_t *net, ipv6_hdr_t *hdr, const uint8 *data,
+int net_ipv6_send_packet(netif_t *net, ipv6_hdr_t *hdr, const uint8_t *data,
                          size_t data_size) {
-    uint8 pkt[data_size + sizeof(ipv6_hdr_t) + sizeof(eth_hdr_t)];
-    uint8 dst_mac[6];
+    uint8_t pkt[data_size + sizeof(ipv6_hdr_t) + sizeof(eth_hdr_t)];
+    uint8_t dst_mac[6];
     int err;
     struct in6_addr dst = hdr->dst_addr;
     eth_hdr_t *ehdr;
@@ -142,7 +143,7 @@ int net_ipv6_send_packet(netif_t *net, ipv6_hdr_t *hdr, const uint8 *data,
     return 0;
 }
 
-int net_ipv6_send(netif_t *net, const uint8 *data, size_t data_size,
+int net_ipv6_send(netif_t *net, const uint8_t *data, size_t data_size,
                   int hop_limit, int proto, const struct in6_addr *src,
                   const struct in6_addr *dst) {
     ipv6_hdr_t hdr;
@@ -192,10 +193,10 @@ int net_ipv6_send(netif_t *net, const uint8 *data, size_t data_size,
     return net_ipv6_send_packet(net, &hdr, data, data_size);
 }
 
-int net_ipv6_input(netif_t *src, const uint8 *pkt, size_t pktsize,
+int net_ipv6_input(netif_t *src, const uint8_t *pkt, size_t pktsize,
                    const eth_hdr_t *eth) {
     ipv6_hdr_t *ip;
-    uint8 next_hdr;
+    uint8_t next_hdr;
     //int pos;
     size_t len;
     int rv;
@@ -252,9 +253,9 @@ net_ipv6_stats_t net_ipv6_get_stats(void) {
     return ipv6_stats;
 }
 
-uint16 net_ipv6_checksum_pseudo(const struct in6_addr *src,
+uint16_t net_ipv6_checksum_pseudo(const struct in6_addr *src,
                                 const struct in6_addr *dst,
-                                uint32 upper_len, uint8 next_hdr) {
+                                uint32_t upper_len, uint8_t next_hdr) {
     ipv6_pseudo_hdr_t ps;
 
     /* Since the src and dst addresses aren't necessarily aligned when we send
@@ -267,20 +268,20 @@ uint16 net_ipv6_checksum_pseudo(const struct in6_addr *src,
             IN6_IS_ADDR_V4MAPPED(&ps.dst_addr)) {
         return net_ipv4_checksum_pseudo(ps.src_addr.__s6_addr.__s6_addr32[3],
                                         ps.dst_addr.__s6_addr.__s6_addr32[3],
-                                        next_hdr, (uint16)upper_len);
+                                        next_hdr, (uint16_t)upper_len);
     }
 
     ps.upper_layer_len = htonl(upper_len);
     ps.next_header = next_hdr;
     ps.zero[0] = ps.zero[1] = ps.zero[2] = 0;
 
-    return ~net_ipv4_checksum((uint8 *)&ps, sizeof(ipv6_pseudo_hdr_t), 0);
+    return ~net_ipv4_checksum((uint8_t *)&ps, sizeof(ipv6_pseudo_hdr_t), 0);
 }
 
 int net_ipv6_init(void) {
     /* Make sure we're registered to get "All nodes" multicasts from the
        ethernet layer. */
-    uint8 mac[6] = { 0x33, 0x33, 0x00, 0x00, 0x00, 0x01 };
+    uint8_t mac[6] = { 0x33, 0x33, 0x00, 0x00, 0x00, 0x01 };
     net_multicast_add(mac);
 
     /* Also register for the one for our link-local address' solicited nodes
@@ -295,7 +296,7 @@ int net_ipv6_init(void) {
 }
 
 void net_ipv6_shutdown(void) {
-    uint8 mac[6] = { 0x33, 0x33, 0x00, 0x00, 0x00, 0x01 };
+    uint8_t mac[6] = { 0x33, 0x33, 0x00, 0x00, 0x00, 0x01 };
 
     /* Remove from the all nodes multicast group */
     net_multicast_del(mac);

--- a/kernel/net/net_ipv6.h
+++ b/kernel/net/net_ipv6.h
@@ -13,17 +13,17 @@
 #include "net_ipv4.h"
 
 typedef struct ipv6_ext_hdr_s {
-    uint8       next_header;
-    uint8       ext_length;
-    uint8       data[];
+    uint8_t       next_header;
+    uint8_t       ext_length;
+    uint8_t       data[];
 } __packed ipv6_ext_hdr_t;
 
 typedef struct ipv6_pseudo_hdr_s {
     struct in6_addr src_addr;
     struct in6_addr dst_addr;
-    uint32          upper_layer_len;
-    uint8           zero[3];
-    uint8           next_header;
+    uint32_t          upper_layer_len;
+    uint8_t           zero[3];
+    uint8_t           next_header;
 } __packed ipv6_pseudo_hdr_t;
 
 #define IPV6_HDR_EXT_HOP_BY_HOP     0
@@ -35,16 +35,16 @@ typedef struct ipv6_pseudo_hdr_s {
 #define IPV6_HDR_NONE               59
 #define IPV6_HDR_EXT_DESTINATION    60
 
-int net_ipv6_send_packet(netif_t *net, ipv6_hdr_t *hdr, const uint8 *data,
+int net_ipv6_send_packet(netif_t *net, ipv6_hdr_t *hdr, const uint8_t *data,
                          size_t data_size);
-int net_ipv6_send(netif_t *net, const uint8 *data, size_t data_size,
+int net_ipv6_send(netif_t *net, const uint8_t *data, size_t data_size,
                   int hop_limit, int proto, const struct in6_addr *src,
                   const struct in6_addr *dst);
-int net_ipv6_input(netif_t *src, const uint8 *pkt, size_t pktsize,
+int net_ipv6_input(netif_t *src, const uint8_t *pkt, size_t pktsize,
                    const eth_hdr_t *eth);
 uint16 net_ipv6_checksum_pseudo(const struct in6_addr *src,
                                 const struct in6_addr *dst,
-                                uint32 upper_len, uint8 next_hdr);
+                                uint32_t upper_len, uint8_t next_hdr);
 
 extern const struct in6_addr in6addr_linklocal_allnodes;
 extern const struct in6_addr in6addr_linklocal_allrouters;

--- a/kernel/net/net_multicast.c
+++ b/kernel/net/net_multicast.c
@@ -9,6 +9,7 @@
    Basically, this is just a set of convenience functions around the if_set_mc
    function that got added to the netif_t structure. */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/queue.h>
@@ -18,7 +19,7 @@
 
 typedef struct mc_entry {
     LIST_ENTRY(mc_entry)    entry;
-    uint8                   mac[6];
+    uint8_t                 mac[6];
 } mc_entry_t;
 
 LIST_HEAD(mc_list, mc_entry);
@@ -29,7 +30,7 @@ static mutex_t mc_mutex = MUTEX_INITIALIZER;
 static void multicast_commit(void) {
     mc_entry_t *i;
     int tmp = 0;
-    uint8 macs[mc_count * 6];
+    uint8_t macs[mc_count * 6];
 
     if(!net_default_dev) {
         return;
@@ -44,7 +45,7 @@ static void multicast_commit(void) {
     net_default_dev->if_set_mc(net_default_dev, macs, tmp);
 }
 
-int net_multicast_add(const uint8 mac[6]) {
+int net_multicast_add(const uint8_t mac[6]) {
     mc_entry_t *ent;
 
     ent = (mc_entry_t *)malloc(sizeof(mc_entry_t));
@@ -69,7 +70,7 @@ int net_multicast_add(const uint8 mac[6]) {
     return 0;
 }
 
-int net_multicast_del(const uint8 mac[6]) {
+int net_multicast_del(const uint8_t mac[6]) {
     mc_entry_t *i, *tmp;
 
     if(mutex_lock_irqsafe(&mc_mutex))
@@ -97,7 +98,7 @@ int net_multicast_del(const uint8 mac[6]) {
     return 0;
 }
 
-int net_multicast_check(const uint8 mac[6]) {
+int net_multicast_check(const uint8_t mac[6]) {
     mc_entry_t *i;
     int rv = 0;
 

--- a/kernel/net/net_ndp.c
+++ b/kernel/net/net_ndp.c
@@ -5,6 +5,7 @@
 
 */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -26,11 +27,11 @@
 typedef struct ndp_entry {
     LIST_ENTRY(ndp_entry)   entry;
     struct in6_addr         ip;
-    uint64                  last_reachable;
+    uint64_t                last_reachable;
     int                     state;
-    uint8                   mac[6];
+    uint8_t                 mac[6];
     ipv6_hdr_t              *pkt;
-    uint8                   *data;
+    uint8_t                 *data;
     int                     data_size;
 } ndp_entry_t;
 
@@ -46,7 +47,7 @@ static struct ndp_list ndp_cache = LIST_HEAD_INITIALIZER(0);
 
 void net_ndp_gc(void) {
     ndp_entry_t *i, *tmp;
-    uint64 now = timer_ms_gettime64();
+    uint64_t now = timer_ms_gettime64();
 
     i = LIST_FIRST(&ndp_cache);
 
@@ -73,10 +74,10 @@ void net_ndp_gc(void) {
     }
 }
 
-int net_ndp_insert(netif_t *net, const uint8 mac[6], const struct in6_addr *ip,
+int net_ndp_insert(netif_t *net, const uint8_t mac[6], const struct in6_addr *ip,
                    int unsol) {
     ndp_entry_t *i;
-    uint64 now = timer_ms_gettime64();
+    uint64_t now = timer_ms_gettime64();
 
     /* Don't allow any multicast or unspecified addresses to end up in the NDP
        cache... */
@@ -156,10 +157,10 @@ static void net_ndp_send_sol(netif_t *net, const struct in6_addr *ip) {
     net_icmp6_send_nsol(net, &dst, ip, 0);
 }
 
-int net_ndp_lookup(netif_t *net, const struct in6_addr *ip, uint8 mac_out[6],
-                   const ipv6_hdr_t *pkt, const uint8 *data, int data_size) {
+int net_ndp_lookup(netif_t *net, const struct in6_addr *ip, uint8_t mac_out[6],
+                   const ipv6_hdr_t *pkt, const uint8_t *data, int data_size) {
     ndp_entry_t *i;
-    uint64 now = timer_ms_gettime64();
+    uint64_t now = timer_ms_gettime64();
 
     /* Garbage collect, so we don't end up returning really stale entries */
     net_ndp_gc();

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -1999,7 +1999,7 @@ static void tcp_rst(netif_t *net, const struct in6_addr *src,
                     uint16_t dst_port, uint16_t flags, uint32_t seq,
                     uint32_t ack) {
     tcp_hdr_t pkt;
-    uint16 c;
+    uint16_t c;
 
     /* Fill in the packet */
     pkt.src_port = src_port;
@@ -2012,9 +2012,9 @@ static void tcp_rst(netif_t *net, const struct in6_addr *src,
     pkt.urg = 0;
 
     c = net_ipv6_checksum_pseudo(src, dst, sizeof(tcp_hdr_t), IPPROTO_TCP);
-    pkt.checksum = net_ipv4_checksum((const uint8 *)&pkt, sizeof(tcp_hdr_t), c);
+    pkt.checksum = net_ipv4_checksum((const uint8_t *)&pkt, sizeof(tcp_hdr_t), c);
 
-    net_ipv6_send(net, (const uint8 *)&pkt, sizeof(tcp_hdr_t), 0, IPPROTO_TCP,
+    net_ipv6_send(net, (const uint8_t *)&pkt, sizeof(tcp_hdr_t), 0, IPPROTO_TCP,
                   src, dst);
 }
 
@@ -2022,8 +2022,8 @@ static void tcp_bpkt_rst(netif_t *net, const struct in6_addr *src,
                          const struct in6_addr *dst, const tcp_hdr_t *ohdr,
                          int size) {
     tcp_hdr_t pkt;
-    uint16 cs;
-    uint16 flags = ntohs(ohdr->off_flags);
+    uint16_t cs;
+    uint16_t flags = ntohs(ohdr->off_flags);
 
     /* Fill in the packet */
     pkt.src_port = ohdr->dst_port;
@@ -2052,10 +2052,10 @@ static void tcp_bpkt_rst(netif_t *net, const struct in6_addr *src,
     pkt.urg = 0;
 
     cs = net_ipv6_checksum_pseudo(dst, src, sizeof(tcp_hdr_t), IPPROTO_TCP);
-    pkt.checksum = net_ipv4_checksum((const uint8 *)&pkt, sizeof(tcp_hdr_t),
+    pkt.checksum = net_ipv4_checksum((const uint8_t *)&pkt, sizeof(tcp_hdr_t),
                                      cs);
 
-    net_ipv6_send(net, (const uint8 *)&pkt, sizeof(tcp_hdr_t), 0, IPPROTO_TCP,
+    net_ipv6_send(net, (const uint8_t *)&pkt, sizeof(tcp_hdr_t), 0, IPPROTO_TCP,
                   dst, src);
 }
 
@@ -2143,9 +2143,9 @@ static void tcp_send_ack(struct tcp_sock *sock) {
     c = net_ipv6_checksum_pseudo(&sock->local_addr.sin6_addr,
                                  &sock->remote_addr.sin6_addr,
                                  sizeof(tcp_hdr_t), IPPROTO_TCP);
-    hdr.checksum = net_ipv4_checksum((const uint8 *)&hdr, sizeof(tcp_hdr_t), c);
+    hdr.checksum = net_ipv4_checksum((const uint8_t *)&hdr, sizeof(tcp_hdr_t), c);
 
-    net_ipv6_send(sock->data.net, (const uint8 *)&hdr, sizeof(tcp_hdr_t),
+    net_ipv6_send(sock->data.net, (const uint8_t *)&hdr, sizeof(tcp_hdr_t),
                   sock->hop_limit, IPPROTO_TCP, &sock->local_addr.sin6_addr,
                   &sock->remote_addr.sin6_addr);
 }

--- a/kernel/net/net_thd.c
+++ b/kernel/net/net_thd.c
@@ -8,6 +8,7 @@
 #include <sys/queue.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include <kos/thread.h>
 #include <arch/timer.h>
@@ -19,8 +20,8 @@ struct thd_cb {
     int cbid;
     void (*cb)(void *);
     void *data;
-    uint64 timeout;
-    uint64 nextrun;
+    uint64_t timeout;
+    uint64_t nextrun;
 };
 
 TAILQ_HEAD(thd_cb_queue, thd_cb);
@@ -32,7 +33,7 @@ static int cbid_top;
 
 static void *net_thd_thd(void *data) {
     struct thd_cb *cb;
-    uint64 now;
+    uint64_t now;
 
     (void)data;
 
@@ -54,7 +55,7 @@ static void *net_thd_thd(void *data) {
     return NULL;
 }
 
-int net_thd_add_callback(void (*cb)(void *), void *data, uint64 timeout) {
+int net_thd_add_callback(void (*cb)(void *), void *data, uint64_t timeout) {
     struct thd_cb *newcb;
 
     /* Allocate space for the new callback and set it up. */

--- a/kernel/net/net_thd.h
+++ b/kernel/net/net_thd.h
@@ -9,12 +9,11 @@
 #define __LOCAL_NET_THD_H
 
 #include <sys/cdefs.h>
+#include <stdint.h>
 
 __BEGIN_DECLS
 
-#include <arch/types.h>
-
-int net_thd_add_callback(void (*cb)(void *), void *data, uint64 timeout);
+int net_thd_add_callback(void (*cb)(void *), void *data, uint64_t timeout);
 int net_thd_del_callback(int cbid);
 
 int net_thd_is_current(void);

--- a/kernel/net/net_udp.c
+++ b/kernel/net/net_udp.c
@@ -34,17 +34,17 @@
 #define UDP_DEFAULT_HOPS    64
 
 typedef struct {
-    uint16 src_port __packed;
-    uint16 dst_port __packed;
-    uint16 length __packed;
-    uint16 checksum __packed;
+    uint16_t src_port __packed;
+    uint16_t dst_port __packed;
+    uint16_t length __packed;
+    uint16_t checksum __packed;
 } udp_hdr_t;
 
 struct udp_pkt {
     TAILQ_ENTRY(udp_pkt) pkt_queue;
     struct sockaddr_in6 from;
-    uint8 *data;
-    uint16 datasize;
+    uint8_t *data;
+    uint16_t datasize;
 };
 
 TAILQ_HEAD(udp_pkt_queue, udp_pkt);
@@ -57,8 +57,8 @@ struct udp_sock {
     struct sockaddr_in6 local_addr;
     struct sockaddr_in6 remote_addr;
 
-    uint32 flags;
-    uint32 int_flags;
+    uint32_t flags;
+    uint32_t int_flags;
     int domain;
     int proto;
     int hop_limit;
@@ -79,7 +79,7 @@ static mutex_t udp_mutex = MUTEX_INITIALIZER;
 static net_udp_stats_t udp_stats = { 0 };
 
 static int net_udp_send_raw(netif_t *net, const struct sockaddr_in6 *src,
-                            const struct sockaddr_in6 *dst, const uint8 *data,
+                            const struct sockaddr_in6 *dst, const uint8_t *data,
                             size_t size, uint32_t flags, int hops,
                             uint32_t iflags, int proto, uint16_t cscov);
 
@@ -484,7 +484,7 @@ static ssize_t net_udp_sendto(net_socket_t *hnd, const void *message,
     }
 
     if(udpsock->local_addr.sin6_port == 0) {
-        uint16 port = 1024, tmp = 0;
+        uint16_t port = 1024, tmp = 0;
         struct udp_sock *iter;
 
         /* Grab the first unused port >= 1024. This is, unfortunately, O(n^2) */
@@ -511,7 +511,7 @@ static ssize_t net_udp_sendto(net_socket_t *hnd, const void *message,
     mutex_unlock(&udp_mutex);
 
     return net_udp_send_raw(NULL, &local_addr, &realaddr6,
-                            (const uint8 *)message, length, sflags, hops,
+                            (const uint8_t *)message, length, sflags, hops,
                             iflags, proto, cscov);
 err:
     mutex_unlock(&udp_mutex);
@@ -1101,10 +1101,10 @@ static short net_udp_poll(net_socket_t *hnd, short events) {
 
 extern void __poll_event_trigger(int fd, short event);
 
-static int net_udp_input4(netif_t *src, const ip_hdr_t *ip, const uint8 *data,
+static int net_udp_input4(netif_t *src, const ip_hdr_t *ip, const uint8_t *data,
                           size_t size) {
     udp_hdr_t *hdr = (udp_hdr_t *)data;
-    uint16 cs, cscov = 0;
+    uint16_t cs, cscov = 0;
     int partial = 1;
     struct udp_sock *sock;
     struct udp_pkt *pkt;
@@ -1211,7 +1211,7 @@ static int net_udp_input4(netif_t *src, const ip_hdr_t *ip, const uint8 *data,
 
         pkt->datasize = size - sizeof(udp_hdr_t);
 
-        if(!(pkt->data = (uint8 *)malloc(pkt->datasize))) {
+        if(!(pkt->data = (uint8_t *)malloc(pkt->datasize))) {
             free(pkt);
             mutex_unlock(&udp_mutex);
             return -1;
@@ -1240,10 +1240,10 @@ static int net_udp_input4(netif_t *src, const ip_hdr_t *ip, const uint8 *data,
     return -1;
 }
 
-static int net_udp_input6(netif_t *src, const ipv6_hdr_t *ip, const uint8 *data,
+static int net_udp_input6(netif_t *src, const ipv6_hdr_t *ip, const uint8_t *data,
                           size_t size) {
     udp_hdr_t *hdr = (udp_hdr_t *)data;
-    uint16 cs, cscov = 0;
+    uint16_t cs, cscov = 0;
     int partial = 1;
     struct udp_sock *sock;
     struct udp_pkt *pkt;
@@ -1348,7 +1348,7 @@ static int net_udp_input6(netif_t *src, const ipv6_hdr_t *ip, const uint8 *data,
 
         pkt->datasize = size - sizeof(udp_hdr_t);
 
-        if(!(pkt->data = (uint8 *)malloc(pkt->datasize))) {
+        if(!(pkt->data = (uint8_t *)malloc(pkt->datasize))) {
             free(pkt);
             mutex_unlock(&udp_mutex);
             return -1;
@@ -1377,7 +1377,7 @@ static int net_udp_input6(netif_t *src, const ipv6_hdr_t *ip, const uint8 *data,
 }
 
 static int net_udp_input(netif_t *src, int domain, const void *hdr,
-                         const uint8 *data, size_t size) {
+                         const uint8_t *data, size_t size) {
     switch(domain) {
         case AF_INET:
             return net_udp_input4(src, (const ip_hdr_t *)hdr, data, size);
@@ -1391,12 +1391,12 @@ static int net_udp_input(netif_t *src, int domain, const void *hdr,
 
 /* XXX */
 static int net_udp_send_raw(netif_t *net, const struct sockaddr_in6 *src,
-                            const struct sockaddr_in6 *dst, const uint8 *data,
+                            const struct sockaddr_in6 *dst, const uint8_t *data,
                             size_t size, uint32_t flags, int hops,
                             uint32_t iflags, int proto, uint16_t cscov) {
-    uint8 buf[size + sizeof(udp_hdr_t)];
+    uint8_t buf[size + sizeof(udp_hdr_t)];
     udp_hdr_t *hdr = (udp_hdr_t *)buf;
-    uint16 cs;
+    uint16_t cs;
     int err;
     struct in6_addr srcaddr = src->sin6_addr;
 


### PR DESCRIPTION
As title, to work toward #840. Only change other than that is that I fixed a small amount of whitespace issues in `include/kos/net.h` function prototypes.