### PR TITLE
Make sysconf() arch agnostic and provide L2 cache specs

### DIFF
--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -812,8 +812,8 @@ static void unlock_dma_memory(void) {
         }
     }
     if(patched) {
-        flush_size = (patch_addr[1] - patch_addr[0]) + CPU_CACHE_BLOCK_SIZE;
-        flush_size &= ~(CPU_CACHE_BLOCK_SIZE - 1);
+        flush_size = (patch_addr[1] - patch_addr[0]) + CACHE_L1_ICACHE_LINESIZE;
+        flush_size &= ~(CACHE_L1_ICACHE_LINESIZE - 1);
         icache_flush_range(patch_addr[0] | MEM_AREA_P1_BASE, flush_size);
     }
     *prot_reg = G1_ATA_DMA_UNLOCK_ALLMEM;

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -4,6 +4,7 @@
    Copyright (C) 2001 Megan Potter
    Copyright (C) 2014, 2016, 2023 Ruslan Rostovtsev
    Copyright (C) 2023 Andy Barajas
+   Copyright (C) 2025 Eric Fradella
 */
 
 /** \file    arch/cache.h
@@ -34,11 +35,59 @@ __BEGIN_DECLS
     @{
 */
 
-/** \brief  SH4 cache block size.
+/** \brief  Level 1 instruction cache size.
 
-    The size of a cache block.
+    The capacity of the L1 instruction cache in bytes.
 */
-#define CPU_CACHE_BLOCK_SIZE 32
+#define CACHE_L1_ICACHE_SIZE 8 * 1024
+
+/** \brief  Level 1 instruction cache associativity.
+
+    Number of ways in the L1 instruction cache.
+*/
+#define CACHE_L1_ICACHE_ASSOC 1
+
+/** \brief  L1 instruction cache line size.
+
+    The size of each cache line in the L1 instruction cache.
+*/
+#define CACHE_L1_ICACHE_LINESIZE 32
+
+/** \brief  Level 1 data cache size.
+
+    The capacity of the L1 data cache in bytes.
+*/
+#define CACHE_L1_DCACHE_SIZE 16 * 1024
+
+/** \brief  Level 1 data cache associativity.
+
+    Number of ways in the L1 data cache.
+*/
+#define CACHE_L1_DCACHE_ASSOC 1
+
+/** \brief  L1 data cache line size.
+
+    The size of each cache line in the L1 data cache.
+*/
+#define CACHE_L1_DCACHE_LINESIZE 32
+
+/** \brief  Level 2 cache size.
+
+    The capacity of the L2 cache in bytes.
+*/
+#define CACHE_L2_CACHE_SIZE 0
+
+/** \brief  Level 2 cache associativity.
+
+    Number of ways in the L2 cache.
+*/
+#define CACHE_L2_CACHE_ASSOC 0
+
+/** \brief  Level 2 cache line size.
+
+    The size of each cache line in the L2 cache.
+*/
+#define CACHE_L2_CACHE_LINESIZE 0
 
 /** \brief  Flush the instruction cache.
 

--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -110,7 +110,7 @@ ATOMIC_FETCH_NAND_N_(unsigned long long, 8)
    around memcpy() calls. */
 
 /* Size of each memory region covered by an individual lock. */
-#define GENERIC_LOCK_BLOCK_SIZE     (CPU_CACHE_BLOCK_SIZE * 4)
+#define GENERIC_LOCK_BLOCK_SIZE     (CACHE_L1_DCACHE_LINESIZE * 4)
 
 /* Locks have to be shared for each page with the MMU enabled,
    otherwise we can fail when aliasing an address range to multiple

--- a/kernel/libc/posix/sysconf.c
+++ b/kernel/libc/posix/sysconf.c
@@ -2,6 +2,7 @@
 
    sysconf.c
    Copyright (C) 2023, 2024, 2025 Falco Girgis
+   Copyright (C) 2025 Eric Fradella
 */
 
 #include <arch/arch.h>
@@ -51,22 +52,31 @@ long sysconf(int name) {
             return PAGESIZE;
 
         case _SC_LEVEL1_ICACHE_SIZE:
-            return 8 * 1024;
+            return CACHE_L1_ICACHE_SIZE;
 
         case _SC_LEVEL1_ICACHE_ASSOC:
-            return 1;
+            return CACHE_L1_ICACHE_ASSOC;
 
         case _SC_LEVEL1_ICACHE_LINESIZE:
-            return CPU_CACHE_BLOCK_SIZE;
+            return CACHE_L1_ICACHE_LINESIZE;
 
         case _SC_LEVEL1_DCACHE_SIZE:
-            return 16 * 1024;
+            return CACHE_L1_DCACHE_SIZE;
 
         case _SC_LEVEL1_DCACHE_ASSOC:
-            return 1;
+            return CACHE_L1_DCACHE_ASSOC;
 
         case _SC_LEVEL1_DCACHE_LINESIZE:
-            return CPU_CACHE_BLOCK_SIZE;
+            return CACHE_L1_DCACHE_LINESIZE;
+
+        case _SC_LEVEL2_CACHE_SIZE:
+            return CACHE_L2_CACHE_SIZE;
+
+        case _SC_LEVEL2_CACHE_ASSOC:
+            return CACHE_L2_CACHE_ASSOC;
+
+        case _SC_LEVEL2_CACHE_LINESIZE:
+            return CACHE_L2_CACHE_LINESIZE;
 
         case _SC_SEM_NSEMS_MAX:
             return UINT32_MAX;


### PR DESCRIPTION
Fixes #1060 