### PR TITLE
dmac: Work around bug in `__is_aligned` macro.

### DIFF
--- a/kernel/arch/dreamcast/hardware/dmac.c
+++ b/kernel/arch/dreamcast/hardware/dmac.c
@@ -143,8 +143,9 @@ int dma_transfer(const dma_config_t *cfg, dma_addr_t dst, dma_addr_t src,
     unsigned int transfer_size = dma_unit_size[cfg->unit_size];
     uint32_t chcr;
 
-    if(!__is_aligned(len | dst | src, transfer_size)) {
-        dbglog(DBG_ERROR, "dmac: src/dst/len not aligned to the bus width\n");
+    if(!__is_aligned((src|dst|len), transfer_size)) {
+        dbglog(DBG_ERROR, "dmac: src=0x%08x dst=0x%08x len=%u not aligned to %u bytes\n",
+               (uintptr_t)src, (uintptr_t)dst, (uintptr_t)len, transfer_size);
         errno = EFAULT;
         return -1;
     }


### PR DESCRIPTION
It seems that the macro can provide incorrect feedback when not used on a single value. Changing this allows the dmac speed test example to perform dmac writes, which otherwise were being flagged as unaligned.

This seems to have slipped by in my v2.2.0 testing as the dmac speedtest was also broken by a dcload-ip bug. Even with this change, the pvr_dma function in the speedtest still seems to hang. I did test reverting the pvr buffers change from [the same commit](https://github.com/KallistiOS/KallistiOS/pull/1085/commits/4111c0c4a42ca96897798012fccbcb1d40406ffe), and that had no impact.