### PR TITLE
`purupuru`: Refactor effects, fix first-party device support

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -183,8 +183,8 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
         vbl_chk_next_subdev(state, frm, p);
     }
     else {
-        /* dbglog(DBG_KDEBUG, "maple: unknown response %d on device %c%c\n",
-            resp->response, 'A'+p, '0'+u); */
+        dbglog(DBG_DEBUG, "maple: unknown response %d on device %c%c\n",
+            resp->response, 'A'+p, '0'+u);
         state->scan_ready_mask |= 1 << p;
         maple_frame_unlock(frm);
     }
@@ -274,6 +274,12 @@ void maple_dma_irq_hnd(uint32 code, void *data) {
         if(resp == MAPLE_RESPONSE_AGAIN) {
             i->state = MAPLE_FRAME_UNSENT;
             continue;
+        }
+        /* This error is generated in the case where bad input is sent to the purupuru.
+           For instance, when setting motor selection to '0' rather than '1'. */
+        else if(resp == MAPLE_RESPONSE_BADFUNC) {
+            dbglog(DBG_ERROR, "maple_irq: error EBADFUNC on %c%i when sending command: %i\n",
+            ('A' - i->dst_port), i->dst_unit, i->cmd);
         }
 
         if(__is_defined(MAPLE_DMA_DEBUG))

--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -7,15 +7,14 @@
 
 #include <assert.h>
 #include <kos/dbglog.h>
-#include <kos/genwait.h>
 #include <dc/maple.h>
 #include <dc/maple/purupuru.h>
 
 /* Be warned, not all purus are created equal, in fact, most of
    them act different for just about everything you feed to them. */
 
-int purupuru_rumble_raw(maple_device_t *dev, uint32 effect) {
-    uint32 *send_buf;
+int purupuru_rumble_raw(maple_device_t *dev, uint32_t effect) {
+    uint32_t *send_buf;
 
     assert(dev != NULL);
 
@@ -25,7 +24,7 @@ int purupuru_rumble_raw(maple_device_t *dev, uint32 effect) {
 
     /* Reset the frame */
     maple_frame_init(&dev->frame);
-    send_buf = (uint32 *)dev->frame.recv_buf;
+    send_buf = (uint32_t *)dev->frame.recv_buf;
     send_buf[0] = MAPLE_FUNC_PURUPURU;
     send_buf[1] = effect;
     dev->frame.cmd = MAPLE_COMMAND_SETCOND;
@@ -40,7 +39,7 @@ int purupuru_rumble_raw(maple_device_t *dev, uint32 effect) {
 }
 
 int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect) {
-    uint32 comp_effect;
+    uint32_t comp_effect;
 
     assert(dev != NULL);
 

--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -3,6 +3,7 @@
    purupuru.c
    Copyright (C) 2003 Megan Potter
    Copyright (C) 2005 Lawrence Sebald
+   Copyright (C) 2025 Donald Haase
 */
 
 #include <assert.h>
@@ -39,6 +40,18 @@ int purupuru_rumble_raw(maple_device_t *dev, uint32_t effect) {
 }
 
 int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect) {
+
+    /* Error checking to prevent hardware-level errors */
+    if(!effect->motor) {
+        dbglog(DBG_WARNING, "puru: invalid rumble effect sent. motor must be nonzero.\n");
+        return MAPLE_EINVALID;
+    }
+
+    if(effect->conv && effect->div) {
+        dbglog(DBG_WARNING, "puru: invalid rumble effect sent. Divergent and Convergent rumble cannot be set together.\n");
+        return MAPLE_EINVALID;
+    }
+
     return purupuru_rumble_raw(dev, effect->raw);
 }
 

--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -39,7 +39,7 @@ int purupuru_rumble_raw(maple_device_t *dev, uint32_t effect) {
     return MAPLE_EOK;
 }
 
-int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect) {
+int purupuru_rumble(maple_device_t *dev, const purupuru_effect_t *effect) {
 
     /* Error checking to prevent hardware-level errors */
     if(!effect->motor) {

--- a/kernel/arch/dreamcast/hardware/maple/purupuru.c
+++ b/kernel/arch/dreamcast/hardware/maple/purupuru.c
@@ -39,15 +39,7 @@ int purupuru_rumble_raw(maple_device_t *dev, uint32_t effect) {
 }
 
 int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect) {
-    uint32_t comp_effect;
-
-    assert(dev != NULL);
-
-    /* "Compile" the effect */
-    comp_effect = (effect->duration << 24) | (effect->effect2 << 16) |
-                  (effect->effect1 << 8) | (effect->special);
-
-    return purupuru_rumble_raw(dev, comp_effect);
+    return purupuru_rumble_raw(dev, effect->raw);
 }
 
 

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -36,7 +36,7 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
+#include <stdint.h>
 #include <dc/maple.h>
 
 /** \defgroup peripherals_rumble    Rumble Pack
@@ -54,16 +54,16 @@ __BEGIN_DECLS
 */
 typedef struct purupuru_effect  {
     /** \brief  The duration of the effect. No idea on units... */
-    uint8 duration;
+    uint8_t duration;
 
     /** \brief  2nd effect field. */
-    uint8 effect2;
+    uint8_t effect2;
 
     /** \brief  1st effect field. */
-    uint8 effect1;
+    uint8_t effect1;
 
     /** \brief  Special effects field. */
-    uint8 special;
+    uint8_t special;
 } purupuru_effect_t;
 
 /* Set one of each of the following in the effect2 field of the
@@ -181,7 +181,7 @@ int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect);
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
 */
-int purupuru_rumble_raw(maple_device_t *dev, uint32 effect);
+int purupuru_rumble_raw(maple_device_t *dev, uint32_t effect);
 
 /* \cond */
 /* Init / Shutdown */

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -52,18 +52,23 @@ __BEGIN_DECLS
     This, along with the various macros in this file can give a slightly better
     idea of the effect being generated than using the raw values.
 */
-typedef struct purupuru_effect  {
-    /** \brief  The duration of the effect. No idea on units... */
-    uint8_t duration;
+typedef union purupuru_effect  {
+    /** \brief Access the raw 32-bit value to be sent to the puru */
+    uint32_t raw;
+    /** \brief Deprecated old structure which has been inverted now to union with raw. */
+    struct {
+        /** \brief  Special effects field. */
+        uint8_t special;
 
-    /** \brief  2nd effect field. */
-    uint8_t effect2;
+        /** \brief  1st effect field. */
+        uint8_t effect1;
 
-    /** \brief  1st effect field. */
-    uint8_t effect1;
+        /** \brief  2nd effect field. */
+        uint8_t effect2;
 
-    /** \brief  Special effects field. */
-    uint8_t special;
+        /** \brief  The duration of the effect. No idea on units... */
+        uint8_t duration;
+    };
 } purupuru_effect_t;
 
 /* Set one of each of the following in the effect2 field of the

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -52,25 +52,19 @@ __BEGIN_DECLS
 /** \brief  Effect generation structure.
 
     This structure is used for convenience to send an effect to the jump pack.
-    This, along with the various macros in this file can give a slightly better
-    idea of the effect being generated than using the raw values.
+    The members in the structure note general explanations of their use as well
+    as some limitations and suggestions. There shouldn't be a need to use the
+    raw accessor with the new fully specified members.
 */
 typedef union purupuru_effect  {
     /** \brief Access the raw 32-bit value to be sent to the puru */
     uint32_t raw;
     /** \brief Deprecated old structure which has been inverted now to union with raw. */
     struct {
-        /** \brief  Special effects field. */
-        uint8_t special;
-
-        /** \brief  1st effect field. */
-        uint8_t effect1;
-
-        /** \brief  2nd effect field. */
-        uint8_t effect2;
-
-        /** \brief  The duration of the effect. No idea on units... */
-        uint8_t duration;
+        uint8_t special     __depr("Please see purupuru_effect_t which has new members.");
+        uint8_t effect1     __depr("Please see purupuru_effect_t which has new members.");
+        uint8_t effect2     __depr("Please see purupuru_effect_t which has new members.");
+        uint8_t duration    __depr("Please see purupuru_effect_t which has new members.");
     };
     struct {
         /** \brief Continuous Vibration. When set vibration will continue until stopped */
@@ -98,97 +92,18 @@ typedef union purupuru_effect  {
 
 _Static_assert(sizeof(purupuru_effect_t) == 4, "Invalid effect size");
 
-/* Set one of each of the following in the effect2 field of the
-   purupuru_effect_t. Valid values for each are 0-7. The LINTENSITY
-   value works with the INTENSITY of effect1 to increase the intensity
-   of the rumble, where UINTENSITY apparently lowers the rumble's
-   intensity somewhat. */
+ /* Compat */
+static inline uint32_t __depr("Please see purupuru_effect_t for modern equivalent.") PURUPURU_EFFECT2_UINTENSITY(uint8_t x) {return (x << 4);}
+static inline uint32_t __depr("Please see purupuru_effect_t for modern equivalent.") PURUPURU_EFFECT2_LINTENSITY(uint8_t x) {return (x);}
+static inline uint32_t __depr("Please see purupuru_effect_t for modern equivalent.") PURUPURU_EFFECT1_INTENSITY(uint8_t x)  {return (x << 4);}
 
-/** \brief  Upper-nibble of effect2 convenience macro.
-
-    This macro is for setting the upper nibble of the effect2 field of the
-    purupuru_effect_t. This apparently lowers the rumble's intensity somewhat.
-    Valid values are 0-7.
-*/
-#define PURUPURU_EFFECT2_UINTENSITY(x) (x << 4)
-
-/** \brief  Lower-nibble of effect2 convenience macro.
-
-    This macro is for setting the lower nibble of the effect2 field of the
-    purupuru_effect_t. This value works with the upper nibble of the effect1
-    field to increase the intensity of the rumble effect. Valid values are 0-7.
-
-    \see    PURUPURU_EFFECT1_INTENSITY
-*/
-#define PURUPURU_EFFECT2_LINTENSITY(x) (x)
-
-/* OR these in with your effect2 value if you feel so inclined.
-   if you or the PULSE effect in here, you probably should also
-   do so with the effect1 one below. */
-/** \brief  Give a decay effect to the rumble on some packs. */
-#define PURUPURU_EFFECT2_DECAY         (8 << 4)
-
-/** \brief  Give a pulse effect to the rumble.
-
-    This probably should be used with PURUPURU_EFFECT1_PULSE as well.
-
-    \see    PURUPURU_EFFECT1_PULSE
-*/
-#define PURUPURU_EFFECT2_PULSE         (8)
-
-/* Set one value for this in the effect1 field of the effect structure. */
-/** \brief  Upper nibble of effect1 convenience macro.
-
-    This macro is for setting the upper nibble of the effect1 field of the
-    purupuru_effect_t. This value works with the lower nibble of the effect2
-    field to increase the intensity of the rumble effect. Valid values are 0-7.
-
-    \see    PURUPURU_EFFECT2_LINTENSITY
-*/
-#define PURUPURU_EFFECT1_INTENSITY(x)  (x << 4)
-
-/* OR these in with your effect1 value, if you need them. PULSE
-   should probably be used with the PULSE in effect2, as well.
-   POWERSAVE will probably make your purupuru ignore that command. */
-/** \brief  Give a pulse effect to the rumble.
-
-    This probably should be used with PURUPURU_EFFECT2_PULSE as well.
-
-    \see    PURUPURU_EFFECT2_PULSE
-*/
-#define PURUPURU_EFFECT1_PULSE         (8 << 4)
-
-/** \brief  Ignore this command.
-
-    Most jump packs will ignore commands with this set in effect1, apparently.
-*/
-#define PURUPURU_EFFECT1_POWERSAVE     (15)
-
-/* Special Effects and motor select. The normal purupuru packs will
-   only have one motor. Selecting MOTOR2 for these is probably not
-   a good idea. The PULSE setting here supposably creates a sharp
-   pulse effect, when ORed with the special field. */
-/** \brief  Select motor #1.
-
-    Most jump packs only have one motor, but on things that do have more than
-    one motor (like PS1->Dreamcast controller adapters that support rumble),
-    this selects the first motor.
-*/
-#define PURUPURU_SPECIAL_MOTOR1        (1 << 4)
-
-/** \brief  Select motor #2.
-
-    Most jump packs only have one motor, but on things that do have more than
-    one motor (like PS1->Dreamcast controller adapters that support rumble),
-    this selects the second motor.
-*/
-#define PURUPURU_SPECIAL_MOTOR2        (1 << 7)
-
-/** \brief  Yet another pulse effect.
-
-    This supposedly creates a sharp pulse effect.
-*/
-#define PURUPURU_SPECIAL_PULSE         (1)
+static const uint8_t PURUPURU_EFFECT2_DECAY     __depr("Please see purupuru_effect_t for modern equivalent.") = (8 << 4);
+static const uint8_t PURUPURU_EFFECT2_PULSE     __depr("Please see purupuru_effect_t for modern equivalent.") = (8);
+static const uint8_t PURUPURU_EFFECT1_PULSE     __depr("Please see purupuru_effect_t for modern equivalent.") = (8 << 4);
+static const uint8_t PURUPURU_EFFECT1_POWERSAVE __depr("Please see purupuru_effect_t for modern equivalent.") = (15);
+static const uint8_t PURUPURU_SPECIAL_MOTOR1    __depr("Please see purupuru_effect_t for modern equivalent.") = (1 << 4);
+static const uint8_t PURUPURU_SPECIAL_MOTOR2    __depr("Please see purupuru_effect_t for modern equivalent.") = (1 << 7);
+static const uint8_t PURUPURU_SPECIAL_PULSE     __depr("Please see purupuru_effect_t for modern equivalent.") = (1);
 
 /** \brief  Send an effect to a jump pack.
 
@@ -206,8 +121,8 @@ int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect);
 /** \brief  Send a raw effect to a jump pack.
 
     This function sends an effect to a jump pack to be executed. This is for if
-    you (for some reason) don't want to use purupuru_effect_t to build the
-    effect up.
+    you want to bypass KOS-based error checking. This is not recommended except
+    for testing purposes.
 
     \param  dev             The device to send the command to.
     \param  effect          The effect to send.

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -116,7 +116,7 @@ static const uint8_t PURUPURU_SPECIAL_PULSE     __depr("Please see purupuru_effe
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
     \retval MAPLE_EINVALID  The command is not being sent due to invalid input.
 */
-int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect);
+int purupuru_rumble(maple_device_t *dev, const purupuru_effect_t *effect);
 
 /** \brief  Send a raw effect to a jump pack.
 

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -3,6 +3,7 @@
    dc/maple/purupuru.h
    Copyright (C) 2003 Megan Potter
    Copyright (C) 2005, 2010 Lawrence Sebald
+   Copyright (C) 2025 Donald Haase
 
 */
 
@@ -28,6 +29,7 @@
     that does absolutely nothing on the first try.
 
     \author Lawrence Sebald
+    \author Donald Haase
 */
 
 #ifndef __DC_MAPLE_PURUPURU_H
@@ -36,6 +38,7 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <dc/maple.h>
 
@@ -69,7 +72,31 @@ typedef union purupuru_effect  {
         /** \brief  The duration of the effect. No idea on units... */
         uint8_t duration;
     };
+    struct {
+        /** \brief Continuous Vibration. When set vibration will continue until stopped */
+        bool     cont    : 1;
+        /** \brief Reserved. Always 0s */
+        uint32_t res     : 3;
+        /** \brief Motor number. 0 will cause an error. 1 is the typical setting. */
+        uint32_t motor   : 4;
+
+        /** \brief Backward direction (- direction) intensity setting bits. 0 stops vibration. */
+        uint32_t bpow    : 3;
+        /** \brief Divergent vibration. The rumble will get stronger until it stops. */
+        bool     div     : 1;
+        /** \brief Forward direction (+ direction) intensity setting bits. 0 stops vibration. */
+        uint32_t fpow    : 3;
+        /** \brief Convergent vibration. The rumble will get weaker until it stops. */
+        bool     conv    : 1;
+
+        /** \brief Vibration frequency. for most purupuru 4-59. */
+        uint8_t  freq;
+        /** \brief Vibration inclination period. */
+        uint8_t  inc;
+    };
 } purupuru_effect_t;
+
+_Static_assert(sizeof(purupuru_effect_t) == 4, "Invalid effect size");
 
 /* Set one of each of the following in the effect2 field of the
    purupuru_effect_t. Valid values for each are 0-7. The LINTENSITY
@@ -172,6 +199,7 @@ typedef union purupuru_effect  {
     \param  effect          The effect to send.
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
+    \retval MAPLE_EINVALID  The command is not being sent due to invalid input.
 */
 int purupuru_rumble(maple_device_t *dev, purupuru_effect_t *effect);
 


### PR DESCRIPTION
Big fixup to rumble support:
- Added error checking in the maple command irq handler. These were essential to diagnosing the illegal commands that we were sending to official rumble packs. If they trip it likely indicates something that we should be doing differently.
- Cleaned up rumble driver to use stdint types.
- Added new struct members based on info provided by @megavolt85 [here](https://github.com/KallistiOS/KallistiOS/pull/1052#issuecomment-2913983412) I've updated the documentation to include what I've found of error conditions.
- Deprecate old struct members.
- Update `purupuru_rumble` to check for values that would trigger a hardware error on official rumble packs. This is what corrects use with official packs. Previously we were using just a flat `0x00000000` to stop rumbling. On third party rumbles, they just didn't care, but on first-party the motor field triggers an error if set to 0 (and we don't recover from those errors well in the root maple driver).
- Update rumble example to reflect new findings.

This should close #1064 and #941.

From my testing in this PR there are a few big sets of future improvements that should be undertaken as followups (but shouldn't hold back this bugfixing):
- Better handle a maple device throwing an error. Currently we just don't do anything for it. But it seems that it may be a good use case for the same reset command I've implemented in #772 . Something like 'if a device repeatedly errors, send a reset command to it'. (I've opened #1147 to try to block similar errors with VMS devices)
- I found that the rumble pack appears to allow various other commands like `MAPLE_RESPONSE_DATATRF` and `MAPLE_COMMAND_BWRITE` which likely have to do with the 'Auto-Stop Timeout' or other patterns. That it can take larger sets of data would indicate it's possible to upload some sort of ongoing pattern or sequence to the device rather than repeatedly sending individual effects to build a sequence.
- Update the rumble example to display and allow setting of the individual struct fields rather than the raw bitfield.
- The rumble example has a bug where it will periodically drop all the text under the hex values and stop updating the screen. Usually happens on device disconnect but also seemingly randomly on sending a stop. After this point the example continues to function and is intractable a bit via the printf output but appears to hang visually.