### PR TITLE
CI: Fix overzealous whitespace check

### DIFF
--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -14,5 +14,5 @@ jobs:
       run: |
         git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
         git diff ${{ github.base_ref }} >/tmp/diff1.txt
-        git diff -w ${{ github.base_ref }} >/tmp/diff2.txt
+        git diff --ignore-space-at-eol ${{ github.base_ref }} >/tmp/diff2.txt
         diff /tmp/diff1.txt /tmp/diff2.txt >/dev/null


### PR DESCRIPTION
The previous check would quite often cause false positives. Reduce the scope of the check, now it only verifies that no spaces are added at the end of lines.

(Btw, it'd be great to have a CI tag)