### PR TITLE
Move arch-specific ELF definitions from elf.c to arch.h

### DIFF
--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -25,6 +25,7 @@ __BEGIN_DECLS
 #include <stdbool.h>
 
 #include <arch/types.h>
+#include <kos/elf.h>
 
 /** \defgroup arch  Architecture
     \brief          Dreamcast Architecture-Specific Options and high-level API
@@ -44,7 +45,7 @@ extern uint32 _arch_mem_top;
 
 /** \brief  Start and End address for .text portion of program. */
 extern char _executable_start;
-extern char _etext; 
+extern char _etext;
 
 #define PAGESIZE        4096            /**< \brief Page size (for MMU) */
 #define PAGESIZE_BITS   12              /**< \brief Bits for page size */
@@ -111,6 +112,15 @@ unsigned HZ __depr("Please use the new THD_SCHED_HZ macro.") = THD_SCHED_HZ;
 
 /** \brief  Length of global symbol prefix in ELF files. */
 #define ELF_SYM_PREFIX_LEN  1
+
+/** \brief  ELF class for this architecture. */
+#define ARCH_ELFCLASS       ELFCLASS32
+
+/** \brief  ELF data encoding for this architecture. */
+#define ARCH_ELFDATA        ELFDATA2LSB
+
+/** \brief  ELF machine type code for this architecture. */
+#define ARCH_CODE           EM_SH
 
 /** \brief  Panic function.
 

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -17,16 +17,6 @@
 #include <kos/library.h>
 #include <kos/dbglog.h>
 
-/* What's our architecture code we're expecting? */
-#if defined(_arch_dreamcast)
-#   define ARCH_ELFCLASS    ELFCLASS32    /* Dreamcast is 32-bit */
-#   define ARCH_ELFDATA     ELFDATA2LSB   /* and little endian */
-#   define ARCH_CODE        EM_SH         /* and uses an SH processor. */
-#else
-#   error Unknown architecture
-#endif
-
-
 /* Finds a given symbol in a relocated ELF symbol table */
 static int find_sym(char *name, elf_sym_t *table, int tablelen) {
     int i;


### PR DESCRIPTION
Arch-specific definitions and code should be kept to each arch's respective arch dir. There are two files violating this at the moment, `include/kos.h` and `kernel/fs/elf.c`. This PR addresses the latter, moving the `ARCH_ELFCLASS`, `ARCH_ELFDATA`, and `ARCH_CODE` definitions to `arch/arch.h` next to other ELF definitions.

Fixing `include/kos.h` will be for later, as some of the headers need to be reorganized across arch lines first.