### PR TITLE
vmu_lcd example: Add wait after draw to throttle animation.

### DIFF
--- a/examples/dreamcast/vmu/vmu_lcd/lcd.c
+++ b/examples/dreamcast/vmu/vmu_lcd/lcd.c
@@ -76,6 +76,9 @@ int main(int argc, char **argv) {
         for(vmu = 0; !!(dev = maple_enum_type(vmu, MAPLE_FUNC_LCD)); vmu++) {
             vmufb_present(&vmufb, dev);
         }
+
+        /* Now sleep for a bit so we can actually see the new frame */
+        usleep(2000);
     }
 
     return 0;


### PR DESCRIPTION
The example never attempted to throttle itself because the screen drawing commands were synchronous and would wait to receive a response from the VMU before moving forward with execution. With the changes in #904 there is no wait and the user is responsible for throttling the drawing.

Without this the example is illegible on the VMU screen, updating faster than can be seen. This wait amount gets it back down to a pace similar to before.