### PR TITLE
dc-chain: Remove fake-kos.o from all libgcc.a

### DIFF
--- a/utils/dc-chain/scripts/gcc-pass2.mk
+++ b/utils/dc-chain/scripts/gcc-pass2.mk
@@ -1,6 +1,9 @@
 # Sega Dreamcast Toolchains Maker (dc-chain)
 # This file is part of KallistiOS.
 
+__comma:=,
+__libgcc=$(foreach item,$(addprefix -,$(subst $(__comma), ,$(precision_modes))) "",$(shell $(toolchain_path)/bin/$(target)-gcc $(item) -print-file-name=libgcc.a))
+
 $(build_gcc_pass2): build = build-gcc-$(target)-$(gcc_ver)-pass2
 $(build_gcc_pass2): logdir
 	@echo "+++ Building $(src_dir) to $(build) (pass 2)..."
@@ -32,7 +35,7 @@ ifdef enable_ada
   endif
 endif
 	$(MAKE) -C $(build) $(install_mode) DESTDIR=$(DESTDIR) $(to_log)
-	$(toolchain_path)/bin/$(target)-gcc-ar d \
-		$(shell $(toolchain_path)/bin/$(target)-gcc -print-file-name=libgcc.a) \
-		fake-kos.o $(to_log)
+	for each in $(__libgcc) ; do \
+		$(toolchain_path)/bin/$(target)-gcc-ar d $$each fake-kos.o $(to_log) ; \
+	done
 	$(clean_up)


### PR DESCRIPTION
When building a multilib toolchain, for instance to support -m4-single-only and -m4-single, multiple variants of libgcc.a are built. We need to remove the fake-kos.o object from all of them.