### PR TITLE
Fixed string-related warnings.

### DIFF
--- a/kernel/fs/fs_utils.c
+++ b/kernel/fs/fs_utils.c
@@ -203,7 +203,7 @@ char *fs_normalize_path(const char *__restrict path, char *__restrict resolved) 
 
     /* Handle absolute path. */
     if(path[0] == '/') {
-        strncpy(temp_path, path, len);
+        strcpy(temp_path, path);
         temp_path[len] = '\0';
     } 
     else {

--- a/kernel/libc/koslib/realpath.c
+++ b/kernel/libc/koslib/realpath.c
@@ -42,8 +42,7 @@ char *realpath(const char *__restrict path, char *__restrict resolved) {
 
     /* Handle absolute path. */
     if(path[0] == '/') {
-        strncpy(temp_path, path, len);
-        temp_path[len] = '\0';
+        strcpy(temp_path, path);
     } 
     else {
         /* Handle relative path: prepend current working directory. */


### PR DESCRIPTION
The following functions:

1) realpath()
2) fs_normalize_path()

had annoying warnings about strncpy() calls which don't copy enough from the source buffer to include its NULL terminator... which... it's not actually a problem, since the lines right after had us manually terminating the strings, but... this appeases GCC, so whatever.