### PR TITLE
dc-chain: Fix removal of fake-kos.o from C library

### DIFF
--- a/utils/dc-chain/scripts/gcc-pass2.mk
+++ b/utils/dc-chain/scripts/gcc-pass2.mk
@@ -32,5 +32,7 @@ ifdef enable_ada
   endif
 endif
 	$(MAKE) -C $(build) $(install_mode) DESTDIR=$(DESTDIR) $(to_log)
-	$(target)-gcc-ar d $(shell $(target)-gcc -print-file-name=libgcc.a) fake-kos.o
+	$(toolchain_path)/bin/$(target)-gcc-ar d \
+		$(shell $(toolchain_path)/bin/$(target)-gcc -print-file-name=libgcc.a) \
+		fake-kos.o $(to_log)
 	$(clean_up)


### PR DESCRIPTION
On some systems it appears that the Makefile's $(shell ) function won't search the extra paths added to a PATH variable overriden inside the Makefile, even if it is exported.

Address this issue by passing the absolute paths to the tools needed to remove the fake-kos.o from the C library.

This is important because if the "fake-kos.o" is silently not removed, all kinds of weird issues will appear in compiled programs.