### PR TITLE
CMake: Set default installation directories only if not defined

### DIFF
--- a/utils/cmake/dreamcast.toolchain.cmake
+++ b/utils/cmake/dreamcast.toolchain.cmake
@@ -84,7 +84,10 @@ set(CMAKE_ASM_FLAGS_RELEASE "")
 
 # Default CMake installations to install to kos-addons
 set(CMAKE_INSTALL_BINDIR     ${DC_TOOLS_BASE})
-set(CMAKE_INSTALL_INCLUDEDIR ${KOS_ADDONS}/include/${KOS_ARCH})
-set(CMAKE_INSTALL_LIBDIR     ${KOS_ADDONS}/lib/${KOS_ARCH})
-
+if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
+    set(CMAKE_INSTALL_INCLUDEDIR ${KOS_ADDONS}/include/${KOS_ARCH})
+endif()
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+    set(CMAKE_INSTALL_LIBDIR ${KOS_ADDONS}/lib/${KOS_ARCH})
+endif()
 include("${KOS_BASE}/utils/cmake/dreamcast.cmake")


### PR DESCRIPTION
The dreamcast.toolchain.cmake file was overriding user-defined CMAKE_INSTALL_INCLUDEDIR and CMAKE_INSTALL_LIBDIR values, making it impossible to customize install paths (e.g., forcing headers into include/dreamcast instead of include/dreamcast/lz4).

tested against lz4
kos-cmake -S "$SCRIPT_DIR" \
      -B "$BUILD_DIR" \
      -DCMAKE_BUILD_TYPE=Release \
      -DCMAKE_INSTALL_PREFIX="${KOS_BASE}/addons" \
      -DCMAKE_INSTALL_LIBDIR:STRING="lib/dreamcast" \
      -DCMAKE_INSTALL_INCLUDEDIR:STRING="include/dreamcast/lz4" \
      -DBUILD_SHARED_LIBS=OFF \
      -DBUILD_STATIC_LIBS=ON \
      -DLZ4_BUILD_CLI=OFF \
      -DLZ4_BUILD_LEGACY_LZ4C=OFF \
      -DCMAKE_C_FLAGS="-DLZ4_FAST_DEC_LOOP=1 -DLZ4_DISTANCE_MAX=32"
      
      