### PR TITLE
sys/lock.h: Roll back change to use kos cdefs.

### DIFF
--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -19,7 +19,7 @@
 #ifndef __SYS_LOCK_H__
 #define __SYS_LOCK_H__
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 __BEGIN_DECLS
 
 /** \cond */


### PR DESCRIPTION
The kos cdefs file isn't available (and shouldn't be exposed) to the toolchain building process that uses this header.