### PR TITLE
`fs_romdisk` cleanup and dynamic file table

### DIFF
--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -50,9 +50,9 @@
 #define __KOS_FS_ROMDISK_H
 
 #include <sys/cdefs.h>
+#include <stdint.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <kos/fs.h>
 
 /** \defgroup vfs_romdisk   Romdisk
@@ -89,7 +89,7 @@ void fs_romdisk_shutdown(void);
     \retval -2              If img is invalid
     \retval -3              If a malloc fails
 */
-int fs_romdisk_mount(const char * mountpoint, const uint8 *img, int own_buffer);
+int fs_romdisk_mount(const char * mountpoint, const uint8_t *img, int own_buffer);
 
 /** \brief  Unmount a ROMFS image.
 

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -50,6 +50,7 @@
 #define __KOS_FS_ROMDISK_H
 
 #include <sys/cdefs.h>
+#include <stdbool.h>
 #include <stdint.h>
 __BEGIN_DECLS
 
@@ -81,22 +82,22 @@ void fs_romdisk_shutdown(void);
 
     \param  mountpoint      The directory to mount this romdisk on
     \param  img             The ROMFS image
-    \param  own_buffer      If 0, you are still responsible for img, and must
-                            free it if appropriate. If non-zero, img will be
+    \param  own_buffer      If false, you are still responsible for img, and
+                            must free it if appropriate. If true, img will be
                             freed when it is unmounted
     \retval 0               On success
     \retval -1              If fs_romdisk_init not called
     \retval -2              If img is invalid
     \retval -3              If a malloc fails
 */
-int fs_romdisk_mount(const char * mountpoint, const uint8_t *img, int own_buffer);
+int fs_romdisk_mount(const char * mountpoint, const uint8_t *img, bool own_buffer);
 
 /** \brief  Unmount a ROMFS image.
 
     This function unmounts a ROMFS image that has been previously mounted with
     fs_romdisk_mount(). This function does not check for open files on the fs,
     so make sure that all files have been closed before calling it. If the VFS
-    owns the buffer (own_buffer was non-zero when you called the mount function)
+    owns the buffer (own_buffer was true when you called the mount function)
     then this function will also free the buffer.
 
     \param  mountpoint      The ROMFS to unmount

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -114,16 +114,6 @@ __BEGIN_DECLS
 #define VMUFS_DEBUG 1
 #endif
 
-/** \brief  The maximum number of cd files that can be open at a time. */
-#ifndef FS_CD_MAX_FILES
-#define FS_CD_MAX_FILES 8
-#endif
-
-/** \brief  The maximum number of romdisk files that can be open at a time. */
-#ifndef FS_ROMDISK_MAX_FILES
-#define FS_ROMDISK_MAX_FILES 16
-#endif
-
 /** \brief  The maximum number of ramdisk files that can be open at a time. */
 #ifndef FS_RAMDISK_MAX_FILES
 #define FS_RAMDISK_MAX_FILES 8

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -107,7 +107,7 @@ void vmu_fs_shutdown(void) {
 
 /* Mount the built-in romdisk to /rd. */
 void fs_romdisk_mount_builtin(void) {
-    fs_romdisk_mount("/rd", __kos_romdisk, 0);
+    fs_romdisk_mount("/rd", __kos_romdisk, false);
 }
 
 void fs_romdisk_mount_builtin_legacy(void) {

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -83,7 +83,7 @@ typedef LIST_HEAD(rdi_list, rd_image) rdi_list_t;
 typedef struct rd_image {
     LIST_ENTRY(rd_image) list_ent;  /* List entry */
 
-    int                 own_buffer; /* Do we own the memory? */
+    bool                own_buffer; /* Do we own the memory? */
     const uint8_t       *image;     /* The actual image */
     const romdisk_hdr_t *hdr;       /* Pointer to the header */
     uint32_t            files;      /* Offset in the image to the files area */
@@ -681,10 +681,10 @@ void fs_romdisk_shutdown(void) {
 
 /* Mount a romdisk image; must have called fs_romdisk_init() earlier.
    Also note that we do _not_ take ownership of the image data if
-   own_buffer is 0, so if you malloc'd that buffer, you must
-   also free it after the unmount. If own_buffer is non-zero, then
+   own_buffer is false, so if you malloc'd that buffer, you must
+   also free it after the unmount. If own_buffer is true, then
    we free the buffer when it is unmounted. */
-int fs_romdisk_mount(const char *mountpoint, const uint8_t *img, int own_buffer) {
+int fs_romdisk_mount(const char *mountpoint, const uint8_t *img, bool own_buffer) {
     const romdisk_hdr_t *hdr;
     rd_image_t          *mnt;
     vfs_handler_t       *vfsh;

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -667,6 +667,7 @@ void fs_romdisk_init(void) {
 /* De-init the file system; also unmounts any mounted images. */
 void fs_romdisk_shutdown(void) {
     rd_image_t  *n, *c;
+    rd_fd_t     *i, *j;
 
     if(!initted)
         return;
@@ -676,6 +677,11 @@ void fs_romdisk_shutdown(void) {
     /* Go through and free all the romdisk mount entries */
     LIST_FOREACH_SAFE(c, &romdisks, list_ent, n) {
         fs_romdisk_list_remove(c);
+    }
+
+    /* Iterate through any dangling files and clean them */
+    TAILQ_FOREACH_SAFE(i, &rd_fd_queue, next, j) {
+        romdisk_close(i);
     }
 
     mutex_unlock(&fh_mutex);

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -200,16 +200,12 @@ static uint32_t romdisk_find(rd_image_t *mnt, const char *fn, bool dir) {
     }
 
     /* Locate the file in the resulting directory */
-    if(*fn) {
-        i = romdisk_find_object(mnt, fn, strlen(fn), dir, i);
+    if(*fn)
+        return romdisk_find_object(mnt, fn, strlen(fn), dir, i);
+    else if(!dir)
+        return 0;
+    else
         return i;
-    }
-    else {
-        if(!dir)
-            return 0;
-        else
-            return i;
-    }
 }
 
 /* Open a file or directory */


### PR DESCRIPTION
First off, dynamic file table allocation now following the effort in #973 . A TAILQ list holds fd objects and we pass out pointers to them rather than indexes into a table.

For the cleanups:
- Replaced all arch/types with stdint.
- Removed an unneeded param from the fd object.
- A number of refactorings.

Each change is well split out. Tried to have the refactors streamline some of the pieces that would need to change.