### PR TITLE
Fix kos_blockdev_t created by sd_blockdev_for_device()

### DIFF
--- a/kernel/arch/dreamcast/hardware/sd.c
+++ b/kernel/arch/dreamcast/hardware/sd.c
@@ -832,6 +832,8 @@ int sd_blockdev_for_device(kos_blockdev_t *rv) {
         return -1;
     }
 
+    /* Copy in the template block device and fill it in */
+    memcpy(rv, &sd_blockdev, sizeof(kos_blockdev_t));
     ddata->start_block = 0;
     ddata->block_count = (sd_get_size() / 512);
     rv->dev_data = ddata;


### PR DESCRIPTION
The `kos_blockdev_t` created by `sd_blockdev_for_device()` is not filled in with the template block device information, leading to all of the data and pointers (besides `dev_data`) being uninitialized garbage data.