### PR TITLE
Elf cleanup

### DIFF
--- a/include/kos/elf.h
+++ b/include/kos/elf.h
@@ -26,6 +26,7 @@ __BEGIN_DECLS
 
 #include <stdint.h>
 #include <sys/queue.h>
+#include <kos/regfield.h>
 
 /** \defgroup elf   ELF File Format
     \brief          API for loading and managing ELF files
@@ -124,9 +125,16 @@ typedef struct elf_hdr {
 #define SHT_NOTE        7       /**< \brief Notes section */
 #define SHT_NOBITS      8       /**< \brief A section that occupies no space in
 the file */
-#define SHT_REL         9       /**< \brief Relocation table, no addends */
-#define SHT_SHLIB       10      /**< \brief Reserved */
-#define SHT_DYNSYM      11      /**< \brief Dynamic-only sym tab */
+#define SHT_REL             9   /**< \brief Relocation table, no addends */
+#define SHT_SHLIB           10  /**< \brief Reserved */
+#define SHT_DYNSYM          11  /**< \brief Dynamic linker symbol table */
+#define SHT_INIT_ARRAY      14  /**< \brief Array of constructors */
+#define SHT_FINI_ARRAY      15  /**< \brief Array of destructors */
+#define SHT_PREINIT_ARRAY   16  /**< \brief Array of pre-constructors */
+#define SHT_GROUP           17  /**< \brief Section group */
+#define SHT_SYMTAB_SHNDX    18  /**< \brief Extended section indices */
+#define SHT_NUM             19  /**< \brief Number of defined types.  */
+
 #define SHT_LOPROC  0x70000000  /**< \brief Start of processor specific types */
 #define SHT_HIPROC  0x7fffffff  /**< \brief End of processor specific types */
 #define SHT_LOUSER  0x80000000  /**< \brief Start of program specific types */
@@ -142,9 +150,15 @@ the file */
 
     @{
 */
-#define SHF_WRITE       1           /**< \brief Writable data */
-#define SHF_ALLOC       2           /**< \brief Resident */
-#define SHF_EXECINSTR   4           /**< \brief Executable instructions */
+#define SHF_WRITE       BIT(0)      /**< \brief Writable data */
+#define SHF_ALLOC       BIT(1)      /**< \brief Resident */
+#define SHF_EXECINSTR   BIT(2)      /**< \brief Executable instructions */
+#define SHF_MERGE       BIT(4)      /**< \brief Might be merged */
+#define SHF_STRINGS     BIT(5)      /**< \brief Contains nul-terminated strings */
+#define SHF_INFO_LINK   BIT(6)      /**< \brief `sh_info' contains SHT index */
+#define SHF_LINK_ORDER  BIT(7)      /**< \brief Preserve order after combining */
+#define SHF_GROUP       BIT(9)      /**< \brief Section is member of a group.  */
+#define SHF_TLS         BIT(10)     /**< \brief Section hold thread-local data.  */
 #define SHF_MASKPROC    0xf0000000  /**< \brief Processor specific mask */
 /** @} */
 
@@ -373,5 +387,5 @@ void elf_free(elf_prog_t *prog);
 
 __END_DECLS
 
-#endif  /* __OS_ELF_H */
+#endif  /* __KOS_ELF_H */
 

--- a/include/kos/elf.h
+++ b/include/kos/elf.h
@@ -40,7 +40,7 @@ __BEGIN_DECLS
 
     \headerfile kos/elf.h
 */
-struct elf_hdr_t {
+typedef struct elf_hdr {
     uint8_t  ident[16];   /**< \brief ELF identifier */
     uint16_t type;        /**< \brief ELF file type */
     uint16_t machine;     /**< \brief ELF file architecture */
@@ -55,7 +55,7 @@ struct elf_hdr_t {
     uint16_t shentsize;   /**< \brief Section header entry size */
     uint16_t shnum;       /**< \brief Section header entry count */
     uint16_t shstrndx;    /**< \brief String table section index */
-};
+} elf_hdr_t;
 
 /** \defgroup elf_archs                 Architecture Types
     \brief                              Relevant ELF architecture type codes
@@ -132,7 +132,7 @@ the file */
 
     \headerfile kos/elf.h
 */
-struct elf_shdr_t {
+typedef struct elf_shdr {
     uint32_t name;        /**< \brief Index into string table */
     uint32_t type;        /**< \brief Section type \see elf_sections */
     uint32_t flags;       /**< \brief Section flags \see elf_hdrflags */
@@ -143,7 +143,7 @@ struct elf_shdr_t {
     uint32_t info;        /**< \brief Section header extra info */
     uint32_t addralign;   /**< \brief Alignment constraints */
     uint32_t entsize;     /**< \brief Fixed-size table entry sizes */
-};
+} elf_shdr_t;
 /* Link and info fields:
 
 switch (sh_type) {
@@ -204,14 +204,14 @@ switch (sh_type) {
 
     \headerfile kos/elf.h
 */
-struct elf_sym_t {
+typedef struct elf_sym {
     uint32_t name;        /**< \brief Index into file's string table */
     uint32_t value;       /**< \brief Value of the symbol */
     uint32_t size;        /**< \brief Size of the symbol */
     uint8_t  info;        /**< \brief Symbol type and binding */
     uint8_t  other;       /**< \brief 0. Holds no meaning. */
     uint16_t shndx;       /**< \brief Section index */
-};
+} elf_sym_t;
 
 /** \brief   Retrieve the binding type for a symbol.
     \ingroup elf
@@ -240,11 +240,11 @@ struct elf_sym_t {
 
     \headerfile kos/elf.h
 */
-struct elf_rela_t {
+typedef struct elf_rela {
     uint32_t offset;      /**< \brief Offset within section */
     uint32_t info;        /**< \brief Symbol and type */
     int32_t  addend;      /**< \brief Constant addend for the symbol */
-};
+} elf_rela_t;
 
 /** \brief   ELF Relocation entry (without explicit addend).
     \ingroup elf
@@ -255,10 +255,10 @@ struct elf_rela_t {
 
     \headerfile kos/elf.h
 */
-struct elf_rel_t {
+typedef struct elf_rel {
     uint32_t      offset;     /**< \brief Offset within section */
     uint32_t      info;       /**< \brief Symbol and type */
-};
+} elf_rel_t;
 
 /** \defgroup elf_reltypes              Relocation Types
     \brief                              ELF relocation type values

--- a/include/kos/elf.h
+++ b/include/kos/elf.h
@@ -25,7 +25,6 @@
 __BEGIN_DECLS
 
 #include <stdint.h>
-#include <arch/types.h>
 #include <sys/queue.h>
 
 /** \defgroup elf   ELF File Format
@@ -42,20 +41,20 @@ __BEGIN_DECLS
     \headerfile kos/elf.h
 */
 struct elf_hdr_t {
-    uint8 ident[16];    /**< \brief ELF identifier */
-    uint16 type;        /**< \brief ELF file type */
-    uint16 machine;     /**< \brief ELF file architecture */
-    uint32 version;     /**< \brief Object file version */
-    uint32 entry;       /**< \brief Entry point */
-    uint32 phoff;       /**< \brief Program header offset */
-    uint32 shoff;       /**< \brief Section header offset */
-    uint32 flags;       /**< \brief Processor flags */
-    uint16 ehsize;      /**< \brief ELF header size in bytes */
-    uint16 phentsize;   /**< \brief Program header entry size */
-    uint16 phnum;       /**< \brief Program header entry count */
-    uint16 shentsize;   /**< \brief Section header entry size */
-    uint16 shnum;       /**< \brief Section header entry count */
-    uint16 shstrndx;    /**< \brief String table section index */
+    uint8_t  ident[16];   /**< \brief ELF identifier */
+    uint16_t type;        /**< \brief ELF file type */
+    uint16_t machine;     /**< \brief ELF file architecture */
+    uint32_t version;     /**< \brief Object file version */
+    uint32_t entry;       /**< \brief Entry point */
+    uint32_t phoff;       /**< \brief Program header offset */
+    uint32_t shoff;       /**< \brief Section header offset */
+    uint32_t flags;       /**< \brief Processor flags */
+    uint16_t ehsize;      /**< \brief ELF header size in bytes */
+    uint16_t phentsize;   /**< \brief Program header entry size */
+    uint16_t phnum;       /**< \brief Program header entry count */
+    uint16_t shentsize;   /**< \brief Section header entry size */
+    uint16_t shnum;       /**< \brief Section header entry count */
+    uint16_t shstrndx;    /**< \brief String table section index */
 };
 
 /** \defgroup elf_archs                 Architecture Types
@@ -134,16 +133,16 @@ the file */
     \headerfile kos/elf.h
 */
 struct elf_shdr_t {
-    uint32 name;        /**< \brief Index into string table */
-    uint32 type;        /**< \brief Section type \see elf_sections */
-    uint32 flags;       /**< \brief Section flags \see elf_hdrflags */
-    uint32 addr;        /**< \brief In-memory offset */
-    uint32 offset;      /**< \brief On-disk offset */
-    uint32 size;        /**< \brief Size (if SHT_NOBITS, amount of 0s needed) */
-    uint32 link;        /**< \brief Section header table index link */
-    uint32 info;        /**< \brief Section header extra info */
-    uint32 addralign;   /**< \brief Alignment constraints */
-    uint32 entsize;     /**< \brief Fixed-size table entry sizes */
+    uint32_t name;        /**< \brief Index into string table */
+    uint32_t type;        /**< \brief Section type \see elf_sections */
+    uint32_t flags;       /**< \brief Section flags \see elf_hdrflags */
+    uint32_t addr;        /**< \brief In-memory offset */
+    uint32_t offset;      /**< \brief On-disk offset */
+    uint32_t size;        /**< \brief Size (if SHT_NOBITS, amount of 0s needed) */
+    uint32_t link;        /**< \brief Section header table index link */
+    uint32_t info;        /**< \brief Section header extra info */
+    uint32_t addralign;   /**< \brief Alignment constraints */
+    uint32_t entsize;     /**< \brief Fixed-size table entry sizes */
 };
 /* Link and info fields:
 
@@ -206,12 +205,12 @@ switch (sh_type) {
     \headerfile kos/elf.h
 */
 struct elf_sym_t {
-    uint32 name;        /**< \brief Index into file's string table */
-    uint32 value;       /**< \brief Value of the symbol */
-    uint32 size;        /**< \brief Size of the symbol */
-    uint8 info;         /**< \brief Symbol type and binding */
-    uint8 other;        /**< \brief 0. Holds no meaning. */
-    uint16 shndx;       /**< \brief Section index */
+    uint32_t name;        /**< \brief Index into file's string table */
+    uint32_t value;       /**< \brief Value of the symbol */
+    uint32_t size;        /**< \brief Size of the symbol */
+    uint8_t  info;        /**< \brief Symbol type and binding */
+    uint8_t  other;       /**< \brief 0. Holds no meaning. */
+    uint16_t shndx;       /**< \brief Section index */
 };
 
 /** \brief   Retrieve the binding type for a symbol.
@@ -242,9 +241,9 @@ struct elf_sym_t {
     \headerfile kos/elf.h
 */
 struct elf_rela_t {
-    uint32 offset;      /**< \brief Offset within section */
-    uint32 info;        /**< \brief Symbol and type */
-    int32 addend;       /**< \brief Constant addend for the symbol */
+    uint32_t offset;      /**< \brief Offset within section */
+    uint32_t info;        /**< \brief Symbol and type */
+    int32_t  addend;      /**< \brief Constant addend for the symbol */
 };
 
 /** \brief   ELF Relocation entry (without explicit addend).
@@ -257,8 +256,8 @@ struct elf_rela_t {
     \headerfile kos/elf.h
 */
 struct elf_rel_t {
-    uint32      offset;     /**< \brief Offset within section */
-    uint32      info;       /**< \brief Symbol and type */
+    uint32_t      offset;     /**< \brief Offset within section */
+    uint32_t      info;       /**< \brief Symbol and type */
 };
 
 /** \defgroup elf_reltypes              Relocation Types
@@ -290,7 +289,7 @@ struct elf_rel_t {
     \return                 The relocation type of that relocation.
     \see                    elf_reltypes
 */
-#define ELF32_R_TYPE(i) ((uint8)(i))
+#define ELF32_R_TYPE(i) ((uint8_t)(i))
 
 struct klibrary;
 
@@ -303,8 +302,8 @@ struct klibrary;
     \headerfile kos/elf.h
 */
 typedef struct elf_prog {
-    void *data;             /**< \brief Pointer to program in memory */
-    uint32 size;            /**< \brief Memory image size (rounded up to page size) */
+    void     *data;             /**< \brief Pointer to program in memory */
+    uint32_t size;              /**< \brief Memory image size (rounded up to page size) */
 
     /* Library exports */
     uintptr_t lib_get_name;     /**< \brief Pointer to get_name() function */
@@ -312,7 +311,7 @@ typedef struct elf_prog {
     uintptr_t lib_open;         /**< \brief Pointer to library's open function */
     uintptr_t lib_close;        /**< \brief Pointer to library's close function */
 
-    char fn[256];           /**< \brief Filename of library */
+    char fn[256];               /**< \brief Filename of library */
 } elf_prog_t;
 
 /** \brief   Load an ELF binary.

--- a/include/kos/elf.h
+++ b/include/kos/elf.h
@@ -36,7 +36,10 @@ __BEGIN_DECLS
     \ingroup elf
 
     Initial bytes of the ELF file, specifying how it should be
-    interpreted.
+    interpreted. This group contains first the indexes of each
+    ident field, then defines for the values they can contain.
+
+    Some of these are shared by other header fields.
     @{
 */
 #define EI_MAG0         0   /**< \brief File identification: 0x7f */
@@ -51,6 +54,17 @@ __BEGIN_DECLS
 #define EI_PAD          9   /**< \brief Start of padding bytes */
 
 #define EI_NIDENT       16  /**< \brief Size of elf_hdr::ident */
+
+#define ELFCLASSNONE    0   /**< \brief Invalid class */
+#define ELFCLASS32      1   /**< \brief 32-bit objects */
+#define ELFCLASS64      2   /**< \brief 64-bit objects */
+
+#define ELFDATANONE     0   /**< \brief Invalid encoding */
+#define ELFDATA2LSB     1   /**< \brief 2's complement, little endian */
+#define ELFDATA2MSB     2   /**< \brief 2's complement, big Endian */
+
+#define EV_NONE         0   /**< \brief Invalid version */
+#define EV_CURRENT      1   /**< \brief Current version */
 /** @} */
 
 /** \brief   ELF file header.
@@ -86,6 +100,7 @@ typedef struct elf_hdr {
     @{
 */
 #define EM_386  3   /**< \brief x86 (IA32) */
+#define EM_PPC  20  /**< \brief PowerPC */
 #define EM_ARM  40  /**< \brief ARM */
 #define EM_SH   42  /**< \brief SuperH */
 /** @} */

--- a/include/kos/elf.h
+++ b/include/kos/elf.h
@@ -32,29 +32,49 @@ __BEGIN_DECLS
     \ingroup        system_libraries
 */
 
+/** \defgroup elf_ident                 ELF Identification Bytes
+    \ingroup elf
+
+    Initial bytes of the ELF file, specifying how it should be
+    interpreted.
+    @{
+*/
+#define EI_MAG0         0   /**< \brief File identification: 0x7f */
+#define EI_MAG1         1   /**< \brief File identification: 'E' */
+#define EI_MAG2         2   /**< \brief File identification: 'L' */
+#define EI_MAG3         3   /**< \brief File identification: 'F' */
+#define EI_CLASS        4   /**< \brief File class (32/64-bit) */
+#define EI_DATA         5   /**< \brief Data encoding (LSB/MSB) */
+#define EI_VERSION      6   /**< \brief File version (must be 1) */
+#define EI_OSABI        7   /**< \brief Operating System/ABI identification */
+#define EI_ABIVERSION   8   /**< \brief ABI version */
+#define EI_PAD          9   /**< \brief Start of padding bytes */
+
+#define EI_NIDENT       16  /**< \brief Size of elf_hdr::ident */
+/** @} */
+
 /** \brief   ELF file header.
     \ingroup elf
 
     This header is at the beginning of any valid ELF binary and serves to
     identify the architecture of the binary and various data about it.
 
-    \headerfile kos/elf.h
 */
 typedef struct elf_hdr {
-    uint8_t  ident[16];   /**< \brief ELF identifier */
-    uint16_t type;        /**< \brief ELF file type */
-    uint16_t machine;     /**< \brief ELF file architecture */
-    uint32_t version;     /**< \brief Object file version */
-    uint32_t entry;       /**< \brief Entry point */
-    uint32_t phoff;       /**< \brief Program header offset */
-    uint32_t shoff;       /**< \brief Section header offset */
-    uint32_t flags;       /**< \brief Processor flags */
-    uint16_t ehsize;      /**< \brief ELF header size in bytes */
-    uint16_t phentsize;   /**< \brief Program header entry size */
-    uint16_t phnum;       /**< \brief Program header entry count */
-    uint16_t shentsize;   /**< \brief Section header entry size */
-    uint16_t shnum;       /**< \brief Section header entry count */
-    uint16_t shstrndx;    /**< \brief String table section index */
+    uint8_t  ident[EI_NIDENT];  /**< \brief ELF identifier */
+    uint16_t type;              /**< \brief ELF file type */
+    uint16_t machine;           /**< \brief ELF file architecture */
+    uint32_t version;           /**< \brief Object file version */
+    uint32_t entry;             /**< \brief Entry point */
+    uint32_t phoff;             /**< \brief Program header offset */
+    uint32_t shoff;             /**< \brief Section header offset */
+    uint32_t flags;             /**< \brief Processor flags */
+    uint16_t ehsize;            /**< \brief ELF header size in bytes */
+    uint16_t phentsize;         /**< \brief Program header entry size */
+    uint16_t phnum;             /**< \brief Program header entry count */
+    uint16_t shentsize;         /**< \brief Section header entry size */
+    uint16_t shnum;             /**< \brief Section header entry count */
+    uint16_t shstrndx;          /**< \brief String table section index */
 } elf_hdr_t;
 
 /** \defgroup elf_archs                 Architecture Types

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -49,7 +49,8 @@ static int find_sym(char *name, elf_sym_t *table, int tablelen) {
    documented by Intel.. I hope that this works for future compilers. */
 int elf_load(const char *fn, klibrary_t *shell, elf_prog_t *out) {
     uint8_t     *img, *imgout;
-    int         sz, i, j, sect;
+    size_t      sz, rsz;
+    int         i, j, sect;
     elf_hdr_t   *hdr;
     elf_shdr_t  *shdrs, *symtabhdr;
     elf_sym_t   *symtab;
@@ -82,8 +83,16 @@ int elf_load(const char *fn, klibrary_t *shell, elf_prog_t *out) {
         return -1;
     }
 
-    fs_read(fd, img, sz);
+    rsz = fs_read(fd, img, sz);
+
+    /* We close it regardless. */
     fs_close(fd);
+
+    if(rsz < sz) {
+        dbglog(DBG_ERROR, "elf_load: only read %d of %d bytes\n", rsz, sz);
+        free(img);
+        return -1;
+    }
 
     /* Header is at the front */
     hdr = (elf_hdr_t *)(img + 0);

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -54,7 +54,7 @@ static int find_sym(char *name, struct elf_sym_t* table, int tablelen) {
 /* There's a lot of shit in here that's not documented or very poorly
    documented by Intel.. I hope that this works for future compilers. */
 int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
-    uint8           *img, *imgout;
+    uint8_t           *img, *imgout;
     int         sz, i, j, sect;
     struct elf_hdr_t    *hdr;
     struct elf_shdr_t   *shdrs, *symtabhdr;
@@ -64,7 +64,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
     struct elf_rela_t   *relatab;
     int         reltabsize;
     char            *stringtab;
-    uint32          vma;
+    uint32_t          vma;
     file_t          fd;
 
     (void)shell;
@@ -161,7 +161,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
 
     /* Relocate symtab entries for quick access */
     for(i = 0; i < symtabsize; i++)
-        symtab[i].name = (uint32)(stringtab + symtab[i].name);
+        symtab[i].name = (uint32_t)(stringtab + symtab[i].name);
 
     /* Build the final memory image */
     sz = 0;
@@ -172,7 +172,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
             sz += shdrs[i].size;
 
             if(shdrs[i].addralign && (shdrs[i].addr % shdrs[i].addralign)) {
-                uint32 orig = shdrs[i].addr;
+                uint32_t orig = shdrs[i].addr;
                 shdrs[i].addr = (shdrs[i].addr + shdrs[i].addralign)
                                 & ~(shdrs[i].addralign - 1);
                 sz += shdrs[i].addr - orig;
@@ -189,7 +189,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
     }
 
     out->size = sz;
-    vma = (uint32)imgout;
+    vma = (uint32_t)imgout;
 
     for(i = 0; i < hdr->shnum; i++) {
         if(shdrs[i].flags & SHF_ALLOC) {
@@ -271,7 +271,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
                              symtab[sym].value,
                              relatab[j].addend,
                              vma + shdrs[sect].addr + relatab[j].offset));
-                        *((uint32 *)(imgout
+                        *((uint32_t *)(imgout
                                      + shdrs[sect].addr
                                      + relatab[j].offset))
                         =     symtab[sym].value
@@ -282,7 +282,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
                              vma + shdrs[symtab[sym].shndx].addr + symtab[sym].value + relatab[j].addend,
                              vma, shdrs[symtab[sym].shndx].addr, symtab[sym].value, relatab[j].addend,
                              vma + shdrs[sect].addr + relatab[j].offset));
-                        *((uint32*)(imgout
+                        *((uint32_t*)(imgout
                                     + shdrs[sect].addr      /* assuming 1 == .text */
                                     + relatab[j].offset))
                         +=    vma
@@ -314,7 +314,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
                     sym = ELF32_R_SYM(reltab[j].info);
 
                     if(symtab[sym].shndx == SHN_UNDEF) {
-                        uint32 value = symtab[sym].value;
+                        uint32_t value = symtab[sym].value;
 
                         if(sect == 1 && j < 5) {
                             DBG(("  Writing undefined %s %08lx -> %08lx",
@@ -326,17 +326,17 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
                         if(pcrel)
                             value -= vma + shdrs[sect].addr + reltab[j].offset;
 
-                        *((uint32 *)(imgout
+                        *((uint32_t *)(imgout
                                      + shdrs[sect].addr
                                      + reltab[j].offset))
                         += value;
 
                         if(sect == 1 && j < 5) {
-                            DBG(("(%08lx)\n", *((uint32 *)(imgout + shdrs[sect].addr + reltab[j].offset))));
+                            DBG(("(%08lx)\n", *((uint32_t *)(imgout + shdrs[sect].addr + reltab[j].offset))));
                         }
                     }
                     else {
-                        uint32 value = vma + shdrs[symtab[sym].shndx].addr
+                        uint32_t value = vma + shdrs[symtab[sym].shndx].addr
                                        + symtab[sym].value;
 
                         if(sect == 1 && j < 5) {
@@ -350,13 +350,13 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
                         if(pcrel)
                             value -= vma + shdrs[sect].addr + reltab[j].offset;
 
-                        *((uint32*)(imgout
+                        *((uint32_t*)(imgout
                                     + shdrs[sect].addr
                                     + reltab[j].offset))
                         += value;
 
                         if(sect == 1 && j < 5) {
-                            DBG(("(%08lx)\n", *((uint32 *)(imgout + shdrs[sect].addr + reltab[j].offset))));
+                            DBG(("(%08lx)\n", *((uint32_t *)(imgout + shdrs[sect].addr + reltab[j].offset))));
                         }
                     }
                 }
@@ -395,7 +395,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
     DBG(("elf_load final ELF stats: memory image at %p, size %08lx\n", out->data, out->size));
 
     /* Flush the icache for that zone */
-    icache_flush_range((uint32)out->data, out->size);
+    icache_flush_range((uint32_t)out->data, out->size);
 
     return 0;
 

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -97,14 +97,14 @@ int elf_load(const char *fn, klibrary_t *shell, elf_prog_t *out) {
     /* Header is at the front */
     hdr = (elf_hdr_t *)(img + 0);
 
-    if(hdr->ident[0] != 0x7f || strncmp((char *)hdr->ident + 1, "ELF", 3)) {
+    /* First four bytes are a magic number */
+    if(strncmp((char *)hdr->ident, "\177ELF", 4)) {
         dbglog(DBG_ERROR, "elf_load: file is not a valid ELF file\n");
-        hdr->ident[4] = 0;
-        dbglog(DBG_ERROR, "   hdr->ident is %d/%s\n", hdr->ident[0], hdr->ident + 1);
+        dbglog(DBG_ERROR, "   hdr->ident is %d/%.3s\n", hdr->ident[EI_MAG0], hdr->ident + 1);
         goto error1;
     }
 
-    if(hdr->ident[4] != 1 || hdr->ident[5] != 1) {
+    if(hdr->ident[EI_CLASS] != 1 || hdr->ident[EI_DATA] != 1) {
         dbglog(DBG_ERROR, "elf_load: invalid architecture flags in ELF file\n");
         goto error1;
     }

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -36,7 +36,7 @@
 } while(0)
 
 /* Finds a given symbol in a relocated ELF symbol table */
-static int find_sym(char *name, struct elf_sym_t* table, int tablelen) {
+static int find_sym(char *name, elf_sym_t *table, int tablelen) {
     int i;
 
     for(i = 0; i < tablelen; i++) {
@@ -53,19 +53,19 @@ static int find_sym(char *name, struct elf_sym_t* table, int tablelen) {
    will be set to the entry point. */
 /* There's a lot of shit in here that's not documented or very poorly
    documented by Intel.. I hope that this works for future compilers. */
-int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
-    uint8_t           *img, *imgout;
+int elf_load(const char *fn, klibrary_t *shell, elf_prog_t *out) {
+    uint8_t     *img, *imgout;
     int         sz, i, j, sect;
-    struct elf_hdr_t    *hdr;
-    struct elf_shdr_t   *shdrs, *symtabhdr;
-    struct elf_sym_t    *symtab;
+    elf_hdr_t   *hdr;
+    elf_shdr_t  *shdrs, *symtabhdr;
+    elf_sym_t   *symtab;
     int         symtabsize;
-    struct elf_rel_t    *reltab;
-    struct elf_rela_t   *relatab;
+    elf_rel_t   *reltab;
+    elf_rela_t  *relatab;
     int         reltabsize;
-    char            *stringtab;
-    uint32_t          vma;
-    file_t          fd;
+    char        *stringtab;
+    uint32_t    vma;
+    file_t      fd;
 
     (void)shell;
 
@@ -92,7 +92,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
     fs_close(fd);
 
     /* Header is at the front */
-    hdr = (struct elf_hdr_t *)(img + 0);
+    hdr = (elf_hdr_t *)(img + 0);
 
     if(hdr->ident[0] != 0x7f || strncmp((char *)hdr->ident + 1, "ELF", 3)) {
         dbglog(DBG_ERROR, "elf_load: file is not a valid ELF file\n");
@@ -127,7 +127,7 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
     /* Locate the string table; SH elf files ought to have
        two string tables, one for section names and one for object
        string names. We'll look for the latter. */
-    shdrs = (struct elf_shdr_t *)(img + hdr->shoff);
+    shdrs = (elf_shdr_t *)(img + hdr->shoff);
     stringtab = NULL;
 
     for(i = 0; i < hdr->shnum; i++) {
@@ -156,8 +156,8 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
         goto error1;
     }
 
-    symtab = (struct elf_sym_t *)(img + symtabhdr->offset);
-    symtabsize = symtabhdr->size / sizeof(struct elf_sym_t);
+    symtab = (elf_sym_t *)(img + symtabhdr->offset);
+    symtabsize = symtabhdr->size / sizeof(elf_sym_t);
 
     /* Relocate symtab entries for quick access */
     for(i = 0; i < symtabsize; i++)
@@ -250,8 +250,8 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
 
         switch(shdrs[i].type) {
             case SHT_RELA:
-                relatab = (struct elf_rela_t *)(img + shdrs[i].offset);
-                reltabsize = shdrs[i].size / sizeof(struct elf_rela_t);
+                relatab = (elf_rela_t *)(img + shdrs[i].offset);
+                reltabsize = shdrs[i].size / sizeof(elf_rela_t);
 
                 for(j = 0; j < reltabsize; j++) {
                     int sym;
@@ -295,8 +295,8 @@ int elf_load(const char * fn, klibrary_t * shell, elf_prog_t * out) {
                 break;
 
             case SHT_REL:
-                reltab = (struct elf_rel_t *)(img + shdrs[i].offset);
-                reltabsize = shdrs[i].size / sizeof(struct elf_rel_t);
+                reltab = (elf_rel_t *)(img + shdrs[i].offset);
+                reltabsize = shdrs[i].size / sizeof(elf_rel_t);
 
                 for(j = 0; j < reltabsize; j++) {
                     int sym, info, pcrel;


### PR DESCRIPTION
Does a chunk of what was being done by #316 as far as cleanup goes.

Moves elf to stdint types, cleans up the usage of the custom debugging stuff, general minor cleanups, and some refactoring to streamline the arch-based checks of the header and prep for future arch usage.