### PR TITLE
Further updates for `__pure` usage

### DIFF
--- a/include/kos/mutex.h
+++ b/include/kos/mutex.h
@@ -211,7 +211,7 @@ int mutex_lock_timed(mutex_t *m, int timeout) __nonnull_all;
     \retval 0               If the mutex is not currently locked
     \retval 1               If the mutex is currently locked
 */
-int mutex_is_locked(const mutex_t *m) __nonnull_all;
+int __pure mutex_is_locked(const mutex_t *m) __nonnull_all;
 
 /** \brief  Attempt to lock a mutex.
 

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -340,7 +340,7 @@ int hardware_sys_mode(int *region);
 
     \return                 A pointer to the banner string.
 */
-const char * __pure kos_get_banner(void);
+const char * __pure2 kos_get_banner(void);
 
 /** \brief   Retrieve the license information for the compiled copy of KOS.
     \ingroup attribution
@@ -351,7 +351,7 @@ const char * __pure kos_get_banner(void);
 
     \return                 A pointer to the license terms.
 */
-const char * __pure kos_get_license(void);
+const char * __pure2 kos_get_license(void);
 
 /** \brief   Retrieve a list of authors and the dates of their contributions.
     \ingroup attribution
@@ -367,7 +367,7 @@ const char * __pure kos_get_license(void);
 
     \return                 A pointer to the authors' copyright information.
 */
-const char *__pure kos_get_authors(void);
+const char *__pure2 kos_get_authors(void);
 
 /** \brief   Dreamcast specific sleep mode function.
     \ingroup arch

--- a/kernel/arch/dreamcast/kernel/banner.c
+++ b/kernel/arch/dreamcast/kernel/banner.c
@@ -35,15 +35,15 @@ static const char license[] =
 "OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF\n"
 "SUCH DAMAGE.";
 
-const char * __pure kos_get_banner(void) {
+const char * __pure2 kos_get_banner(void) {
     __asm__ __volatile__("nop" : : "r"(license), "r"(authors));
     return banner;
 }
 
-const char * __pure kos_get_license(void) {
+const char * __pure2 kos_get_license(void) {
     return license;
 }
 
-const char * __pure kos_get_authors(void) {
+const char * __pure2 kos_get_authors(void) {
     return authors;
 }


### PR DESCRIPTION
Addressing some feedback on #992 .

- `mutex_is_locked` was missing the `__pure` attribute in mutex.h
- The `kos_get_banner` functions qualify to be the stricter `__pure2` which maps to the gcc function attribute [const](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-const-function-attribute)