### PR TITLE
vmu: Distinguish between VMS and VMU, don't send invalid commands

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/vmu.c
+++ b/kernel/arch/dreamcast/hardware/maple/vmu.c
@@ -317,6 +317,10 @@ int vmu_beep_raw(maple_device_t *dev, uint32_t beep) {
 
     assert(dev);
 
+    /* Only send a beep if this is a real VMU */
+    if(!vmu_is_vmu(dev))
+        return MAPLE_EINVALID;
+
     /* Lock the frame */
     if(maple_frame_lock(&dev->frame) < 0)
         return MAPLE_EAGAIN;
@@ -350,6 +354,10 @@ int vmu_draw_lcd(maple_device_t *dev, const void *bitmap) {
     uint32_t *send_buf;
 
     assert(dev != NULL);
+
+    /* Only try to draw to screen if this is a real VMU */
+    if(!vmu_is_vmu(dev))
+        return MAPLE_EINVALID;
 
     /* Lock the frame */
     if(maple_frame_lock(&dev->frame) < 0)
@@ -643,6 +651,10 @@ int vmu_set_datetime(maple_device_t *dev, time_t unix) {
 
     assert(dev);
 
+    /* Only set datetime if this is a real VMU */
+    if(!vmu_is_vmu(dev))
+        return MAPLE_EINVALID;
+
     btime = localtime(&unix);
     assert(btime); /* A failure here means an invalid unix timestamp was given. */
 
@@ -692,6 +704,10 @@ int vmu_get_datetime(maple_device_t *dev, time_t *unix) {
     uint32_t          *send_buf;
 
     assert(dev);
+
+    /* Only get datetime if this is a real VMU */
+    if(!vmu_is_vmu(dev))
+        return MAPLE_EINVALID;
 
     /* Lock the frame */
     if(maple_frame_lock(&dev->frame) < 0)

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -253,6 +253,7 @@ int vmu_get_icon_shape(maple_device_t *dev, uint8_t *icon_shape);
 
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
+    \retval MAPLE_EINVALID  The device does not support this functionality (VMS).
 
     \sa vmu_draw_lcd_rotated, vmu_draw_lcd_xbm, vmu_set_icon
 */
@@ -274,6 +275,7 @@ int vmu_draw_lcd(maple_device_t *dev, const void *bitmap);
     \param  bitmap          The bitmap to show.
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
+    \retval MAPLE_EINVALID  The device does not support this functionality (VMS).
 
     \sa vmu_draw_lcd, vmu_draw_lcd_xbm, vmu_set_icon
 */
@@ -290,6 +292,7 @@ int vmu_draw_lcd_rotated(maple_device_t *dev, const void *bitmap);
 
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
+    \retval MAPLE_EINVALID  The device does not support this functionality (VMS).
 
     \sa vmu_draw_lcd, vmu_set_icon
 */
@@ -410,6 +413,7 @@ int vmu_block_write(maple_device_t *dev, uint16_t blocknum, const uint8_t *buffe
 
     \retval MAPLE_EOK       On success.
     \retval MAPLE_EAGAIN    If the command couldn't be sent. Try again later.
+    \retval MAPLE_EINVALID  The device does not support this functionality (VMS).
 
     \sa vmu_beep_waveform
 */
@@ -471,6 +475,7 @@ int vmu_beep_raw(maple_device_t *dev, uint32_t beep);
 
     \retval MAPLE_EOK           On success.
     \retval MAPLE_EAGAIN        If the command couldn't be sent. Try again later.
+    \retval MAPLE_EINVALID  The device does not support this functionality (VMS).
 */
 int vmu_beep_waveform(maple_device_t *dev, uint8_t period1, uint8_t duty_cycle1, uint8_t period2, uint8_t duty_cycle2);
 
@@ -493,6 +498,7 @@ int vmu_beep_waveform(maple_device_t *dev, uint8_t period1, uint8_t duty_cycle1,
     \retval MAPLE_EOK       On success.
     \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
     \retval MAPLE_EFAIL     On errors other than timeout.
+    \retval MAPLE_EINVALID  The device does not support this functionality (VMS).
 
     \sa vmu_get_datetime
 */
@@ -513,6 +519,7 @@ int vmu_set_datetime(maple_device_t *dev, time_t unix);
     \retval MAPLE_EOK       On success.
     \retval MAPLE_ETIMEOUT  If the command timed out while blocking.
     \retval MAPLE_EFAIL     On errors other than timeout.
+    \retval MAPLE_EINVALID  The device does not support this functionality (VMS).
 
     \sa vmu_set_datetime
 */


### PR DESCRIPTION
- Add an internal function to help distinguish between VMU devices that have clock + lcd functions from VMS devices that only have memcard functionality. The testing is based on a magic number I've found via data gathered with my MapleTest program from many first and third part VMU/VMS devices.
- Prevent sending commands for non-memcard functions on VMS devices.

This helps prevent the possibility of 3rd party devices erroring out by sending them unsupported/invalid commands. The one device I had no info to be able to factor in or test with is the official 4x memory card. The detection may need to be adjusted to ensure that it is also included, but I would presume that it does not present with clock+lcd functions as first part devices at least should follow the spec.