### PR TITLE
Backport dmac, __is_aligned fixes to 2.2.x branch

### DIFF
--- a/kernel/arch/dreamcast/hardware/dmac.c
+++ b/kernel/arch/dreamcast/hardware/dmac.c
@@ -129,8 +129,9 @@ int dma_transfer(const dma_config_t *cfg, dma_addr_t dst, dma_addr_t src,
     unsigned int transfer_size = dma_unit_size[cfg->unit_size];
     uint32_t chcr;
 
-    if(!__is_aligned(len | dst | src, transfer_size)) {
-        dbglog(DBG_ERROR, "dmac: src/dst/len not aligned to the bus width\n");
+    if(!__is_aligned((src|dst|len), transfer_size)) {
+        dbglog(DBG_ERROR, "dmac: src=0x%08x dst=0x%08x len=%u not aligned to %u bytes\n",
+               (uintptr_t)src, (uintptr_t)dst, (uintptr_t)len, transfer_size);
         errno = EFAULT;
         return -1;
     }

--- a/utils/dc-chain/patches/newlib-4.3.0.20230120-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.3.0.20230120-kos.diff
@@ -264,3 +264,16 @@ diff --color -ruN newlib-4.3.0.20230120/newlib/libc/stdlib/assert.c newlib-4.3.0
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
 +
+diff --color -ruN newlib-4.3.0.20230120/newlib/libc/include/sys/cdefs.h newlib-4.3.0.20230120-kos/newlib/libc/include/sys/cdefs.h
+diff --git a/newlib/libc/include/sys/cdefs.h b/newlib/libc/include/sys/cdefs.h
+--- newlib-4.3.0.20230120/newlib/libc/include/sys/cdefs.h	2023-02-02 15:26:13.661093102 -0600
++++ newlib-4.3.0.20230120-kos/newlib/libc/include/sys/cdefs.h	2023-02-02 15:26:28.806127897 -0600
+@@ -736,7 +736,7 @@
+ /* Provide fallback versions for other compilers (GCC/Clang < 10): */
+ #if !__has_builtin(__builtin_is_aligned)
+ #define __builtin_is_aligned(x, align)	\
+-	(((__uintptr_t)x & ((align) - 1)) == 0)
++	(((__uintptr_t)(x) & ((align) - 1)) == 0)
+ #endif
+ #if !__has_builtin(__builtin_align_up)
+ #define __builtin_align_up(x, align)	\

--- a/utils/dc-chain/patches/newlib-4.5.0.20241231-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.5.0.20241231-kos.diff
@@ -264,3 +264,16 @@ diff --color -ruN newlib-4.5.0.20241231/newlib/libc/stdlib/assert.c newlib-4.5.0
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
 +
+diff --color -ruN newlib-4.5.0.20241231/newlib/libc/include/sys/cdefs.h newlib-4.5.0.20241231-kos/newlib/libc/include/sys/cdefs.h
+diff --git a/newlib/libc/include/sys/cdefs.h b/newlib/libc/include/sys/cdefs.h
+--- newlib-4.5.0.20241231/newlib/libc/include/sys/cdefs.h	2023-02-02 15:26:13.661093102 -0600
++++ newlib-4.5.0.20241231-kos/newlib/libc/include/sys/cdefs.h	2023-02-02 15:26:28.806127897 -0600
+@@ -736,7 +736,7 @@
+ /* Provide fallback versions for other compilers (GCC/Clang < 10): */
+ #if !__has_builtin(__builtin_is_aligned)
+ #define __builtin_is_aligned(x, align)	\
+-	(((__uintptr_t)x & ((align) - 1)) == 0)
++	(((__uintptr_t)(x) & ((align) - 1)) == 0)
+ #endif
+ #if !__has_builtin(__builtin_align_up)
+ #define __builtin_align_up(x, align)	\


### PR DESCRIPTION
This bug is still causing issues with users of the 2.2.x branch, so we need to backport the fix there.