### PR TITLE
Cleaning doxygen warnings

### DIFF
--- a/kernel/arch/dreamcast/include/arch/byteorder.h
+++ b/kernel/arch/dreamcast/include/arch/byteorder.h
@@ -5,134 +5,44 @@
 
 */
 
-/** \file    arch/byteorder.h
-    \brief   Byte-order related macros.
-    \ingroup system_arch
-
-    This file contains architecture-specific byte-order related macros and/or
-    functions. Each platform should define six macros/functions in this file:
-    arch_swap16, arch_swap32, arch_ntohs, arch_ntohl, arch_htons, and
-    arch_htonl. The first two of these swap the byte order of 16-bit and 32-bit
-    integers, respectively. The other four macros will be used by the kernel to
-    implement the network-related byte order functions.
-
-    \author Lawrence Sebald
-*/
-
 #ifndef __ARCH_BYTEORDER_H
 #define __ARCH_BYTEORDER_H
 
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
-#ifdef BYTE_ORDER
-/* If we've included <arch/types.h>, this might already be defined... */
-#undef BYTE_ORDER
-#endif
+/* Bring in the newlib header that defines the BYTE_ORDER macro */
+#include <machine/endian.h>
 
-/** \defgroup system_arch  Byte Order
-    \brief                 Byte-order management for the SH4 architecture
-    \ingroup               arch
-
-    @{
-*/
-
-/** \brief  Define the byte-order of the platform in use. */
-#define BYTE_ORDER      LITTLE_ENDIAN
-
-/** \brief  Swap the byte order of a 16-bit integer.
-
-    This macro swaps the byte order of a 16-bit integer in an architecture-
-    defined manner.
-
-    \param  x           The value to be byte-swapped. This should be a uint16,
-                        or equivalent.
-    \return             The swapped value.
-*/
 __depr("arch_swap16() is deprecated, use __builtin_bswap16().")
 static inline uint16_t arch_swap16(uint16_t x) {
     return __builtin_bswap16(x);
 }
 
-/** \brief  Swap the byte order of a 32-bit integer.
-
-    This macro swaps the byte order of a 32-bit integer in an architecture-
-    defined manner.
-
-    \param  x           The value to be byte-swapped. This should be a uint32,
-                        or equivalent.
-    \return             The swapped value.
-*/
 __depr("arch_swap32() is deprecated, use __builtin_bswap32().")
 static inline uint32_t arch_swap32(uint32_t x) {
     return __builtin_bswap32(x);
 }
 
-/** \brief  Convert network-to-host short.
-
-    This macro converts a network byte order (big endian) value to the host's
-    native byte order. On a little endian system (like the Dreamcast), this
-    should just call arch_swap16(). On a big endian system, this should be a
-    no-op.
-
-    \param  x           The value to be converted. This should be a uint16,
-                        or equivalent.
-    \return             The converted value.
-*/
 __depr("arch_ntohs() is deprecated, use ntohs() from <arpa/inet.h>")
 static inline uint16_t arch_ntohs(uint16_t x) {
     return __builtin_bswap16(x);
 }
 
-/** \brief  Convert network-to-host long.
-
-    This macro converts a network byte order (big endian) value to the host's
-    native byte order. On a little endian system (like the Dreamcast), this
-    should just call arch_swap32(). On a big endian system, this should be a
-    no-op.
-
-    \param  x           The value to be converted. This should be a uint32,
-                        or equivalent.
-    \return             The converted value.
-*/
 __depr("arch_ntohl() is deprecated, use ntohl() from <arpa/inet.h>")
 static inline uint32_t arch_ntohl(uint32_t x) {
     return __builtin_bswap32(x);
 }
 
-/** \brief  Convert host-to-network short.
-
-    This macro converts a value in the host's native byte order to network byte
-    order (big endian). On a little endian system (like the Dreamcast), this
-    should just call arch_swap16(). On a big endian system, this should be a
-    no-op.
-
-    \param  x           The value to be converted. This should be a uint16,
-                        or equivalent.
-    \return             The converted value.
-*/
 __depr("arch_htons() is deprecated, use htons() from <arpa/inet.h>")
 static inline uint16_t arch_htons(uint16_t x) {
     return __builtin_bswap16(x);
 }
 
-/** \brief  Convert host-to-network long.
-
-    This macro converts a value in the host's native byte order to network byte
-    order (big endian). On a little endian system (like the Dreamcast), this
-    should just call arch_swap32(). On a big endian system, this should be a
-    no-op.
-
-    \param  x           The value to be converted. This should be a uint32,
-                        or equivalent.
-    \return             The converted value.
-*/
 __depr("arch_htonl() is deprecated, use htonl() from <arpa/inet.h>")
 static inline uint32_t arch_htonl(uint32_t x) {
     return __builtin_bswap32(x);
 }
-
-/** @} */
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -319,7 +319,7 @@ static inline irq_mask_t irq_get_sr(void) {
     This function will restore the interrupt state to the value specified. This
     should correspond to a value returned by irq_disable().
 
-    \param  v               The IRQ state to restore. This should be a value
+    \param  old             The IRQ state to restore. This should be a value
                             returned by irq_disable().
 
     \sa irq_disable()

--- a/kernel/arch/dreamcast/include/dc/maple/purupuru.h
+++ b/kernel/arch/dreamcast/include/dc/maple/purupuru.h
@@ -59,13 +59,15 @@ __BEGIN_DECLS
 typedef union purupuru_effect  {
     /** \brief Access the raw 32-bit value to be sent to the puru */
     uint32_t raw;
-    /** \brief Deprecated old structure which has been inverted now to union with raw. */
+    /* \cond */
+    /* Deprecated old structure which has been inverted now to union with raw. */
     struct {
         uint8_t special     __depr("Please see purupuru_effect_t which has new members.");
         uint8_t effect1     __depr("Please see purupuru_effect_t which has new members.");
         uint8_t effect2     __depr("Please see purupuru_effect_t which has new members.");
         uint8_t duration    __depr("Please see purupuru_effect_t which has new members.");
     };
+    /* \endcond */
     struct {
         /** \brief Continuous Vibration. When set vibration will continue until stopped */
         bool     cont    : 1;


### PR DESCRIPTION
Three sets of warnings that had cropped up in some recent PRs:
- irq.c - Correct param name for `irq_restore`
- purupuru.c - The deprecated struct members had an incorrect `brief`. Set as cond to have them ignored entirely.
- byteorder.h - Remove doxygen entirely for deprecated functions, as well as replace the custom-defined `BYTE_ORDER` with the standard header that defines it.