### PR TITLE
Enhance mutex code

### DIFF
--- a/addons/libpthread/pthread_mutex_lock.c
+++ b/addons/libpthread/pthread_mutex_lock.c
@@ -13,6 +13,9 @@
 int pthread_mutex_lock(pthread_mutex_t *mutex) {
     int old, rv = 0;
 
+    if(mutex->mutex.type > MUTEX_TYPE_RECURSIVE)
+        return EINVAL;
+
     old = errno;
     if(mutex_lock(&mutex->mutex))
         rv = errno;

--- a/addons/libpthread/pthread_mutex_timedlock.c
+++ b/addons/libpthread/pthread_mutex_timedlock.c
@@ -21,6 +21,9 @@ int pthread_mutex_timedlock(pthread_mutex_t *__RESTRICT mutex,
     if(!mutex || !abstime)
         return EFAULT;
 
+    if(mutex->mutex.type > MUTEX_TYPE_RECURSIVE)
+        return EINVAL;
+
     if(abstime->tv_nsec < 0 || abstime->tv_nsec > 1000000000L)
         return EINVAL;
 

--- a/addons/libpthread/pthread_mutex_trylock.c
+++ b/addons/libpthread/pthread_mutex_trylock.c
@@ -13,6 +13,9 @@
 int pthread_mutex_trylock(pthread_mutex_t *mutex) {
     int old, rv = 0;
 
+    if(mutex->mutex.type > MUTEX_TYPE_RECURSIVE)
+        return EINVAL;
+
     old = errno;
     if(mutex_trylock(&mutex->mutex))
         rv = errno;

--- a/include/kos/mutex.h
+++ b/include/kos/mutex.h
@@ -248,7 +248,8 @@ int mutex_unlock(mutex_t *m) __nonnull_all;
 
     This function allows an IRQ handler to unlock a mutex that was locked by a
     normal kernel thread. This function is only for use in IRQ handlers, so it
-    will generally not be of much use outside of the kernel itself.
+    will generally not be of much use outside of the kernel itself. It cannot
+    be used with recursive mutexes.
 
     \param  m               The mutex to unlock
     \param  thd             The thread owning the mutex

--- a/include/kos/mutex.h
+++ b/include/kos/mutex.h
@@ -148,7 +148,6 @@ int mutex_destroy(mutex_t *m) __nonnull_all;
 
     \par    Error Conditions:
     \em     EPERM - called inside an interrupt \n
-    \em     EINVAL - the mutex has not been initialized properly \n
     \em     EAGAIN - lock has been acquired too many times (recursive) \n
     \em     EDEADLK - would deadlock (error-checking)
 */
@@ -169,7 +168,6 @@ int mutex_lock(mutex_t *m) __nonnull_all;
     \retval -1              On error, sets errno as appropriate
 
     \par    Error Conditions:
-    \em     EINVAL - the mutex has not been initialized properly \n
     \em     EAGAIN - lock has been acquired too many times (recursive), or the
                      function was called inside an interrupt and the mutex was
                      already locked \n
@@ -192,7 +190,6 @@ int mutex_lock_irqsafe(mutex_t *m) __nonnull_all;
 
     \par    Error Conditions:
     \em     EPERM - called inside an interrupt \n
-    \em     EINVAL - the mutex has not been initialized properly \n
     \em     EINVAL - the timeout value was invalid (less than 0) \n
     \em     ETIMEDOUT - the timeout expired \n
     \em     EAGAIN - lock has been acquired too many times (recursive) \n
@@ -227,7 +224,6 @@ int __pure mutex_is_locked(const mutex_t *m) __nonnull_all;
 
     \par    Error Conditions:
     \em     EBUSY  - the mutex is already locked (mutex_lock() would block) \n
-    \em     EINVAL - the mutex has not been initialized properly \n
     \em     EAGAIN - lock has been acquired too many times (recursive) \n
     \em     EDEADLK - would deadlock (error-checking)
 */

--- a/kernel/libc/c11/mtx_lock.c
+++ b/kernel/libc/c11/mtx_lock.c
@@ -4,8 +4,14 @@
    Copyright (C) 2014 Lawrence Sebald
 */
 
+#include <errno.h>
 #include <threads.h>
 
 int mtx_lock(mtx_t *mtx) {
+    if(mtx->type > MUTEX_TYPE_RECURSIVE) {
+        errno = EINVAL;
+        return -1;
+    }
+
     return mutex_lock(mtx);
 }

--- a/kernel/libc/c11/mtx_timedlock.c
+++ b/kernel/libc/c11/mtx_timedlock.c
@@ -10,6 +10,11 @@
 int mtx_timedlock(mtx_t *restrict mtx, const struct timespec *restrict ts) {
     int ms = 0;
 
+    if(mtx->type > MUTEX_TYPE_RECURSIVE) {
+        errno = EINVAL;
+        return -1;
+    }
+
     /* Calculate the number of milliseconds to sleep for. No, you don't get
        anywhere near nanosecond precision here. */
     ms = ts->tv_sec * 1000 + ts->tv_nsec / 1000000;

--- a/kernel/libc/c11/mtx_trylock.c
+++ b/kernel/libc/c11/mtx_trylock.c
@@ -8,6 +8,11 @@
 #include <errno.h>
 
 int mtx_trylock(mtx_t *mtx) {
+    if(mtx->type > MUTEX_TYPE_RECURSIVE) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if(mutex_trylock(mtx)) {
         if(errno == EBUSY)
             return thrd_busy;

--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -184,28 +184,18 @@ int mutex_trylock(mutex_t *m) {
 }
 
 static int __nonnull_all mutex_unlock_common(mutex_t *m, kthread_t *thd) {
-    int wakeup = 0;
-
-    irq_disable_scoped();
-
     switch(m->type) {
-        default:
-        case MUTEX_TYPE_NORMAL:
-        case MUTEX_TYPE_OLDNORMAL:
-            m->count = 0;
-            m->holder = NULL;
-            wakeup = 1;
-            break;
-
         case MUTEX_TYPE_ERRORCHECK:
             if(m->holder != thd) {
                 errno = EPERM;
                 return -1;
             }
-
+            __fallthrough;
+        default:
+        case MUTEX_TYPE_NORMAL:
+        case MUTEX_TYPE_OLDNORMAL:
             m->count = 0;
             m->holder = NULL;
-            wakeup = 1;
             break;
 
         case MUTEX_TYPE_RECURSIVE:
@@ -214,21 +204,19 @@ static int __nonnull_all mutex_unlock_common(mutex_t *m, kthread_t *thd) {
                 return -1;
             }
 
-            if(!--m->count) {
-                m->holder = NULL;
-                wakeup = 1;
-            }
+            if(--m->count)
+                return 0;
+
+            m->holder = NULL;
             break;
     }
 
-    /* If we need to wake up a thread, do so. */
-    if(wakeup) {
-        /* Restore real priority in case we were dynamically boosted. */
-        if (thd != IRQ_THREAD)
-            thd->prio = thd->real_prio;
+    /* Restore real priority in case we were dynamically boosted. */
+    if (thd != IRQ_THREAD)
+        thd->prio = thd->real_prio;
 
-        genwait_wake_one(m);
-    }
+    /* If we need to wake up a thread, do so. */
+    genwait_wake_one(m);
 
     return 0;
 }

--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -6,6 +6,7 @@
 
 */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <limits.h>
@@ -70,6 +71,8 @@ int mutex_lock_timed(mutex_t *m, int timeout) {
     uint64_t deadline = 0;
     int rv = 0;
 
+    assert(m->type <= MUTEX_TYPE_RECURSIVE);
+
     if((rv = irq_inside_int())) {
         dbglog(DBG_WARNING, "%s: called inside an interrupt with code: "
                "%x evt: %.4x\n",
@@ -86,11 +89,7 @@ int mutex_lock_timed(mutex_t *m, int timeout) {
 
     irq_disable_scoped();
 
-    if(m->type > MUTEX_TYPE_RECURSIVE) {
-        errno = EINVAL;
-        rv = -1;
-    }
-    else if(!m->count) {
+    if(!m->count) {
         m->count = 1;
         m->holder = thd_current;
     }
@@ -159,17 +158,14 @@ int __pure mutex_is_locked(const mutex_t *m) {
 int mutex_trylock(mutex_t *m) {
     kthread_t *thd = thd_current;
 
+    assert(m->type <= MUTEX_TYPE_RECURSIVE);
+
     irq_disable_scoped();
 
     /* If we're inside of an interrupt, pick a special value for the thread that
        would otherwise be impossible... */
     if(irq_inside_int())
         thd = IRQ_THREAD;
-
-    if(m->type > MUTEX_TYPE_RECURSIVE) {
-        errno = EINVAL;
-        return -1;
-    }
 
     /* Check if the lock is held by some other thread already */
     if(m->count && m->holder != thd) {
@@ -207,9 +203,12 @@ int mutex_trylock(mutex_t *m) {
 static int __nonnull_all mutex_unlock_common(mutex_t *m, kthread_t *thd) {
     int wakeup = 0;
 
+    assert(m->type <= MUTEX_TYPE_RECURSIVE);
+
     irq_disable_scoped();
 
     switch(m->type) {
+        default:
         case MUTEX_TYPE_NORMAL:
         case MUTEX_TYPE_OLDNORMAL:
             m->count = 0;
@@ -239,10 +238,6 @@ static int __nonnull_all mutex_unlock_common(mutex_t *m, kthread_t *thd) {
                 wakeup = 1;
             }
             break;
-
-        default:
-            errno = EINVAL;
-            return -1;
     }
 
     /* If we need to wake up a thread, do so. */


### PR DESCRIPTION
- Use `assert()` to check that the mutex type is one of the supported types. This means the check can be disabled for release builds.
- Try to make critical sections as small as possible, by moving the recursive / errcheck tests outside the critical section.
- Trylock / unlock without disabling IRQs. The trylock() can use an atomic compare-and-swap instead, and the unlock() just doesn't need to disable them.
- Wake up all threads waiting on a lock instead of just one, to respect thread priorities.

Tested with Bloom's threaded compiler, which is a very heavy mutex user.