### PR TITLE
Fix strided texture settings, add API and example

### DIFF
--- a/examples/dreamcast/kgl/basic/elements/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/elements/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/basic/gl/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/gl/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/basic/scissor/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/scissor/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/basic/txrenv/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/txrenv/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/basic/zclip_arrays/pvr-texture.c
+++ b/examples/dreamcast/kgl/basic/zclip_arrays/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/blur/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/blur/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/mipmap/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/mipmap/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/multitexture-arrays/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/multitexture-arrays/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/multitexture-elements/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/multitexture-elements/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/specular/pvr-texture.c
+++ b/examples/dreamcast/kgl/demos/specular/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/demos/specular/texture.c
+++ b/examples/dreamcast/kgl/demos/specular/texture.c
@@ -82,7 +82,7 @@ GLuint glTextureLoadPVR(char *fname, unsigned char UseMipMap) {
             break;//RECTANGLE
 
         case 0x0B:
-            texFormat = PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;
+            texFormat = PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;
             break;//RECTANGULAR STRIDE
 
         case 0x0D:

--- a/examples/dreamcast/kgl/nehe/nehe06/pvr-texture.c
+++ b/examples/dreamcast/kgl/nehe/nehe06/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/nehe/nehe08/pvr-texture.c
+++ b/examples/dreamcast/kgl/nehe/nehe08/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/nehe/nehe09/pvr-texture.c
+++ b/examples/dreamcast/kgl/nehe/nehe09/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/kgl/nehe/nehe16/pvr-texture.c
+++ b/examples/dreamcast/kgl/nehe/nehe16/pvr-texture.c
@@ -134,7 +134,7 @@ static GLuint PVR_TextureFormat(unsigned char *HDR) {
             return PVR_TXRFMT_NONTWIDDLED;                        //RECTANGLE
 
         case 0x0B:
-            return PVR_TXRFMT_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
+            return PVR_TXRFMT_X32_STRIDE | PVR_TXRFMT_NONTWIDDLED;    //RECTANGULAR STRIDE
 
         case 0x0D:
             return PVR_TXRFMT_TWIDDLED;                           //RECTANGULAR TWIDDLED

--- a/examples/dreamcast/pvr/fb_tex/fb_tex.c
+++ b/examples/dreamcast/pvr/fb_tex/fb_tex.c
@@ -7,10 +7,6 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-/* XXX: KallistiOS has the wrong value for the stride bit. */
-#undef PVR_TXRFMT_STRIDE
-#define PVR_TXRFMT_STRIDE BIT(25)
-
 #define SQUARE_SIZE 64
 
 struct square_fcoords {
@@ -157,7 +153,7 @@ static void render_back_buffer_step2(pvr_ptr_t frontbuf, bool hi_chip) {
     float uoffset;
 
     pvr_poly_cxt_txr(&cxt, PVR_LIST_TR_POLY,
-                     PVR_TXRFMT_RGB565 | PVR_TXRFMT_NONTWIDDLED | PVR_TXRFMT_STRIDE,
+                     PVR_TXRFMT_RGB565 | PVR_TXRFMT_NONTWIDDLED | PVR_TXRFMT_X32_STRIDE,
                      1024, 1024, frontbuf, PVR_FILTER_NEAREST);
 
     if(fbuf_color == 0xffffffff) {

--- a/examples/dreamcast/pvr/fb_tex/fb_tex.c
+++ b/examples/dreamcast/pvr/fb_tex/fb_tex.c
@@ -200,9 +200,8 @@ int main(int argc, char **argv) {
 
     pvr_init_defaults();
 
-    /* Set the stride length for strided textures.
-     * Unit is a set of 32 pixels, hence the /32. */
-    PVR_SET(PVR_TEXTURE_MODULO, 640 / 32);
+    /* Set the stride length for strided textures. */
+    pvr_txr_set_stride(640);
 
     fake_tex = pvr_mem_malloc(sizeof(fake_tex_data));
     pvr_txr_load(fake_tex_data, fake_tex, sizeof(fake_tex_data));

--- a/examples/dreamcast/pvr/strided_texture/Makefile
+++ b/examples/dreamcast/pvr/strided_texture/Makefile
@@ -1,0 +1,27 @@
+#
+# strided_texture
+# Copyright (C) 2024 Andress Barajas
+#
+
+TARGET = strided_texture.elf
+OBJS = strided_texture.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist: $(TARGET)
+	-rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/pvr/strided_texture/strided_texture.c
+++ b/examples/dreamcast/pvr/strided_texture/strided_texture.c
@@ -1,0 +1,221 @@
+/* KallistiOS ##version##
+   strided_texture.c
+   Copyright (C) 2024 Andress Barajas
+*/
+
+/*
+    This example demonstrates rendering a black-and-white chessboard pattern
+    using a 640x480 texture with 16bpp color depth. In this example, the texture
+    width and stride are both set to 640. However, because 640 is not a power
+    of two, we need to use the `PVR_TXRFMT_X32_STRIDE` flag. This flag informs the
+    PVR that the texture's width (or "stride") is a multiple of 32 rather than
+    a power of two.
+    Steps to configure and render a texture with a 32-pixel multiple width:
+
+    1. Configure the Polygon Header for Textures:
+
+       - Use `pvr_poly_cxt_txr()` to set up the polygon context for the texture.
+       - Specify `PVR_TXRFMT_NONTWIDDLED | PVR_TXRFMT_X32_STRIDE` in the format
+         flags.
+       - Provide dimensions in powers of two, which should be larger than the
+         actual texture. For example, if your texture is 640x480, set width and
+         height to `1024` and `512`, respectively.
+       Example:
+           ```c
+           pvr_poly_cxt_txr(&cxt, PVR_LIST_OP_POLY,
+                            PVR_TXRFMT_RGB565 | PVR_TXRFMT_NONTWIDDLED |
+                            PVR_TXRFMT_X32_STRIDE, 1024, 512,
+                            texture_pointer, PVR_FILTER_NONE);
+           ```
+    2. Set the Global Texture Stride Register:
+       - Use `pvr_txr_set_stride(texture_width);` to define a custom texture
+         stride width in increments of 32 pixels.
+       - The `texture_width` parameter should be the full width of the texture
+         in pixels.
+       - This setting instructs the hardware on how to interpret each row's
+         width in VRAM for non-power-of-two textures. For a 640-pixel wide
+         texture, you would call:
+
+           ```c
+           pvr_txr_set_stride(640);
+           ```
+    Important Notes:
+       - Texture widths that are multiples of 32 (but not powers of two) require
+         the `PVR_TXRFMT_X32_STRIDE` flag.
+       - Palette-based textures are incompatible with the `PVR_TXRFMT_X32_STRIDE`
+         flag, as are mipmaps as both require the texture format to be twiddled.
+       - `pvr_txr_set_stride()` sets a global PVR register. All textures using
+         the `PVR_TXRFMT_X32_STRIDE` flag in the same frame must share the same
+         stride. Changing `pvr_txr_set_stride()` affects all such textures
+         rendered afterward.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
+
+#include <dc/pvr.h>
+#include <dc/maple.h>
+#include <dc/maple/controller.h>
+
+/* The width of the texture in pixels (must be a multiple of 32) */
+#define TEXTURE_WIDTH    640
+
+/* The height of the texture in pixels */
+#define TEXTURE_HEIGHT   480
+
+/*
+   Macro to calculate the next power of two for a given integer `x`.
+
+   Example:
+     NEXT_POWER_OF_TWO(640) -> 1024
+*/
+#define NEXT_POWER_OF_TWO(x)    (1 << (32 - __builtin_clz((x) - 1)))
+
+/*
+   The power-of-two width to be passed to texture setup functions.
+   Based on TEXTURE_WIDTH, this should be equal to or greater than
+   TEXTURE_WIDTH, and will match the hardware requirement for
+   power-of-two texture dimensions.
+*/
+#define TEXTURE_PADDED_WIDTH    NEXT_POWER_OF_TWO(TEXTURE_WIDTH)
+
+/*
+   The power-of-two height to be passed to texture setup functions.
+   Based on TEXTURE_HEIGHT, this should be equal to or greater than
+   TEXTURE_HEIGHT, following the power-of-two requirement.
+*/
+#define TEXTURE_PADDED_HEIGHT   NEXT_POWER_OF_TWO(TEXTURE_HEIGHT)
+
+/* RGB565 colors for chessboard pattern */
+#define COLOR_BLACK   0x0000
+#define COLOR_WHITE   0xFFFF
+
+static pvr_poly_hdr_t hdr;
+static pvr_vertex_t verts[4];
+
+static pvr_ptr_t board_texture;
+
+static void draw_frame(void) {
+    pvr_wait_ready();
+    pvr_scene_begin();
+
+    pvr_list_begin(PVR_LIST_OP_POLY);
+
+    pvr_prim(&hdr, sizeof(hdr));
+
+    pvr_prim(&verts[0], sizeof(pvr_vertex_t));
+    pvr_prim(&verts[1], sizeof(pvr_vertex_t));
+    pvr_prim(&verts[2], sizeof(pvr_vertex_t));
+    pvr_prim(&verts[3], sizeof(pvr_vertex_t));
+
+    pvr_list_finish();
+    pvr_scene_finish();
+}
+
+static void load_texture(void) {
+    pvr_poly_cxt_t cxt;
+    uint16_t *grid_texture;
+
+    /* Allocate memory for the texture with 32-byte alignment */
+    grid_texture = (uint16_t *)aligned_alloc(32, TEXTURE_WIDTH * TEXTURE_HEIGHT * 2);
+
+    /* Generate a chessboard pattern */
+    for(int y = 0; y < TEXTURE_HEIGHT; y++) {
+        for(int x = 0; x < TEXTURE_WIDTH; x++) {
+            /* Determine if we are in an even or odd square. */
+            int square_x = x / 32;
+            int square_y = y / 32;
+            int is_white_square = (square_x + square_y) % 2;
+
+            grid_texture[y * TEXTURE_WIDTH + x] = is_white_square
+                                    ? COLOR_WHITE : COLOR_BLACK;
+        }
+    }
+
+    /* Allocate space in VRAM for the texture */
+    board_texture = pvr_mem_malloc(TEXTURE_WIDTH * TEXTURE_HEIGHT * 2);
+
+    /* Load the chessboard pattern into VRAM */
+    pvr_txr_load(grid_texture, board_texture,
+                 TEXTURE_WIDTH * TEXTURE_HEIGHT * 2);
+
+    /* Set texture context format for nontwiddled, strided texture */
+    pvr_poly_cxt_txr(&cxt, PVR_LIST_OP_POLY,
+                     PVR_TXRFMT_RGB565 | PVR_TXRFMT_NONTWIDDLED
+                     | PVR_TXRFMT_X32_STRIDE, TEXTURE_PADDED_WIDTH,
+                     TEXTURE_PADDED_HEIGHT, board_texture, PVR_FILTER_NONE);
+    pvr_poly_compile(&hdr, &cxt);
+
+    /* Set the global non-power-of-two stride register */
+    pvr_txr_set_stride(TEXTURE_WIDTH);
+
+    free(grid_texture);
+}
+
+/*
+   When setting up the vertices, the texture width (stride) is divided by
+   the padded texture width (and similarly for the height) to ensure that
+   the non-power-of-two dimensions are mapped correctly to the power-of-two
+   padded dimensions used in VRAM. This allows textures with non-standard
+   widths (e.g., multiples of 32) to render accurately on the Dreamcast's
+   PVR hardware.
+*/
+static void setup_vertices(void) {
+    int color = PVR_PACK_COLOR(1.0f, 1.0f, 1.0f, 1.0f);
+
+    verts[0].x = 0.0f;
+    verts[0].y = 0.0f;
+    verts[0].z = 1.0f;
+    verts[0].u = 0.0f;
+    verts[0].v = 0.0f;
+    verts[0].argb = color;
+    verts[0].oargb = 0;
+    verts[0].flags = PVR_CMD_VERTEX;
+
+    verts[1].x = 640.0f;
+    verts[1].y = 0.0f;
+    verts[1].z = 1.0f;
+    verts[1].u = (float)TEXTURE_WIDTH / (float)TEXTURE_PADDED_WIDTH;
+    verts[1].v = 0.0f;
+    verts[1].argb = color;
+    verts[1].oargb = 0;
+    verts[1].flags = PVR_CMD_VERTEX;
+
+    verts[2].x = 0.0f;
+    verts[2].y = 480.0f;
+    verts[2].z = 1.0f;
+    verts[2].u = 0.0f;
+    verts[2].v = (float)TEXTURE_HEIGHT / (float)TEXTURE_PADDED_HEIGHT;
+    verts[2].argb = color;
+    verts[2].oargb = 0;
+    verts[2].flags = PVR_CMD_VERTEX;
+
+    verts[3].x = 640.0f;
+    verts[3].y = 480.0f;
+    verts[3].z = 1.0f;
+    verts[3].u = (float)TEXTURE_WIDTH / (float)TEXTURE_PADDED_WIDTH;
+    verts[3].v = (float)TEXTURE_HEIGHT / (float)TEXTURE_PADDED_HEIGHT;
+    verts[3].argb = color;
+    verts[3].oargb = 0;
+    verts[3].flags = PVR_CMD_VERTEX_EOL;
+}
+
+int main(int argc, char **argv) {
+
+    pvr_init_defaults();
+
+    /* If the user hits start, bail */
+    cont_btn_callback(0, CONT_START, (cont_btn_callback_t)exit);
+
+    load_texture();
+
+    setup_vertices();
+
+    draw_frame();
+
+    /* Wait for exit */
+    for(;;) { }
+
+    return 0;
+}

--- a/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
@@ -145,8 +145,6 @@ static int setup_pvr(void) {
                     PVR_FILTER_BILINEAR);
     pvr_poly_compile(&hdr, &cxt);
 
-    hdr.mode3 |= PVR_TXRFMT_STRIDE;
-
     vert[0].z     = vert[1].z     = vert[2].z     = vert[3].z     = 1.0f; 
     vert[0].argb  = vert[1].argb  = vert[2].argb  = vert[3].argb  = 
         PVR_PACK_COLOR(1.0f, 1.0f, 1.0f, 1.0f);    

--- a/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV422/yuv422.c
@@ -144,8 +144,6 @@ static int setup_pvr(void) {
                     PVR_FILTER_BILINEAR);
     pvr_poly_compile(&hdr, &cxt);
 
-    hdr.mode3 |= PVR_TXRFMT_STRIDE;
-
     vert[0].z     = vert[1].z     = vert[2].z     = vert[3].z     = 1.0f; 
     vert[0].argb  = vert[1].argb  = vert[2].argb  = vert[3].argb  = 
         PVR_PACK_COLOR(1.0f, 1.0f, 1.0f, 1.0f);    

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_texture.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_texture.c
@@ -43,12 +43,9 @@ size_t pvr_txr_get_stride(void) {
 }
 
 /* Load raw texture data from an SH-4 buffer into PVR RAM */
-void pvr_txr_load(const void *src, pvr_ptr_t dst, uint32 count) {
-    if(count & 3) {
-        count = (count + 4) & ~3;
-    }
-
-    pvr_sq_load((uint32 *)dst, (const uint32 *)src, count, PVR_DMA_VRAM64);
+void pvr_txr_load(const void *src, pvr_ptr_t dst, size_t count) {
+    count = __align_up(count, 4);
+    pvr_sq_load((uint32_t *)dst, (const uint32_t *)src, count, PVR_DMA_VRAM64);
 }
 
 /* Linear/iterative twiddling algorithm from Marcus' tatest */
@@ -75,9 +72,9 @@ void pvr_txr_load(const void *src, pvr_ptr_t dst, uint32 count) {
        PVR_TXRLOAD_INVERT
 
 */
-void pvr_txr_load_ex(const void *src, pvr_ptr_t dst, uint32 w, uint32 h,
-                     uint32 flags) {
-    uint32 x, y, yout, min, mask, bpp, invert;
+void pvr_txr_load_ex(const void *src, pvr_ptr_t dst, uint32_t w, uint32_t h,
+                     uint32_t flags) {
+    uint32_t x, y, yout, min, mask, bpp, invert;
 
     /* Make sure we're attempting something we can do */
     switch(flags & PVR_TXRLOAD_FMT_MASK) {
@@ -103,10 +100,10 @@ void pvr_txr_load_ex(const void *src, pvr_ptr_t dst, uint32 w, uint32 h,
 
     switch(bpp) {
         case 4: {
-            uint8 * pixels;
-            uint16 * vtex;
-            pixels = (uint8 *) src;
-            vtex = (uint16*)dst;
+            uint8_t * pixels;
+            uint16_t * vtex;
+            pixels = (uint8_t *) src;
+            vtex = (uint16_t *)dst;
 
             for(y = 0; y < h; y += 2) {
                 if(!invert)
@@ -124,10 +121,10 @@ void pvr_txr_load_ex(const void *src, pvr_ptr_t dst, uint32 w, uint32 h,
         }
         break;
         case 8: {
-            uint8 * pixels;
-            uint16 * vtex;
-            pixels = (uint8 *) src;
-            vtex = (uint16*)dst;
+            uint8_t * pixels;
+            uint16_t * vtex;
+            pixels = (uint8_t *) src;
+            vtex = (uint16_t *)dst;
 
             for(y = 0; y < h; y += 2) {
                 if(!invert)
@@ -144,10 +141,10 @@ void pvr_txr_load_ex(const void *src, pvr_ptr_t dst, uint32 w, uint32 h,
         }
         break;
         case 16: {
-            uint16 * pixels;
-            uint16 * vtex;
-            pixels = (uint16 *) src;
-            vtex = (uint16*)dst;
+            uint16_t * pixels;
+            uint16_t * vtex;
+            pixels = (uint16_t *) src;
+            vtex = (uint16_t *)dst;
 
             for(y = 0; y < h; y++) {
                 if(!invert)
@@ -166,8 +163,8 @@ void pvr_txr_load_ex(const void *src, pvr_ptr_t dst, uint32 w, uint32 h,
 }
 
 /* Load a KOS Platform Independent Image (subject to restraint checking) */
-void pvr_txr_load_kimg(const kos_img_t *img, pvr_ptr_t dst, uint32 flags) {
-    uint32 fmt, w, h;
+void pvr_txr_load_kimg(const kos_img_t *img, pvr_ptr_t dst, uint32_t flags) {
+    uint32_t fmt, w, h;
 
     /* First check and make sure it's a format we can use */
     fmt = KOS_IMG_FMT_I(img->fmt) & KOS_IMG_FMT_MASK;

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -508,8 +508,12 @@ typedef struct {
 #define PVR_TXRFMT_PAL8BPP      (6 << 27)   /**< \brief 8BPP paletted format */
 #define PVR_TXRFMT_TWIDDLED     (0 << 26)   /**< \brief Texture is twiddled */
 #define PVR_TXRFMT_NONTWIDDLED  (1 << 26)   /**< \brief Texture is not twiddled */
-#define PVR_TXRFMT_NOSTRIDE     (0 << 21)   /**< \brief Texture is not strided */
-#define PVR_TXRFMT_STRIDE       (1 << 21)   /**< \brief Texture is strided */
+#define PVR_TXRFMT_POW2_STRIDE  (0 << 25)   /**< \brief Stride is a power-of-two */
+#define PVR_TXRFMT_X32_STRIDE   (1 << 25)   /**< \brief Stride is multiple of 32 */
+
+/* Compat. */
+static const uint32_t PVR_TXRFMT_NOSTRIDE   __depr("Please use PVR_TXRFMT_POW2_STRIDE.") = PVR_TXRFMT_POW2_STRIDE;
+static const uint32_t PVR_TXRFMT_STRIDE     __depr("Please use PVR_TXRFMT_X32_STRIDE. Note this may cause breakage as PVR_TXRFMT_STRIDE was never working correctly." ) = PVR_TXRFMT_X32_STRIDE;
 
 /* OR one of these into your texture format if you need it. Note that
    these coincide with the twiddled/stride bits, so you can't have a

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
@@ -210,6 +210,13 @@ __BEGIN_DECLS
 #define PVR_TA_INIT_GO      0x80000000  /**< \brief Write to the PVR_TA_INIT register to confirm settings */
 /** @} */
 
+/** \defgroup pvr_tex_mod   PVR_TEXTURE_MODULO Values
+    \brief                  Definitions for the contents of the PVR_TEXTURE_MODULO register.
+    \ingroup                pvr_registers
+    @{
+*/
+#define PVR_TXR_STRIDE_MULT GENMASK(4, 0)   /**< \brief Bottom 5 bits contain the size when using PVR_TXRFMT_X32_STRIDE */
+/** @} */
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_txr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_txr.h
@@ -93,7 +93,7 @@ size_t pvr_txr_get_stride(void);
     \param  count           The size of the texture in bytes (must be a multiple
                             of 32).
 */
-void pvr_txr_load(const void *src, pvr_ptr_t dst, uint32_t count);
+void pvr_txr_load(const void *src, pvr_ptr_t dst, size_t count);
 
 /** \defgroup pvr_txrload_constants     Flags
     \brief                              Texture loading constants

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_txr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_txr.h
@@ -5,6 +5,7 @@
    Copyright (C) 2014 Lawrence Sebald
    Copyright (C) 2023 Ruslan Rostovtsev
    Copyright (C) 2024 Falco Girgis
+   Copyright (C) 2024 Andress Barajas
 */
 
 /** \file       dc/pvr/pvr_txr.h
@@ -24,6 +25,7 @@
 #ifndef __DC_PVR_PVR_TEXTURE_H
 #define __DC_PVR_PVR_TEXTURE_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <sys/cdefs.h>
@@ -37,6 +39,48 @@ __BEGIN_DECLS
     
     Helper functions for handling texture tasks of various kinds.
 */
+
+/** \brief   Set the global stride width for non-power-of-two textures in PVR RAM.
+    \ingroup pvr_txr_mgmt
+
+    This function configures the register `PVR_TEXTURE_MODULO`, whose
+    first five bits define the row width in VRAM for non-power-of-two
+    textures. The setting applies to all textures rendered with the
+    `PVR_TXRFMT_X32_STRIDE` flag in the same frame.
+
+    The stride width configured here is **only supported for textures
+    with widths that are multiples of 32 pixels** and up to a maximum
+    of 992 pixels.
+
+    \warning
+    - Textures that are twiddled cannot use the `PVR_TXRFMT_X32_STRIDE`
+      flag so the stride set here will not apply to them. This includes
+      all paletted and mipmap textures.
+
+    \param  texture_width   The width of the texture in pixels. Must be a
+                            multiple of 32 and up to 992 pixels.
+
+    \sa pvr_txr_get_stride()
+*/
+void pvr_txr_set_stride(size_t texture_width);
+
+/** \brief   Get the current texture stride width in pixels as set in the PVR.
+    \ingroup pvr_txr_mgmt
+
+    This function reads the `PVR_TEXTURE_MODULO` register and calculates the
+    texture stride width in pixels. The value returned is the width in pixels
+    that has been configured for all textures using the `PVR_TXRFMT_X32_STRIDE`
+    flag in the same frame.
+
+    The stride width is computed by taking the current multiplier in
+    `PVR_TEXTURE_MODULO` (which stores the width divided by 32), and
+    multiplying it back by 32 to return the full width in pixels.
+
+    \return                 The current texture stride width in pixels.
+                            Or 0 if not set
+    \sa pvr_txr_set_stride()
+*/
+size_t pvr_txr_get_stride(void);
 
 /** \brief   Load raw texture data from an SH-4 buffer into PVR RAM.
     \ingroup pvr_txr_mgmt 


### PR DESCRIPTION
This PR recreates the changes from #836 . Key differences are that there is no renaming here of the PVR register used for the global setting, the functions are being added to different files due to refactoring that has happened between then and now, some of the descriptions have been changed to emphasize these only can apply to non-twiddled textures, and compatibility consts have been provided for the old define flag names.