### PR TITLE
kos-cmake to use "Unix Makefiles" generator.

### DIFF
--- a/utils/build_wrappers/kos-cmake
+++ b/utils/build_wrappers/kos-cmake
@@ -8,6 +8,7 @@ if [ -z "${KOS_BASE}" ]; then
 fi
 
 cmake \
+  -G "Unix Makefiles" \
   -DCMAKE_TOOLCHAIN_FILE="${KOS_BASE}/utils/cmake/kallistios.toolchain.cmake" \
   "$@"
 


### PR DESCRIPTION
Apparently CMake on Windows will default to favoring Visual Studio as its generator of choice when none have been explicitly provided. This causes every CMake-based KOS-port to fail to install from DreamSDK, due to Visual Studio being selected as the target compiler.

This small change is simply to make the kos-cmake wrapper explicitly tell cmake to use the "Unix Makefiles" generator, so that the rest of our build system and toolchain get honored, rather than Visual Studio.

NOTE: Fully resolving this issue requires also merging this PR into kos-ports as well: https://github.com/KallistiOS/kos-ports/pull/116. 