### PR TITLE
Add new arch-agnostic timer API and implement old timer functions on top

### DIFF
--- a/include/kos/timer.h
+++ b/include/kos/timer.h
@@ -39,6 +39,156 @@ static inline timespec_t timer_gettime(void) {
     return arch_timer_gettime();
 }
 
+/** \brief   Get the current uptime of the system (in milliseconds).
+    \ingroup timers
+
+    This function retrieves the number of milliseconds since KOS was started. It
+    is equivalent to calling timer_ms_gettime() and combining the number of
+    seconds and milliseconds into one 64-bit value.
+
+    \return                 The number of milliseconds since KOS started.
+*/
+static inline uint64_t timer_ms_gettime64(void) {
+    timespec_t time = timer_gettime();
+
+    return (uint64_t)time.tv_sec * 1000 + time.tv_nsec / 1000000;
+}
+
+/** \brief   Get the current uptime of the system (in microseconds).
+    \ingroup timers
+
+    This function retrieves the number of microseconds since KOS was started.
+
+    \return                 The uptime in microseconds.
+*/
+static inline uint64_t timer_us_gettime64(void) {
+    timespec_t time = timer_gettime();
+
+    return (uint64_t)time.tv_sec * 1000000 + time.tv_nsec / 1000;
+}
+
+/** \brief   Get the current uptime of the system (in nanoseconds).
+    \ingroup timers
+
+    This function retrieves the number of nanoseconds since KOS was started.
+
+    \return                 The uptime in nanoseconds.
+*/
+static inline uint64_t timer_ns_gettime64(void) {
+    timespec_t time = timer_gettime();
+
+    return (uint64_t)time.tv_sec * 1000000000 + time.tv_nsec;
+}
+
+/** \brief   Get the current uptime of the system (in secs and millisecs).
+    \ingroup timers
+
+    This function retrieves the number of seconds and milliseconds since KOS was
+    started.
+
+    \param  secs            A pointer to store the number of seconds since boot
+                            into.
+    \param  msecs           A pointer to store the number of milliseconds past
+                            a second since boot.
+    \note                   To get the total number of milliseconds since boot,
+                            calculate (*secs * 1000) + *msecs, or use the
+                            timer_ms_gettime64() function.
+*/
+static inline void timer_ms_gettime(uint32_t *secs, uint32_t *msecs) {
+    timespec_t time = timer_gettime();
+
+    if(secs)  *secs = time.tv_sec;
+    if(msecs) *msecs = time.tv_nsec / 1000000;
+}
+
+/** \brief   Get the current uptime of the system (in secs and microsecs).
+    \ingroup timers
+
+    This function retrieves the number of seconds and microseconds since KOS was
+    started.
+
+    \note                   To get the total number of microseconds since boot,
+                            calculate (*secs * 1000000) + *usecs, or use the
+                            timer_us_gettime64() function.
+
+    \param  secs            A pointer to store the number of seconds since boot
+                            into.
+    \param  usecs           A pointer to store the number of microseconds past
+                            a second since boot.
+*/
+static inline void timer_us_gettime(uint32_t *secs, uint32_t *usecs) {
+    timespec_t time = timer_gettime();
+
+    if(secs)  *secs = time.tv_sec;
+    if(usecs) *usecs = time.tv_nsec / 1000;
+}
+
+/** \brief   Get the current uptime of the system (in secs and nanosecs).
+    \ingroup timers
+
+    This function retrieves the number of seconds and nanoseconds since KOS was
+    started.
+
+    \note                   To get the total number of nanoseconds since boot,
+                            calculate (*secs * 1000000000) + *nsecs, or use the
+                            timer_ns_gettime64() function.
+
+    \param  secs            A pointer to store the number of seconds since boot
+                            into.
+    \param  nsecs           A pointer to store the number of nanoseconds past
+                            a second since boot.
+*/
+static inline void timer_ns_gettime(uint32_t *secs, uint32_t *nsecs) {
+    timespec_t time = timer_gettime();
+
+    if(secs)  *secs = time.tv_sec;
+    if(nsecs) *nsecs = time.tv_nsec;
+}
+
+/** \brief  Spin-loop delay function with microsecond granularity
+    \ingroup timers
+
+    This function is meant as a very accurate delay function, even if threading
+    and interrupts are disabled. It is a delay and not a sleep, which means that
+    the CPU will be busy-looping during that time frame. For any time frame
+    bigger than a few hundred microseconds, it is recommended to sleep instead.
+
+    Note that the parameter is 16-bit, which means that the maximum acceptable
+    value is 65535 microseconds.
+
+    \param  us              The number of microseconds to wait for.
+    \sa timer_spin_delay_ns, thd_sleep
+*/
+static inline void timer_spin_delay_us(unsigned short us) {
+    uint64_t timeout = timer_us_gettime64() + us;
+
+    /* Note that we don't actually care about the counter overflowing.
+       Nobody will run their Dreamcast straight for 584942 years. */
+    while(timer_us_gettime64() < timeout);
+}
+
+
+/** \brief  Spin-loop delay function with nanosecond granularity
+    \ingroup timers
+
+    This function is meant as a very accurate delay function, even if threading
+    and interrupts are disabled. It is a delay and not a sleep, which means that
+    the CPU will be busy-looping during that time frame.
+
+    Note that the parameter is 16-bit, which means that the maximum acceptable
+    value is 65535 nanoseconds.
+
+    \param  ns              The number of nanoseconds to wait for.
+    \sa timer_spin_delay_us, thd_sleep
+*/
+static inline void timer_spin_delay_ns(unsigned short ns) {
+    uint64_t timeout = timer_ns_gettime64() + ns;
+
+    /* Note that we don't actually care about the counter overflowing.
+       Nobody will run their Dreamcast straight for 585 years. */
+    while(timer_ns_gettime64() < timeout);
+}
+
 __END_DECLS
 
 #endif /* __KOS_TIMER_H */

--- a/include/kos/timer.h
+++ b/include/kos/timer.h
@@ -1,0 +1,44 @@
+/* KallistiOS ##version##
+
+   include/kos/timer.h
+   Copyright (C) 2025 Paul Cercueil
+*/
+
+/** \file    kos/timer.h
+    \brief   Timer functionality.
+    \ingroup timers
+
+    This file contains functions for reading the internal timer provided
+    by the architecture.
+
+    \sa arch/timer.h
+
+    \author Paul Cercueil
+*/
+#ifndef __KOS_TIMER_H
+#define __KOS_TIMER_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+#include <arch/timer.h>
+#include <stdint.h>
+#include <time.h>
+
+typedef struct timespec timespec_t;
+
+/** \brief   Get the current uptime of the system.
+    \ingroup timers
+
+    This function retrieves the number of seconds and nanoseconds since KOS was
+    started.
+
+    \return                 The current uptime of the system as a timespec struct.
+*/
+static inline timespec_t timer_gettime(void) {
+    return arch_timer_gettime();
+}
+
+__END_DECLS
+
+#endif /* __KOS_TIMER_H */

--- a/include/kos/timer.h
+++ b/include/kos/timer.h
@@ -189,6 +189,23 @@ static inline void timer_spin_delay_ns(unsigned short ns) {
     while(timer_ns_gettime64() < timeout);
 }
 
+/** \brief  Spin-loop delay function with millisecond granularity
+    \ingroup timers
+
+    This function should never be used, and is only used for compatibility with
+    older code. It makes no sense to busy-wait for that long.
+
+    \param  ms              The number of microseconds to wait for.
+    \sa thd_sleep
+*/
+
+__depr("Do not use timer_spin_sleep(), use thd_sleep() instead")
+static inline void timer_spin_sleep(unsigned int ms) {
+    uint64_t timeout = timer_ms_gettime64() + ms;
+
+    while(timer_ms_gettime64() < timeout);
+}
+
 __END_DECLS
 
 #endif /* __KOS_TIMER_H */

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -12,7 +12,7 @@
 #include <assert.h>
 
 #include <arch/cache.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <arch/memory.h>
 #include <arch/irq.h>
 

--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -965,7 +965,7 @@ int g1_ata_flush(void) {
 
     /* Select the slave device. */
     g1_ata_select_device(G1_ATA_SLAVE | G1_ATA_LBA_MODE);
-    timer_spin_sleep(1);
+    thd_sleep(1);
 
     /* Flush the disk's write cache to make sure everything gets written out. */
     if(CAN_USE_LBA48())
@@ -973,7 +973,7 @@ int g1_ata_flush(void) {
     else
         OUT8(G1_ATA_COMMAND_REG, ATA_CMD_FLUSH_CACHE);
 
-    timer_spin_sleep(1);
+    thd_sleep(1);
     g1_ata_wait_bsydrq();
     g1_ata_mutex_unlock();
 
@@ -1006,7 +1006,7 @@ static int g1_ata_set_transfer_mode(uint8_t mode) {
 
     /* Send the SET FEATURES command. */
     OUT8(G1_ATA_COMMAND_REG, ATA_CMD_SET_FEATURES);
-    timer_spin_sleep(1);
+    thd_sleep(1);
 
     /* Wait for command completion. */
     g1_ata_wait_nbsy();
@@ -1034,7 +1034,7 @@ static int g1_ata_scan(void) {
     /* For now, just check if there's a slave device. We don't care about the
        primary device, since it should always be the GD-ROM drive. */
     OUT8(G1_ATA_DEVICE_SELECT, 0xF0);
-    timer_spin_sleep(1);
+    thd_sleep(1);
 
     OUT8(G1_ATA_SECTOR_COUNT, 0);
     OUT8(G1_ATA_LBA_LOW, 0);
@@ -1043,7 +1043,7 @@ static int g1_ata_scan(void) {
 
     /* Send the IDENTIFY command. */
     OUT8(G1_ATA_COMMAND_REG, ATA_CMD_IDENTIFY);
-    timer_spin_sleep(1);
+    thd_sleep(1);
     st = IN8(G1_ATA_STATUS_REG);
 
     /* Check if there's anything on the bus. */

--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -17,7 +17,7 @@
 #include <kos/mutex.h>
 #include <kos/thread.h>
 
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <arch/cache.h>
 #include <arch/irq.h>
 #include <arch/memory.h>

--- a/kernel/arch/dreamcast/hardware/maple/keyboard.c
+++ b/kernel/arch/dreamcast/hardware/maple/keyboard.c
@@ -15,7 +15,8 @@
 
 #include <kos/dbglog.h>
 
-#include <arch/timer.h>
+#include <kos/timer.h>
+#include <arch/irq.h>
 #include <dc/maple.h>
 #include <dc/maple/keyboard.h>
 

--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -25,7 +25,7 @@
 #include <dc/math.h>
 #include <dc/biosfont.h>
 #include <dc/vmufs.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 #define VMU_BLOCK_WRITE_RETRY_TIME  100     /* time to sleep until retrying a failed write */
 

--- a/kernel/arch/dreamcast/hardware/modem/modem.c
+++ b/kernel/arch/dreamcast/hardware/modem/modem.c
@@ -448,14 +448,14 @@ void modemHardReset(void) {
     /* This zeroes out all of the modem's registers */
     modemWrite(G2_8BP_RST, 0);
 
-    timer_spin_sleep(25); /* A slight delay just to be safe */
+    thd_sleep(25); /* A slight delay just to be safe */
 
     /* This sets the modem's registers to their default settings */
     modemWrite(G2_8BP_RST, 1);
 
     /* Wait for a little while so the modem has time to reset itself
        completely */
-    timer_spin_sleep(150);
+    thd_sleep(150);
 }
 
 void modemSoftReset(void) {
@@ -465,7 +465,7 @@ void modemSoftReset(void) {
     while(modemRead(REGLOC(0x1F)) & 0x1);  /* Wait for NEWC to clear */
 
     /* Wait a minimum of 10ms before using the MDP again */
-    timer_spin_sleep(100);
+    thd_sleep(100);
 }
 
 void modemConfigurationReset(void) {
@@ -600,7 +600,7 @@ int modem_set_mode(int mode, modem_speed_t speed) {
             modemSetBits(REGLOC(0x1F), 0x1); /* Set NEWC */
 
             /* Delay at least 4ms */
-            timer_spin_sleep(10);
+            thd_sleep(10);
 
             /* Dial using DTMF tones, and set the modem in origination
                mode */
@@ -801,7 +801,7 @@ void modemEstablishConnection(void) {
        can be answered */
     if(!(modemCfg.flags & MODEM_CFG_FLAG_ORIGINATE)) {
         modemSetBits(REGLOC(0x7), 0x2); /* Set RA */
-        timer_spin_sleep(10);
+        thd_sleep(10);
     }
 
     /* Note that in all modes of operation RTS will be turned on as soon

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <float.h>
 
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <dc/pvr.h>
 #include <dc/video.h>
 #include <kos/regfield.h>

--- a/kernel/arch/dreamcast/hardware/sci.c
+++ b/kernel/arch/dreamcast/hardware/sci.c
@@ -8,7 +8,7 @@
 #include <dc/math.h>
 #include <arch/cache.h>
 #include <arch/dmac.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 #include <kos/dbglog.h>
 #include <kos/regfield.h>

--- a/kernel/arch/dreamcast/hardware/scif-spi.c
+++ b/kernel/arch/dreamcast/hardware/scif-spi.c
@@ -8,7 +8,7 @@
 
 #include <dc/scif.h>
 #include <dc/fs_dcload.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <kos/dbglog.h>
 #include <kos/regfield.h>
 

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -9,7 +9,7 @@
 #include <dc/spu.h>
 #include <dc/g2bus.h>
 #include <dc/sq.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <errno.h>
 
 /*

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -355,7 +355,7 @@ int spu_init(void) {
     spu_enable();
 
     /* Wait a few clocks */
-    timer_spin_sleep(10);
+    thd_sleep(10);
 
     /* Initialize CDDA channels */
     spu_cdda_init();

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -82,8 +82,7 @@ __BEGIN_DECLS
 /** \brief  SH4 Timer Channel 1.
 
     \warning
-    This timer channel is used for the timer_spin_sleep() function, which also
-    backs the kthread, C, C++, and POSIX sleep functions.
+    This timer channel is free to use.
 */
 #define TMU1    1
 
@@ -333,21 +332,7 @@ uint64_t timer_ns_gettime64(void);
 
     This API provides the low-level functionality used to implement thread
     sleeping, used by the KOS, C, C++, and POSIX threading APIs.
-
-    \warning
-    This API and its underlying functionality are using \ref TMU1, so any
-    direct manipulation of it will interfere with the API's proper functioning.
 */
-
-/** \brief  Spin-loop sleep function.
-    \ingroup tmu_sleep
-
-    This function is meant as a very accurate delay function, even if threading
-    and interrupts are disabled. It uses \ref TMU1 to sleep.
-
-    \param  ms              The number of milliseconds to sleep.
-*/
-void timer_spin_sleep(int ms);
 
 /** \brief  Spin-loop delay function with microsecond granularity
     \ingroup tmu_sleep

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -266,118 +266,6 @@ static inline struct timespec arch_timer_gettime(void) {
     };
 }
 
-/** \brief   Get the current uptime of the system (in secs and millisecs).
-    \ingroup tmu_uptime
-
-    This function retrieves the number of seconds and milliseconds since KOS was
-    started.
-
-    \param  secs            A pointer to store the number of seconds since boot
-                            into.
-    \param  msecs           A pointer to store the number of milliseconds past
-                            a second since boot.
-    \note                   To get the total number of milliseconds since boot,
-                            calculate (*secs * 1000) + *msecs, or use the
-                            timer_ms_gettime64() function.
-*/
-void timer_ms_gettime(uint32_t *secs, uint32_t *msecs);
-
-/** \brief   Get the current uptime of the system (in milliseconds).
-    \ingroup tmu_uptime
-
-    This function retrieves the number of milliseconds since KOS was started. It
-    is equivalent to calling timer_ms_gettime() and combining the number of
-    seconds and milliseconds into one 64-bit value.
-
-    \return                 The number of milliseconds since KOS started.
-*/
-uint64_t timer_ms_gettime64(void);
-
-/** \brief   Get the current uptime of the system (in secs and microsecs).
-    \ingroup tmu_uptime
-
-    This function retrieves the number of seconds and microseconds since KOS was
-    started.
-
-    \note                   To get the total number of microseconds since boot,
-                            calculate (*secs * 1000000) + *usecs, or use the
-                            timer_us_gettime64() function.
-
-    \param  secs            A pointer to store the number of seconds since boot
-                            into.
-    \param  usecs           A pointer to store the number of microseconds past
-                            a second since boot.
-*/
-void timer_us_gettime(uint32_t *secs, uint32_t *usecs);
-
-/** \brief   Get the current uptime of the system (in microseconds).
-    \ingroup tmu_uptime
-
-    This function retrieves the number of microseconds since KOS was started.
-
-    \return                 The number of microseconds since KOS started.
-*/
-uint64_t timer_us_gettime64(void);
-
-/** \brief   Get the current uptime of the system (in secs and nanosecs).
-    \ingroup tmu_uptime
-
-    This function retrieves the number of seconds and nanoseconds since KOS was
-    started.
-
-    \note                   To get the total number of nanoseconds since boot,
-                            calculate (*secs * 1000000000) + *nsecs, or use the
-                            timer_ns_gettime64() function.
-
-    \param  secs            A pointer to store the number of seconds since boot
-                            into.
-    \param  nsecs           A pointer to store the number of nanoseconds past
-                            a second since boot.
-*/
-void timer_ns_gettime(uint32_t *secs, uint32_t *nsecs);
-
-/** \brief   Get the current uptime of the system (in nanoseconds).
-    \ingroup tmu_uptime
-
-    This function retrieves the number of nanoseconds since KOS was started. 
-
-    \return                 The number of nanoseconds since KOS started.
-*/
-uint64_t timer_ns_gettime64(void);
-
-/** \defgroup tmu_sleep     Sleeping
-    \brief                  Low-level thread sleeping
-    \ingroup                timers
-
-    This API provides the low-level functionality used to implement thread
-    sleeping, used by the KOS, C, C++, and POSIX threading APIs.
-*/
-
-/** \brief  Spin-loop delay function with microsecond granularity
-    \ingroup tmu_sleep
-
-    This function is meant as a very accurate delay function, even if threading
-    and interrupts are disabled. It is a delay and not a sleep, which means that
-    the CPU will be busy-looping during that time frame. For any time frame
-    bigger than a few hundred microseconds, it is recommended to sleep instead.
-
-    \param  us              The number of microseconds to wait for.
-    \sa timer_spin_delay_ns, thd_sleep
-*/
-void timer_spin_delay_us(unsigned short us);
-
-/** \brief  Spin-loop delay function with nanosecond granularity
-    \ingroup tmu_sleep
-
-    This function is meant as a very accurate delay function, even if threading
-    and interrupts are disabled. It is a delay and not a sleep, which means that
-    the CPU will be busy-looping during that time frame.
-
-    \param  ns              The number of nanoseconds to wait for.
-    \sa timer_spin_delay_us, thd_sleep
-*/
-void timer_spin_delay_ns(unsigned short ns);
-
 /** \defgroup tmu_primary   Primary Timer
     \brief                  Primary timer used by the kernel.
     \ingroup                timers
@@ -437,5 +325,6 @@ void timer_shutdown(void);
 
 __END_DECLS
 
-#endif  /* __ARCH_TIMER_H */
+#include <kos/timer.h>
 
+#endif  /* __ARCH_TIMER_H */

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -230,23 +230,6 @@ int timer_ints_enabled(int channel);
     The highest actual tick resolution of \ref TMU2 is 80ns.
 */
 
-/** \brief   Enable the millisecond timer.
-    \ingroup tmu_uptime
-
-    This function enables the timer used for the gettime functions. This is on
-    by default. These functions use \ref TMU2 to do their work.
-*/
-void timer_ms_enable(void);
-
-/** \brief   Disable the millisecond timer.
-    \ingroup tmu_uptime
-
-    This function disables the timer used for the gettime functions. Generally,
-    you will not want to do this, unless you have some need to use the timer
-    \ref TMU2 for something else.
-*/
-void timer_ms_disable(void);
-
 /** \brief   Get the current uptime of the system (in secs and millisecs).
     \ingroup tmu_uptime
 

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -230,6 +230,22 @@ int timer_ints_enabled(int channel);
     The highest actual tick resolution of \ref TMU2 is 80ns.
 */
 
+/** \brief   Structure that holds timer values in seconds + ticks. */
+typedef struct timer_value {
+    uint32_t secs;      /**< \brief Number of seconds */
+    uint32_t ticks;     /**< \brief Number of ticks in the current second */
+} timer_val_t;
+
+/** \brief   Get the current uptime of the system (in seconds and ticks).
+    \ingroup tmu_uptime
+
+    This function retrieves the number of seconds and ticks since KOS was
+    started.
+
+    \return                 The time since KOS started as a timer_val_t.
+*/
+timer_val_t __dreamcast_get_ticks(void);
+
 /** \brief   Get the current uptime of the system (in secs and millisecs).
     \ingroup tmu_uptime
 

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -34,6 +34,8 @@ __BEGIN_DECLS
 
 #include <arch/irq.h>
 
+#include <time.h>
+
 /** \defgroup timers    Timer Unit
     \brief              SH4 CPU peripheral providing timers and counters
     \ingroup            timing
@@ -245,6 +247,24 @@ typedef struct timer_value {
     \return                 The time since KOS started as a timer_val_t.
 */
 timer_val_t __dreamcast_get_ticks(void);
+
+/** \brief   Get the current uptime of the system (in seconds and nanoseconds).
+    \ingroup tmu_uptime
+
+    This function retrieves the time since KOS was started, in a standard
+    timespec format.
+
+    \return                 The time since KOS started as a struct timespec.
+*/
+static inline struct timespec arch_timer_gettime(void) {
+    timer_val_t time = __dreamcast_get_ticks();
+
+    /* Convert from ticks to nanoseconds: each clock tick is 80ns. */
+    return (struct timespec){
+        .tv_sec = time.secs,
+        .tv_nsec = time.ticks * 80,
+    };
+}
 
 /** \brief   Get the current uptime of the system (in secs and millisecs).
     \ingroup tmu_uptime

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -15,11 +15,11 @@
 #include <kos/dbglog.h>
 #include <kos/init.h>
 #include <kos/platform.h>
+#include <kos/timer.h>
 #include <arch/arch.h>
 #include <arch/irq.h>
 #include <arch/memory.h>
 #include <arch/rtc.h>
-#include <arch/timer.h>
 #include <dc/perfctr.h>
 #include <dc/ubc.h>
 #include <dc/pvr.h>

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -191,7 +191,6 @@ int  __weak_symbol arch_auto_init(void) {
 
     /* Initialize our timer */
     perf_cntr_timer_enable();
-    timer_ms_enable();
     rtc_init();
 
     thd_init();

--- a/kernel/arch/dreamcast/kernel/initall_hdrs.h
+++ b/kernel/arch/dreamcast/kernel/initall_hdrs.h
@@ -21,5 +21,5 @@
 #include <dc/sound/sound.h>
 #include <dc/scif.h>
 #include <arch/irq.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <dc/fb_console.h>

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -15,7 +15,7 @@
 #include <arch/arch.h>
 #include <arch/types.h>
 #include <arch/irq.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <arch/stack.h>
 #include <kos/dbgio.h>
 #include <kos/dbglog.h>

--- a/kernel/arch/dreamcast/kernel/perf_monitor.c
+++ b/kernel/arch/dreamcast/kernel/perf_monitor.c
@@ -4,7 +4,7 @@
    Copyright (C) 2024 Paul Cercueil
 */
 
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <dc/perf_monitor.h>
 
 extern struct perf_monitor _monitors_start, _monitors_end;

--- a/kernel/arch/dreamcast/kernel/perfctr.c
+++ b/kernel/arch/dreamcast/kernel/perfctr.c
@@ -6,7 +6,7 @@
 */
 
 #include <dc/perfctr.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <kos/cdefs.h>
 
 /* Control Registers */

--- a/kernel/arch/dreamcast/kernel/rtc.c
+++ b/kernel/arch/dreamcast/kernel/rtc.c
@@ -26,7 +26,7 @@
  */
 
 #include <arch/rtc.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <dc/g2bus.h>
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -157,24 +157,6 @@ int timer_clear(int which) {
     return !!(value & UNF);
 }
 
-/* Spin-loop kernel sleep func: uses the secondary timer in the
-   SH-4 to very accurately delay even when interrupts are disabled */
-void timer_spin_sleep(int ms) {
-    timer_prime(TMU1, 1000, 0);
-    timer_clear(TMU1);
-    timer_start(TMU1);
-
-    while(ms > 0) {
-        while(!(TIMER16(tcrs[TMU1]) & UNF))
-            ;
-
-        timer_clear(TMU1);
-        ms--;
-    }
-
-    timer_stop(TMU1);
-}
-
 void timer_spin_delay_ns(unsigned short ns) {
     uint64_t timeout = timer_ns_gettime64() + ns;
 

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -157,22 +157,6 @@ int timer_clear(int which) {
     return !!(value & UNF);
 }
 
-void timer_spin_delay_ns(unsigned short ns) {
-    uint64_t timeout = timer_ns_gettime64() + ns;
-
-    /* Note that we don't actually care about the counter overflowing.
-       Nobody will run their Dreamcast straight for 585 years. */
-    while(timer_ns_gettime64() < timeout);
-}
-
-void timer_spin_delay_us(unsigned short us) {
-    uint64_t timeout = timer_us_gettime64() + us;
-
-    /* Note that we don't actually care about the counter overflowing.
-       Nobody will run their Dreamcast straight for 584942 years. */
-    while(timer_us_gettime64() < timeout);
-}
-
 /* Enable timer interrupts; needs to move to irq.c sometime. */
 void timer_enable_ints(int which) {
     irq_set_priority(IRQ_SRC_TMU0 - which, TIMER_PRIO);
@@ -254,80 +238,6 @@ timer_val_t __dreamcast_get_ticks(void) {
     delta = timer_ms_countdown - counter2;
 
     return (timer_val_t){ .secs = secs, .ticks = delta, };
-}
-
-/* Generic function for retrieving the current time maintained by TMU2.
-   Returns the total amount of time that has elapsed since KOS has been
-   initialized by using a LUT of precomputed, scaled timing values (tns)
-   plus a shift for optimized division. */
-static timer_val_t timer_getticks(uint32_t tns, uint32_t shift) {
-    timer_val_t time = __dreamcast_get_ticks();
-
-    /* We have to do the elapsed time calculations as a 64-bit unsigned
-    integer, otherwise when using the fastest clock speed for timers,
-    this value will very quickly overflow mid-expression, before the
-    final division. */
-    time.ticks = ((uint64_t)time.ticks * tns) >> shift;
-
-    return time;
-}
-
-/* Millisecond timer */
-static const uint32_t tns_values_ms[] = {
-    /* 80, 320, 1280, 5120, 20480
-       each multiplied by (1 << 37) / (1000 * 1000) */
-    10995116, 43980465, 175921860, 703687442, 2814749767
-};
-
-void timer_ms_gettime(uint32_t *secs, uint32_t *msecs) {
-    const timer_val_t val = timer_getticks(tns_values_ms[TIMER_TPSC], 37);
-
-    if(secs)  *secs = val.secs;
-    if(msecs) *msecs = val.ticks;
-}
-
-uint64_t timer_ms_gettime64(void) {
-   const timer_val_t val = timer_getticks(tns_values_ms[TIMER_TPSC], 37);
-
-    return (uint64_t)val.secs * 1000ull + (uint64_t)val.ticks;
-}
-
-/* Microsecond timer */
-static const uint32_t tns_values_us[] = {
-    /* 80, 320, 1280, 5120, 20480,
-       each multiplied by (1 << 27) / 1000 */
-    10737418, 42949673, 171798692, 687194767, 2748779069,
-};
-
-void timer_us_gettime(uint32_t *secs, uint32_t *usecs) {
-    const timer_val_t val = timer_getticks(tns_values_us[TIMER_TPSC], 27);
-
-    if(secs)  *secs = val.secs;
-    if(usecs) *usecs = val.ticks;
-}
-
-uint64_t timer_us_gettime64(void) {
-   const timer_val_t val = timer_getticks(tns_values_us[TIMER_TPSC], 27);
-
-    return (uint64_t)val.secs * 1000000ull + (uint64_t)val.ticks;
-}
-
-/* Nanosecond timer */
-static const uint32_t tns_values_ns[] = {
-    80, 320, 1280, 5120, 20480,
-};
-
-void timer_ns_gettime(uint32_t *secs, uint32_t *nsecs) { 
-    const timer_val_t val = timer_getticks(tns_values_ns[TIMER_TPSC], 0);
-
-    if(secs)  *secs = val.secs;
-    if(nsecs) *nsecs = val.ticks;
-}
-
-uint64_t timer_ns_gettime64(void) {
-   const timer_val_t val = timer_getticks(tns_values_ns[TIMER_TPSC], 0);
-
-    return (uint64_t)val.secs * 1000000000ull + (uint64_t)val.ticks;
 }
 
 /* Primary kernel timer. What we'll do here is handle actual timer IRQs

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -214,17 +214,11 @@ static void timer_ms_enable(void) {
     timer_start(TMU2);
 }
 
-/* Internal structure used to hold timer values in seconds + ticks. */
-typedef struct timer_value {
-    uint32_t secs, ticks;
-} timer_val_t;
-
-/* Generic function for retrieving the current time maintained by TMU2. 
+/* Generic function for retrieving the current time maintained by TMU2.
    Returns the total amount of time that has elapsed since KOS has been
-   initialized by using a LUT of precomputed, scaled timing values (tns)
-   plus a shift for optimized division. */
-static timer_val_t timer_getticks(uint32_t tns, uint32_t shift) {
-    uint32_t secs, unf1, unf2, counter1, counter2, delta, ticks;
+   initialized, in seconds + ticks. */
+timer_val_t __dreamcast_get_ticks(void) {
+    uint32_t secs, unf1, unf2, counter1, counter2, delta;
     uint16_t tmu2;
 
     do {
@@ -259,13 +253,23 @@ static timer_val_t timer_getticks(uint32_t tns, uint32_t shift) {
 
     delta = timer_ms_countdown - counter2;
 
+    return (timer_val_t){ .secs = secs, .ticks = delta, };
+}
+
+/* Generic function for retrieving the current time maintained by TMU2.
+   Returns the total amount of time that has elapsed since KOS has been
+   initialized by using a LUT of precomputed, scaled timing values (tns)
+   plus a shift for optimized division. */
+static timer_val_t timer_getticks(uint32_t tns, uint32_t shift) {
+    timer_val_t time = __dreamcast_get_ticks();
+
     /* We have to do the elapsed time calculations as a 64-bit unsigned
     integer, otherwise when using the fastest clock speed for timers,
     this value will very quickly overflow mid-expression, before the
     final division. */
-    ticks = ((uint64_t)delta * tns) >> shift;
+    time.ticks = ((uint64_t)time.ticks * tns) >> shift;
 
-    return (timer_val_t){ .secs = secs, .ticks = ticks, };
+    return time;
 }
 
 /* Millisecond timer */

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -206,17 +206,12 @@ static void timer_ms_handler(irq_t source, irq_context_t *context, void *data) {
     TIMER16(tcrs[TMU2]) &= ~UNF;
 }
 
-void timer_ms_enable(void) {
+static void timer_ms_enable(void) {
     irq_set_handler(EXC_TMU2_TUNI2, timer_ms_handler, NULL);
     timer_prime(TMU2, 1, 1);
     timer_ms_countdown = timer_count(TMU2);
     timer_clear(TMU2);
     timer_start(TMU2);
-}
-
-void timer_ms_disable(void) {
-    timer_stop(TMU2);
-    timer_disable_ints(TMU2);
 }
 
 /* Internal structure used to hold timer values in seconds + ticks. */
@@ -428,6 +423,9 @@ int timer_init(void) {
 
     /* Setup the primary timer stuff */
     timer_primary_init();
+
+    /* Setup the 1 HZ timer */
+    timer_ms_enable();
 
     return 0;
 }

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -223,7 +223,7 @@ typedef struct timer_value {
    Returns the total amount of time that has elapsed since KOS has been
    initialized by using a LUT of precomputed, scaled timing values (tns)
    plus a shift for optimized division. */
-static timer_val_t timer_getticks(const uint32_t *tns, uint32_t shift) {
+static timer_val_t timer_getticks(uint32_t tns, uint32_t shift) {
     uint32_t secs, unf1, unf2, counter1, counter2, delta, ticks;
     uint16_t tmu2;
 
@@ -263,7 +263,7 @@ static timer_val_t timer_getticks(const uint32_t *tns, uint32_t shift) {
     integer, otherwise when using the fastest clock speed for timers,
     this value will very quickly overflow mid-expression, before the
     final division. */
-    ticks = ((uint64_t)delta * tns[tmu2 & TPSC]) >> shift;
+    ticks = ((uint64_t)delta * tns) >> shift;
 
     return (timer_val_t){ .secs = secs, .ticks = ticks, };
 }
@@ -276,14 +276,14 @@ static const uint32_t tns_values_ms[] = {
 };
 
 void timer_ms_gettime(uint32_t *secs, uint32_t *msecs) {
-    const timer_val_t val = timer_getticks(tns_values_ms, 37);
+    const timer_val_t val = timer_getticks(tns_values_ms[TIMER_TPSC], 37);
 
     if(secs)  *secs = val.secs;
     if(msecs) *msecs = val.ticks;
 }
 
 uint64_t timer_ms_gettime64(void) {
-   const timer_val_t val = timer_getticks(tns_values_ms, 37);
+   const timer_val_t val = timer_getticks(tns_values_ms[TIMER_TPSC], 37);
 
     return (uint64_t)val.secs * 1000ull + (uint64_t)val.ticks;
 }
@@ -296,14 +296,14 @@ static const uint32_t tns_values_us[] = {
 };
 
 void timer_us_gettime(uint32_t *secs, uint32_t *usecs) {
-    const timer_val_t val = timer_getticks(tns_values_us, 27);
+    const timer_val_t val = timer_getticks(tns_values_us[TIMER_TPSC], 27);
 
     if(secs)  *secs = val.secs;
     if(usecs) *usecs = val.ticks;
 }
 
 uint64_t timer_us_gettime64(void) {
-   const timer_val_t val = timer_getticks(tns_values_us, 27);
+   const timer_val_t val = timer_getticks(tns_values_us[TIMER_TPSC], 27);
 
     return (uint64_t)val.secs * 1000000ull + (uint64_t)val.ticks;
 }
@@ -314,14 +314,14 @@ static const uint32_t tns_values_ns[] = {
 };
 
 void timer_ns_gettime(uint32_t *secs, uint32_t *nsecs) { 
-    const timer_val_t val = timer_getticks(tns_values_ns, 0);
+    const timer_val_t val = timer_getticks(tns_values_ns[TIMER_TPSC], 0);
 
     if(secs)  *secs = val.secs;
     if(nsecs) *nsecs = val.ticks;
 }
 
 uint64_t timer_ns_gettime64(void) {
-   const timer_val_t val = timer_getticks(tns_values_ns, 0);
+   const timer_val_t val = timer_getticks(tns_values_ns[TIMER_TPSC], 0);
 
     return (uint64_t)val.secs * 1000000000ull + (uint64_t)val.ticks;
 }

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -14,7 +14,7 @@
 
 #include <kos/dbglog.h>
 #include <kos/mutex.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <dc/g2bus.h>
 #include <dc/spu.h>
 #include <dc/sound/sound.h>

--- a/kernel/arch/dreamcast/sound/snd_iface.c
+++ b/kernel/arch/dreamcast/sound/snd_iface.c
@@ -51,7 +51,7 @@ int snd_init(void) {
 
         /* Enable the AICA and give it a few ms to start up */
         spu_enable();
-        timer_spin_sleep(10);
+        thd_sleep(10);
 
         /* Initialize the RAM allocator */
         snd_mem_init(AICA_RAM_START);

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -20,7 +20,7 @@
 #include <kos/dbglog.h>
 #include <kos/mutex.h>
 #include <arch/cache.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <dc/g2bus.h>
 #include <dc/sq.h>
 #include <dc/spu.h>

--- a/kernel/arch/dreamcast/util/screenshot.c
+++ b/kernel/arch/dreamcast/util/screenshot.c
@@ -16,7 +16,7 @@
 #include <kos/fs.h>
 #include <arch/irq.h>
 
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 /*
     Provides a very simple screen shot facility (dumps raw 24bpp RGB image

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -247,7 +247,6 @@ arch_stk_trace
 arch_stk_trace_at
 
 # Timers
-timer_spin_sleep
 timer_ms_gettime
 timer_ms_gettime64
 timer_us_gettime64

--- a/kernel/libc/newlib/newlib_gettimeofday.c
+++ b/kernel/libc/newlib/newlib_gettimeofday.c
@@ -8,7 +8,7 @@
 #include <assert.h>
 #include <sys/time.h>
 #include <time.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <arch/rtc.h>
 
 /* This is kind of approximate and works only with "localtime" */

--- a/kernel/libc/newlib/newlib_times.c
+++ b/kernel/libc/newlib/newlib_times.c
@@ -11,7 +11,7 @@
 #include <stdint.h>
 #include <sys/reent.h>
 #include <sys/times.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 int _times_r(struct _reent *re, struct tms *tmsbuf) {
     (void)re;

--- a/kernel/libc/posix/clock_gettime.c
+++ b/kernel/libc/posix/clock_gettime.c
@@ -6,7 +6,7 @@
 
 #include <kos/thread.h>
 
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <arch/rtc.h>
 
 #include <time.h>

--- a/kernel/net/net_arp.c
+++ b/kernel/net/net_arp.c
@@ -14,7 +14,7 @@
 #include <kos/dbglog.h>
 #include <kos/net.h>
 #include <kos/thread.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 #include "net_ipv4.h"
 

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -23,7 +23,7 @@
 #include <kos/mutex.h>
 #include <kos/fs_socket.h>
 
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 #include "net_dhcp.h"
 #include "net_thd.h"

--- a/kernel/net/net_icmp.c
+++ b/kernel/net/net_icmp.c
@@ -16,7 +16,7 @@
 #include <kos/dbglog.h>
 #include <kos/net.h>
 #include <kos/thread.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <arpa/inet.h>
 
 #include "net_icmp.h"

--- a/kernel/net/net_icmp6.c
+++ b/kernel/net/net_icmp6.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <kos/dbglog.h>
 
 #include "net_icmp6.h"

--- a/kernel/net/net_ipv4.c
+++ b/kernel/net/net_ipv4.c
@@ -18,7 +18,7 @@
 #include <arpa/inet.h>
 #include <kos/net.h>
 #include <kos/fs_socket.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 #include "net_ipv4.h"
 #include "net_icmp.h"

--- a/kernel/net/net_ipv4_frag.c
+++ b/kernel/net/net_ipv4_frag.c
@@ -13,7 +13,7 @@
 
 #include <kos/net.h>
 #include <kos/mutex.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <arch/irq.h>
 
 #include "net_ipv4.h"

--- a/kernel/net/net_ndp.c
+++ b/kernel/net/net_ndp.c
@@ -12,7 +12,7 @@
 #include <netinet/in.h>
 #include <sys/queue.h>
 #include <kos/net.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 #include "net_ipv6.h"
 #include "net_icmp6.h"

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -21,7 +21,7 @@
 #include <kos/rwsem.h>
 #include <kos/fs_socket.h>
 
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 #include <kos/dbglog.h>
 

--- a/kernel/net/net_thd.c
+++ b/kernel/net/net_thd.c
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 #include <kos/thread.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include "net_thd.h"
 
 struct thd_cb {

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -20,7 +20,7 @@
 #include <assert.h>
 #include <errno.h>
 
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <kos/dbglog.h>
 #include <kos/genwait.h>
 #include <kos/sem.h>

--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -17,7 +17,7 @@
 #include <kos/dbglog.h>
 
 #include <arch/irq.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 
 /* Thread pseudo-ptr representing an active IRQ context. */
 #define IRQ_THREAD  ((kthread_t *)0xFFFFFFFF)

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -13,7 +13,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <reent.h>
 #include <errno.h>
 #include <stdalign.h>
@@ -750,12 +749,7 @@ static void thd_timer_hnd(irq_context_t *context) {
    threads. */
 void thd_sleep(unsigned int ms) {
     /* This should never happen. This should, perhaps, assert. */
-    if(thd_mode == THD_MODE_NONE) {
-        dbglog(DBG_WARNING, "thd_sleep called when threading not "
-               "initialized.\n");
-        timer_spin_sleep(ms);
-        return;
-    }
+    assert(thd_mode != THD_MODE_NONE);
 
     /* A timeout of zero is the same as thd_pass() and passing zero
        down to genwait_wait() causes bad juju. */

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -28,7 +28,7 @@
 #include <arch/arch.h>
 #include <arch/irq.h>
 #include <arch/stack.h>
-#include <arch/timer.h>
+#include <kos/timer.h>
 #include <arch/tls_static.h>
 
 /*


### PR DESCRIPTION
Add new arch-agnostic timer functions, that should be provided by all supported architectures.

The previous API functions are now static inlines that are built on top.

The point of this PR is to reduce the amount of code duplicated between the Dreamcast arch and the other upcoming archs.