### PR TITLE
Added kos_run_target() to CMake toolchain.

### DIFF
--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -58,7 +58,7 @@ function(kos_bin2o inFile symbol)
     if(NOT ${ARGC} EQUAL 3)
         set(outFile ${CMAKE_CURRENT_BINARY_DIR}/${symbol}.o)
     else()
-        set(outFileOH CRA ${ARGV2})
+        set(outFile ${ARGV2})
     endif()
 
     # Custom Command to generate romdisk object file from image

--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -1,12 +1,13 @@
 # Auxiliary CMake Utility Functions
 #   Copyright (C) 2023 Colton Pawielski
-#   Copyright (C) 2024 Falco Girgis
+#   Copyright (C) 2024, 2025 Falco Girgis
 #   Copyright (C) 2024 Paul Cercueil
 #
 # This file implements utilities for the following additional functionality
 # which exists in the KOS Make build system:
 #   1) linking to existing binaries
 #   2) adding a romdisk
+#   3) running the binary using KOS_LOADER
 #
 # NOTE: When using the KOS CMake toolchain file, you do not need to include
 #       this file directly!
@@ -30,6 +31,18 @@ if(NOT DEFINED KOS_CC_BASE)
         set(KOS_CC_BASE $ENV{KOS_CC_BASE})
     endif()
 endif()
+
+### Adds a custom "run" target which uses $KOS_LOADER to run the given target. ###
+function(kos_run_target target)
+    # phony.txt is never created, so this command should always be executed
+    add_custom_command(
+        OUTPUT  phony.txt
+        COMMAND bash -c "$ENV{KOS_LOADER} $<TARGET_FILE:${target}>"
+    )
+
+    # Makes the "run" target dependent upon the main target and forces it to run
+    add_custom_target(run DEPENDS ${target} phony.txt)
+endfunction()
 
 ### Helper Function for Bin2Object ###
 function(kos_bin2o inFile symbol)

--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -34,14 +34,11 @@ endif()
 
 ### Adds a custom "run" target which uses $KOS_LOADER to run the given target. ###
 function(kos_run_target target)
-    # phony.txt is never created, so this command should always be executed
-    add_custom_command(
-        OUTPUT  phony.txt
-        COMMAND bash -c "$ENV{KOS_LOADER} $<TARGET_FILE:${target}>"
+    add_custom_target(run 
+        COMMAND $ENV{KOS_LOADER} $<TARGET_FILE:${target}> 
+        DEPENDS ${target} 
+        USES_TERMINAL
     )
-
-    # Makes the "run" target dependent upon the main target and forces it to run
-    add_custom_target(run DEPENDS ${target} phony.txt)
 endfunction()
 
 ### Helper Function for Bin2Object ###

--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -34,8 +34,19 @@ endif()
 
 ### Adds a custom "run" target which uses $KOS_LOADER to run the given target. ###
 function(kos_run_target target)
-    add_custom_target(run 
-        COMMAND $ENV{KOS_LOADER} $<TARGET_FILE:${target}> 
+    # targetName is optional and defaults to "run" when not provided.
+    if(NOT ${ARGC} EQUAL 2)
+        set(runTarget run)
+    else()
+        set(runTarget ${ARGN})
+    endif()
+
+    # Convert KOS ENV variable to semicolon-separated list of args
+    string(REPLACE " " ";" _kos_loader $ENV{KOS_LOADER})
+
+    # Create a new target which simply passes the source target to $KOS_LOADER to run
+    add_custom_target(${runTarget}
+        COMMAND ${_kos_loader};$<TARGET_FILE:${target}>
         DEPENDS ${target} 
         USES_TERMINAL
     )

--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -38,7 +38,7 @@ function(kos_run_target target)
     if(NOT ${ARGC} EQUAL 2)
         set(runTarget run)
     else()
-        set(runTarget ${ARGN})
+        set(runTarget ${ARGV1})
     endif()
 
     # Convert KOS ENV variable to semicolon-separated list of args
@@ -58,7 +58,7 @@ function(kos_bin2o inFile symbol)
     if(NOT ${ARGC} EQUAL 3)
         set(outFile ${CMAKE_CURRENT_BINARY_DIR}/${symbol}.o)
     else()
-        set(outFile ${ARGN})
+        set(outFile ${ARGV2})
     endif()
 
     # Custom Command to generate romdisk object file from image

--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -58,7 +58,7 @@ function(kos_bin2o inFile symbol)
     if(NOT ${ARGC} EQUAL 3)
         set(outFile ${CMAKE_CURRENT_BINARY_DIR}/${symbol}.o)
     else()
-        set(outFile ${ARGV2})
+        set(outFileOH CRA ${ARGV2})
     endif()
 
     # Custom Command to generate romdisk object file from image
@@ -82,7 +82,7 @@ function(kos_add_romdisk target romdiskPath)
     if(NOT ${ARGC} EQUAL 3)
         set(romdiskName romdisk)
     else()
-        set(romdiskName ${ARGN})
+        set(romdiskName ${ARGV2})
     endif()
 
     file(REAL_PATH "${romdiskPath}" romdiskPath)


### PR DESCRIPTION
It's currently a total PITA to run a CMake project you're actively building... you gotta go find the binary output wherever CMake puts it by default and call dc-tool with it..

We already have a nice, convenient, standardized rule for this kind of crap in all of our Makefiles, which you can call with "make run." It simply uses the KOS_LOADER environment variable configured from environ.sh.

This PR is an attempt to map this functionality to CMake as directly as possible.