### PR TITLE
Replace `arch/types.h` types in addons, examples, and platform-agnostic kernel

### DIFF
--- a/addons/include/kos/img.h
+++ b/addons/include/kos/img.h
@@ -26,7 +26,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
+#include <stdint.h>
 
 /** \defgroup video_img  Images
     \brief               Platform-independent image representation
@@ -49,13 +49,13 @@ __BEGIN_DECLS
     \headerfile kos/img.h
 */
 typedef struct kos_img {
-    void *data;         /**< \brief Image data in the specified format. */
-    uint32 w;           /**< \brief Width of the image. */
-    uint32 h;           /**< \brief Height of the image. */
-    uint32 fmt;         /**< \brief Format of the image data.
+    void *data;             /**< \brief Image data in the specified format. */
+    uint32_t w;             /**< \brief Width of the image. */
+    uint32_t h;             /**< \brief Height of the image. */
+    uint32_t fmt;           /**< \brief Format of the image data.
                              \see   kos_img_fmts
                              \see   kos_img_fmt_macros */
-    uint32 byte_count;  /**< \brief Length of the image data, in bytes. */
+    uint32_t byte_count;    /**< \brief Length of the image data, in bytes. */
 } kos_img_t;
 
 /** \defgroup video_img_fmt Format

--- a/addons/include/kos/md5.h
+++ b/addons/include/kos/md5.h
@@ -20,7 +20,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
+#include <stdint.h>
 
 /** \brief  MD5 context.
 
@@ -31,9 +31,9 @@ __BEGIN_DECLS
     \headerfile kos/md5.h
 */
 typedef struct kos_md5_cxt {
-    uint64 size;        /**< \brief Size of the data in buf. */
-    uint32 hash[4];     /**< \brief Intermediate hash value. */
-    uint8  buf[64];     /**< \brief Temporary storage of values to be hashed. */
+    uint64_t size;        /**< \brief Size of the data in buf. */
+    uint32_t hash[4];     /**< \brief Intermediate hash value. */
+    uint8_t  buf[64];     /**< \brief Temporary storage of values to be hashed. */
 } kos_md5_cxt_t;
 
 /** \brief  Initialize a MD5 context.
@@ -58,7 +58,7 @@ void kos_md5_start(kos_md5_cxt_t *cxt);
     \param  input       The block of data to hash.
     \param  size        The number of bytes of input data passed in.
 */
-void kos_md5_hash_block(kos_md5_cxt_t *cxt, const uint8 *input, uint32 size);
+void kos_md5_hash_block(kos_md5_cxt_t *cxt, const uint8_t *input, uint32_t size);
 
 /** \brief  Complete a MD5 hash.
 
@@ -68,7 +68,7 @@ void kos_md5_hash_block(kos_md5_cxt_t *cxt, const uint8 *input, uint32 size);
     \param  cxt         The MD5 context to finalize.
     \param  output      Where to store the final digest.
 */
-void kos_md5_finish(kos_md5_cxt_t *cxt, uint8 output[16]);
+void kos_md5_finish(kos_md5_cxt_t *cxt, uint8_t output[16]);
 
 /** \brief  Compute the hash of a block of data with MD5.
 
@@ -81,7 +81,7 @@ void kos_md5_finish(kos_md5_cxt_t *cxt, uint8 output[16]);
     \param  size        The number of bytes of input data passed in.
     \param  output      Where to store the final message digest.
 */
-void kos_md5(const uint8 *input, uint32 size, uint8 output[16]);
+void kos_md5(const uint8_t *input, uint32_t size, uint8_t output[16]);
 
 __END_DECLS
 

--- a/addons/include/kos/netcfg.h
+++ b/addons/include/kos/netcfg.h
@@ -26,7 +26,7 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
+#include <stdint.h>
 
 /** \defgroup   netcfg          Configuration
     \brief                      KOS Network Configuration Management
@@ -83,11 +83,11 @@ typedef struct netcfg {
     */
     int method;
 
-    uint32 ip;              /**< \brief IPv4 address of the console */
-    uint32 gateway;         /**< \brief IPv4 address of the gateway/router. */
-    uint32 netmask;         /**< \brief Network mask for the local net. */
-    uint32 broadcast;       /**< \brief Broadcast address for the local net. */
-    uint32 dns[2];          /**< \brief IPv4 address of the DNS servers. */
+    uint32_t ip;            /**< \brief IPv4 address of the console */
+    uint32_t gateway;       /**< \brief IPv4 address of the gateway/router. */
+    uint32_t netmask;       /**< \brief Network mask for the local net. */
+    uint32_t broadcast;     /**< \brief Broadcast address for the local net. */
+    uint32_t dns[2];        /**< \brief IPv4 address of the DNS servers. */
     char hostname[64];      /**< \brief DNS/DHCP hostname. */
     char email[64];         /**< \brief E-Mail address. */
     char smtp[64];          /**< \brief SMTP server address. */
@@ -114,7 +114,7 @@ typedef struct netcfg {
     
     \return             0 on success, <0 on failure.
 */
-int netcfg_load_from(const char * fn, netcfg_t * out);
+int netcfg_load_from(const char *fn, netcfg_t *out);
 
 /** \brief   Load network configuration from the Dreamcast's flashrom.
     \ingroup netcfg
@@ -129,7 +129,7 @@ int netcfg_load_from(const char * fn, netcfg_t * out);
     
     \return             0 on success, <0 on failure.
 */
-int netcfg_load_flash(netcfg_t * out);
+int netcfg_load_flash(netcfg_t *out);
 
 /** \brief   Load network configuration.
     \ingroup netcfg
@@ -144,7 +144,7 @@ int netcfg_load_flash(netcfg_t * out);
     
     \return             0 on success, <0 on failure.
 */
-int netcfg_load(netcfg_t * out);
+int netcfg_load(netcfg_t *out);
 
 /** \brief   Save network configuration to a file.
     \ingroup netcfg
@@ -158,7 +158,7 @@ int netcfg_load(netcfg_t * out);
     
     \return             0 on success, <0 on failure.
 */
-int netcfg_save_to(const char * fn, const netcfg_t * cfg);
+int netcfg_save_to(const char *fn, const netcfg_t *cfg);
 
 /** \brief   Save network configuration to the first available VMU.
     \ingroup netcfg
@@ -170,7 +170,7 @@ int netcfg_save_to(const char * fn, const netcfg_t * cfg);
     
     \return             0 on success, <0 on failure.
 */
-int netcfg_save(const netcfg_t * cfg);
+int netcfg_save(const netcfg_t *cfg);
 
 __END_DECLS
 

--- a/addons/include/navi/flash.h
+++ b/addons/include/navi/flash.h
@@ -19,7 +19,7 @@
 #ifndef __NAVI_FLASH_H
 #define __NAVI_FLASH_H
 
-#include <arch/types.h>
+#include <stdint.h>
 
 /** \brief  Try to detect a compatible flashrom.
     \return                 0 if a compatible flashrom is detected, <0 if the
@@ -31,7 +31,7 @@ int nvflash_detect(void);
     \param  addr            The block of the flashrom to erase.
     \return                 0 on success, <0 on error.
 */
-int nvflash_erase_block(uint32 addr);
+int nvflash_erase_block(uint32_t addr);
 
 /** \brief  Write data to the flashrom.
     \param  addr            The block of the flashrom to write to.
@@ -39,7 +39,7 @@ int nvflash_erase_block(uint32 addr);
     \param  len             The length of the data, in bytes.
     \return                 0 on success, <0 on error.
 */
-int nvflash_write_block(uint32 addr, void * data, uint32 len);
+int nvflash_write_block(uint32_t addr, void *data, uint32_t len);
 
 /* Erase the whole flash chip */
 /** \brief  Erase the whole flashrom.

--- a/addons/include/navi/ide.h
+++ b/addons/include/navi/ide.h
@@ -19,7 +19,7 @@
 #ifndef __NAVI_IDE_H
 #define __NAVI_IDE_H
 
-#include <arch/types.h>
+#include <stdint.h>
 
 /** \brief  Read sectors from the hard disk via PIO.
     \param  linear          The address to begin reading from.
@@ -27,7 +27,7 @@
     \param  bufptr          The buffer to read into.
     \return                 0 on success, <0 on error.
 */
-int ide_read(uint32 linear, uint32 numsects, void *bufptr);
+int ide_read(uint32_t linear, uint32_t numsects, void *bufptr);
 
 /** \brief  Write sectors from the hard disk via PIO.
     \param  linear          The address to begin writing to.
@@ -35,12 +35,12 @@ int ide_read(uint32 linear, uint32 numsects, void *bufptr);
     \param  bufptr          The buffer to write out of.
     \return                 0 on success, <0 on error.
 */
-int ide_write(uint32 linear, uint32 numsects, void *bufptr);
+int ide_write(uint32_t linear, uint32_t numsects, void *bufptr);
 
 /** \brief  Retrieve the number of sectors from the hard disk.
     \returns                The total number of linear sectors.
 */
-uint32 ide_num_sectors(void);
+uint32_t ide_num_sectors(void);
 
 /** \brief  Initialize Navi IDE.
     \return                 0 on success (no error conditions defined).

--- a/addons/libkosext2fs/fs_ext2.c
+++ b/addons/libkosext2fs/fs_ext2.c
@@ -540,7 +540,7 @@ static _off64_t fs_ext2_tell64(void *h) {
     return rv;
 }
 
-static uint64 fs_ext2_total64(void *h) {
+static uint64_t fs_ext2_total64(void *h) {
     file_t fd = ((file_t)h) - 1;
     size_t rv;
 

--- a/addons/libkosfat/fs_fat.c
+++ b/addons/libkosfat/fs_fat.c
@@ -740,7 +740,7 @@ static _off64_t fs_fat_tell64(void *h) {
     return rv;
 }
 
-static uint64 fs_fat_total64(void *h) {
+static uint64_t fs_fat_total64(void *h) {
     file_t fd = ((file_t)h) - 1;
     size_t rv;
 

--- a/addons/libkosutils/md5.c
+++ b/addons/libkosutils/md5.c
@@ -5,18 +5,16 @@
 */
 
 #include <string.h>
-#include <arch/types.h>
-
 #include <kos/md5.h>
 
 /* Initial values used in starting the MD5 checksum */
-static const uint32 md5initial[4] = {
+static const uint32_t md5initial[4] = {
     0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476
 };
 
 /* We will append somewhere between 1 and 64 bytes of padding to every message,
    depending on its length. This is the padding that is to be used. */
-static const uint8 md5padding[64] = {
+static const uint8_t md5padding[64] = {
     0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -24,7 +22,7 @@ static const uint8 md5padding[64] = {
 };
 
 /* MD5 "magic" values */
-static const uint32 md5tab[64] = {
+static const uint32_t md5tab[64] = {
     0xD76AA478, 0xE8C7B756, 0x242070DB, 0xC1BDCEEE,
     0xF57C0FAF, 0x4787C62A, 0xA8304613, 0xFD469501,
     0x698098D8, 0x8B44F7AF, 0xFFFF5BB1, 0x895CD7BE,
@@ -52,7 +50,7 @@ int main(int argc, char *argv[]) {
     int i;
     double tmp;
 
-    printf("static const uint32 md5tab[64] = {");
+    printf("static const uint32_t md5tab[64] = {");
 
     for(i = 0; i < 64; ++i) {
         if((i % 4) == 0)
@@ -119,8 +117,8 @@ void kos_md5_start(kos_md5_cxt_t *cxt) {
 }
 
 /* input must be at least 64 bytes long */
-static void kos_md5_process(kos_md5_cxt_t *cxt, const uint8 *input) {
-    uint32 a, b, c, d, w[16];
+static void kos_md5_process(kos_md5_cxt_t *cxt, const uint8_t *input) {
+    uint32_t a, b, c, d, w[16];
     int i;
 
     /* Read in what we're starting with */
@@ -214,11 +212,11 @@ static void kos_md5_process(kos_md5_cxt_t *cxt, const uint8 *input) {
     cxt->hash[3] += d;
 }
 
-void kos_md5_hash_block(kos_md5_cxt_t *cxt, const uint8 *input, uint32 size) {
-    uint32 left, copy;
+void kos_md5_hash_block(kos_md5_cxt_t *cxt, const uint8_t *input, uint32_t size) {
+    uint32_t left, copy;
 
     /* Figure out what we had left over from last time (if anything) */
-    left = (uint32)((cxt->size >> 3) & 0x3F);
+    left = (uint32_t)((cxt->size >> 3) & 0x3F);
     copy = 64 - left;
 
     /* Update the size */
@@ -246,35 +244,35 @@ void kos_md5_hash_block(kos_md5_cxt_t *cxt, const uint8 *input, uint32 size) {
     }
 }
 
-void kos_md5_finish(kos_md5_cxt_t *cxt, uint8 output[16]) {
-    uint64 len = cxt->size;
-    uint32 blen = (cxt->size >> 3) & 0x3F;
-    uint32 plen = MD5_PAD_LEN(blen);
+void kos_md5_finish(kos_md5_cxt_t *cxt, uint8_t output[16]) {
+    uint64_t len = cxt->size;
+    uint32_t blen = (cxt->size >> 3) & 0x3F;
+    uint32_t plen = MD5_PAD_LEN(blen);
     int i;
-    uint8 len_bytes[8];
+    uint8_t len_bytes[8];
 
     /* Add in the padding */
     kos_md5_hash_block(cxt, md5padding, plen);
 
     /* Hash in the length -- this will finish the last 64-byte block */
-    len_bytes[0] = (uint8)(len);
-    len_bytes[1] = (uint8)(len >> 8);
-    len_bytes[2] = (uint8)(len >> 16);
-    len_bytes[3] = (uint8)(len >> 24);
-    len_bytes[4] = (uint8)(len >> 32);
-    len_bytes[5] = (uint8)(len >> 40);
-    len_bytes[6] = (uint8)(len >> 48);
-    len_bytes[7] = (uint8)(len >> 56);
+    len_bytes[0] = (uint8_t)(len);
+    len_bytes[1] = (uint8_t)(len >> 8);
+    len_bytes[2] = (uint8_t)(len >> 16);
+    len_bytes[3] = (uint8_t)(len >> 24);
+    len_bytes[4] = (uint8_t)(len >> 32);
+    len_bytes[5] = (uint8_t)(len >> 40);
+    len_bytes[6] = (uint8_t)(len >> 48);
+    len_bytes[7] = (uint8_t)(len >> 56);
     kos_md5_hash_block(cxt, len_bytes, 8);
 
     /* Copy out the hash, since we're done */
     for(i = 0; i < 16; ++i) {
-        output[i] = (uint8)(cxt->hash[i >> 2] >> ((i & 0x03) << 3));
+        output[i] = (uint8_t)(cxt->hash[i >> 2] >> ((i & 0x03) << 3));
     }
 }
 
 /* Convenience function for computing an MD5 of a complete block. */
-void kos_md5(const uint8 *input, uint32 size, uint8 output[16]) {
+void kos_md5(const uint8_t *input, uint32_t size, uint8_t output[16]) {
     kos_md5_cxt_t cxt;
 
     kos_md5_start(&cxt);

--- a/addons/libkosutils/netcfg.c
+++ b/addons/libkosutils/netcfg.c
@@ -25,13 +25,13 @@
 
 void netcfg_vmuify(const char *filename_in, const char *filename_out) {
     int fd, pkg_size;
-    uint8   *buf;
-    uint8   *pkg_out;
+    uint8_t  *buf;
+    uint8_t  *pkg_out;
     vmu_pkg_t pkg;
 
     dbgp("Opening source file\n");
     fd = fs_open(filename_in, O_RDONLY);
-    buf = (uint8 *) malloc(fs_total(fd));
+    buf = (uint8_t *) malloc(fs_total(fd));
     if(buf == NULL)
         return;
 
@@ -69,7 +69,7 @@ void netcfg_vmuify(const char *filename_in, const char *filename_out) {
    this fails, we try reading settings from the current dir in the VFS,
    and then from the root of the CD. If that fails, we give up. */
 
-int netcfg_load_from(const char * fn, netcfg_t * out) {
+int netcfg_load_from(const char *fn, netcfg_t *out) {
     FILE * f;
     char buf[64], *b;
     int l;
@@ -189,7 +189,7 @@ int netcfg_load_from(const char * fn, netcfg_t * out) {
     return 0;
 }
 
-int netcfg_load_flash(netcfg_t * out) {
+int netcfg_load_flash(netcfg_t *out) {
     flashrom_ispcfg_t cfg;
 
     if(flashrom_get_ispcfg(&cfg) < 0)
@@ -256,7 +256,7 @@ int netcfg_load_flash(netcfg_t * out) {
     return 0;
 }
 
-int netcfg_load(netcfg_t * out) {
+int netcfg_load(netcfg_t *out) {
     file_t f;
     dirent_t * d;
     char buf[64];
@@ -305,7 +305,7 @@ int netcfg_load(netcfg_t * out) {
     return -1;
 }
 
-int netcfg_save_to(const char * fn, const netcfg_t * cfg) {
+int netcfg_save_to(const char *fn, const netcfg_t *cfg) {
     FILE * f;
     char buf[256];
 
@@ -383,7 +383,7 @@ error:
     return -1;
 }
 
-int netcfg_save(const netcfg_t * cfg) {
+int netcfg_save(const netcfg_t *cfg) {
     file_t f;
     dirent_t * d;
     char buf[64];

--- a/addons/libkosutils/pcx_small.c
+++ b/addons/libkosutils/pcx_small.c
@@ -7,7 +7,6 @@
 */
 
 #include <stdio.h>
-#include <arch/types.h>
 #include <kos/fs.h>
 #include <kos/pcx.h>
 
@@ -17,15 +16,15 @@ typedef struct {
     char   ver;               /* encoder version number (5)     */
     char   enc;               /* encoding code, always 1        */
     char   bpp;               /* bits per pixel, 8 in mode 0x13 */
-    uint16 xmin, ymin;        /* image origin, usually 0,0      */
-    uint16 xmax, ymax;        /* image dimensions           */
-    uint16 hres;              /* horizontal resolution value    */
-    uint16 vres;              /* vertical resolution value      */
+    uint16_t xmin, ymin;      /* image origin, usually 0,0      */
+    uint16_t xmax, ymax;      /* image dimensions           */
+    uint16_t hres;            /* horizontal resolution value    */
+    uint16_t vres;            /* vertical resolution value      */
     char   pal[48];           /* palette (not in mode 0x13)     */
     char   reserved;          /* who knows?             */
     char   clrplanes;         /* number of planes, 1 in mode 0x13   */
-    uint16 bpl;               /* bytes per line, 80 in mode 0x13    */
-    uint16 pltype;            /* Grey or Color palette flag     */
+    uint16_t bpl;             /* bytes per line, 80 in mode 0x13    */
+    uint16_t pltype;          /* Grey or Color palette flag     */
     char   filler[58];        /* Zsoft wanted a 128 byte header */
 } __packed pcx_hdr;
 
@@ -33,13 +32,13 @@ typedef struct {
 int pcx_load_flat(const char *fn, int *w_out, int *h_out, void *pic_out) {
     pcx_hdr *pcxh;
     file_t  fd;
-    uint8   *pcx, *pal;
+    uint8_t *pcx, *pal;
     int bytes = 0;  /* counts unpacked bytes */
-    uint8   c;      /* byte being processed */
-    uint16  oc;     /* output pixel */
+    uint8_t     c;  /* byte being processed */
+    uint16_t    oc; /* output pixel */
     int runlen;     /* length of packet */
     int num_bytes;
-    uint16  *iout;
+    uint16_t    *iout;
 
     /* Open the file */
     fd = fs_open(fn, O_RDONLY);
@@ -58,7 +57,7 @@ int pcx_load_flat(const char *fn, int *w_out, int *h_out, void *pic_out) {
     }
 
     /* Load the PCX header */
-    pcxh = (pcx_hdr*)(pcx + 0);
+    pcxh = (pcx_hdr *)(pcx + 0);
 
     if(pcxh->bpp != 8) {
         printf("pcx_load(%s): PCX data is not 8bpp\n", fn);
@@ -77,8 +76,8 @@ int pcx_load_flat(const char *fn, int *w_out, int *h_out, void *pic_out) {
     /* Skip header */
     pcx += sizeof(pcx_hdr);
 
-    /* uint16 version of the output buffer */
-    iout = (uint16*)pic_out;
+    /* uint16_t version of the output buffer */
+    iout = (uint16_t *)pic_out;
 
     do {
         c = *pcx++;     /* Read one byte */
@@ -118,13 +117,13 @@ int pcx_load_flat(const char *fn, int *w_out, int *h_out, void *pic_out) {
 int pcx_load_palette(const char *fn, int *w_out, int *h_out, void *pic_out, void *pal_out) {
     pcx_hdr *pcxh;
     file_t  fd;
-    uint8   *pcx, *pal;
-    int bytes = 0;  /* counts unpacked bytes */
-    uint8   c;      /* byte being processed */
-    uint16  oc = 0;     /* output pixel */
-    int runlen, i;  /* length of packet */
+    uint8_t   *pcx, *pal;
+    int bytes = 0;      /* counts unpacked bytes */
+    uint8_t   c;        /* byte being processed */
+    uint16_t  oc = 0;   /* output pixel */
+    int runlen, i;      /* length of packet */
     int num_bytes;
-    uint16  *iout;
+    uint16_t  *iout;
 
     /* Open the file */
     fd = fs_open(fn, O_RDONLY);
@@ -143,7 +142,7 @@ int pcx_load_palette(const char *fn, int *w_out, int *h_out, void *pic_out, void
     }
 
     /* Load the PCX header */
-    pcxh = (pcx_hdr*)(pcx + 0);
+    pcxh = (pcx_hdr *)(pcx + 0);
 
     if(pcxh->bpp != 8) {
         printf("pcx_load(%s): PCX data is not 8bpp\n", fn);
@@ -155,7 +154,7 @@ int pcx_load_palette(const char *fn, int *w_out, int *h_out, void *pic_out, void
     pal = pcx + (fs_total(fd) - 768);
 
     /* Write the palette into the output buffer */
-    iout = (uint16*)pal_out;
+    iout = (uint16_t *)pal_out;
 
     for(i = 0; i < 256; i++) {
         iout[i] =
@@ -173,8 +172,8 @@ int pcx_load_palette(const char *fn, int *w_out, int *h_out, void *pic_out, void
     /* Skip header */
     pcx += sizeof(pcx_hdr);
 
-    /* uint16 version of the output buffer */
-    iout = (uint16*)pic_out;
+    /* uint16_t version of the output buffer */
+    iout = (uint16_t *)pic_out;
     i = 0;
 
     do {

--- a/addons/libnavi/navi_flash.c
+++ b/addons/libnavi/navi_flash.c
@@ -72,7 +72,7 @@
 #define STMICRO             0x0020
 #define D6_MASK                         0x40
 
-static vuint8   * const flashport = (vuint8 *)0xa0000000;
+static volatile uint8_t   * const flashport = (volatile uint8_t *)0xa0000000;
 
 /* We'll do this before sending a command */
 static void send_unlock(void) {
@@ -81,23 +81,23 @@ static void send_unlock(void) {
 }
 
 /* Send a command (including unlock) */
-static void send_cmd(uint32 cmd) {
+static void send_cmd(uint32_t cmd) {
     send_unlock();
     flashport[ADDR_UNLOCK_1] = cmd;
 }
 
 /* Read a flash value */
-static uint32 nvflash_read(uint32 addr) {
+static uint32_t nvflash_read(uint32_t addr) {
     return flashport[addr];
 }
 
 /* Determine if the flash memory is busy writing */
-static int nvflash_busy(uint32 addr) {
+static int nvflash_busy(uint32_t addr) {
     return (nvflash_read(addr) & D6_MASK) != (nvflash_read(addr) & D6_MASK);
 }
 
 /* Wait until the flash is ready, with timeout */
-static int nvflash_wait_ready(uint32 addr, int timeout) {
+static int nvflash_wait_ready(uint32_t addr, int timeout) {
     int wait = 0;
 
     if(timeout < 0) {
@@ -119,7 +119,7 @@ static int nvflash_wait_ready(uint32 addr, int timeout) {
 }
 
 /* Write a single flash value, return -1 if we fail or timeout */
-static int nvflash_write(uint32 addr, uint8 value) {
+static int nvflash_write(uint32_t addr, uint8_t value) {
     send_cmd(CMD_PROGRAM_UNLOCK_DATA);
     flashport[addr] = value;
 
@@ -139,8 +139,8 @@ static int nvflash_write(uint32 addr, uint8 value) {
 }
 
 /* Write a block of data */
-int nvflash_write_block(uint32 addr, void * data, uint32 len) {
-    uint8   * db = (uint8 *)data;
+int nvflash_write_block(uint32_t addr, void *data, uint32_t len) {
+    uint8_t   *db = (uint8_t *)data;
     unsigned i;
 
     for(i = 0; i < len; i++) {
@@ -158,7 +158,7 @@ int nvflash_write_block(uint32 addr, void * data, uint32 len) {
 }
 
 /* Erase a block of flash */
-int nvflash_erase_block(uint32 addr) {
+int nvflash_erase_block(uint32_t addr) {
     send_cmd(CMD_SECTOR_ERASE_UNLOCK_DATA);
     send_unlock();
     flashport[addr] = CMD_SECTOR_ERASE_UNLOCK_DATA_2;
@@ -196,7 +196,7 @@ int nvflash_erase_all(void) {
 
 /* Return 0 if we successfully detect a compatible device */
 int nvflash_detect(void) {
-    uint16      mfr_id, dev_id;
+    uint16_t      mfr_id, dev_id;
 
     if(nvflash_read(0) == 0xff && nvflash_read(2) == 0x28) {
         printf("flash_detect: normal DC BIOS detected\n");

--- a/addons/libnavi/navi_ide.c
+++ b/addons/libnavi/navi_ide.c
@@ -18,13 +18,13 @@
    from the _original_ KallistiOS =) (PC based)
  */
 
-static uint16 dd[256];          /* hard disk parameters, read from controller */
-static uint32 hd_cyls, hd_heads, hd_sects;          /* hard disk geometry */
+static uint16_t dd[256];          /* hard disk parameters, read from controller */
+static uint32_t hd_cyls, hd_heads, hd_sects;          /* hard disk geometry */
 
 
-static void ide_outp(int port, uint16 value, int size) {
+static void ide_outp(int port, uint16_t value, int size) {
     (void)size;
-    uint32 addr;
+    uint32_t addr;
 
     switch(port & 0xff0) {
         case 0x1f0:
@@ -42,9 +42,9 @@ static void ide_outp(int port, uint16 value, int size) {
     g2_write_16(addr, value);
 }
 
-uint16 ide_inp(int port, int size) {
-    uint32 addr;
-    uint16 value;
+uint16_t ide_inp(int port, int size) {
+    uint32_t addr;
+    uint16_t value;
 
     switch(port & 0xff0) {
         case 0x1f0:
@@ -103,7 +103,7 @@ static void wait_data(void) {
 }
 
 /* Reads a chunk of ascii out of the hd params table */
-static char *get_ascii(uint16 *in_data, uint32 off_start, uint32 off_end) {
+static char *get_ascii(uint16_t *in_data, uint32_t off_start, uint32_t off_end) {
     static char ret_val [255];
     unsigned loop;
     int loop1;
@@ -122,9 +122,9 @@ static char *get_ascii(uint16 *in_data, uint32 off_start, uint32 off_end) {
 }
 
 /* Read n sectors from the hard disk using PIO mode */
-static int ide_read_chs(uint32 cyl, uint32 head, uint32 sector, uint32 numsects, uint8 *bufptr) {
+static int ide_read_chs(uint32_t cyl, uint32_t head, uint32_t sector, uint32_t numsects, uint8_t *bufptr) {
     int o;
-    uint16  *bufptr16 = (uint16*)bufptr;
+    uint16_t  *bufptr16 = (uint16_t *)bufptr;
 
     /** printf("reading C/H/S/Cnt %d/%d/%d/%d\n",
         cyl, head, sector, numsects); */
@@ -156,9 +156,9 @@ static int ide_read_chs(uint32 cyl, uint32 head, uint32 sector, uint32 numsects,
 }
 
 /* Write n sectors to the hard disk using PIO mode */
-static int ide_write_chs(uint32 cyl, uint32 head, uint32 sector, uint32 numsects, uint8 *bufptr) {
+static int ide_write_chs(uint32_t cyl, uint32_t head, uint32_t sector, uint32_t numsects, uint8_t *bufptr) {
     int o;
-    uint16  *bufptr16 = (uint16*)bufptr;
+    uint16_t  *bufptr16 = (uint16_t *)bufptr;
 
     /** printf("writing C/H/S/Cnt %d/%d/%d/%d\n",
         cyl, head, sector, numsects); */
@@ -191,27 +191,27 @@ static int ide_write_chs(uint32 cyl, uint32 head, uint32 sector, uint32 numsects
 
 /* Translate a linear sector address relative to the first of the partition
    to a CHS address suitable for feeding to the hard disk */
-static void linear_to_chs(uint32 linear, uint32 * cyl, uint32 * head, uint32 * sector) {
+static void linear_to_chs(uint32_t linear, uint32_t *cyl, uint32_t *head, uint32_t *sector) {
     *sector = linear % hd_sects + 1;
     *head = (linear / hd_sects) % hd_heads;
     *cyl = linear / (hd_sects * hd_heads);
 }
 
 /* Read n sectors from the hard disk using PIO mode */
-int ide_read(uint32 linear, uint32 numsects, void * bufptr) {
+int ide_read(uint32_t linear, uint32_t numsects, void *bufptr) {
     unsigned i;
-    uint32  cyl, head, sector;
+    uint32_t  cyl, head, sector;
 
     if(numsects > 1) {
         for(i = 0; i < numsects; i++) {
-            if(ide_read(linear + i, 1, ((uint8 *)bufptr) + i * 512) < 0)
+            if(ide_read(linear + i, 1, ((uint8_t *)bufptr) + i * 512) < 0)
                 return -1;
         }
     }
     else {
         linear_to_chs(linear, &cyl, &head, &sector);
 
-        if(ide_read_chs(cyl, head, sector, numsects, (uint8*)bufptr) < 0)
+        if(ide_read_chs(cyl, head, sector, numsects, (uint8_t *)bufptr) < 0)
             return -1;
     }
 
@@ -219,26 +219,26 @@ int ide_read(uint32 linear, uint32 numsects, void * bufptr) {
 }
 
 /* Write n sectors to the hard disk using PIO mode */
-int ide_write(uint32 linear, uint32 numsects, void *bufptr) {
+int ide_write(uint32_t linear, uint32_t numsects, void *bufptr) {
     unsigned i;
-    uint32  cyl, head, sector;
+    uint32_t  cyl, head, sector;
 
     if(numsects > 1) {
         for(i = 0; i < numsects; i++) {
-            if(ide_write(linear + i, 1, ((uint8 *)bufptr) + i * 512) < 0)
+            if(ide_write(linear + i, 1, ((uint8_t *)bufptr) + i * 512) < 0)
                 return -1;
         }
     }
     else {
         linear_to_chs(linear, &cyl, &head, &sector);
-        ide_write_chs(cyl, head, sector, numsects, (uint8*)bufptr);
+        ide_write_chs(cyl, head, sector, numsects, (uint8_t *)bufptr);
     }
 
     return 0;
 }
 
 /* Get the available space */
-uint32 ide_num_sectors(void) {
+uint32_t ide_num_sectors(void) {
     return hd_cyls * hd_heads * hd_sects;
 }
 
@@ -277,5 +277,4 @@ int ide_init(void) {
 
 void ide_shutdown(void) {
 }
-
 

--- a/addons/libppp/ipcp.c
+++ b/addons/libppp/ipcp.c
@@ -303,10 +303,10 @@ reject_opt:
         /* Save all the accepted configuration options in the network
            device structure. */
         if(nif) {
-            nif->gateway[0] = (uint8)(addr >> 24);
-            nif->gateway[1] = (uint8)(addr >> 16);
-            nif->gateway[2] = (uint8)(addr >> 8);
-            nif->gateway[3] = (uint8)addr;
+            nif->gateway[0] = (uint8_t)(addr >> 24);
+            nif->gateway[1] = (uint8_t)(addr >> 16);
+            nif->gateway[2] = (uint8_t)(addr >> 8);
+            nif->gateway[3] = (uint8_t)addr;
         }
 
         if(ipcp_state.state == PPP_STATE_ACK_RECEIVED) {
@@ -518,15 +518,15 @@ static int ipcp_handle_configure_nak(ppp_protocol_t *self,
     if(ipcp_state.ppp_state->netif) {
         netif_t *nif = ipcp_state.ppp_state->netif;
 
-        nif->ip_addr[0] = (uint8)(addr >> 24);
-        nif->ip_addr[1] = (uint8)(addr >> 16);
-        nif->ip_addr[2] = (uint8)(addr >> 8);
-        nif->ip_addr[3] = (uint8)addr;
+        nif->ip_addr[0] = (uint8_t)(addr >> 24);
+        nif->ip_addr[1] = (uint8_t)(addr >> 16);
+        nif->ip_addr[2] = (uint8_t)(addr >> 8);
+        nif->ip_addr[3] = (uint8_t)addr;
 
-        nif->dns[0] = (uint8)(dns >> 24);
-        nif->dns[1] = (uint8)(dns >> 16);
-        nif->dns[2] = (uint8)(dns >> 8);
-        nif->dns[3] = (uint8)dns;
+        nif->dns[0] = (uint8_t)(dns >> 24);
+        nif->dns[1] = (uint8_t)(dns >> 16);
+        nif->dns[2] = (uint8_t)(dns >> 8);
+        nif->dns[3] = (uint8_t)dns;
     }
 
     return ipcp_send_client_cfg(self, 0);

--- a/addons/libppp/ppp.c
+++ b/addons/libppp/ppp.c
@@ -587,7 +587,7 @@ static int ppp_if_shutdown(netif_t *self) {
     return ppp_shutdown();
 }
 
-static int ppp_if_tx(netif_t *self, const uint8 *data, int len, int blocking) {
+static int ppp_if_tx(netif_t *self, const uint8_t *data, int len, int blocking) {
     (void)self;
     (void)blocking;
 
@@ -595,13 +595,13 @@ static int ppp_if_tx(netif_t *self, const uint8 *data, int len, int blocking) {
     return ppp_send(data, len, PPP_PROTOCOL_IPv4);
 }
 
-static int ppp_if_set_flags(netif_t *self, uint32 flags_and, uint32 flags_or) {
+static int ppp_if_set_flags(netif_t *self, uint32_t flags_and, uint32_t flags_or) {
     self->flags = (self->flags & flags_and) | flags_or;
     return 0;
 }
 
 
-static int ppp_if_set_mc(netif_t *self, const uint8 *list, int count) {
+static int ppp_if_set_mc(netif_t *self, const uint8_t *list, int count) {
     (void)self;
     (void)list;
     (void)count;

--- a/examples/dreamcast/keyboard/keyrawtest/keyrawtest.c
+++ b/examples/dreamcast/keyboard/keyrawtest/keyrawtest.c
@@ -33,15 +33,15 @@
 #include <assert.h>
 #include <kos.h>
 
-extern uint16 *vram_s;
+extern uint16_t *vram_s;
 
 static cont_state_t *first_kbd_state;
 static maple_device_t *first_kbd_dev = NULL;
 
 /* Track how many times we try to find a keyboard before just quitting. */
-static uint8 no_kbd_loop = 0;
+static uint8_t no_kbd_loop = 0;
 /* This is set up to have multiple tests in the future. */
-static uint8 test_phase = 0;
+static uint8_t test_phase = 0;
 
 // Add this helper function above basic_typing()
 static const char *kbd_key_name(kbd_key_t key) {

--- a/include/kos/dbgio.h
+++ b/include/kos/dbgio.h
@@ -23,7 +23,7 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
+#include <stdint.h>
 
 /** \brief   Debug I/O Interface.
     \ingroup logging
@@ -93,7 +93,7 @@ typedef struct dbgio_handler {
         \return             Number of characters written on success, or -1 on
                             failure (set errno as appropriate)
     */
-    int (*write_buffer)(const uint8 *data, int len, int xlat);
+    int (*write_buffer)(const uint8_t *data, int len, int xlat);
 
     /** \brief  Read an entire buffer of data from the console.
         \param  data        The buffer to read into
@@ -101,7 +101,7 @@ typedef struct dbgio_handler {
         \return             Number of characters read on success, or -1 on
                             failure (set errno as appropriate)
     */
-    int (*read_buffer)(uint8 *data, int len);
+    int (*read_buffer)(uint8_t *data, int len);
 } dbgio_handler_t;
 
 /** \cond */
@@ -217,7 +217,7 @@ int dbgio_flush(void);
     \return                 Number of characters written on success, or -1 on
                             failure (errno should be set as appropriate)
 */
-int dbgio_write_buffer(const uint8 *data, int len);
+int dbgio_write_buffer(const uint8_t *data, int len);
 
 /** \brief   Read an entire buffer of data from the console.
     \ingroup logging
@@ -228,7 +228,7 @@ int dbgio_write_buffer(const uint8 *data, int len);
     \return                 Number of characters read on success, or -1 on
                             failure (errno should be set as appropriate)
 */
-int dbgio_read_buffer(uint8 *data, int len);
+int dbgio_read_buffer(uint8_t *data, int len);
 
 /** \brief   Write an entire buffer of data to the console (potentially with
              newline transformations).
@@ -240,7 +240,7 @@ int dbgio_read_buffer(uint8 *data, int len);
     \return                 Number of characters written on success, or -1 on
                             failure (errno should be set as appropriate)
 */
-int dbgio_write_buffer_xlat(const uint8 *data, int len);
+int dbgio_write_buffer_xlat(const uint8_t *data, int len);
 
 /** \brief   Write a NUL-terminated string to the console.
     \ingroup logging

--- a/include/kos/exports.h
+++ b/include/kos/exports.h
@@ -24,7 +24,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <stdint.h>
 
 /** \addtogroup system_libraries

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -51,9 +51,9 @@ __BEGIN_DECLS
 */
 typedef struct kos_dirent {
     int size;               /**< \brief Size of the file in bytes. */
-    char name[NAME_MAX];  /**< \brief Name of the file. */
+    char name[NAME_MAX];    /**< \brief Name of the file. */
     time_t time;            /**< \brief Last access/mod/change time (depends on VFS) */
-    uint32 attr;            /**< \brief Attributes of the file. */
+    uint32_t attr;          /**< \brief Attributes of the file. */
 } dirent_t;
 
 /* Forward declaration */
@@ -189,7 +189,7 @@ typedef struct vfs_handler {
     _off64_t (*tell64)(void *hnd);
 
     /** \brief Return the size of an opened file as a 64-bit integer */
-    uint64 (*total64)(void *hnd);
+    uint64_t (*total64)(void *hnd);
 
     /** \brief Read the value of a symbolic link
         \note  path will not be passed through realpath() before calling the
@@ -369,14 +369,14 @@ size_t fs_total(file_t hnd);
     This file retrieves the length of the file associated with the given file
     descriptor.
 
-    \note                   uint64 is unsigned, so the error return value is not
-                            less than 0.                            
+    \note                   uint64_t is unsigned, so the error return value is
+                            not less than 0.
 
     \param  hnd             The file descriptor to retrieve the size from.
     
     \return                 The length of the file on success, -1 on failure.
 */
-uint64 fs_total64(file_t hnd);
+uint64_t fs_total64(file_t hnd);
 
 
 /** \brief   Read an entry from an opened directory.

--- a/include/kos/fs_socket.h
+++ b/include/kos/fs_socket.h
@@ -29,7 +29,6 @@
 
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <kos/fs.h>
 #include <kos/net.h>
 #include <sys/queue.h>
@@ -274,7 +273,7 @@ typedef struct fs_socket_proto {
         \retval -1          On error (the packet is discarded)
         \retval 0           On success
     */
-    int (*input)(netif_t *src, int domain, const void *hdr, const uint8 *data,
+    int (*input)(netif_t *src, int domain, const void *hdr, const uint8_t *data,
                  size_t size);
 
     /** \brief  Get socket options.
@@ -448,7 +447,7 @@ net_socket_t *fs_socket_open_sock(fs_socket_proto_t *proto);
     \retval 0           On success
 */
 int fs_socket_input(netif_t *src, int domain, int protocol, const void *hdr,
-                    const uint8 *data, size_t size);
+                    const uint8_t *data, size_t size);
 
 /** \brief   Add a new protocol for use with fs_socket.
     \ingroup vfs_sockets

--- a/include/kos/library.h
+++ b/include/kos/library.h
@@ -61,7 +61,7 @@ typedef tid_t libid_t;                  /**< \brief Library ID type. */
     Each loaded library should export at least the functions described in this
     structure:
     \li     const char *lib_get_name()
-    \li     uint32 %lib_get_version()
+    \li     uint32_t %lib_get_version()
     \li     int lib_open(struct klibrary *lib)
     \li     int lib_close(struct klibrary *lib)
 

--- a/include/kos/net.h
+++ b/include/kos/net.h
@@ -528,7 +528,7 @@ net_ipv4_stats_t net_ipv4_get_stats(void);
 */
 uint32_t __pure net_ipv4_address(const uint8_t addr[4]);
 
-/** \brief   Parse an IP address that is packet into a uint32 into an array of
+/** \brief   Parse an IP address that is packet into a uint32_t into an array of
              the individual bytes.
     \ingroup networking_ipv4
 

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -41,7 +41,7 @@ __BEGIN_DECLS
 #include <kos/cdefs.h>
 #include <kos/tls.h>
 #include <arch/irq.h>
-#include <arch/types.h>
+
 #include <sys/queue.h>
 #include <sys/reent.h>
 

--- a/kernel/debug/dbgio.c
+++ b/kernel/debug/dbgio.c
@@ -122,7 +122,7 @@ int dbgio_flush(void) {
     return -1;
 }
 
-int dbgio_write_buffer(const uint8 *data, int len) {
+int dbgio_write_buffer(const uint8_t *data, int len) {
     if(dbgio_enabled) {
         assert(dbgio);
         return dbgio->write_buffer(data, len, 0);
@@ -131,7 +131,7 @@ int dbgio_write_buffer(const uint8 *data, int len) {
     return -1;
 }
 
-int dbgio_read_buffer(uint8 *data, int len) {
+int dbgio_read_buffer(uint8_t *data, int len) {
     if(dbgio_enabled) {
         assert(dbgio);
         return dbgio->read_buffer(data, len);
@@ -140,7 +140,7 @@ int dbgio_read_buffer(uint8 *data, int len) {
     return -1;
 }
 
-int dbgio_write_buffer_xlat(const uint8 *data, int len) {
+int dbgio_write_buffer_xlat(const uint8_t *data, int len) {
     if(dbgio_enabled) {
         assert(dbgio);
         return dbgio->write_buffer(data, len, 1);
@@ -152,7 +152,7 @@ int dbgio_write_buffer_xlat(const uint8 *data, int len) {
 int dbgio_write_str(const char *str) {
     if(dbgio_enabled) {
         assert(dbgio);
-        return dbgio_write_buffer_xlat((const uint8*)str, strlen(str));
+        return dbgio_write_buffer_xlat((const uint8_t *)str, strlen(str));
     }
 
     return -1;
@@ -211,13 +211,13 @@ static int null_write(int c) {
 static int null_flush(void) {
     return 0;
 }
-static int null_write_buffer(const uint8 *data, int len, int xlat) {
+static int null_write_buffer(const uint8_t *data, int len, int xlat) {
     (void)data;
     (void)len;
     (void)xlat;
     return len;
 }
-static int null_read_buffer(uint8 * data, int len) {
+static int null_read_buffer(uint8_t * data, int len) {
     (void)data;
     (void)len;
     errno = EAGAIN;

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -51,16 +51,16 @@ typedef struct fs_hnd {
 } fs_hnd_t;
 
 /* The global file descriptor table */
-fs_hnd_t * fd_table[FD_SETSIZE] = { NULL };
+fs_hnd_t *fd_table[FD_SETSIZE] = { NULL };
 
 /* Internal file commands for root dir reading */
-static fs_hnd_t * fs_root_opendir(void) {
+static fs_hnd_t *fs_root_opendir(void) {
     return calloc(1, sizeof(fs_hnd_t));
 }
 
 /* Not thread-safe right now */
 static dirent_t root_readdir_dirent;
-static dirent_t *fs_root_readdir(fs_hnd_t * handle) {
+static dirent_t *fs_root_readdir(fs_hnd_t *handle) {
     nmmgr_handler_t *nmhnd;
     nmmgr_list_t    *nmhead;
     int         cnt;
@@ -161,7 +161,7 @@ static fs_hnd_t * fs_hnd_open(const char *fn, int mode) {
 
 /* Reference a file handle. This should be called when a persistent reference
    to a raw handle is created somewhere. */
-static void fs_hnd_ref(fs_hnd_t * ref) {
+static void fs_hnd_ref(fs_hnd_t *ref) {
     assert(ref);
     assert(ref->refcnt < (1 << 30));
     ref->refcnt++;
@@ -242,7 +242,7 @@ file_t fs_open(const char *fn, int mode) {
 }
 
 /* See header for comments */
-file_t fs_open_handle(vfs_handler_t * vfs, void * vhnd) {
+file_t fs_open_handle(vfs_handler_t *vfs, void *vhnd) {
     fs_hnd_t * hnd;
 
     /* Wrap it up in a structure */
@@ -317,7 +317,7 @@ file_t fs_dup2(file_t oldfd, file_t newfd) {
 
 /* Returns a file handle for a given fd, or NULL if the parameters
    are not valid. */
-static fs_hnd_t * fs_map_hnd(file_t fd) {
+static fs_hnd_t *fs_map_hnd(file_t fd) {
     if(fd < 0 || fd >= FD_SETSIZE) {
         errno = EBADF;
         return NULL;
@@ -474,7 +474,7 @@ size_t fs_total(file_t fd) {
     return -1;
 }
 
-uint64 fs_total64(file_t fd) {
+uint64_t fs_total64(file_t fd) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
     if(!h) return -1;
@@ -488,7 +488,7 @@ uint64 fs_total64(file_t fd) {
     if(h->handler->total64)
         return h->handler->total64(h->hnd);
     else if(h->handler->total)
-        return (uint64)h->handler->total(h->hnd);
+        return (uint64_t)h->handler->total(h->hnd);
 
     errno = EINVAL;
     return -1;
@@ -582,7 +582,7 @@ int fs_ioctl(file_t fd, int cmd, ...) {
     return rv;
 }
 
-static vfs_handler_t * fs_verify_handler(const char * fn) {
+static vfs_handler_t *fs_verify_handler(const char *fn) {
     nmmgr_handler_t *nh;
 
     nh = nmmgr_lookup(fn);
@@ -676,7 +676,7 @@ void *fs_mmap(file_t fd) {
     return h->handler->mmap(h->hnd);
 }
 
-int fs_complete(file_t fd, ssize_t * rv) {
+int fs_complete(file_t fd, ssize_t *rv) {
     fs_hnd_t *h = fs_map_hnd(fd);
 
     if(!h) return -1;
@@ -689,7 +689,7 @@ int fs_complete(file_t fd, ssize_t * rv) {
     return h->handler->complete(h->hnd, rv);
 }
 
-int fs_mkdir(const char * fn) {
+int fs_mkdir(const char *fn) {
     vfs_handler_t   *cur;
     char        rfn[PATH_MAX];
 
@@ -709,7 +709,7 @@ int fs_mkdir(const char * fn) {
     }
 }
 
-int fs_rmdir(const char * fn) {
+int fs_rmdir(const char *fn) {
     vfs_handler_t   *cur;
     char        rfn[PATH_MAX];
 

--- a/kernel/fs/fs_dev.c
+++ b/kernel/fs/fs_dev.c
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <errno.h>
 
-#include <arch/types.h>
 #include <kos/dbglog.h>
 #include <kos/fs_dev.h>
 #include <sys/queue.h>

--- a/kernel/fs/fs_null.c
+++ b/kernel/fs/fs_null.c
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <errno.h>
 
-#include <arch/types.h>
 #include <kos/mutex.h>
 #include <kos/fs_null.h>
 #include <sys/queue.h>

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -29,8 +29,6 @@ or space present.
 #include <kos/cond.h>
 #include <kos/fs_pty.h>
 
-#include <arch/types.h>
-
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -53,10 +51,10 @@ typedef LIST_HEAD(ptylist, ptyhalf) ptylist_t;
 typedef struct ptyhalf {
     LIST_ENTRY(ptyhalf) list;
 
-    struct ptyhalf * other;         /* Other end of the pipe */
+    struct ptyhalf *other;  /* Other end of the pipe */
     int master;             /* Non-zero if we are master */
 
-    uint8   buffer[PTY_BUFFER_SIZE];    /* Our _receive_ buffer */
+    uint8_t   buffer[PTY_BUFFER_SIZE];    /* Our _receive_ buffer */
     int head, tail;         /* Insert at head, remove at tail */
     size_t cnt;             /* Byte count in the queue */
 
@@ -325,15 +323,15 @@ static void * pty_open_dir(const char * fn, int mode) {
     return (void *)fdobj;
 }
 
-static void * pty_open_file(const char * fn, int mode) {
+static void *pty_open_file(const char *fn, int mode) {
     /* Ok, they want an actual pty. We always give them one RDWR, no
        matter what is asked for (it's much simpler). Also we don't have to
        handle fds of our own here thanks to the VFS layer, just reference
        counting so a pty can be opened by more than one process. */
     int     master;
     int     id;
-    ptyhalf_t   * ph;
-    pipefd_t    * fdobj;
+    ptyhalf_t   *ph;
+    pipefd_t    *fdobj;
 
     /* Parse out the name we got */
     if(strlen(fn) != 4) {
@@ -394,7 +392,7 @@ static void * pty_open_file(const char * fn, int mode) {
     return (void *)fdobj;
 }
 
-static void * pty_open(vfs_handler_t * vfs, const char * fn, int mode) {
+static void *pty_open(vfs_handler_t *vfs, const char *fn, int mode) {
     (void)vfs;
 
     /* Skip any preceding slash */
@@ -452,7 +450,7 @@ static int pty_close(void *h) {
 }
 
 /* Read from a pty endpoint, kernel console special case */
-static ssize_t pty_read_serial(pipefd_t * fdobj, ptyhalf_t * ph, void * buf, size_t bytes) {
+static ssize_t pty_read_serial(pipefd_t *fdobj, ptyhalf_t *ph, void *buf, size_t bytes) {
     int c, r = 0;
 
     (void)ph;
@@ -486,7 +484,7 @@ static ssize_t pty_read_serial(pipefd_t * fdobj, ptyhalf_t * ph, void * buf, siz
         }
 
         /* Add the obtained char to the buffer and echo it */
-        ((uint8 *)buf)[r] = c;
+        ((uint8_t *)buf)[r] = c;
         dbgio_write(c);
         r++;
     }
@@ -499,7 +497,7 @@ static ssize_t pty_read_serial(pipefd_t * fdobj, ptyhalf_t * ph, void * buf, siz
 }
 
 /* Read from a pty endpoint */
-static ssize_t pty_read(void * h, void * buf, size_t bytes) {
+static ssize_t pty_read(void *h, void *buf, size_t bytes) {
     size_t avail;
     pipefd_t *fdobj;
     ptyhalf_t *ph;
@@ -547,7 +545,7 @@ static ssize_t pty_read(void * h, void * buf, size_t bytes) {
     if((ph->head + bytes) > PTY_BUFFER_SIZE) {
         avail = PTY_BUFFER_SIZE - ph->head;
         memcpy(buf, ph->buffer + ph->head, avail);
-        memcpy(((uint8 *)buf) + avail, ph->buffer, bytes - avail);
+        memcpy(((uint8_t *)buf) + avail, ph->buffer, bytes - avail);
     }
     else
         memcpy(buf, ph->buffer + ph->head, bytes);
@@ -564,7 +562,7 @@ done:
 }
 
 /* Write to a pty endpoint */
-static ssize_t pty_write(void * h, const void * buf, size_t bytes) {
+static ssize_t pty_write(void *h, const void *buf, size_t bytes) {
     size_t avail;
     pipefd_t *fdobj;
     ptyhalf_t *ph;
@@ -580,7 +578,7 @@ static ssize_t pty_write(void * h, const void * buf, size_t bytes) {
     /* Special case the unattached console */
     if(ph->id == 0 && !ph->master && ph->other->refcnt == 0) {
         /* This actually blocks, but fooey.. :) */
-        dbgio_write_buffer_xlat((const uint8 *)buf, bytes);
+        dbgio_write_buffer_xlat((const uint8_t *)buf, bytes);
         return bytes;
     }
 
@@ -617,7 +615,7 @@ static ssize_t pty_write(void * h, const void * buf, size_t bytes) {
     if((ph->tail + bytes) > PTY_BUFFER_SIZE) {
         avail = PTY_BUFFER_SIZE - ph->tail;
         memcpy(ph->buffer + ph->tail, buf, avail);
-        memcpy(ph->buffer, ((const uint8 *)buf) + avail, bytes - avail);
+        memcpy(ph->buffer, ((const uint8_t *)buf) + avail, bytes - avail);
     }
     else
         memcpy(ph->buffer + ph->tail, buf, bytes);
@@ -635,9 +633,9 @@ done:
 }
 
 /* Get total size. For this we return the number of bytes available for reading. */
-static size_t pty_total(void * h) {
-    pipefd_t    * fdobj;
-    ptyhalf_t   * ph;
+static size_t pty_total(void *h) {
+    pipefd_t    *fdobj;
+    ptyhalf_t   *ph;
 
     fdobj = (pipefd_t *)h;
     ph = fdobj->d.p;
@@ -651,9 +649,9 @@ static size_t pty_total(void * h) {
 }
 
 /* Read a directory entry */
-static dirent_t * pty_readdir(void * h) {
-    pipefd_t * fdobj = (pipefd_t *)h;
-    dirlist_t * dl;
+static dirent_t *pty_readdir(void *h) {
+    pipefd_t *fdobj = (pipefd_t *)h;
+    dirlist_t *dl;
 
     assert(h);
 

--- a/kernel/fs/fs_random.c
+++ b/kernel/fs/fs_random.c
@@ -11,7 +11,6 @@
 #include <errno.h>
 #include <time.h>
 
-#include <arch/types.h>
 #include <kos/mutex.h>
 #include <kos/fs_random.h>
 #include <kos/dbglog.h>

--- a/kernel/fs/fs_socket.c
+++ b/kernel/fs/fs_socket.c
@@ -186,7 +186,7 @@ int fs_socket_shutdown(void) {
 }
 
 int fs_socket_input(netif_t *src, int domain, int protocol, const void *hdr,
-                    const uint8 *data, size_t size) {
+                    const uint8_t *data, size_t size) {
     fs_socket_proto_t *i;
     int rv = -2;
 

--- a/kernel/fs/fs_utils.c
+++ b/kernel/fs/fs_utils.c
@@ -23,7 +23,7 @@ XXX This probably belongs in something like libc...
 
 /* Copies a file from 'src' to 'dst'. The amount of the file
    actually copied without error is returned. */
-ssize_t fs_copy(const char * src, const char * dst) {
+ssize_t fs_copy(const char *src, const char *dst) {
     char    *buff;
     ssize_t left, total, r;
     file_t  fs, fd;
@@ -76,11 +76,11 @@ ssize_t fs_copy(const char * src, const char * dst) {
    memory (and must free it). The file size is returned, or -1
    on failure; on success, out_ptr is filled with the address
    of the loaded buffer. */
-ssize_t fs_load(const char * src, void ** out_ptr) {
+ssize_t fs_load(const char *src, void **out_ptr) {
     file_t  f;
-    void    * data;
-    void    * new_data;
-    uint8   * out;
+    void    *data;
+    void    *new_data;
+    uint8_t *out;
     ssize_t total, left, r;
 
     assert(out_ptr != NULL);
@@ -101,7 +101,7 @@ ssize_t fs_load(const char * src, void ** out_ptr) {
         return -1;
     }
 
-    out = (uint8 *)data;
+    out = (uint8_t *)data;
 
     /* Load the data */
     while(left > 0) {

--- a/kernel/libc/koslib/malloc.c
+++ b/kernel/libc/koslib/malloc.c
@@ -1663,19 +1663,19 @@ static pthread_mutex_t mALLOC_MUTEx = PTHREAD_MUTEX_INITIALIZER;
  */
 
 typedef struct memctl {
-    uint32          magic;
-    uint32          size;
+    uint32_t        magic;
+    uint32_t        size;
     tid_t           thread;
-    uint32          addr;
-    uint32          *post;
+    uint32_t        addr;
+    uint32_t        *post;
     const char      *type;
     LIST_ENTRY(memctl)  list;
 } memctl_t;
 
 static LIST_HEAD(memctl_list, memctl) block_list;
 
-#define get_memctl(p) ((memctl_t *)( ((uint32)(p)) - BUFFER_SIZE ))
-#define get_buff_p(m) ((void *)( ((uint32)(m)) + BUFFER_SIZE ))
+#define get_memctl(p) ((memctl_t *)( ((uint32_t)(p)) - BUFFER_SIZE ))
+#define get_buff_p(m) ((void *)( ((uint32_t)(m)) + BUFFER_SIZE ))
 
 #define get_cur_tid_safe ((thd_current == NULL) ? (tid_t)0 : thd_current->tid)
 
@@ -1689,7 +1689,7 @@ enum func_type_names { name_MALLOC = 0, name_REALLOC = 1, name_MEMALIGN = 2, nam
 static const char *func_type[8] =
     {"malloc", "realloc", "memalign", "calloc", "free", "check_all", "check", "stats"};
 
-void dbg_print_thd_addr_action(tid_t thread, uint32 addr, void *m, size_t s, uint8_t which) {
+void dbg_print_thd_addr_action(tid_t thread, uint32_t addr, void *m, size_t s, uint8_t which) {
     strcpy(dbg_print_buffer, "Thread ");
     itoa(thread, (dbg_print_buffer + strlen(dbg_print_buffer)), 10);
     strcat(dbg_print_buffer, ", addr 0x");
@@ -1701,13 +1701,13 @@ void dbg_print_thd_addr_action(tid_t thread, uint32 addr, void *m, size_t s, uin
         strcat(dbg_print_buffer, "ing all memory blocks");
     else if(which == name_FREE) {
         strcat(dbg_print_buffer, "ing mem @ 0x");
-        itoa((uint32)m, (dbg_print_buffer + strlen(dbg_print_buffer)), 16);
+        itoa((uint32_t)m, (dbg_print_buffer + strlen(dbg_print_buffer)), 16);
     }
     else {
         strcat(dbg_print_buffer, "ing ");
         itoa(s, (dbg_print_buffer + strlen(dbg_print_buffer)), 10);
         strcat(dbg_print_buffer, " bytes @ 0x");
-        itoa((uint32)m, (dbg_print_buffer + strlen(dbg_print_buffer)), 16);
+        itoa((uint32_t)m, (dbg_print_buffer + strlen(dbg_print_buffer)), 16);
     }
 
     strcat(dbg_print_buffer, "\n");
@@ -1716,7 +1716,7 @@ void dbg_print_thd_addr_action(tid_t thread, uint32 addr, void *m, size_t s, uin
 }
 
 int mem_check_block_int(memctl_t *ctl, int source) {
-    uint32 rv = arch_get_ret_addr(), *nt, i;
+    uint32_t rv = arch_get_ret_addr(), *nt, i;
     int dmg = 0;
     int retv = 0;
 
@@ -1731,7 +1731,7 @@ int mem_check_block_int(memctl_t *ctl, int source) {
         retv = -1;
     }
     else {
-        nt = (uint32 *)ctl;
+        nt = (uint32_t *)ctl;
 
         for(i = sizeof(memctl_t) / 4; i < BUFFER_SIZE / 4; i++) {
             if(nt[i] != PRE_MAGIC) {
@@ -1781,7 +1781,7 @@ Void_t* public_mALLOc(size_t bytes) {
     Void_t* m;
 
 #ifdef KM_DBG
-    uint32 rv = arch_get_ret_addr(), *nt1, *nt2, i, rs;
+    uint32_t rv = arch_get_ret_addr(), *nt1, *nt2, i, rs;
     memctl_t * ctl;
 #endif
 
@@ -1803,7 +1803,7 @@ Void_t* public_mALLOc(size_t bytes) {
     ctl->thread = get_cur_tid_safe;
     ctl->addr = rv;
 
-    nt1 = (uint32*)ctl;
+    nt1 = (uint32_t *)ctl;
 
     for(i = sizeof(memctl_t) / 4; i < BUFFER_SIZE / 4; i++)
         nt1[i] = PRE_MAGIC;
@@ -1838,7 +1838,7 @@ void public_fREe(Void_t* m) {
 #ifdef KM_DBG
     memctl_t * ctl;
 #ifdef KM_DBG_VERBOSE
-    uint32 rv = arch_get_ret_addr();
+    uint32_t rv = arch_get_ret_addr();
 #endif
 #endif
 
@@ -1886,7 +1886,7 @@ int mem_check_all(void) {
 #ifdef KM_DBG
     int retv = 0, rvp;
 #ifdef KM_DBG_VERBOSE
-    uint32 rv = arch_get_ret_addr();
+    uint32_t rv = arch_get_ret_addr();
 #endif
     memctl_t * ctl;
 
@@ -1916,7 +1916,7 @@ int mem_check_all(void) {
 
 Void_t* public_rEALLOc(Void_t* m, size_t bytes) {
 #ifdef KM_DBG
-    uint32 rv = arch_get_ret_addr(), rs, *nt, i;
+    uint32_t rv = arch_get_ret_addr(), rs, *nt, i;
     memctl_t * ctl;
     int dmg = 0;
 #endif
@@ -1954,9 +1954,9 @@ Void_t* public_rEALLOc(Void_t* m, size_t bytes) {
 
 #ifdef KM_DBG_VERBOSE
     strcpy(dbg_print_buffer, " realloc'd block 0x");
-    itoa((uint32)m, (dbg_print_buffer + strlen(dbg_print_buffer)), 16);
+    itoa((uint32_t)m, (dbg_print_buffer + strlen(dbg_print_buffer)), 16);
     strcat(dbg_print_buffer, " to 0x");
-    itoa(((uint32)ctl) + BUFFER_SIZE, (dbg_print_buffer + strlen(dbg_print_buffer)), 16);
+    itoa(((uint32_t)ctl) + BUFFER_SIZE, (dbg_print_buffer + strlen(dbg_print_buffer)), 16);
     strcat(dbg_print_buffer, "\n");
     dbgio_write_str(dbg_print_buffer);
 #endif
@@ -1974,14 +1974,14 @@ Void_t* public_rEALLOc(Void_t* m, size_t bytes) {
             ctl->thread = get_cur_tid_safe;
             ctl->addr = rv;
 
-            nt = (uint32*)ctl;
+            nt = (uint32_t *)ctl;
 
             for(i = sizeof(memctl_t) / 4; i < BUFFER_SIZE / 4; i++)
                 nt[i] = PRE_MAGIC;
 
             ctl->size = bytes;
 
-            ctl->post = nt = ((uint32*)ctl) + BUFFER_SIZE / 4 + rs / 4;
+            ctl->post = nt = ((uint32_t *)ctl) + BUFFER_SIZE / 4 + rs / 4;
 
             for(i = 0; i < BUFFER_SIZE / 4; i++)
                 nt[i] = POST_MAGIC;
@@ -1990,7 +1990,7 @@ Void_t* public_rEALLOc(Void_t* m, size_t bytes) {
 
             ctl->type = func_type[1];
 
-            m = (void *)(((uint32)ctl) + BUFFER_SIZE);
+            m = (void *)(((uint32_t)ctl) + BUFFER_SIZE);
         }
         else
             m = NULL;
@@ -2010,7 +2010,7 @@ Void_t* public_mEMALIGn(size_t alignment, size_t bytes) {
     Void_t* m;
 
 #ifdef KM_DBG
-    uint32 rv = arch_get_ret_addr(), rs, *nt1, *nt2, i;
+    uint32_t rv = arch_get_ret_addr(), rs, *nt1, *nt2, i;
     memctl_t * ctl;
 #endif
 
@@ -2032,7 +2032,7 @@ Void_t* public_mEMALIGn(size_t alignment, size_t bytes) {
     ctl->thread = get_cur_tid_safe;
     ctl->addr = rv;
 
-    nt1 = (uint32*)ctl;
+    nt1 = (uint32_t *)ctl;
 
     for(i = sizeof(memctl_t) / 4; i < BUFFER_SIZE / 4; i++)
         nt1[i] = PRE_MAGIC;
@@ -2047,7 +2047,7 @@ Void_t* public_mEMALIGn(size_t alignment, size_t bytes) {
     LIST_INSERT_HEAD(&block_list, ctl, list);
 
     m = (void *)(nt1 + BUFFER_SIZE / 4);
-    assert(!((uint32)m % alignment));
+    assert(!((uint32_t)m % alignment));
 
 #ifdef KM_DBG_VERBOSE
     dbg_print_thd_addr_action(ctl->thread, ctl->addr, m, bytes, name_MEMALIGN);
@@ -2083,7 +2083,7 @@ Void_t* public_cALLOc(size_t n, size_t elem_size) {
     Void_t* m;
 
 #ifdef KM_DBG
-    uint32 rv = arch_get_ret_addr(), *nt1, *nt2, i, rs;
+    uint32_t rv = arch_get_ret_addr(), *nt1, *nt2, i, rs;
     size_t bytes = n * elem_size;
     memctl_t * ctl;
 #endif
@@ -2106,7 +2106,7 @@ Void_t* public_cALLOc(size_t n, size_t elem_size) {
     ctl->thread = get_cur_tid_safe;
     ctl->addr = rv;
 
-    nt1 = (uint32*)ctl;
+    nt1 = (uint32_t *)ctl;
 
     for(i = sizeof(memctl_t) / 4; i < BUFFER_SIZE / 4; i++)
         nt1[i] = PRE_MAGIC;
@@ -2206,7 +2206,7 @@ void public_mSTATs(void) {
         dbglog(DBG_CRITICAL, "KM_DBG: Still-allocated memory blocks:\n");
         LIST_FOREACH(c, &block_list, list) {
             dbglog(DBG_CRITICAL, "  INUSE %08lx: size %lu, thread %d, addr %08lx, type %s\n",
-                   (uint32)c + BUFFER_SIZE, c->size, c->thread,
+                   (uint32_t)c + BUFFER_SIZE, c->size, c->thread,
                    c->addr, c->type);
 
             mem_check_block_int(c, name_STATS);

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -79,7 +79,7 @@ static int net_dhcp_fill_options(netif_t *net, dhcp_pkt_t *req, uint8_t msgtype,
 
     /* Host Name: Dreamcast */
     const char* host_name = "KallistiOS";
-    const uint8 size = strlen(host_name);
+    const uint8_t size = strlen(host_name);
     req->options[pos++] = DHCP_OPTION_HOST_NAME;
     req->options[pos++] = size;
     memcpy(req->options + pos, host_name, size);
@@ -464,7 +464,7 @@ static void net_dhcp_bind(dhcp_pkt_t *pkt, int len) {
         int expiry = ntohl(tmp) * 1000;
 
         renew_time = now + (expiry >> 1);
-        rebind_time = now + (uint64)(expiry * 0.875);
+        rebind_time = now + (uint64_t)(expiry * 0.875);
         lease_expires = now + expiry;
     }
     else if(tmp == 0xFFFFFFFF) {

--- a/kernel/net/net_icmp6.c
+++ b/kernel/net/net_icmp6.c
@@ -119,7 +119,7 @@ static void net_icmp6_input_128(netif_t *net, ipv6_hdr_t *ip, icmp6_hdr_t *icmp,
     /* Recompute the ICMP header checksum */
     icmp->checksum = 0;
     cs = net_ipv6_checksum_pseudo(&src, &dst, ntohs(ip->length), IPV6_HDR_ICMP);
-    icmp->checksum = net_ipv4_checksum((uint8 *)icmp, ntohs(ip->length), cs);
+    icmp->checksum = net_ipv4_checksum((uint8_t *)icmp, ntohs(ip->length), cs);
 
     /* Send the result away */
     net_ipv6_send_packet(net, ip, d, s);
@@ -690,7 +690,7 @@ int net_icmp6_send_rsol(netif_t *net) {
 /* Convenience function for handling the parts of error packets that are the
    same no matter what kind we're dealing with. */
 static int send_err_pkt(netif_t *net, uint8_t buf[1240], int ptr,
-                        const uint8 *ppkt, size_t pktsz, int mc_allow) {
+                        const uint8_t *ppkt, size_t pktsz, int mc_allow) {
     size_t size = 1240 - ptr;
     icmp6_hdr_t *pkt = (icmp6_hdr_t *)buf;
     const ipv6_hdr_t *orig = (const ipv6_hdr_t *)ppkt;

--- a/kernel/net/net_ipv4.c
+++ b/kernel/net/net_ipv4.c
@@ -296,7 +296,7 @@ uint16_t __pure net_ipv4_checksum_pseudo(in_addr_t src, in_addr_t dst, uint8_t p
                                 uint16_t len) {
     ipv4_pseudo_hdr_t ps = { src, dst, 0, proto, htons(len) };
 
-    return ~net_ipv4_checksum((uint8 *)&ps, sizeof(ipv4_pseudo_hdr_t), 0);
+    return ~net_ipv4_checksum((uint8_t *)&ps, sizeof(ipv4_pseudo_hdr_t), 0);
 }
 
 net_ipv4_stats_t net_ipv4_get_stats(void) {

--- a/kernel/net/net_ipv4_frag.c
+++ b/kernel/net/net_ipv4_frag.c
@@ -223,7 +223,7 @@ int net_ipv4_frag_send(netif_t *net, ip_hdr_t *hdr, const uint8_t *data,
 
     /* Recompute the checksum. */
     newhdr.checksum = 0;
-    newhdr.checksum = net_ipv4_checksum((uint8 *)&newhdr, sizeof(ip_hdr_t), 0);
+    newhdr.checksum = net_ipv4_checksum((uint8_t *)&newhdr, sizeof(ip_hdr_t), 0);
 
     if(net_ipv4_send_packet(net, &newhdr, data, ds)) {
         return -1;
@@ -235,7 +235,7 @@ int net_ipv4_frag_send(netif_t *net, ip_hdr_t *hdr, const uint8_t *data,
     hdr->length = htons(ihl + size - ds);
     hdr->flags_frag_offs = htons((flags & 0xE000) | ((flags & 0x1FFF) + nfb));
     hdr->checksum = 0;
-    hdr->checksum = net_ipv4_checksum((uint8 *)hdr, sizeof(ip_hdr_t), 0);
+    hdr->checksum = net_ipv4_checksum((uint8_t *)hdr, sizeof(ip_hdr_t), 0);
 
     return net_ipv4_frag_send(net, hdr, data + ds, size - ds);
 }

--- a/kernel/net/net_ipv6.h
+++ b/kernel/net/net_ipv6.h
@@ -42,7 +42,7 @@ int net_ipv6_send(netif_t *net, const uint8_t *data, size_t data_size,
                   const struct in6_addr *dst);
 int net_ipv6_input(netif_t *src, const uint8_t *pkt, size_t pktsize,
                    const eth_hdr_t *eth);
-uint16 net_ipv6_checksum_pseudo(const struct in6_addr *src,
+uint16_t net_ipv6_checksum_pseudo(const struct in6_addr *src,
                                 const struct in6_addr *dst,
                                 uint32_t upper_len, uint8_t next_hdr);
 

--- a/kernel/net/net_ndp.c
+++ b/kernel/net/net_ndp.c
@@ -193,7 +193,7 @@ int net_ndp_lookup(netif_t *net, const struct in6_addr *ip, uint8_t mac_out[6],
 
     /* Copy our packet if we have one to copy. */
     if(pkt && data && data_size) {
-        i->data = (uint8 *)malloc(data_size);
+        i->data = (uint8_t *)malloc(data_size);
 
         if(i->data) {
             i->pkt = (ipv6_hdr_t *)malloc(sizeof(ipv6_hdr_t));

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -2738,7 +2738,7 @@ static int process_pkt(netif_t *src, const struct in6_addr *srca,
 }
 
 static int net_tcp_input(netif_t *src, int domain, const void *hdr,
-                         const uint8 *data, size_t size) {
+                         const uint8_t *data, size_t size) {
     struct in6_addr srca, dsta;
     const ip_hdr_t *ip4;
     const ipv6_hdr_t *ip6;

--- a/kernel/net/net_udp.c
+++ b/kernel/net/net_udp.c
@@ -181,7 +181,7 @@ static int net_udp_bind(net_socket_t *hnd, const struct sockaddr *addr,
         udpsock->local_addr = realaddr6;
     }
     else {
-        uint16 port = 1024, tmp = 0;
+        uint16_t port = 1024, tmp = 0;
 
         /* Grab the first unused port >= 1024. This is, unfortunately, O(n^2) */
         while(tmp != port) {


### PR DESCRIPTION
Per #840 . With this, the types are now only present in some utils and dc-arch code.

Additionally a minor amount of whitespace cleanup around function prototypes and comment spacing for variables (as they had these types in them).