### PR TITLE
dc-chain: Export PATH variable

### DIFF
--- a/utils/dc-chain/scripts/variables.mk
+++ b/utils/dc-chain/scripts/variables.mk
@@ -11,7 +11,7 @@ patches      := $(pwd)/patches
 logdir       := $(pwd)/logs
 
 # Handling PATH environment variable
-PATH         := $(toolchain_path)/bin:$(PATH)
+export PATH  := $(toolchain_path)/bin:$(PATH)
 
 arch         := $(word 1,$(subst -, ,$(target)))
 gcc_arch     := $(subst powerpc,rs6000,$(arch))


### PR DESCRIPTION
If we don't export it, the programs called inside the $(shell ) function won't have the updated $PATH.

This could cause the fake-kos.o to not be removed from the libc.a library which in turns caused all kinds of weird issues.