### PR TITLE
examples: Only build one arch's examples dir based on KOS_ARCH

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -9,7 +9,7 @@
 # Get a list of the sub-directories that contain a Makefile
 get_subdirs=$(foreach each,$(wildcard $(1)/*),$(if $(wildcard $(each)/Makefile),$(each),) $(call get_subdirs,$(each)))
 
-DIRS := $(call get_subdirs, $(shell pwd))
+DIRS := $(call get_subdirs, $(shell pwd)/$(KOS_ARCH))
 
 .PHONY: all $(DIRS)
 


### PR DESCRIPTION
Instead of building all subdirs of `$KOS_BASE/examples`, only build the subdirs of `$KOS_BASE/examples/$KOS_ARCH`.