### PR TITLE
treewide: Update all files to include <kos/cdefs.h>

### DIFF
--- a/include/arpa/inet.h
+++ b/include/arpa/inet.h
@@ -18,7 +18,7 @@
 #ifndef __ARPA_INET_H
 #define __ARPA_INET_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/kos/barrier.h
+++ b/include/kos/barrier.h
@@ -7,7 +7,7 @@
 #ifndef __KOS_BARRIER_H
 #define __KOS_BARRIER_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \file       kos/barrier.h

--- a/include/kos/blockdev.h
+++ b/include/kos/blockdev.h
@@ -25,7 +25,7 @@
 #ifndef __KOS_BLOCKDEV_H
 #define __KOS_BLOCKDEV_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/include/kos/elf.h
+++ b/include/kos/elf.h
@@ -21,7 +21,7 @@
 #ifndef __KOS_ELF_H
 #define __KOS_ELF_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/include/kos/exports.h
+++ b/include/kos/exports.h
@@ -21,7 +21,7 @@
 #ifndef __KOS_EXPORTS_H
 #define __KOS_EXPORTS_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -24,7 +24,7 @@
 #ifndef __KOS_FS_H
 #define __KOS_FS_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <sys/types.h>

--- a/include/kos/fs_dev.h
+++ b/include/kos/fs_dev.h
@@ -19,7 +19,7 @@
 #ifndef __DC_FS_DEV_H
 #define __DC_FS_DEV_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/fs.h>

--- a/include/kos/fs_null.h
+++ b/include/kos/fs_null.h
@@ -18,7 +18,7 @@
 #ifndef __DC_FS_NULL_H
 #define __DC_FS_NULL_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/fs.h>

--- a/include/kos/fs_pty.h
+++ b/include/kos/fs_pty.h
@@ -23,7 +23,7 @@
 #ifndef __KOS_FS_PTY_H
 #define __KOS_FS_PTY_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/fs.h>

--- a/include/kos/fs_ramdisk.h
+++ b/include/kos/fs_ramdisk.h
@@ -23,7 +23,7 @@
 #ifndef __KOS_FS_RAMDISK_H
 #define __KOS_FS_RAMDISK_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/fs.h>

--- a/include/kos/fs_random.h
+++ b/include/kos/fs_random.h
@@ -25,7 +25,7 @@
 #ifndef __DC_FS_RANDOM_H
 #define __DC_FS_RANDOM_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/fs.h>

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -49,7 +49,7 @@
 #ifndef __KOS_FS_ROMDISK_H
 #define __KOS_FS_ROMDISK_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 #include <stdbool.h>
 #include <stdint.h>
 __BEGIN_DECLS

--- a/include/kos/fs_socket.h
+++ b/include/kos/fs_socket.h
@@ -25,7 +25,7 @@
 #ifndef __KOS_FS_SOCKET_H
 #define __KOS_FS_SOCKET_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/kos/genwait.h
+++ b/include/kos/genwait.h
@@ -23,7 +23,7 @@
 #ifndef __KOS_GENWAIT_H
 #define __KOS_GENWAIT_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/thread.h>

--- a/include/kos/library.h
+++ b/include/kos/library.h
@@ -28,7 +28,7 @@
 #ifndef __KOS_LIBRARY_H
 #define __KOS_LIBRARY_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/thread.h>

--- a/include/kos/net.h
+++ b/include/kos/net.h
@@ -20,7 +20,7 @@
 #ifndef __KOS_NET_H
 #define __KOS_NET_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 #include <stdint.h>
 __BEGIN_DECLS
 

--- a/include/kos/nmmgr.h
+++ b/include/kos/nmmgr.h
@@ -19,7 +19,7 @@
 #ifndef __KOS_NMMGR_H
 #define __KOS_NMMGR_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/include/kos/once.h
+++ b/include/kos/once.h
@@ -21,7 +21,7 @@
     \author Lawrence Sebald
 */
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/kos/oneshot_timer.h
+++ b/include/kos/oneshot_timer.h
@@ -21,7 +21,7 @@
 #ifndef __KOS_ONESHOT_TIMER_H
 #define __KOS_ONESHOT_TIMER_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 struct oneshot_timer;

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -29,7 +29,7 @@
 #ifndef __KOS_OPTS_H
 #define __KOS_OPTS_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup debugging_options Options

--- a/include/kos/regfield.h
+++ b/include/kos/regfield.h
@@ -16,7 +16,7 @@
 #ifndef __KOS_REGFIELD_H
 #define __KOS_REGFIELD_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \brief  Create a mask with a bit set

--- a/include/kos/string.h
+++ b/include/kos/string.h
@@ -29,7 +29,7 @@
 #ifndef __KOS_STRING_H
 #define __KOS_STRING_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <string.h>

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -35,7 +35,7 @@
 #ifndef __KOS_THREAD_H
 #define __KOS_THREAD_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/cdefs.h>

--- a/include/kos/tls.h
+++ b/include/kos/tls.h
@@ -18,7 +18,7 @@
 #ifndef __KOS_TLS_H
 #define __KOS_TLS_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/kos/worker_thread.h
+++ b/include/kos/worker_thread.h
@@ -29,7 +29,7 @@
 #ifndef __KOS_WORKER_THREAD_H
 #define __KOS_WORKER_THREAD_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/thread.h>

--- a/include/libgen.h
+++ b/include/libgen.h
@@ -23,7 +23,7 @@
 #ifndef __LIBGEN_H
 #define __LIBGEN_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \addtogroup vfs_posix

--- a/include/malloc.h
+++ b/include/malloc.h
@@ -19,7 +19,7 @@
 #ifndef __MALLOC_H
 #define __MALLOC_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup system_allocator  Allocator

--- a/include/netdb.h
+++ b/include/netdb.h
@@ -18,7 +18,7 @@
 #ifndef __NETDB_H
 #define __NETDB_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -20,7 +20,7 @@
 #ifndef __NETINET_IN_H
 #define __NETINET_IN_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/netinet/tcp.h
+++ b/include/netinet/tcp.h
@@ -21,7 +21,7 @@
 #ifndef __NETINET_TCP_H
 #define __NETINET_TCP_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/netinet/udp.h
+++ b/include/netinet/udp.h
@@ -21,7 +21,7 @@
 #ifndef __NETINET_UDP_H
 #define __NETINET_UDP_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/netinet/udplite.h
+++ b/include/netinet/udplite.h
@@ -21,7 +21,7 @@
 #ifndef __NETINET_UDPLITE_H
 #define __NETINET_UDPLITE_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/poll.h
+++ b/include/poll.h
@@ -22,7 +22,7 @@
 #ifndef __POLL_H
 #define __POLL_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -32,7 +32,7 @@
 
 /** \cond **/
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 #include <sys/features.h>
 #include <sys/_pthreadtypes.h>
 

--- a/include/sys/_pthreadtypes.h
+++ b/include/sys/_pthreadtypes.h
@@ -8,7 +8,7 @@
 #ifndef __SYS_PTHREADTYPES_H
 #define __SYS_PTHREADTYPES_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 typedef unsigned long int pthread_t;

--- a/include/sys/ioctl.h
+++ b/include/sys/ioctl.h
@@ -20,7 +20,7 @@
 #ifndef __SYS_IOCTL_H
 #define __SYS_IOCTL_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -19,7 +19,7 @@
 #ifndef __SYS_LOCK_H__
 #define __SYS_LOCK_H__
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \cond */

--- a/include/sys/sched.h
+++ b/include/sys/sched.h
@@ -7,7 +7,7 @@
 #ifndef __SYS_SCHED_H
 #define __SYS_SCHED_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 // These are copied from Newlib to make stuff compile as expected.

--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -20,7 +20,7 @@
 #ifndef __SYS_SELECT_H
 #define __SYS_SELECT_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -21,7 +21,7 @@
 #ifndef __SYS_SOCKET_H
 #define __SYS_SOCKET_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 

--- a/include/sys/stdio.h
+++ b/include/sys/stdio.h
@@ -8,7 +8,7 @@
 #ifndef _NEWLIB_STDIO_H
 #define _NEWLIB_STDIO_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 // Cribbed from newlib sys/stdio.h

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -19,7 +19,7 @@
 #ifndef __SYS_UIO_H
 #define __SYS_UIO_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/include/sys/utsname.h
+++ b/include/sys/utsname.h
@@ -19,7 +19,7 @@
 #ifndef __SYS_UTSNAME_H
 #define __SYS_UTSNAME_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/threads.h
+++ b/include/threads.h
@@ -25,7 +25,7 @@
 
 #if !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 201112L)
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 #include <time.h>
 
 /* Bring in all the threading-related stuff we'll need. */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.h
@@ -14,7 +14,7 @@
 #ifndef __PVR_MEM_CORE_H
 #define __PVR_MEM_CORE_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /*

--- a/kernel/arch/dreamcast/include/arch/byteorder.h
+++ b/kernel/arch/dreamcast/include/arch/byteorder.h
@@ -22,7 +22,7 @@
 #ifndef __ARCH_BYTEORDER_H
 #define __ARCH_BYTEORDER_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #ifdef BYTE_ORDER

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -23,7 +23,7 @@
 #ifndef __ARCH_CACHE_H
 #define __ARCH_CACHE_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/arch/dmac.h
+++ b/kernel/arch/dreamcast/include/arch/dmac.h
@@ -17,7 +17,7 @@
 #ifndef __ARCH_DMAC_H
 #define __ARCH_DMAC_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/arch/exec.h
+++ b/kernel/arch/dreamcast/include/arch/exec.h
@@ -20,7 +20,7 @@
 #ifndef __ARCH_EXEC_H
 #define __ARCH_EXEC_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup system_overlays   Overlays

--- a/kernel/arch/dreamcast/include/arch/gdb.h
+++ b/kernel/arch/dreamcast/include/arch/gdb.h
@@ -17,7 +17,7 @@
 #ifndef __ARCH_GDB_H
 #define __ARCH_GDB_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup debugging_gdb GDB

--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -29,7 +29,7 @@
 #include <stdalign.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup irqs  Interrupts

--- a/kernel/arch/dreamcast/include/arch/memory.h
+++ b/kernel/arch/dreamcast/include/arch/memory.h
@@ -20,7 +20,7 @@
 #ifndef __ARCH_MEMORY_H
 #define __ARCH_MEMORY_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup memory Address Space

--- a/kernel/arch/dreamcast/include/arch/mmu.h
+++ b/kernel/arch/dreamcast/include/arch/mmu.h
@@ -45,7 +45,7 @@
 #ifndef __ARCH_MMU_H
 #define __ARCH_MMU_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdbool.h>

--- a/kernel/arch/dreamcast/include/arch/rtc.h
+++ b/kernel/arch/dreamcast/include/arch/rtc.h
@@ -24,7 +24,7 @@
 #ifndef __ARCH_RTC_H
 #define __ARCH_RTC_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <time.h>

--- a/kernel/arch/dreamcast/include/arch/spinlock.h
+++ b/kernel/arch/dreamcast/include/arch/spinlock.h
@@ -25,7 +25,7 @@
 
 /* Defines processor specific spinlocks */
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdbool.h>

--- a/kernel/arch/dreamcast/include/arch/stack.h
+++ b/kernel/arch/dreamcast/include/arch/stack.h
@@ -23,7 +23,7 @@
 #ifndef __ARCH_STACK_H
 #define __ARCH_STACK_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/arch/timer.h
+++ b/kernel/arch/dreamcast/include/arch/timer.h
@@ -29,7 +29,7 @@
 
 
 #include <stdint.h>
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/irq.h>

--- a/kernel/arch/dreamcast/include/arch/tls_static.h
+++ b/kernel/arch/dreamcast/include/arch/tls_static.h
@@ -20,7 +20,7 @@
 #ifndef __ARCH_TLS_STATIC_H
 #define __ARCH_TLS_STATIC_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/thread.h>

--- a/kernel/arch/dreamcast/include/arch/trap.h
+++ b/kernel/arch/dreamcast/include/arch/trap.h
@@ -28,7 +28,7 @@
 #include <stdint.h>
 
 #include <arch/irq.h>
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup traps  Traps

--- a/kernel/arch/dreamcast/include/arch/types.h
+++ b/kernel/arch/dreamcast/include/arch/types.h
@@ -19,7 +19,7 @@
 #ifndef __ARCH_TYPES_H
 #define __ARCH_TYPES_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stddef.h>

--- a/kernel/arch/dreamcast/include/arch/wdt.h
+++ b/kernel/arch/dreamcast/include/arch/wdt.h
@@ -21,7 +21,7 @@
 #ifndef __ARCH_WDT_H
 #define __ARCH_WDT_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/asic.h
+++ b/kernel/arch/dreamcast/include/dc/asic.h
@@ -22,7 +22,7 @@
 #ifndef __DC_ASIC_H
 #define __DC_ASIC_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -9,7 +9,7 @@
 #ifndef __DC_CDROM_H
 #define __DC_CDROM_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/types.h>

--- a/kernel/arch/dreamcast/include/dc/fb_console.h
+++ b/kernel/arch/dreamcast/include/dc/fb_console.h
@@ -24,7 +24,7 @@
 #ifndef __DC_FB_CONSOLE_H
 #define __DC_FB_CONSOLE_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/dbgio.h>

--- a/kernel/arch/dreamcast/include/dc/fifo.h
+++ b/kernel/arch/dreamcast/include/dc/fifo.h
@@ -18,7 +18,7 @@
 #ifndef __DC_FIFO_H
 #define __DC_FIFO_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/regfield.h>

--- a/kernel/arch/dreamcast/include/dc/flashrom.h
+++ b/kernel/arch/dreamcast/include/dc/flashrom.h
@@ -23,7 +23,7 @@
 #ifndef __DC_FLASHROM_H
 #define __DC_FLASHROM_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/types.h>

--- a/kernel/arch/dreamcast/include/dc/fmath.h
+++ b/kernel/arch/dreamcast/include/dc/fmath.h
@@ -18,7 +18,7 @@
 #ifndef __DC_FMATH_H
 #define __DC_FMATH_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/fmath_base.h
+++ b/kernel/arch/dreamcast/include/dc/fmath_base.h
@@ -20,7 +20,7 @@
 
 #include <arch/args.h>
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 

--- a/kernel/arch/dreamcast/include/dc/fs_dcload.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dcload.h
@@ -22,7 +22,7 @@
 
 /* Definitions for the "dcload" file system */
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/fs.h>

--- a/kernel/arch/dreamcast/include/dc/fs_dclsocket.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dclsocket.h
@@ -20,7 +20,7 @@
 #ifndef __DC_FSDCLSOCKET_H
 #define __DC_FSDCLSOCKET_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/fs_dcload.h>

--- a/kernel/arch/dreamcast/include/dc/fs_iso9660.h
+++ b/kernel/arch/dreamcast/include/dc/fs_iso9660.h
@@ -26,7 +26,7 @@
 #ifndef __DC_FS_ISO9660_H
 #define __DC_FS_ISO9660_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/limits.h>

--- a/kernel/arch/dreamcast/include/dc/fs_vmu.h
+++ b/kernel/arch/dreamcast/include/dc/fs_vmu.h
@@ -30,7 +30,7 @@
 #ifndef __DC_FS_VMU_H
 #define __DC_FS_VMU_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/fs.h>

--- a/kernel/arch/dreamcast/include/dc/g1ata.h
+++ b/kernel/arch/dreamcast/include/dc/g1ata.h
@@ -34,7 +34,7 @@
 #ifndef __DC_G1ATA_H
 #define __DC_G1ATA_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/g2bus.h
+++ b/kernel/arch/dreamcast/include/dc/g2bus.h
@@ -32,7 +32,7 @@
 #ifndef __DC_G2BUS_H
 #define __DC_G2BUS_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -36,7 +36,7 @@
 #ifndef __DC_MAPLE_H
 #define __DC_MAPLE_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdbool.h>

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -24,7 +24,7 @@
 #ifndef __DC_MAPLE_CONTROLLER_H
 #define __DC_MAPLE_CONTROLLER_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/maple/dreameye.h
+++ b/kernel/arch/dreamcast/include/dc/maple/dreameye.h
@@ -20,7 +20,7 @@
 #ifndef __DC_MAPLE_DREAMEYE_H
 #define __DC_MAPLE_DREAMEYE_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/types.h>

--- a/kernel/arch/dreamcast/include/dc/maple/keyboard.h
+++ b/kernel/arch/dreamcast/include/dc/maple/keyboard.h
@@ -24,7 +24,7 @@
 #ifndef __DC_MAPLE_KEYBOARD_H
 #define __DC_MAPLE_KEYBOARD_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/maple.h>

--- a/kernel/arch/dreamcast/include/dc/maple/lightgun.h
+++ b/kernel/arch/dreamcast/include/dc/maple/lightgun.h
@@ -19,7 +19,7 @@
 #ifndef __DC_MAPLE_LIGHTGUN_H
 #define __DC_MAPLE_LIGHTGUN_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup peripherals_lightgun  Lightgun

--- a/kernel/arch/dreamcast/include/dc/maple/mouse.h
+++ b/kernel/arch/dreamcast/include/dc/maple/mouse.h
@@ -19,7 +19,7 @@
 #ifndef __DC_MAPLE_MOUSE_H
 #define __DC_MAPLE_MOUSE_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -33,7 +33,7 @@
 #ifndef __DC_MAPLE_PURUPURU_H
 #define __DC_MAPLE_PURUPURU_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/types.h>

--- a/kernel/arch/dreamcast/include/dc/maple/sip.h
+++ b/kernel/arch/dreamcast/include/dc/maple/sip.h
@@ -23,7 +23,7 @@
 #ifndef __DC_MAPLE_SIP_H
 #define __DC_MAPLE_SIP_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <sys/types.h>

--- a/kernel/arch/dreamcast/include/dc/maple/vmu.h
+++ b/kernel/arch/dreamcast/include/dc/maple/vmu.h
@@ -27,7 +27,7 @@
 #ifndef __DC_MAPLE_VMU_H
 #define __DC_MAPLE_VMU_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/maple.h>

--- a/kernel/arch/dreamcast/include/dc/math.h
+++ b/kernel/arch/dreamcast/include/dc/math.h
@@ -16,7 +16,7 @@
 #ifndef __DC_MATH_H
 #define __DC_MATH_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup math_general  General

--- a/kernel/arch/dreamcast/include/dc/matrix.h
+++ b/kernel/arch/dreamcast/include/dc/matrix.h
@@ -24,7 +24,7 @@
 #ifndef __DC_MATRIX_H
 #define __DC_MATRIX_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/vector.h>

--- a/kernel/arch/dreamcast/include/dc/matrix3d.h
+++ b/kernel/arch/dreamcast/include/dc/matrix3d.h
@@ -19,7 +19,7 @@
 #ifndef __KOS_MATRIX3D_H
 #define __KOS_MATRIX3D_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/matrix.h>

--- a/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
+++ b/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
@@ -19,7 +19,7 @@
 #ifndef __DC_NET_BROADBAND_ADAPTER_H
 #define __DC_NET_BROADBAND_ADAPTER_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup bba Broadband Adapter

--- a/kernel/arch/dreamcast/include/dc/net/lan_adapter.h
+++ b/kernel/arch/dreamcast/include/dc/net/lan_adapter.h
@@ -19,7 +19,7 @@
 #ifndef __DC_NET_LAN_ADAPTER_H
 #define __DC_NET_LAN_ADAPTER_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/net.h>

--- a/kernel/arch/dreamcast/include/dc/perf_monitor.h
+++ b/kernel/arch/dreamcast/include/dc/perf_monitor.h
@@ -18,7 +18,7 @@
 #ifndef __KOS_PERF_MONITOR_H
 #define __KOS_PERF_MONITOR_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/perfctr.h>

--- a/kernel/arch/dreamcast/include/dc/perfctr.h
+++ b/kernel/arch/dreamcast/include/dc/perfctr.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup   perf_counters Performance Counters

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -36,7 +36,7 @@
 #ifndef __DC_PVR_H
 #define __DC_PVR_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdalign.h>

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_dma.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_dma.h
@@ -32,7 +32,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup pvr_dma   DMA

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_fog.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_fog.h
@@ -23,7 +23,7 @@
 #ifndef __DC_PVR_PVR_FOG_H
 #define __DC_PVR_PVR_FOG_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup   pvr_fog     Fog

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
@@ -18,7 +18,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/pvr/pvr_regs.h>

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
@@ -26,7 +26,7 @@
 
 #include <stdint.h>
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup pvr_vram   VRAM

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_misc.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_misc.h
@@ -26,7 +26,7 @@
 
 #include <stdint.h>
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_pal.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_pal.h
@@ -26,7 +26,7 @@
 
 #include <stdint.h>
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup pvr_pal_mgmt  Palettes

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
@@ -27,7 +27,7 @@
 #ifndef __DC_PVR_PVR_REGS_H
 #define __DC_PVR_PVR_REGS_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/platform.h>

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_txr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_txr.h
@@ -28,7 +28,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/img.h>

--- a/kernel/arch/dreamcast/include/dc/sci.h
+++ b/kernel/arch/dreamcast/include/dc/sci.h
@@ -18,7 +18,7 @@
 #ifndef __DC_SCI_H
 #define __DC_SCI_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/dmac.h>

--- a/kernel/arch/dreamcast/include/dc/scif.h
+++ b/kernel/arch/dreamcast/include/dc/scif.h
@@ -21,7 +21,7 @@
 #ifndef __DC_SCIF_H
 #define __DC_SCIF_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/types.h>

--- a/kernel/arch/dreamcast/include/dc/sd.h
+++ b/kernel/arch/dreamcast/include/dc/sd.h
@@ -41,7 +41,7 @@
 #ifndef __DC_SD_H
 #define __DC_SD_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/types.h>

--- a/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sfxmgr.h
@@ -26,7 +26,7 @@
 #ifndef __DC_SOUND_SFXMGR_H
 #define __DC_SOUND_SFXMGR_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/fs.h>

--- a/kernel/arch/dreamcast/include/dc/sound/sound.h
+++ b/kernel/arch/dreamcast/include/dc/sound/sound.h
@@ -22,7 +22,7 @@
 #ifndef __DC_SOUND_SOUND_H
 #define __DC_SOUND_SOUND_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/types.h>

--- a/kernel/arch/dreamcast/include/dc/sound/stream.h
+++ b/kernel/arch/dreamcast/include/dc/sound/stream.h
@@ -25,7 +25,7 @@
 #ifndef __DC_SOUND_STREAM_H
 #define __DC_SOUND_STREAM_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/types.h>

--- a/kernel/arch/dreamcast/include/dc/spu.h
+++ b/kernel/arch/dreamcast/include/dc/spu.h
@@ -19,7 +19,7 @@
 #ifndef __DC_SPU_H
 #define __DC_SPU_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <arch/memory.h>

--- a/kernel/arch/dreamcast/include/dc/sq.h
+++ b/kernel/arch/dreamcast/include/dc/sq.h
@@ -38,7 +38,7 @@
 #ifndef __DC_SQ_H
 #define __DC_SQ_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/syscalls.h
+++ b/kernel/arch/dreamcast/include/dc/syscalls.h
@@ -32,7 +32,7 @@
 #ifndef __DC_SYSCALLS_H
 #define __DC_SYSCALLS_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/vblank.h
+++ b/kernel/arch/dreamcast/include/dc/vblank.h
@@ -19,7 +19,7 @@
 #ifndef __DC_VBLANK_H
 #define __DC_VBLANK_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/asic.h>

--- a/kernel/arch/dreamcast/include/dc/vec3f.h
+++ b/kernel/arch/dreamcast/include/dc/vec3f.h
@@ -20,7 +20,7 @@
 #ifndef __DC_VEC3F_H
 #define __DC_VEC3F_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <math.h>

--- a/kernel/arch/dreamcast/include/dc/vector.h
+++ b/kernel/arch/dreamcast/include/dc/vector.h
@@ -18,7 +18,7 @@
     \author Megan Potter
 */
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \addtogroup math_matrices

--- a/kernel/arch/dreamcast/include/dc/video.h
+++ b/kernel/arch/dreamcast/include/dc/video.h
@@ -24,7 +24,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 /** \defgroup video_display Display

--- a/kernel/arch/dreamcast/include/dc/vmu_fb.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_fb.h
@@ -18,7 +18,7 @@
     \author Paul Cercueil
 */
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/maple.h>

--- a/kernel/arch/dreamcast/include/dc/vmu_pkg.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_pkg.h
@@ -20,7 +20,7 @@
 #ifndef __DC_VMU_PKG_H
 #define __DC_VMU_PKG_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <stdint.h>

--- a/kernel/arch/dreamcast/include/dc/vmufs.h
+++ b/kernel/arch/dreamcast/include/dc/vmufs.h
@@ -25,7 +25,7 @@
 #ifndef __DC_VMUFS_H
 #define __DC_VMUFS_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <dc/maple.h>

--- a/kernel/net/net_dhcp.h
+++ b/kernel/net/net_dhcp.h
@@ -8,7 +8,7 @@
 #ifndef __LOCAL_NET_DHCP_H
 #define __LOCAL_NET_DHCP_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/kernel/net/net_icmp.h
+++ b/kernel/net/net_icmp.h
@@ -9,7 +9,7 @@
 #ifndef __LOCAL_NET_ICMP_H
 #define __LOCAL_NET_ICMP_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 __BEGIN_DECLS
 
 #include <kos/net.h>

--- a/kernel/net/net_thd.h
+++ b/kernel/net/net_thd.h
@@ -8,7 +8,7 @@
 #ifndef __LOCAL_NET_THD_H
 #define __LOCAL_NET_THD_H
 
-#include <sys/cdefs.h>
+#include <kos/cdefs.h>
 #include <stdint.h>
 
 __BEGIN_DECLS


### PR DESCRIPTION
Plenty of files would use macros defined within `<kos/cdefs.h>`, but would
include `<sys/cdefs.h>`. Those would only compile because they would also
include `<arch/types.h>`, includes `<arch/_types.h>` that itself includes
`<kos/cdefs.h>`.

This gets nastier, when taking into consideration that the
`<arch/_types.h>` include is only done if the BYTE_ORDER macro is unset.

This is an automated search-and-replace with:
`find include/ kernel/ -name '*.h' -exec sed -i 's/<sys\/cdefs\.h>/<kos\/cdefs.h>/' {} \;`