### PR TITLE
dc-chain: Remove fake KOS objects from libgcc after build

### DIFF
--- a/utils/dc-chain/scripts/gcc-pass2.mk
+++ b/utils/dc-chain/scripts/gcc-pass2.mk
@@ -32,4 +32,5 @@ ifdef enable_ada
   endif
 endif
 	$(MAKE) -C $(build) $(install_mode) DESTDIR=$(DESTDIR) $(to_log)
+	$(target)-gcc-ar d $(shell $(target)-gcc -print-file-name=libgcc.a) fake-kos.o
 	$(clean_up)


### PR DESCRIPTION
This should not be necessary and I don't understand why we need this; the symbols inside fake-kos.o are all weak, and should all be replaced by symbols provided by libkallisti.a. Alas, this does not seem to work reliably, and cause crashes and issues that are hard to debug.

Address these issues by just dropping the fake-kos.o object from the libgcc.a archive.