### PR TITLE
`fs_romdisk` and `exec` example fixup

### DIFF
--- a/examples/dreamcast/basic/exec/exec.c
+++ b/examples/dreamcast/basic/exec/exec.c
@@ -9,20 +9,38 @@
 
 int main(int argc, char **argv) {
     file_t f;
-    void *subelf;
+    size_t s;
+    ssize_t rv;
+    void *subbin;
 
     /* Print a hello */
     printf("\n\nHello world from the exec.elf process\n");
 
-    /* Map the sub-elf */
+    /* Open the sub-bin. Note normally this wouldn't be from a
+       romdisk as that means that you'd already have it loaded
+       in memory.
+    */
     f = fs_open("/rd/sub.bin", O_RDONLY);
     assert(f);
-    subelf = fs_mmap(f);
-    assert(subelf);
+
+    /* Get the size of sub.bin */
+    s = fs_total(f);
+    assert(s);
+
+    /* Allocate space for it */
+    subbin = malloc(s);
+    assert(subbin);
+
+    /* Copy in the sub.bin */
+    rv = fs_read(f, subbin, s);
+    assert(rv == s);
+
+    /* Lets be nice and tidy up after ourselves */
+    fs_close(f);
 
     /* Tell exec to replace us */
-    printf("sub.bin mapped at %08x, jumping to it!\n\n\n", (unsigned int)subelf);
-    arch_exec(subelf, fs_total(f));
+    printf("sub.bin loaded at %08x, jumping to it!\n\n\n", (uintptr_t)subbin);
+    arch_exec(subbin, s);
 
     /* Shouldn't get here */
     assert_msg(false, "exec call failed");

--- a/kernel/fs/fs_romdisk.c
+++ b/kernel/fs/fs_romdisk.c
@@ -672,6 +672,8 @@ void fs_romdisk_shutdown(void) {
     if(!initted)
         return;
 
+    initted = 0;
+
     mutex_lock(&fh_mutex);
 
     /* Go through and free all the romdisk mount entries */
@@ -679,17 +681,15 @@ void fs_romdisk_shutdown(void) {
         fs_romdisk_list_remove(c);
     }
 
+    mutex_unlock(&fh_mutex);
+
     /* Iterate through any dangling files and clean them */
     TAILQ_FOREACH_SAFE(i, &rd_fd_queue, next, j) {
         romdisk_close(i);
     }
 
-    mutex_unlock(&fh_mutex);
-
     /* Free mutex */
     mutex_destroy(&fh_mutex);
-
-    initted = 0;
 }
 
 /* Mount a romdisk image; must have called fs_romdisk_init() earlier.


### PR DESCRIPTION
Bundling these together as the exec example breaking revealed the issue with `fs_romdisk_shutdown`. After the romdisk commit, the exec example should work again with its older fragile `fs_mmap` to help validate the issue before then adjusting the example to `fs_close` the subbin.