### PR TITLE
dc-chain: Use regular KOS includes with C++ in gthr-kos.h

### DIFF
--- a/utils/dc-chain/patches/gcc/gthr-kos.h
+++ b/utils/dc-chain/patches/gcc/gthr-kos.h
@@ -40,7 +40,7 @@ __BEGIN_DECLS
 #define __GTHREADS_CXX0X 1
 #define __GTHREAD_HAS_COND 1
 
-#ifdef TEST_GTHR_KOS_API
+#if defined(TEST_GTHR_KOS_API) || defined(__cplusplus)
 #include <kos/thread.h>
 #include <kos/tls.h>
 #include <kos/mutex.h>
@@ -54,6 +54,7 @@ __BEGIN_DECLS
 #include <stdbool.h>
 #include <time.h>
 
+#if !defined(__cplusplus)
 /* KOS types */
 struct kthread;
 
@@ -102,15 +103,6 @@ int cond_wait_timed(condvar_t *cv, mutex_t *m, int timeout) __nonnull_all;
 int cond_broadcast(condvar_t *cv) __nonnull_all;
 int cond_signal(condvar_t *cv) __nonnull_all;
 
-/* These should work just fine. */
-typedef kthread_key_t __gthread_key_t;
-typedef kthread_once_t __gthread_once_t;
-typedef mutex_t __gthread_mutex_t;
-typedef mutex_t __gthread_recursive_mutex_t;
-typedef condvar_t __gthread_cond_t;
-typedef kthread_t *__gthread_t;
-typedef struct timespec __gthread_time_t;
-
 #define KTHREAD_ONCE_INIT   0
 
 #define MUTEX_TYPE_NORMAL       0
@@ -119,6 +111,17 @@ typedef struct timespec __gthread_time_t;
 #define MUTEX_INITIALIZER               { MUTEX_TYPE_NORMAL, NULL, 0 }
 #define RECURSIVE_MUTEX_INITIALIZER     { MUTEX_TYPE_RECURSIVE, NULL, 0 }
 #define COND_INITIALIZER    { 0 }
+
+#endif /* !defined(__cplusplus) */
+
+/* These should work just fine. */
+typedef kthread_key_t __gthread_key_t;
+typedef kthread_once_t __gthread_once_t;
+typedef mutex_t __gthread_mutex_t;
+typedef mutex_t __gthread_recursive_mutex_t;
+typedef condvar_t __gthread_cond_t;
+typedef kthread_t *__gthread_t;
+typedef struct timespec __gthread_time_t;
 
 #define __GTHREAD_ONCE_INIT KTHREAD_ONCE_INIT
 #define __GTHREAD_MUTEX_INIT MUTEX_INITIALIZER


### PR DESCRIPTION
The gthr-kos.h file is not just used during the GCC build to compile the C library, it is also copied into the toolchain for use with C++.

If we detect C++, then just fall back to including the headers.