### PR TITLE
Drop KOS header includes from toolchain files

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -41,6 +41,7 @@ __BEGIN_DECLS
 #include <kos/cdefs.h>
 #include <kos/tls.h>
 #include <arch/irq.h>
+#include <arch/types.h>
 
 #include <sys/queue.h>
 #include <sys/reent.h>

--- a/include/sys/_pthreadtypes.h
+++ b/include/sys/_pthreadtypes.h
@@ -8,7 +8,7 @@
 #ifndef __SYS_PTHREADTYPES_H
 #define __SYS_PTHREADTYPES_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 __BEGIN_DECLS
 
 typedef unsigned long int pthread_t;

--- a/include/sys/_types.h
+++ b/include/sys/_types.h
@@ -10,7 +10,7 @@
 #ifndef _SYS__TYPES_H
 #define _SYS__TYPES_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 __BEGIN_DECLS
 
 #include <sys/lock.h>

--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -19,7 +19,7 @@
 #ifndef __SYS_DIRENT_H
 #define __SYS_DIRENT_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/sys/ioctl.h
+++ b/include/sys/ioctl.h
@@ -20,7 +20,7 @@
 #ifndef __SYS_IOCTL_H
 #define __SYS_IOCTL_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -19,7 +19,7 @@
 #ifndef __SYS_LOCK_H__
 #define __SYS_LOCK_H__
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 __BEGIN_DECLS
 
 /** \cond */

--- a/include/sys/sched.h
+++ b/include/sys/sched.h
@@ -7,7 +7,7 @@
 #ifndef __SYS_SCHED_H
 #define __SYS_SCHED_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 __BEGIN_DECLS
 
 // These are copied from Newlib to make stuff compile as expected.

--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -20,7 +20,7 @@
 #ifndef __SYS_SELECT_H
 #define __SYS_SELECT_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -21,7 +21,7 @@
 #ifndef __SYS_SOCKET_H
 #define __SYS_SOCKET_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 

--- a/include/sys/stdio.h
+++ b/include/sys/stdio.h
@@ -8,7 +8,7 @@
 #ifndef _NEWLIB_STDIO_H
 #define _NEWLIB_STDIO_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 __BEGIN_DECLS
 
 // Cribbed from newlib sys/stdio.h

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -19,7 +19,7 @@
 #ifndef __SYS_UIO_H
 #define __SYS_UIO_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/include/sys/utsname.h
+++ b/include/sys/utsname.h
@@ -19,7 +19,7 @@
 #ifndef __SYS_UTSNAME_H
 #define __SYS_UTSNAME_H
 
-#include <kos/cdefs.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/kernel/thread/Makefile
+++ b/kernel/thread/Makefile
@@ -9,7 +9,12 @@ OBJS += thread.o rwsem.o once.o tls.o barrier.o
 OBJS += oneshot_timer.o worker.o
 SUBDIRS = 
 
+# On toolchains that support the C23 standard (aka. GCC > 14), compile-test
+# our gthr-kos.h against the regular KOS includes, to make sure that the
+# toolchain file does not lag behind.
+OBJS += $(intcmp $(firstword $(subst ., ,${KOS_GCCVER})),14,,,toolchain_test.o)
+
 include $(KOS_BASE)/Makefile.prefab
 
-
-
+toolchain_test.o: ${KOS_BASE}/utils/dc-chain/patches/gcc/gthr-kos.h
+	kos-cc -DTEST_GTHR_KOS_API -std=c23 -c $< -o $@

--- a/utils/dc-chain/patches/gcc/gthr-kos.h
+++ b/utils/dc-chain/patches/gcc/gthr-kos.h
@@ -31,6 +31,9 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #ifndef GCC_GTHR_KOS_H
 #define GCC_GTHR_KOS_H
 
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
 /* KallistiOS threads specific definitions. */
 
 #define __GTHREADS 1
@@ -458,5 +461,6 @@ static inline int __gthread_cond_destroy(__gthread_cond_t *cond) {
 
 #endif /* !_LIBOBJC */
 
+__END_DECLS
 
 #endif /* ! GCC_GTHR_KOS_H */


### PR DESCRIPTION
Hijacking #1015.

This PR drops all KOS-specific includes from the toolchain files.

This includes all files in `include/sys/` which are copied to the toolchain.

It also updates the `gthr-kos.h`, which now redefines locally all the types and symbols it needs.
To make sure that it stays in sync with the KOS headers, a verification mechanism is in place, automatically enabled for GCC >= 15 (because of the use of C23).