### PR TITLE
irq.c: Replace old `__unlikely` with newlib standard macro

### DIFF
--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -217,7 +217,7 @@ void irq_handle_exception(int code) {
     int handled = 0;
 
     if(__is_defined(__SH_ATOMIC_MODEL_SOFT_GUSA__)
-       && __unlikely((int32_t)irq_srt_addr->r[15] >= -128
+       && __predict_false((int32_t)irq_srt_addr->r[15] >= -128
                      && irq_srt_addr->pc != irq_srt_addr->r[0])) {
         /* The stack pointer has been altered: it means we are in the middle of
            an atomic section, and we need to roll-back.


### PR DESCRIPTION
A break from #1136 , as #1174 was added afterwards and did not use the newlib standard macro.