### PR TITLE
Add missing include path for architecture-specific addons

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -26,7 +26,7 @@ fi
 
 # Our includes.
 export KOS_INC_PATHS="${KOS_INC_PATHS} -I${KOS_BASE}/include \
--I${KOS_BASE}/kernel/arch/${KOS_ARCH}/include -I${KOS_BASE}/addons/include \
+-I${KOS_BASE}/kernel/arch/${KOS_ARCH}/include -I${KOS_BASE}/addons/include/ -I${KOS_BASE}/addons/include/${KOS_ARCH} \
 -I${KOS_PORTS}/include"
 
 # "System" libraries.


### PR DESCRIPTION
with the new change to kos-cmake to put addons includes into arch dependent include folder we need to add that path to the KOS environment.