### PR TITLE
Add -mtas to environ_dreamcast KOS_CFLAGS.

### DIFF
--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -24,7 +24,7 @@ if [ -z "${KOS_SH4_PRECISION}" ] || [ "${KOS_SH4_PRECISION}" = "-m4-single" ]; t
     fi
 fi
 
-export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_SH4_PRECISION} -ml -mfsrra -mfsca -ffunction-sections -fdata-sections -matomic-model=soft-imask -ftls-model=local-exec"
+export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_SH4_PRECISION} -ml -mfsrra -mfsca -ffunction-sections -fdata-sections -mtas -matomic-model=soft-imask -ftls-model=local-exec"
 export KOS_AFLAGS="${KOS_AFLAGS} -little"
 export KOS_LDFLAGS="${KOS_LDFLAGS} ${KOS_SH4_PRECISION} -ml -Wl,--gc-sections"
 export KOS_LD_SCRIPT="-T${KOS_BASE}/utils/ldscripts/shlelf.xc"


### PR DESCRIPTION
At the moment, the atomic_flag type in C11 is emitting suboptimal code for atomic_flag_test_and_set(), the fundamental operation used to create spinlocks from C's atomics.

Rather than emitting a single tas.b instruction to do the operation atomically in HW, it's emitting byte-wise read-modify-write code with the IRQ disable/reenable preamble/postamble from the imask-soft atomics model.

Turns out that Oleg Endo implemented support for backing atomic_flag by the tas.b instruction, as we'd desire, which can be used in combination with any atomics model type, by simply using the -mtas flag.

This PR simply enables that flag by default, as it's both correct and far more optimal to do for our atomics.

This will also now allow us to implement spinlocks with atomic_flag allowing us to get spinlocks for both SH and PPC that are optimal AND backed by purely standard C code.