### PR TITLE
Update 15.x profiles to 15.2.0/15.2.1-dev. All dev profiles upgraded to Binutils 2.45 and GDB 16.3

### DIFF
--- a/utils/dc-chain/Makefile.dreamcast.cfg
+++ b/utils/dc-chain/Makefile.dreamcast.cfg
@@ -17,11 +17,12 @@ platform=dreamcast
 # - stable:       Stable: Well-tested; based on GCC 13.2.0, released 2023-07-27.
 # - 13.4.0:       Testing: Latest release in the GCC 13 series, released 2025-06-05.
 # - 14.3.0:       Testing: Latest release in the GCC 14 series, released 2025-05-23.
-# - 15.1.0:       Testing: Latest release in the GCC 15 series, released 2025-04-25.
+# - 15.2.0:       Testing: Latest release in the GCC 15 series, released 2025-08-08.
 # Development toolchains:
 # - 13.4.1-dev    Bleeding edge GCC 13 series from git.
 # - 14.3.1-dev    Bleeding edge GCC 14 series from git.
-# - 15.1.1-dev    Bleeding edge GCC 15 series from git.
+# - 15.0.0-lra    GCC 15 branch containing experimental SuperH fixes for LRA.
+# - 15.2.1-dev    Bleeding edge GCC 15 series from git.
 # - 16.0.0-dev    Bleeding edge GCC 16 series from git.
 # If unsure, select stable. See README.md for more detailed descriptions.
 toolchain_profile=stable

--- a/utils/dc-chain/Makefile.gamecube.cfg
+++ b/utils/dc-chain/Makefile.gamecube.cfg
@@ -12,7 +12,7 @@
 platform=gamecube
 
 # Choose a toolchain profile from the following available options:
-# - stable:       Stable: Well-tested; based on GCC 15.1.0, released 2025-04-25.
+# - stable:       Stable: Well-tested; based on GCC 15.2.0, released 2025-08-08.
 # If unsure, select stable. See README.md for more detailed descriptions.
 toolchain_profile=stable
 

--- a/utils/dc-chain/doc/CHANGELOG.md
+++ b/utils/dc-chain/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Date<br/>_____________ | Author(s)<br/>_____________ | Changes<br/>_____________ |
 |:-----------------------|:----------------------------|---------------------------|
+| 2025-08-03 | Eric Fradella | Update 15.x profiles to 15.2.0/15.2.1-dev. All dev profiles upgraded to Binutils 2.45 and GDB 16.3 |
 | 2025-07-13 | Paul Cercueil | Add new profile for the LRA development toolchain |
 | 2025-07-13 | Paul Cercueil | Re-introduce ARM toolchain support |
 | 2025-07-13 | Paul Cercueil | Add support for PPC toolchains and add GameCube profile |

--- a/utils/dc-chain/patches/targets/gcc-15.2.0-kos.diff
+++ b/utils/dc-chain/patches/targets/gcc-15.2.0-kos.diff
@@ -1,6 +1,6 @@
-diff -ruN gcc-15.1.0/gcc/config/elfos.h gcc-15.1.0-kos/gcc/config/elfos.h
---- gcc-15.1.0/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
-+++ gcc-15.1.0-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
+diff -ruN gcc-15.2.0/gcc/config/elfos.h gcc-15.2.0-kos/gcc/config/elfos.h
+--- gcc-15.2.0/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
++++ gcc-15.2.0-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
 @@ -486,3 +486,6 @@
  
  #undef TARGET_LIBC_HAS_FUNCTION
@@ -8,9 +8,9 @@ diff -ruN gcc-15.1.0/gcc/config/elfos.h gcc-15.1.0-kos/gcc/config/elfos.h
 +
 +#define TARGET_OS_CPP_BUILTINS()			\
 +  builtin_define ("__KOS_GCC_PATCHLEVEL__=2025062800")
-diff -ruN gcc-15.1.0/gcc/configure gcc-15.1.0-kos/gcc/configure
---- gcc-15.1.0/gcc/configure	2025-04-18 16:01:33.801051764 -0600
-+++ gcc-15.1.0-kos/gcc/configure	2025-04-18 16:01:42.913094480 -0600
+diff -ruN gcc-15.2.0/gcc/configure gcc-15.2.0-kos/gcc/configure
+--- gcc-15.2.0/gcc/configure	2025-04-18 16:01:33.801051764 -0600
++++ gcc-15.2.0-kos/gcc/configure	2025-04-18 16:01:42.913094480 -0600
 @@ -13165,7 +13165,7 @@
      target_thread_file='single'
      ;;
@@ -20,9 +20,9 @@ diff -ruN gcc-15.1.0/gcc/configure gcc-15.1.0-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff --color -ruN gcc-15.1.0/libgcc/config.host gcc-15.1.0-kos/libgcc/config.host
---- gcc-15.1.0/libgcc/config.host	2025-04-27 14:45:09.695053718 -0600
-+++ gcc-15.1.0-kos/libgcc/config.host	2025-04-27 15:10:10.267714917 -0600
+diff --color -ruN gcc-15.2.0/libgcc/config.host gcc-15.2.0-kos/libgcc/config.host
+--- gcc-15.2.0/libgcc/config.host	2025-04-27 14:45:09.695053718 -0600
++++ gcc-15.2.0-kos/libgcc/config.host	2025-04-27 15:10:10.267714917 -0600
 @@ -71,7 +71,7 @@
  asm_hidden_op=.hidden
  enable_execute_stack=
@@ -32,14 +32,14 @@ diff --color -ruN gcc-15.1.0/libgcc/config.host gcc-15.1.0-kos/libgcc/config.hos
  tm_file=
  tm_define=
  md_unwind_def_header=no-unwind.h
-diff -ruN /dev/null gcc-15.1.0-kos/libgcc/config/t-kos
+diff -ruN /dev/null gcc-15.2.0-kos/libgcc/config/t-kos
 --- /dev/null	2025-04-27 14:45:09.695053718 -0600
-+++ gcc-15.1.0-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
++++ gcc-15.2.0-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
 @@ -0,0 +1 @@
 +LIB2ADD = $(srcdir)/config/fake-kos.c
-diff -ruN gcc-15.1.0/libgcc/configure gcc-15.1.0-kos/libgcc/configure
---- gcc-15.1.0/libgcc/configure	2025-04-18 16:01:37.139067412 -0600
-+++ gcc-15.1.0-kos/libgcc/configure	2025-04-18 16:01:42.914094485 -0600
+diff -ruN gcc-15.2.0/libgcc/configure gcc-15.2.0-kos/libgcc/configure
+--- gcc-15.2.0/libgcc/configure	2025-04-18 16:01:37.139067412 -0600
++++ gcc-15.2.0-kos/libgcc/configure	2025-04-18 16:01:42.914094485 -0600
 @@ -5733,6 +5733,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -48,9 +48,9 @@ diff -ruN gcc-15.1.0/libgcc/configure gcc-15.1.0-kos/libgcc/configure
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
-diff -ruN gcc-15.1.0/libobjc/Makefile.in gcc-15.1.0-kos/libobjc/Makefile.in
---- gcc-15.1.0/libobjc/Makefile.in	2025-04-18 16:01:37.499069099 -0600
-+++ gcc-15.1.0-kos/libobjc/Makefile.in	2025-04-18 16:01:42.915094489 -0600
+diff -ruN gcc-15.2.0/libobjc/Makefile.in gcc-15.2.0-kos/libobjc/Makefile.in
+--- gcc-15.2.0/libobjc/Makefile.in	2025-04-18 16:01:37.499069099 -0600
++++ gcc-15.2.0-kos/libobjc/Makefile.in	2025-04-18 16:01:42.915094489 -0600
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -81,9 +81,9 @@ diff -ruN gcc-15.1.0/libobjc/Makefile.in gcc-15.1.0-kos/libobjc/Makefile.in
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff -ruN gcc-15.1.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-15.1.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-15.1.0/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:37.608069611 -0600
-+++ gcc-15.1.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:42.916094494 -0600
+diff -ruN gcc-15.2.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-15.2.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-15.2.0/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:37.608069611 -0600
++++ gcc-15.2.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:42.916094494 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -134,9 +134,9 @@ diff -ruN gcc-15.1.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-15.1.0-kos/libst
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-15.1.0/libstdc++-v3/configure gcc-15.1.0-kos/libstdc++-v3/configure
---- gcc-15.1.0/libstdc++-v3/configure	2025-04-18 16:01:37.616069648 -0600
-+++ gcc-15.1.0-kos/libstdc++-v3/configure	2025-04-18 16:01:42.919094508 -0600
+diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0-kos/libstdc++-v3/configure
+--- gcc-15.2.0/libstdc++-v3/configure	2025-04-18 16:01:37.616069648 -0600
++++ gcc-15.2.0-kos/libstdc++-v3/configure	2025-04-18 16:01:42.919094508 -0600
 @@ -15974,6 +15974,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/patches/targets/gcc-15.2.1-kos.diff
+++ b/utils/dc-chain/patches/targets/gcc-15.2.1-kos.diff
@@ -1,6 +1,6 @@
-diff -ruN gcc-15.1.1/gcc/config/elfos.h gcc-15.1.1-kos/gcc/config/elfos.h
---- gcc-15.1.1/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
-+++ gcc-15.1.1-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
+diff -ruN gcc-15.2.1/gcc/config/elfos.h gcc-15.2.1-kos/gcc/config/elfos.h
+--- gcc-15.2.1/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
++++ gcc-15.2.1-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
 @@ -486,3 +486,6 @@
  
  #undef TARGET_LIBC_HAS_FUNCTION
@@ -8,9 +8,9 @@ diff -ruN gcc-15.1.1/gcc/config/elfos.h gcc-15.1.1-kos/gcc/config/elfos.h
 +
 +#define TARGET_OS_CPP_BUILTINS()			\
 +  builtin_define ("__KOS_GCC_PATCHLEVEL__=2025062800")
-diff -ruN gcc-15.1.1/gcc/configure gcc-15.1.1-kos/gcc/configure
---- gcc-15.1.1/gcc/configure	2025-04-18 16:01:33.801051764 -0600
-+++ gcc-15.1.1-kos/gcc/configure	2025-04-18 16:01:42.913094480 -0600
+diff -ruN gcc-15.2.1/gcc/configure gcc-15.2.1-kos/gcc/configure
+--- gcc-15.2.1/gcc/configure	2025-04-18 16:01:33.801051764 -0600
++++ gcc-15.2.1-kos/gcc/configure	2025-04-18 16:01:42.913094480 -0600
 @@ -13165,7 +13165,7 @@
      target_thread_file='single'
      ;;
@@ -20,9 +20,9 @@ diff -ruN gcc-15.1.1/gcc/configure gcc-15.1.1-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff --color -ruN gcc-15.1.1/libgcc/config.host gcc-15.1.1-kos/libgcc/config.host
---- gcc-15.1.1/libgcc/config.host	2025-04-27 14:45:09.695053718 -0600
-+++ gcc-15.1.1-kos/libgcc/config.host	2025-04-27 15:10:10.267714917 -0600
+diff --color -ruN gcc-15.2.1/libgcc/config.host gcc-15.2.1-kos/libgcc/config.host
+--- gcc-15.2.1/libgcc/config.host	2025-04-27 14:45:09.695053718 -0600
++++ gcc-15.2.1-kos/libgcc/config.host	2025-04-27 15:10:10.267714917 -0600
 @@ -71,7 +71,7 @@
  asm_hidden_op=.hidden
  enable_execute_stack=
@@ -32,14 +32,14 @@ diff --color -ruN gcc-15.1.1/libgcc/config.host gcc-15.1.1-kos/libgcc/config.hos
  tm_file=
  tm_define=
  md_unwind_def_header=no-unwind.h
-diff -ruN /dev/null gcc-15.1.1-kos/libgcc/config/t-kos
+diff -ruN /dev/null gcc-15.2.1-kos/libgcc/config/t-kos
 --- /dev/null	2025-04-27 14:45:09.695053718 -0600
-+++ gcc-15.1.1-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
++++ gcc-15.2.1-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
 @@ -0,0 +1 @@
 +LIB2ADD = $(srcdir)/config/fake-kos.c
-diff -ruN gcc-15.1.1/libgcc/configure gcc-15.1.1-kos/libgcc/configure
---- gcc-15.1.1/libgcc/configure	2025-04-18 16:01:37.139067412 -0600
-+++ gcc-15.1.1-kos/libgcc/configure	2025-04-18 16:01:42.914094485 -0600
+diff -ruN gcc-15.2.1/libgcc/configure gcc-15.2.1-kos/libgcc/configure
+--- gcc-15.2.1/libgcc/configure	2025-04-18 16:01:37.139067412 -0600
++++ gcc-15.2.1-kos/libgcc/configure	2025-04-18 16:01:42.914094485 -0600
 @@ -5733,6 +5733,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -48,9 +48,9 @@ diff -ruN gcc-15.1.1/libgcc/configure gcc-15.1.1-kos/libgcc/configure
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
-diff -ruN gcc-15.1.1/libobjc/Makefile.in gcc-15.1.1-kos/libobjc/Makefile.in
---- gcc-15.1.1/libobjc/Makefile.in	2025-04-18 16:01:37.499069099 -0600
-+++ gcc-15.1.1-kos/libobjc/Makefile.in	2025-04-18 16:01:42.915094489 -0600
+diff -ruN gcc-15.2.1/libobjc/Makefile.in gcc-15.2.1-kos/libobjc/Makefile.in
+--- gcc-15.2.1/libobjc/Makefile.in	2025-04-18 16:01:37.499069099 -0600
++++ gcc-15.2.1-kos/libobjc/Makefile.in	2025-04-18 16:01:42.915094489 -0600
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -81,9 +81,9 @@ diff -ruN gcc-15.1.1/libobjc/Makefile.in gcc-15.1.1-kos/libobjc/Makefile.in
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff -ruN gcc-15.1.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-15.1.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-15.1.1/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:37.608069611 -0600
-+++ gcc-15.1.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:42.916094494 -0600
+diff -ruN gcc-15.2.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-15.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-15.2.1/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:37.608069611 -0600
++++ gcc-15.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:42.916094494 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -134,9 +134,9 @@ diff -ruN gcc-15.1.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-15.1.1-kos/libst
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-15.1.1/libstdc++-v3/configure gcc-15.1.1-kos/libstdc++-v3/configure
---- gcc-15.1.1/libstdc++-v3/configure	2025-04-18 16:01:37.616069648 -0600
-+++ gcc-15.1.1-kos/libstdc++-v3/configure	2025-04-18 16:01:42.919094508 -0600
+diff -ruN gcc-15.2.1/libstdc++-v3/configure gcc-15.2.1-kos/libstdc++-v3/configure
+--- gcc-15.2.1/libstdc++-v3/configure	2025-04-18 16:01:37.616069648 -0600
++++ gcc-15.2.1-kos/libstdc++-v3/configure	2025-04-18 16:01:42.919094508 -0600
 @@ -15974,6 +15974,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;

--- a/utils/dc-chain/profiles/aica/stable.mk
+++ b/utils/dc-chain/profiles/aica/stable.mk
@@ -6,7 +6,7 @@ target=arm-eabi
 cpu_configure_args=--with-arch=armv4 --with-mode=arm --disable-multilib
 
 # Toolchain versions
-binutils_ver=2.44
+binutils_ver=2.45
 gcc_ver=8.5.0
 newlib_ver=4.5.0.20241231
 

--- a/utils/dc-chain/profiles/dreamcast/13.4.1-dev.mk
+++ b/utils/dc-chain/profiles/dreamcast/13.4.1-dev.mk
@@ -13,10 +13,10 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.44
+binutils_ver=2.45
 gcc_ver=13.4.1
 newlib_ver=4.5.0.20241231
-gdb_ver=16.2
+gdb_ver=16.3
 
 # Overide SH toolchain download type
 gcc_download_type=git

--- a/utils/dc-chain/profiles/dreamcast/14.3.1-dev.mk
+++ b/utils/dc-chain/profiles/dreamcast/14.3.1-dev.mk
@@ -13,10 +13,10 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.44
+binutils_ver=2.45
 gcc_ver=14.3.1
 newlib_ver=4.5.0.20241231
-gdb_ver=16.2
+gdb_ver=16.3
 
 # Overide SH toolchain download type
 gcc_download_type=git

--- a/utils/dc-chain/profiles/dreamcast/15.0.0-lra.mk
+++ b/utils/dc-chain/profiles/dreamcast/15.0.0-lra.mk
@@ -13,9 +13,10 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.44
+binutils_ver=2.45
 gcc_ver=15.0.0
 newlib_ver=4.5.0.20241231
+gdb_ver=16.3
 
 # Overide SH toolchain download type
 gcc_download_type=git

--- a/utils/dc-chain/profiles/dreamcast/15.2.0.mk
+++ b/utils/dc-chain/profiles/dreamcast/15.2.0.mk
@@ -6,10 +6,10 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.44
-gcc_ver=15.1.0
+binutils_ver=2.45
+gcc_ver=15.2.0
 newlib_ver=4.5.0.20241231
-gdb_ver=16.2
+gdb_ver=16.3
 
 # GCC custom dependencies
 # Specify here if you want to use custom GMP, MPFR and MPC libraries when

--- a/utils/dc-chain/profiles/dreamcast/15.2.1-dev.mk
+++ b/utils/dc-chain/profiles/dreamcast/15.2.1-dev.mk
@@ -4,7 +4,7 @@
 ###############################################################################
 ###############################################################################
 ### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
-## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2025-04-18.
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2025-08-03.
 ###############################################################################
 ###############################################################################
 
@@ -13,10 +13,10 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.44
-gcc_ver=15.1.1
+binutils_ver=2.45
+gcc_ver=15.2.1
 newlib_ver=4.5.0.20241231
-gdb_ver=16.2
+gdb_ver=16.3
 
 # Overide SH toolchain download type
 gcc_download_type=git

--- a/utils/dc-chain/profiles/dreamcast/16.0.0-dev.mk
+++ b/utils/dc-chain/profiles/dreamcast/16.0.0-dev.mk
@@ -13,10 +13,10 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.44
+binutils_ver=2.45
 gcc_ver=16.0.0
 newlib_ver=4.5.0.20241231
-gdb_ver=16.2
+gdb_ver=16.3
 
 # Overide SH toolchain download type
 gcc_download_type=git

--- a/utils/dc-chain/profiles/gamecube/stable.mk
+++ b/utils/dc-chain/profiles/gamecube/stable.mk
@@ -7,10 +7,10 @@ cpu_configure_args=--with-endian=big --with-cpu=750 --disable-multilib --disable
 newlib_extra_configure_args += --disable-libgloss
 
 # Toolchain versions for PowerPC
-binutils_ver=2.44
-gcc_ver=15.1.0
+binutils_ver=2.45
+gcc_ver=15.2.0
 newlib_ver=4.5.0.20241231
-gdb_ver=16.2
+gdb_ver=16.3
 
 # GCC custom dependencies
 # Specify here if you want to use custom GMP, MPFR and MPC libraries when


### PR DESCRIPTION
GCC 15.2.0 release is scheduled for Fri, August 8, with 15.2.0-RC1 released this past Friday.

- Profiles updated for GCC 15.2.0 and GCC 15.2.1.
- All dev profiles upgraded to Binutils 2.45 and GDB 16.3.

All dev profiles tested to patch and build without error under Linux (latest Gentoo).

This PR cannot be merged until release candidacy is over. Please approve before 8/8/25 and merge on 8/8/25 once the official release is confirmed upstream.

Since the official 15.2.0 tarballs will not exist upstream until the release, the following command must be run within the `dc-chain` dir to grab the release candidate tarball and set it up before running the dc-chain build scripts:

```
wget https://gcc.gnu.org/pub/gcc/snapshots/15.2.0-RC-20250801/gcc-15.2.0-RC-20250801.tar.xz && \
    mv gcc-15.2.0-RC-20250801.tar.xz gcc-15.2.0.tar.xz && \
    tar Jxvf gcc-15.2.0.tar.xz && \
    mv gcc-15.2.0-RC-20250801 gcc-15.2.0 && \
    touch gcc-15.2.0/gcc_download.stamp
```

**NOTE**: This release is what I would like to be the new `stable` release going forward. Once this support is merged, I'll open an issue for testing examples/ports with 15.2.0, and we can afterwards mark 13.2.0 as `legacy` and 15.2.0 as `stable`.