### PR TITLE
Backport Rollup for v2.2.x

### DIFF
--- a/examples/dreamcast/vmu/vmu_lcd/lcd.c
+++ b/examples/dreamcast/vmu/vmu_lcd/lcd.c
@@ -30,7 +30,7 @@
 
 #include <arch/arch.h>
 
-static const char smiley[] = {
+static const uint8_t smiley[] = {
     0b00111100,
     0b01000010,
     0b10100101,

--- a/include/kos/version.h
+++ b/include/kos/version.h
@@ -72,7 +72,7 @@
 
     ## App Versioning
     The same \ref version_utils used to implement the KOS versioning
-    API are available as part of the public API so that they may be used to 
+    API are available as part of the public API so that they may be used to
     implement your own similar versioning scheme at the app-level.
 
     @{
@@ -99,7 +99,7 @@
 
 #define KOS_VERSION_MAJOR   2   /**< KOS's current major revision number. */
 #define KOS_VERSION_MINOR   2   /**< KOS's current minor revision number. */
-#define KOS_VERSION_PATCH   0   /**< KOS's current patch revision number. */
+#define KOS_VERSION_PATCH   1   /**< KOS's current patch revision number. */
 
 /** KOS's current version as an integer ID. */
 #define KOS_VERSION \

--- a/kernel/arch/dreamcast/hardware/dmac.c
+++ b/kernel/arch/dreamcast/hardware/dmac.c
@@ -129,8 +129,9 @@ int dma_transfer(const dma_config_t *cfg, dma_addr_t dst, dma_addr_t src,
     unsigned int transfer_size = dma_unit_size[cfg->unit_size];
     uint32_t chcr;
 
-    if(!__is_aligned(len | dst | src, transfer_size)) {
-        dbglog(DBG_ERROR, "dmac: src/dst/len not aligned to the bus width\n");
+    if(!__is_aligned((src|dst|len), transfer_size)) {
+        dbglog(DBG_ERROR, "dmac: src=0x%08x dst=0x%08x len=%u not aligned to %u bytes\n",
+               (uintptr_t)src, (uintptr_t)dst, (uintptr_t)len, transfer_size);
         errno = EFAULT;
         return -1;
     }

--- a/kernel/arch/dreamcast/include/dc/vmu_fb.h
+++ b/kernel/arch/dreamcast/include/dc/vmu_fb.h
@@ -50,11 +50,11 @@ typedef struct vmufb {
     layout, and a pointer to the raw font data.
  */
 typedef struct vmufb_font {
-    unsigned int id;        /**< Font id */
-    unsigned int w;         /**< Character width in pixels */
-    unsigned int h;         /**< Character height in pixels */
-    size_t       stride;    /**< Size of one character in bytes */
-    const char  *fontdata;  /**< Pointer to the font data */
+    unsigned int    id;        /**< Font id */
+    unsigned int    w;         /**< Character width in pixels */
+    unsigned int    h;         /**< Character height in pixels */
+    size_t          stride;    /**< Size of one character in bytes */
+    const uint8_t  *fontdata;  /**< Pointer to the font data */
 } vmufb_font_t;
 
 /** \brief  Render into the VMU framebuffer
@@ -75,7 +75,7 @@ typedef struct vmufb_font {
 void vmufb_paint_area(vmufb_t *fb,
                       unsigned int x, unsigned int y,
                       unsigned int w, unsigned int h,
-                      const char *data);
+                      const uint8_t *data);
 
 /** \brief  Clear a specific area of the VMU framebuffer
 

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -802,6 +802,9 @@ int snd_stream_poll(snd_stream_hnd_t hnd) {
         return -1;
     }
 
+    /* The stream has been initted but not started, so we don't know stereo/mono. */
+    assert(stream->channels != 0);
+
     /* Get channels position */
     current_play_pos = g2_read_32(SPU_RAM_UNCACHED_BASE +
                         AICA_CHANNEL(stream->ch[0]) +

--- a/kernel/arch/dreamcast/util/vmu_fb.c
+++ b/kernel/arch/dreamcast/util/vmu_fb.c
@@ -21,7 +21,7 @@
  * Created by Kenneth Albanowski.
  * No rights reserved, released to the public domain.
  */
-static const char fontdata_4x6[] = {
+static const uint8_t fontdata_4x6[] = {
     0xee, 0xee, 0xe0, 0xee, 0xee, 0xe0, 0xee, 0xee,
     0xe0, 0xee, 0xee, 0xe0, 0xee, 0xee, 0xe0, 0xee,
     0xee, 0xe0, 0xee, 0xee, 0xe0, 0xee, 0xee, 0xe0,
@@ -204,8 +204,8 @@ static void vmufb_paint_area_strided(vmufb_t *fb,
 void vmufb_paint_area(vmufb_t *fb,
                       unsigned int x, unsigned int y,
                       unsigned int w, unsigned int h,
-                      const char *data) {
-    vmufb_paint_area_strided(fb, x, y, w, h, w, (const uint8_t *)data);
+                      const uint8_t *data) {
+    vmufb_paint_area_strided(fb, x, y, w, h, w, data);
 }
 
 void vmufb_paint_xbm(vmufb_t *fb,
@@ -230,7 +230,7 @@ void vmufb_clear_area(vmufb_t *fb,
                       unsigned int w, unsigned int h) {
     uint32_t tmp[VMU_SCREEN_WIDTH] = {};
 
-    vmufb_paint_area(fb, x, y, w, h, (const char *) tmp);
+    vmufb_paint_area(fb, x, y, w, h, (const uint8_t *) tmp);
 }
 
 void vmufb_present(const vmufb_t *fb, maple_device_t *dev) {

--- a/kernel/net/net_core.c
+++ b/kernel/net/net_core.c
@@ -138,7 +138,10 @@ int net_dev_init(void) {
 
     dbglog(DBG_DEBUG, "net_dev_init: detected %d usable network device(s)\n", detected);
 
-    return 0;
+    if(detected)
+        return 0;
+    else
+        return -1;
 }
 
 /* Init */

--- a/utils/dc-chain/patches/newlib-4.3.0.20230120-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.3.0.20230120-kos.diff
@@ -264,3 +264,16 @@ diff --color -ruN newlib-4.3.0.20230120/newlib/libc/stdlib/assert.c newlib-4.3.0
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
 +
+diff --color -ruN newlib-4.3.0.20230120/newlib/libc/include/sys/cdefs.h newlib-4.3.0.20230120-kos/newlib/libc/include/sys/cdefs.h
+diff --git a/newlib/libc/include/sys/cdefs.h b/newlib/libc/include/sys/cdefs.h
+--- newlib-4.3.0.20230120/newlib/libc/include/sys/cdefs.h	2023-02-02 15:26:13.661093102 -0600
++++ newlib-4.3.0.20230120-kos/newlib/libc/include/sys/cdefs.h	2023-02-02 15:26:28.806127897 -0600
+@@ -736,7 +736,7 @@
+ /* Provide fallback versions for other compilers (GCC/Clang < 10): */
+ #if !__has_builtin(__builtin_is_aligned)
+ #define __builtin_is_aligned(x, align)	\
+-	(((__uintptr_t)x & ((align) - 1)) == 0)
++	(((__uintptr_t)(x) & ((align) - 1)) == 0)
+ #endif
+ #if !__has_builtin(__builtin_align_up)
+ #define __builtin_align_up(x, align)	\

--- a/utils/dc-chain/patches/newlib-4.5.0.20241231-kos.diff
+++ b/utils/dc-chain/patches/newlib-4.5.0.20241231-kos.diff
@@ -264,3 +264,16 @@ diff --color -ruN newlib-4.5.0.20241231/newlib/libc/stdlib/assert.c newlib-4.5.0
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
 +
+diff --color -ruN newlib-4.5.0.20241231/newlib/libc/include/sys/cdefs.h newlib-4.5.0.20241231-kos/newlib/libc/include/sys/cdefs.h
+diff --git a/newlib/libc/include/sys/cdefs.h b/newlib/libc/include/sys/cdefs.h
+--- newlib-4.5.0.20241231/newlib/libc/include/sys/cdefs.h	2023-02-02 15:26:13.661093102 -0600
++++ newlib-4.5.0.20241231-kos/newlib/libc/include/sys/cdefs.h	2023-02-02 15:26:28.806127897 -0600
+@@ -736,7 +736,7 @@
+ /* Provide fallback versions for other compilers (GCC/Clang < 10): */
+ #if !__has_builtin(__builtin_is_aligned)
+ #define __builtin_is_aligned(x, align)	\
+-	(((__uintptr_t)x & ((align) - 1)) == 0)
++	(((__uintptr_t)(x) & ((align) - 1)) == 0)
+ #endif
+ #if !__has_builtin(__builtin_align_up)
+ #define __builtin_align_up(x, align)	\


### PR DESCRIPTION
As with #1156, getting these commits from PRs flagged as v2.2.1 (#1098 #1099 #1100 and #1101) into the v2.2.x stable branch.