### PR TITLE
cdefs/newlib cleanup

### DIFF
--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -4,6 +4,7 @@
    Copyright (C) 2002, 2004 Megan Potter
    Copyright (C) 2020, 2023 Lawrence Sebald
    Copyright (C) 2023 Falco Girgis
+   Copyright (C) 2024, 2025 Donald Haase
 
    Based loosely around some stuff in BSD's sys/cdefs.h
 */
@@ -19,6 +20,7 @@
     \author Megan Potter
     \author Lawrence Sebald
     \author Falco Girgis
+    \author Donald Haase
 */
 
 #ifndef __KOS_CDEFS_H
@@ -47,29 +49,9 @@
 #define __noreturn  __attribute__((__noreturn__))
 #endif
 
-#ifndef __unused
-/** \brief  Identify a function or variable that may be unused. */
-#define __unused    __attribute__((__unused__))
-#endif
-
-#ifndef __used
-/** \brief  Prevent a symbol from being removed from the binary. */
-#define __used      __attribute__((used))
-#endif
-
 #ifndef __weak
 /** \brief  Identify a function or variable that may be overridden by another symbol. */
 #define __weak      __attribute__((weak))
-#endif
-
-#ifndef __packed
-/** \brief  Force a structure, enum, or other type to be packed as small as possible. */
-#define __packed    __attribute__((packed))
-#endif
-
-#ifndef __dead2
-/** \brief  Alias for \ref __noreturn. For BSD compatibility. */
-#define __dead2     __noreturn  /* BSD compat */
 #endif
 
 #ifndef __likely
@@ -115,44 +97,12 @@
 #define __depr(m) __attribute__((deprecated(m)))
 #endif
 
-/* Printf/Scanf-like declaration */
-#ifndef __printflike
-/** \brief  Identify a function as accepting formatting like printf().
-
-    Using this macro allows GCC to typecheck calls to printf-like functions,
-    which can aid in finding mistakes.
-
-    \param  fmtarg          The argument number (1-based) of the format string.
-    \param  firstvararg     The argument number of the first vararg (the ...).
-*/
-#define __printflike(fmtarg, firstvararg) \
-    __attribute__((__format__ (__printf__, fmtarg, firstvararg)))
-#endif
-
-#ifndef __scanflike
-/** \brief  Identify a function as accepting formatting like scanf().
-
-    Using this macro allows GCC to typecheck calls to scanf-like functions,
-    which can aid in finding mistakes.
-
-    \param  fmtarg          The argument number (1-based) of the format string.
-    \param  firstvararg     The argument number of the first vararg (the ...).
-*/
-#define __scanflike(fmtarg, firstvararg) \
-    __attribute__((__format__ (__scanf__, fmtarg, firstvararg)))
-#endif
-
 #if __GNUC__ >= 7
 /** \brief  Identify a case statement that is expected to fall through to the
             statement underneath it. */
 #define __fallthrough __attribute__((__fallthrough__))
 #else
 #define __fallthrough /* Fall through */
-#endif
-
-#ifndef __always_inline
-/** \brief  Ask the compiler to \a always inline a given function. */
-#define __always_inline inline __attribute__((__always_inline__))
 #endif
 
 #ifndef __no_inline

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -27,7 +27,7 @@
 #include <sys/cdefs.h>
 
 /* Check GCC version */
-#if __GNUC__ <= 3
+#if __GNUC__ < 9
 #   warning Your GCC is too old. This will probably not work right.
 #endif
 

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -255,16 +255,11 @@
  */
 #define __array_size(arr) (sizeof(arr) / sizeof((arr)[0]) + _array_size_chk(arr))
 
-/* Helper for __array_size's type check */
-#if HAVE_BUILTIN_TYPES_COMPATIBLE_P && HAVE_TYPEOF
 /* Two gcc extensions.
  * &a[0] degrades to a pointer: a different type from an array */
 #define _array_size_chk(arr)                        \
     __build_assert_or_zero(!__builtin_types_compatible_p(typeof(arr),   \
                             typeof(&(arr)[0])))
-#else
-#define _array_size_chk(arr) 0
-#endif
 
 /** \brief Create a string from the argument.
 

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -49,11 +49,6 @@
 #define __noreturn  __attribute__((__noreturn__))
 #endif
 
-#ifndef __weak
-/** \brief  Identify a function or variable that may be overridden by another symbol. */
-#define __weak      __attribute__((weak))
-#endif
-
 #ifndef __likely
 /** \brief  Directive to inform the compiler the condition is in the likely path.
 

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -74,11 +74,6 @@
 #define __fallthrough /* Fall through */
 #endif
 
-#ifndef __no_inline
-/** \brief Ask the compiler to \a never inline a given function. */
-#define __no_inline __attribute__((__noinline__))
-#endif
-
 /** @} */
 
 /** \defgroup system_compat Language Compatibility Defines

--- a/include/kos/cdefs.h
+++ b/include/kos/cdefs.h
@@ -49,32 +49,6 @@
 #define __noreturn  __attribute__((__noreturn__))
 #endif
 
-#ifndef __likely
-/** \brief  Directive to inform the compiler the condition is in the likely path.
-
-    This can be used around conditionals or loops to help inform the
-    compiler which path to optimize for as the common-case.
-
-    \param  exp     Boolean expression which expected to be true.
-
-    \sa __unlikely()
-*/
-#define __likely(exp)   __builtin_expect(!!(exp), 1)
-#endif
-
-#ifndef __unlikely
-/** \brief  Directive to inform the compiler the condition is in the unlikely path.
-
-    This can be used around conditionals or loops to help inform the
-    compiler which path to optimize against as the infrequent-case.
-
-    \param  exp     Boolean expression which is expected to be false.
-
-    \sa __likely()
-*/
-#define __unlikely(exp) __builtin_expect(!!(exp), 0)
-#endif
-
 #ifndef __deprecated
 /** \brief  Mark something as deprecated.
     This should be used to warn users that a function/type/etc will be removed

--- a/include/kos/init_base.h
+++ b/include/kos/init_base.h
@@ -30,7 +30,7 @@ __BEGIN_DECLS
 /* Declares a weak function pointer which can be optionally
    overridden and given a value later. */
 #define KOS_INIT_FLAG_WEAK(func, dft_on) \
-    void (*func##_weak)(void) __weak = (dft_on) ? func : NULL
+    void (*func##_weak)(void) __weak_symbol = (dft_on) ? func : NULL
 
 /* Invokes the given function if its weak function pointer
    has been overridden to point to a valid function. */

--- a/include/sys/_types.h
+++ b/include/sys/_types.h
@@ -137,13 +137,7 @@ typedef unsigned long __mode_t;
 typedef unsigned short __nlink_t;
 typedef long        __suseconds_t;  /* microseconds (signed) */
 typedef unsigned long   __useconds_t;   /* microseconds (unsigned) */
-
-#if __NEWLIB__ >= 3
-#define _TIME_T_ long long
-#else
-#define _TIME_T_ long
-#endif
-typedef _TIME_T_    __time_t;
+typedef long long    __time_t;
 
 #ifndef __clockid_t_defined
 #define _CLOCKID_T_     unsigned long

--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -27,13 +27,7 @@ __BEGIN_DECLS
 
 #include <newlib.h>
 #include <kos/opts.h>
-
-#if __NEWLIB__ > 2 || (__NEWLIB__ == 2 && __NEWLIB_MINOR__ > 2)
 #include <sys/_timeval.h>
-#else
-#include <time.h>
-#include <sys/time.h>
-#endif
 
 /* Newlib used to define fd_set and friends in <sys/types.h>, but at some point
    that stopped being the case... This should tell us whether we need to define

--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -121,7 +121,7 @@ void sq_wait(void) {
 }
 
 /* Copies n bytes from src to dest, dest must be 32-byte aligned */
-__no_inline void *sq_cpy(void *dest, const void *src, size_t n) {
+__noinline void *sq_cpy(void *dest, const void *src, size_t n) {
     const uint32_t *s = src;
     void *curr_dest = dest;
     uint32_t *d;

--- a/kernel/arch/dreamcast/include/dc/fmath.h
+++ b/kernel/arch/dreamcast/include/dc/fmath.h
@@ -31,22 +31,11 @@ __BEGIN_DECLS
     @{
 */
 
-/* Sigh... C99 treats inline stuff a lot differently than traditional GCC did,
-   so we need to take care of that... */
-#if __STDC_VERSION__ >= 199901L
-#define __FMINLINE static inline
-#elif __GNUC__
-#define __FMINLINE extern inline
-#else
-/* Uhm... I guess this is the best we can do? */
-#define __FMINLINE static
-#endif
-
 /**
     \brief  Floating point inner product.
     \return v1 dot v2 (inner product)
 */
-__FMINLINE float __pure fipr(float x, float y, float z, float w,
+static inline float __pure fipr(float x, float y, float z, float w,
                       float a, float b, float c, float d) {
     return __fipr(x, y, z, w, a, b, c, d);
 }
@@ -55,7 +44,7 @@ __FMINLINE float __pure fipr(float x, float y, float z, float w,
     \brief  Floating point inner product w/self (square of vector magnitude)
     \return v1 dot v1 (square of magnitude)
 */
-__FMINLINE float __pure fipr_magnitude_sqr(float x, float y, float z, float w) {
+static inline float __pure fipr_magnitude_sqr(float x, float y, float z, float w) {
     return __fipr_magnitude_sqr(x, y, z, w);
 }
 
@@ -64,7 +53,7 @@ __FMINLINE float __pure fipr_magnitude_sqr(float x, float y, float z, float w) {
     \param r a floating point number between 0 and 2*PI
     \return sin(r), where r is [0..2*PI]
 */
-__FMINLINE float __pure fsin(float r) {
+static inline float __pure fsin(float r) {
     return __fsin(r);
 }
 
@@ -73,7 +62,7 @@ __FMINLINE float __pure fsin(float r) {
     \param r a floating point number between 0 and 2*PI
     \return cos(r), where r is [0..2*PI]
 */
-__FMINLINE __pure float fcos(float r) {
+static inline __pure float fcos(float r) {
     return __fcos(r);
 }
 
@@ -82,7 +71,7 @@ __FMINLINE __pure float fcos(float r) {
     \param r a floating point number between 0 and 2*PI
     \return tan(r), where r is [0..2*PI]
 */
-__FMINLINE __pure float ftan(float r) {
+static inline __pure float ftan(float r) {
     return __ftan(r);
 }
 
@@ -91,7 +80,7 @@ __FMINLINE __pure float ftan(float r) {
     \param d an integer between 0 and 65535
     \return sin(d), where d is [0..65535]
 */
-__FMINLINE __pure float fisin(int d) {
+static inline __pure float fisin(int d) {
     return __fisin(d);
 }
 
@@ -100,7 +89,7 @@ __FMINLINE __pure float fisin(int d) {
     \param d an integer between 0 and 65535
     \return cos(d), where d is [0..65535]
 */
-__FMINLINE __pure float ficos(int d) {
+static inline __pure float ficos(int d) {
     return __ficos(d);
 }
 
@@ -109,7 +98,7 @@ __FMINLINE __pure float ficos(int d) {
     \param d an integer between 0 and 65535
     \return tan(d), where d is [0..65535]
 */
-__FMINLINE float __pure fitan(int d) {
+static inline float __pure fitan(int d) {
     return __fitan(d);
 }
 
@@ -117,14 +106,14 @@ __FMINLINE float __pure fitan(int d) {
     \brief Floating point square root
     \return sqrt(f)
 */
-__FMINLINE float __pure fsqrt(float f) {
+static inline float __pure fsqrt(float f) {
     return __fsqrt(f);
 }
 
 /**
     \return 1.0f / sqrt(f)
 */
-__FMINLINE float __pure frsqrt(float f) {
+static inline float __pure frsqrt(float f) {
     return __frsqrt(f);
 }
 
@@ -137,7 +126,7 @@ __FMINLINE float __pure frsqrt(float f) {
     \param  s               Storage for the returned sine value.
     \param  c               Storage for the returned cosine value.
 */
-__FMINLINE void fsincos(float f, float *s, float *c) {
+static inline void fsincos(float f, float *s, float *c) {
     __fsincos(f, *s, *c);
 }
 
@@ -150,7 +139,7 @@ __FMINLINE void fsincos(float f, float *s, float *c) {
     \param  s               Storage for the returned sine value.
     \param  c               Storage for the returned cosine value.
 */
-__FMINLINE void fsincosr(float f, float *s, float *c) {
+static inline void fsincosr(float f, float *s, float *c) {
     __fsincosr(f, *s, *c);
 }
 
@@ -178,7 +167,7 @@ __FMINLINE void fsincosr(float f, float *s, float *c) {
     \note   Thanks to Fredrik Ehnbom for figuring this stuff out and posting it
             to the mailing list back in 2005!
 */
-__FMINLINE uint32_t __pure pvr_pack_bump(float h, float t, float q) {
+static inline uint32_t __pure pvr_pack_bump(float h, float t, float q) {
     uint8_t hp = (uint8_t)(h * 255.0f);
     uint8_t k1 = ~hp;
     uint8_t k2 = (uint8_t)(hp * __fsin(t));

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -153,7 +153,7 @@ KOS_INIT_FLAG_WEAK(library_shutdown, true);
 /* Auto-init stuff: override with a non-weak symbol if you don't want all of
    this to be linked into your code (and do the same with the
    arch_auto_shutdown function too). */
-int  __weak arch_auto_init(void) {
+int  __weak_symbol arch_auto_init(void) {
     /* Initialize memory management */
     mm_init();
 
@@ -234,7 +234,7 @@ int  __weak arch_auto_init(void) {
     return 0;
 }
 
-void  __weak arch_auto_shutdown(void) {
+void  __weak_symbol arch_auto_shutdown(void) {
     KOS_INIT_FLAG_CALL(fs_dclsocket_shutdown);
     if (!KOS_PLATFORM_IS_NAOMI)
         KOS_INIT_FLAG_CALL(net_shutdown);

--- a/kernel/arch/dreamcast/kernel/perfctr.c
+++ b/kernel/arch/dreamcast/kernel/perfctr.c
@@ -81,7 +81,7 @@ uint64_t perf_cntr_count(perf_cntr_t counter) {
         hi = PMCTR_HIGH(counter);
         lo = PMCTR_LOW(counter);
         hi2 = PMCTR_HIGH(counter);
-    } while (__unlikely(hi != hi2));
+    } while (__predict_false(hi != hi2));
 
     return (uint64_t)hi << 32 | lo;
 }

--- a/kernel/arch/dreamcast/kernel/timer.c
+++ b/kernel/arch/dreamcast/kernel/timer.c
@@ -278,7 +278,7 @@ static timer_val_t timer_getticks(const uint32_t *tns, uint32_t shift) {
         counter2 = TIMER32(tcnts[TMU2]);
         tmu2 = TIMER16(tcrs[TMU2]);
         unf2 = !!(tmu2 & UNF);
-    } while (__unlikely(unf1 != unf2 || counter1 < counter2));
+    } while (__predict_false(unf1 != unf2 || counter1 < counter2));
 
     delta = timer_ms_countdown - counter2;
 

--- a/kernel/fs/fs_random.c
+++ b/kernel/fs/fs_random.c
@@ -22,16 +22,6 @@
    Declaring as extern here to avoid implicit declaration */
 extern void arc4random_buf(void *, size_t);
 
-#if !defined(__NEWLIB__) || (__NEWLIB__ < 2 && __NEWLIB_MINOR__ < 4)
-/* Ensure the function is defined on versions of Newlib where it doesn't exist,
-   even though this isn't functional at all. This makes sure we don't get any
-   linker errors when -ffunction-sections isn't used, for instance. */
-void arc4random_buf(void *a, size_t b) {
-    (void)a;
-    (void)b;
-}
-#endif
-
 /* File handles */
 typedef struct rnd_fh_str {
     int mode;                           /* mode the file was opened with */


### PR DESCRIPTION
Cleaning up various macros revolving around newlib:
- Drop compatibility patches for newlib < 4.
- As possible, remove macros from our `<kos/cdefs.h>` that are already available directly from newlib.
- Remove a specific bespoke compatibility shim being used by fmath that we already have common protection for.

This *could* cause issues if external software had started to use some of our slightly differently named macros:
`__no_inline` vs `__noinline`
`__{un}likely` vs `__predict_{true, false}`
`__weak` vs `__weak_symbol`

If anyone thinks that would be a problem, could add some compatibility/deprecation wrappers for them, but I'd presume that the only users might be the contributors who provided them.