### PR TITLE
Adjust dbglog usage in examples.

### DIFF
--- a/examples/dreamcast/cdrom/stream/cd-stream-test.c
+++ b/examples/dreamcast/cdrom/stream/cd-stream-test.c
@@ -60,7 +60,7 @@ static int cd_stream_test(uint32_t lba, uint8_t *buffer, size_t size, int mode) 
     size_t cb_count = 0;
     char *stream_name = (mode == CDROM_READ_PIO ? "PIO" : "DMA");
 
-    dbglog(DBG_DEBUG, "Start %s stream.\n", stream_name);
+    dbglog(DBG_INFO, "Start %s stream.\n", stream_name);
     rs = cdrom_stream_start(lba, size / 2048, mode);
 
     if (rs != ERR_OK) {
@@ -112,7 +112,7 @@ static int cd_stream_test(uint32_t lba, uint8_t *buffer, size_t size, int mode) 
         return -1;
     }
 
-    dbglog(DBG_DEBUG, "%s transfer is done.\n", stream_name);
+    dbglog(DBG_INFO, "%s transfer is done.\n", stream_name);
     return 0;
 }
 

--- a/examples/dreamcast/filesystem/sd/speedtest/sd-speedtest.c
+++ b/examples/dreamcast/filesystem/sd/speedtest/sd-speedtest.c
@@ -68,14 +68,14 @@ static int run_speed_test(sd_interface_t interface, bool check_crc) {
     const char *interface_name = (interface == SD_IF_SCI) ? "SCI-SPI" : "SCIF-SPI";
 
     while(sd_init_ex(&params)) {
-        dbglog(DBG_DEBUG, "Could not initialize the SD card on %s interface.\n", interface_name);
+        dbglog(DBG_ERROR, "Could not initialize the SD card on %s interface.\n", interface_name);
         return -1;
     }
 
     /* Grab the block device for the first partition on the SD card. Note that
        you must have the SD card formatted with an MBR partitioning scheme. */
     if(sd_blockdev_for_partition(0, &sd_dev, &pt)) {
-        dbglog(DBG_DEBUG, "Could not find the first partition on the SD card!\n");
+        dbglog(DBG_ERROR, "Could not find the first partition on the SD card!\n");
         sd_shutdown();
         return -1;
     }
@@ -84,7 +84,7 @@ static int run_speed_test(sd_interface_t interface, bool check_crc) {
         begin = timer_ms_gettime64();
 
         if(sd_dev.read_blocks(&sd_dev, 0, TEST_BLOCK_COUNT, tbuf)) {
-            dbglog(DBG_DEBUG, "couldn't read block: %s\n", strerror(errno));
+            dbglog(DBG_ERROR, "couldn't read block: %s\n", strerror(errno));
             sd_shutdown();
             return -1;
         }
@@ -96,7 +96,7 @@ static int run_speed_test(sd_interface_t interface, bool check_crc) {
 
     average = sum / 10;
 
-    dbglog(DBG_DEBUG, "%s: read average took %llu ms (%.3f KB/sec)\n",
+    dbglog(DBG_INFO, "%s: read average took %llu ms (%.3f KB/sec)\n",
            interface_name, average, (512 * TEST_BLOCK_COUNT) / ((double)average));
 
     sd_shutdown();
@@ -106,27 +106,27 @@ static int run_speed_test(sd_interface_t interface, bool check_crc) {
 int main(int argc, char *argv[]) {
     // dbgio_dev_select("fb");
 
-    dbglog(DBG_DEBUG, "Starting SD card speed tests\n");
+    dbglog(DBG_INFO, "Starting SD card speed tests\n");
 
-    dbglog(DBG_DEBUG, "Testing SCI-SPI interface with CRC disabled\n");
+    dbglog(DBG_INFO, "Testing SCI-SPI interface with CRC disabled\n");
     if (run_speed_test(SD_IF_SCI, false) == 0) {
-        dbglog(DBG_DEBUG, "Testing SCI-SPI interface with CRC enabled\n");
+        dbglog(DBG_INFO, "Testing SCI-SPI interface with CRC enabled\n");
         run_speed_test(SD_IF_SCI, true);
     }
     else {
-        dbglog(DBG_DEBUG, "Skipping SCI-SPI interface with CRC enabled\n");
+        dbglog(DBG_INFO, "Skipping SCI-SPI interface with CRC enabled\n");
     }
 
-    dbglog(DBG_DEBUG, "Testing SCIF-SPI interface with CRC disabled\n");
+    dbglog(DBG_INFO, "Testing SCIF-SPI interface with CRC disabled\n");
     if (run_speed_test(SD_IF_SCIF, false) == 0) {
-        dbglog(DBG_DEBUG, "Testing SCIF-SPI interface with CRC enabled\n");
+        dbglog(DBG_INFO, "Testing SCIF-SPI interface with CRC enabled\n");
         run_speed_test(SD_IF_SCIF, true);
     }
     else {
-        dbglog(DBG_DEBUG, "Skipping SCIF-SPI interface with CRC enabled\n");
+        dbglog(DBG_INFO, "Skipping SCIF-SPI interface with CRC enabled\n");
     }
 
-    dbglog(DBG_DEBUG, "All tests completed\n");
+    dbglog(DBG_INFO, "All tests completed\n");
 
     wait_exit();
     return 0;

--- a/examples/dreamcast/gldc/benchmarks/quadmark/quadmark.c
+++ b/examples/dreamcast/gldc/benchmarks/quadmark/quadmark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_INFO, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, stats.frame_rate);
 }
 

--- a/examples/dreamcast/gldc/benchmarks/trimark/trimark.c
+++ b/examples/dreamcast/gldc/benchmarks/trimark/trimark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_INFO, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, stats.frame_rate);
 }
 

--- a/examples/dreamcast/gldc/benchmarks/tristripmark/tristripmark.c
+++ b/examples/dreamcast/gldc/benchmarks/tristripmark/tristripmark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_INFO, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, stats.frame_rate);
 }
 

--- a/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
+++ b/examples/dreamcast/kgl/benchmarks/quadmark/quadmark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_INFO, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
+++ b/examples/dreamcast/kgl/benchmarks/trimark/trimark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_INFO, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
+++ b/examples/dreamcast/kgl/benchmarks/tristripmark/tristripmark.c
@@ -39,7 +39,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_INFO, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/library/library-test.c
+++ b/examples/dreamcast/library/library-test.c
@@ -42,7 +42,7 @@ static void __attribute__((__noreturn__)) wait_exit(void) {
     maple_device_t *dev;
     cont_state_t *state;
 
-    dbglog(DBG_DEBUG, "Press any button to exit.\n");
+    dbglog(DBG_INFO, "Press any button to exit.\n");
 
     for(;;) {
         dev = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
     library_test_func2_t library_test_func2;
 
     // dbgio_dev_select("fb");
-    dbglog(DBG_DEBUG, "Initializing exports.\n");
+    dbglog(DBG_INFO, "Initializing exports.\n");
 
     if(nmmgr_handler_add(&st_libtest.nmmgr) < 0) {
         dbglog(DBG_ERROR, "Failed.");
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    dbglog(DBG_DEBUG, "Loading /rd/library-dependence.klf\n");
+    dbglog(DBG_INFO, "Loading /rd/library-dependence.klf\n");
     lib_dependence = library_open("dependence", "/rd/library-dependence.klf");
 
     if (lib_dependence == NULL) {
@@ -87,11 +87,11 @@ int main(int argc, char *argv[]) {
 
     ver = library_get_version(lib_dependence);
 
-    dbglog(DBG_DEBUG, "Successfully loaded: %s v%ld.%ld.%ld\n",
+    dbglog(DBG_INFO, "Successfully loaded: %s v%ld.%ld.%ld\n",
         library_get_name(lib_dependence),
         (ver >> 16) & 0xff, (ver >> 8) & 0xff, ver & 0xff);
 
-    dbglog(DBG_DEBUG, "Loading /rd/library-dependence.klf\n");
+    dbglog(DBG_INFO, "Loading /rd/library-dependence.klf\n");
     lib_dependent = library_open("dependent", "/rd/library-dependent.klf");
 
     if (lib_dependence == NULL) {
@@ -102,11 +102,11 @@ int main(int argc, char *argv[]) {
 
     ver = library_get_version(lib_dependent);
 
-    dbglog(DBG_DEBUG, "Successfully loaded: %s v%ld.%ld.%ld\n",
+    dbglog(DBG_INFO, "Successfully loaded: %s v%ld.%ld.%ld\n",
         library_get_name(lib_dependent),
         (ver >> 16) & 0xff, (ver >> 8) & 0xff, ver & 0xff);
 
-    dbglog(DBG_DEBUG, "Testing exports runtime on host\n");
+    dbglog(DBG_INFO, "Testing exports runtime on host\n");
 
     sym = export_lookup("library_test_func");
     

--- a/examples/dreamcast/library/loadable-dependence/library-dependence.c
+++ b/examples/dreamcast/library/loadable-dependence/library-dependence.c
@@ -35,21 +35,21 @@ uint32_t lib_get_version() {
 }
 
 int lib_open(klibrary_t *lib) {
-    dbglog(DBG_DEBUG, "Library \"%s\" opened.\n", lib_get_name());
+    dbglog(DBG_INFO, "Library \"%s\" opened.\n", lib_get_name());
     return nmmgr_handler_add(&library_hnd.nmmgr);
 }
 
 int lib_close(klibrary_t *lib) {
-    dbglog(DBG_DEBUG, "Library \"%s\" closed.\n", lib_get_name());
+    dbglog(DBG_INFO, "Library \"%s\" closed.\n", lib_get_name());
     return nmmgr_handler_remove(&library_hnd.nmmgr);
 }
 
 /* Exported functions */
 int library_test_func(int arg) {
-    dbglog(DBG_DEBUG, "Library \"%s\" test int: %d\n", lib_get_name(), arg);
+    dbglog(DBG_INFO, "Library \"%s\" test int: %d\n", lib_get_name(), arg);
     return 0;
 }
 
 void library_test_func2(const char *arg) {
-    dbglog(DBG_DEBUG, "Library \"%s\" test char: %s\n", lib_get_name(), arg);
+    dbglog(DBG_INFO, "Library \"%s\" test char: %s\n", lib_get_name(), arg);
 }

--- a/examples/dreamcast/library/loadable-dependent/library-dependent.c
+++ b/examples/dreamcast/library/loadable-dependent/library-dependent.c
@@ -27,7 +27,7 @@ uint32_t lib_get_version() {
 int lib_open(klibrary_t *lib) {
     uint8_t output[16];
 
-    dbglog(DBG_DEBUG, "Library \"%s\" opened.\n", lib_get_name());
+    dbglog(DBG_INFO, "Library \"%s\" opened.\n", lib_get_name());
 
     // Test exports from dependence library
     library_test_func(333);
@@ -35,7 +35,7 @@ int lib_open(klibrary_t *lib) {
 
     // Test libkosutils from dependence library
     kos_md5((const uint8_t *)lib_get_name(), strlen(lib_get_name()), output);
-    dbglog(DBG_DEBUG, "MD5 of \"%s\": %02X%02X%02X%02X...\n",
+    dbglog(DBG_INFO, "MD5 of \"%s\": %02X%02X%02X%02X...\n",
         lib_get_name(), output[0], output[1], output[2], output[3]);
 
     // Test host exported newlib
@@ -47,6 +47,6 @@ int lib_open(klibrary_t *lib) {
 }
 
 int lib_close(klibrary_t *lib) {
-    dbglog(DBG_DEBUG, "Library \"%s\" closed.\n", lib_get_name());
+    dbglog(DBG_INFO, "Library \"%s\" closed.\n", lib_get_name());
     return 0;
 }

--- a/examples/dreamcast/parallax/delay_cube/delay_cube.c
+++ b/examples/dreamcast/parallax/delay_cube/delay_cube.c
@@ -185,7 +185,7 @@ int main(int argc, char **argv) {
     // You have to keep a watch on these, especially the vertex used
     // for really poly intensive effects.
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
+    dbglog(DBG_INFO, "3D Stats: %d vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
            stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;

--- a/examples/dreamcast/parallax/rotocube/rotocube.c
+++ b/examples/dreamcast/parallax/rotocube/rotocube.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv) {
     // You have to keep a watch on these, especially the vertex used
     // for really poly intensive effects.
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
+    dbglog(DBG_INFO, "3D Stats: %d vblanks, frame rate ~%f fps, max vertex used %d bytes\n",
            stats.vbl_count, (double)stats.frame_rate, stats.vtx_buffer_used_max);
 
     return 0;

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -295,7 +295,7 @@ int main(int argc, char **argv) {
     do_sphere_test();
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %u vblanks, frame rate ~%f fps, max vertex used %u bytes\n",
+    dbglog(DBG_INFO, "3D Stats: %u vblanks, frame rate ~%f fps, max vertex used %u bytes\n",
            stats.vbl_count, stats.frame_rate, stats.vtx_buffer_used_max);
 
     free(big_sphere.data);

--- a/examples/dreamcast/pvr/pvrmark/pvrmark.c
+++ b/examples/dreamcast/pvr/pvrmark/pvrmark.c
@@ -33,7 +33,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_INFO, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
+++ b/examples/dreamcast/pvr/pvrmark_strips/pvrmark_strips.c
@@ -33,7 +33,7 @@ void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d VBLs, frame rate ~%f fps\n",
+    dbglog(DBG_INFO, "3D Stats: %d VBLs, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 

--- a/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
+++ b/examples/dreamcast/pvr/pvrmark_strips_direct/pvrmark_strips_direct.c
@@ -42,7 +42,7 @@ static void stats(void) {
     pvr_stats_t stats;
 
     pvr_get_stats(&stats);
-    dbglog(DBG_DEBUG, "3D Stats: %d frames, frame rate ~%f fps\n",
+    dbglog(DBG_INFO, "3D Stats: %d frames, frame rate ~%f fps\n",
            stats.vbl_count, (double)stats.frame_rate);
 }
 


### PR DESCRIPTION
After #1118 some examples became completely silent by default as they were written presuming dbglog output set to maximum all the time. I've set these to use `DBG_INFO` where appropriate to ensure the baseline informational content is output.