### PR TITLE
Speed up autotools / CMake configuration by disabling LTO

### DIFF
--- a/utils/build_wrappers/kos-cc
+++ b/utils/build_wrappers/kos-cc
@@ -15,7 +15,7 @@ for i in $ARGS; do
 			# Partial compile
 			USEMODE=2
 		;;
-		conftest.c | conftest.cc | conftest.cpp)
+		conftest.c | conftest.cc | conftest.cpp | conftest__.c | conftest__.cc | conftest__.cpp)
 			# Used in autoconf... we really probably need
 			# a better way to do this. (scan for any .c?)
 			USEMODE=3

--- a/utils/build_wrappers/kos-cc
+++ b/utils/build_wrappers/kos-cc
@@ -6,7 +6,7 @@ USEMODE=0
 for i in $ARGS; do
 	case "${i}" in
 		-o)
-			if [ $USEMODE != 2 ]; then
+			if [ $USEMODE != 2 -a $USEMODE != 3 ]; then
 				# Link
 				USEMODE=1
 			fi
@@ -18,7 +18,7 @@ for i in $ARGS; do
 		conftest.c | conftest.cc | conftest.cpp)
 			# Used in autoconf... we really probably need
 			# a better way to do this. (scan for any .c?)
-			USEMODE=1
+			USEMODE=3
 		;;
 		*)
 		;;
@@ -40,6 +40,14 @@ case $USEMODE in
 			echo ${KOS_CC} ${KOS_CFLAGS} ${KOS_LDFLAGS} "$@" ${KOS_LIBS}
 		fi
 		exec ${KOS_CC} ${KOS_CFLAGS} ${KOS_LDFLAGS} "$@" ${KOS_LIBS}
+	;;
+
+	3)
+		# Link mode for autoconf: pass -fno-lto to speed up process
+		if [ x${KOS_WRAPPERS_VERBOSE} = x"1" ]; then
+			echo ${KOS_CC} ${KOS_CFLAGS} ${KOS_LDFLAGS} -fno-lto "$@" ${KOS_LIBS}
+		fi
+		exec ${KOS_CC} ${KOS_CFLAGS} ${KOS_LDFLAGS} -fno-lto "$@" ${KOS_LIBS}
 	;;
 
 	2)

--- a/utils/cmake/kallistios.toolchain.cmake
+++ b/utils/cmake/kallistios.toolchain.cmake
@@ -78,6 +78,11 @@ add_compile_options(
 set(CMAKE_ASM_FLAGS "")
 set(CMAKE_ASM_FLAGS_RELEASE "")
 
+# Disable LTO for Debug build
+set(CMAKE_TRY_COMPILE_CONFIGURATION DEBUG)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG -fno-lto)
+
 # Default CMake installations to install to kos-addons
 set(CMAKE_INSTALL_BINDIR     ${DC_TOOLS_BASE})
 if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)


### PR DESCRIPTION
Speed up autotools configuration by tweaking the already existing algorithm inside kos-cc.

Speed up CMake by defaulting to disabling LTO for the Debug build configuration, and using that configuration for all the test programs compiled during the project configuration.