### PR TITLE
Remove deprecated cdrom_change_dataype function

### DIFF
--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -311,11 +311,6 @@ int cdrom_get_status(int *status, int *disc_type) {
     return rv;
 }
 
-/* Helper function to account for long-standing typo */
-int cdrom_change_dataype(int sector_part, int cdxa, int sector_size) {
-    return cdrom_change_datatype(sector_part, cdxa, sector_size);
-}
-
 /* Wrapper for the change datatype syscall */
 int cdrom_change_datatype(int sector_part, int cdxa, int sector_size) {
     uint32_t params[4];

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -350,17 +350,6 @@ int cdrom_get_status(int *status, int *disc_type);
 /** \brief    Change the datatype of disc.
     \ingroup  gdrom
 
-    \note                   This function is formally deprecated. It should not
-                            be used in any future code, and may be removed in
-                            the future. You should instead use
-                            cdrom_change_datatype.
-*/
-int cdrom_change_dataype(int sector_part, int cdxa, int sector_size)
-                        __depr("Use cdrom_change_datatype instead.");
-
-/** \brief    Change the datatype of disc.
-    \ingroup  gdrom
-
     This function will take in all parameters to pass to the change_datatype 
     syscall. This allows these parameters to be modified without a reinit. 
     Each parameter allows -1 as a default, which is tied to the former static 


### PR DESCRIPTION
In 2014 when the CD-ROM API was expanded, the `cdrom_change_dataype()` (with the "dataype" typo) was introduced, and in #86 in Jan 2023 I deprecated the typo function and created a corrected function in the API.
Over 2 1/2 years and two point releases later, I'd say it's time to clear the deprecated function from the codebase.