### PR TITLE
Move video/serial defines from arch.h to their respective headers

### DIFF
--- a/kernel/arch/dreamcast/hardware/scif.c
+++ b/kernel/arch/dreamcast/hardware/scif.c
@@ -11,6 +11,7 @@
 #include <arch/spinlock.h>
 #include <arch/irq.h>
 #include <dc/fs_dcload.h>
+#include <dc/scif.h>
 
 /*
 

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -79,12 +79,6 @@ extern char _etext;
 static const
 unsigned HZ __depr("Please use the new THD_SCHED_HZ macro.") = THD_SCHED_HZ;
 
-/** \brief  Default video mode. */
-#define DEFAULT_VID_MODE    DM_640x480
-
-/** \brief  Default pixel mode for video. */
-#define DEFAULT_PIXEL_MODE  PM_RGB565
-
 /** \brief  Default serial bitrate. */
 #define DEFAULT_SERIAL_BAUD 115200
 

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -79,12 +79,6 @@ extern char _etext;
 static const
 unsigned HZ __depr("Please use the new THD_SCHED_HZ macro.") = THD_SCHED_HZ;
 
-/** \brief  Default serial bitrate. */
-#define DEFAULT_SERIAL_BAUD 115200
-
-/** \brief  Default serial FIFO behavior. */
-#define DEFAULT_SERIAL_FIFO 1
-
 /** \brief  Global symbol prefix in ELF files. */
 #define ELF_SYM_PREFIX      "_"
 

--- a/kernel/arch/dreamcast/include/dc/scif.h
+++ b/kernel/arch/dreamcast/include/dc/scif.h
@@ -34,6 +34,12 @@ __BEGIN_DECLS
     @{
 */
 
+/** \brief  Default serial bitrate. */
+#define DEFAULT_SERIAL_BAUD 115200
+
+/** \brief  Default serial FIFO behavior. */
+#define DEFAULT_SERIAL_FIFO 1
+
 /** \brief  Set serial parameters.
     \param  baud            The bitrate to set.
     \param  fifo            1 to enable FIFO mode.

--- a/kernel/arch/dreamcast/include/dc/video.h
+++ b/kernel/arch/dreamcast/include/dc/video.h
@@ -107,6 +107,12 @@ typedef enum vid_display_mode_generic {
 */
 #define DM_MULTIBUFFER  0x2000
 
+/** \brief  Default video mode. */
+#define DEFAULT_VID_MODE    DM_640x480
+
+/** \brief  Default pixel mode for video. */
+#define DEFAULT_PIXEL_MODE  PM_RGB565
+
 /* ------------------------------------------------------------------------- */
 /* More specific modes (and actual indices into the mode table) */
 


### PR DESCRIPTION
This PR removes the default video/serial modes from `arch.h`.
None of these definitions are used in the codebase outside of their respective `video.c`/`scif.c` files, so we should get them out of the "dumping ground" `arch.h` file.
