### PR TITLE
dc: Add functions to toggle OCINDEX, ICINDEX, OCRAM modes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,4 +47,6 @@ Falco Girgis: 2023, 2024, 2025, 2026
 Ruslan Rostovtsev: 2014, 2016, 2023, 2024, 2025
 Colton Pawielski: 2023
 Andy Barajas: 2023, 2024, 2026
-Paul Cercueil: 2023, 2024, 2025
+Paul Cercueil: 2023, 2024, 2025, 2026
+Matt Slevinsky: 2025
+TapamN: 2025

--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -29,6 +29,8 @@
 #include <kos/init_base.h>
 __BEGIN_DECLS
 
+#include <stdint.h>
+
 /** \brief   Dreamcast-specific KOS_INIT Exports
     \ingroup init_flags
 
@@ -106,7 +108,7 @@ __BEGIN_DECLS
 
 #define INIT_CDROM          0x00100000  /**< \brief Enable CD-ROM support */
 
-#define INIT_OCRAM          0x10000000  /**< \brief Use half of the dcache as RAM */
+static const uint32_t INIT_OCRAM __depr("INIT_OCRAM has been removed. Use dcache_toggle_ocram().");
 #define INIT_NO_DCLOAD      0x20000000  /**< \brief Disable dcload */
 
 /** @} */

--- a/kernel/arch/dreamcast/include/dc/cache.h
+++ b/kernel/arch/dreamcast/include/dc/cache.h
@@ -1,0 +1,110 @@
+/* KallistiOS ##version##
+
+   arch/dreamcast/include/dc/cache.h
+   Copyright (C) 2025 Paul Cercueil
+   Copyright (C) 2025 Matt Slevinsky
+   Copyright (C) 2025 TapamN
+*/
+
+/** \file    dc/cache.h
+    \brief   Cache management functionality.
+    \ingroup system_cache
+
+    This file contains definitions and low-level routines to manipulate the
+    instruction and data caches.
+
+    \author Paul Cercueil
+    \author Matt Slevinsky
+    \author TapamN
+*/
+
+#ifndef __DC_CACHE_H
+#define __DC_CACHE_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+#include <kos/regfield.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define CCR_OCE         BIT(0)  /** \< OC enable */
+#define CCR_WT          BIT(1)  /** \< Write-through enable (for P0/U0/P3 in non-MMU mode) */
+#define CCR_CB          BIT(2)  /** \< Copy-back enable for P1 area */
+#define CCR_OCI         BIT(3)  /** \< OC invalidate */
+#define CCR_ORA         BIT(5)  /** \< OC RAM enable */
+#define CCR_OIX         BIT(7)  /** \< OC INDEX enable */
+#define CCR_ICE         BIT(8)  /** \< IC enable (in non-MMU mode) */
+#define CCR_ICI         BIT(11) /** \< IC invalidate */
+#define CCR_IIX         BIT(15) /** \< IC INDEX enable */
+
+/** \brief  Write CCR register.
+
+    This function is used internally to write the cache control register.
+
+    \param  mask            Mask of the bits to update
+    \param  value           Value to replace the masked bits with
+*/
+void cache_write_ccr(uint32_t mask, uint32_t value);
+
+/** \brief  Enable or disable OCINDEX mode.
+
+    This function can be used to enable or disable OCINDEX mode.
+
+    In OCINDEX mode, the bits 25 and 12-5 are used as the data cache line index.
+    In non-OCINDEX mode, the bits 13-5 are used as the data cache line index.
+
+    Using OCINDEX, data memory-mapped to an address with bit 25 set
+    (e.g. 0x2000000) will always stay in cache (unless its cache line is
+    reused by another address with bit 25 set), as the RAM size on supported
+    SH4 platforms is lower than (1 << 25), meaning that for common RAM
+    addresses, bit 25 is always cleared.
+
+    \param  enable          Whether or not to enable OCINDEX mode
+*/
+static inline void dcache_toggle_ocindex(bool enable) {
+    cache_write_ccr(CCR_OIX, enable ? CCR_OIX : 0);
+}
+
+/** \brief  Enable or disable OCRAM mode.
+
+    This function can be used to enable or disable OCRAM mode.
+
+    In OCRAM mode, half the cache can be used as a scratchpad.
+
+    In OCRAM mode, the bits 13 and 11-5 are used as the cache line index.
+    In non-OCRAM mode, the bits 13-5 are used as the cache line index.
+
+    Using OCRAM mode, the cache lines 128 to 255 and 384 to 511 are guaranteed
+    to be unused, and can be accessed directly as if it was RAM. The 8 KiB
+    scratchpad can then be accessed at address 0x7c001000.
+
+    \param  enable          Whether or not to enable OCINDEX mode
+*/
+static inline void dcache_toggle_ocram(bool enable) {
+    cache_write_ccr(CCR_ORA, enable ? CCR_ORA : 0);
+}
+
+/** \brief  Enable or disable ICINDEX mode.
+
+    This function can be used to enable or disable ICINDEX mode.
+
+    In ICINDEX mode, the bits 25 and 11-5 are used as the instruction cache line
+    index. In non-ICINDEX mode, the bits 12-5 are used as the instruction cache
+    line index.
+
+    Using ICINDEX, code memory-mapped to an address with bit 25 set
+    (e.g. 0x2000000) will always stay in cache (unless its cache line is
+    reused by another address with bit 25 set), as the RAM size on supported
+    SH4 platforms is lower than (1 << 25), meaning that for common RAM
+    addresses, bit 25 is always cleared.
+
+    \param  enable          Whether or not to enable ICINDEX mode
+*/
+static inline void icache_toggle_icindex(bool enable) {
+    cache_write_ccr(CCR_IIX, (enable ? CCR_IIX : 0) | CCR_ICI);
+}
+
+__END_DECLS
+
+#endif  /* __DC_CACHE_H */

--- a/kernel/arch/dreamcast/include/dc/cache.h
+++ b/kernel/arch/dreamcast/include/dc/cache.h
@@ -80,7 +80,8 @@ static inline void dcache_toggle_ocindex(bool enable) {
 
     Using OCRAM mode, the cache lines 128 to 255 and 384 to 511 are guaranteed
     to be unused, and can be accessed directly as if it was RAM. The 8 KiB
-    scratchpad can then be accessed at address 0x7c001000.
+    scratchpad can then be accessed at address 0x7c001000, or preferably
+    through any variable tagged with the __ocram tag.
 
     \param  enable          Whether or not to enable OCINDEX mode
 */
@@ -107,6 +108,19 @@ static inline void dcache_toggle_ocram(bool enable) {
 static inline void icache_toggle_icindex(bool enable) {
     cache_write_ccr(CCR_IIX, (enable ? CCR_IIX : 0) | CCR_ICI);
 }
+
+/** \brief  Mark a variable as residing in OCRAM
+
+    This can be used to place a variable in OCRAM space. Before any access
+    (read or write) can be made, OCRAM needs to be enabled.
+    Also note that after enabling OCRAM the variable will contain garbage, so
+    the code must not rely on the content of the variable, and must not be
+    statically initialized (even to zero).
+
+    Example:
+    __ocram static uint32_t my_array[16];
+*/
+#define __ocram __attribute__((section(".ocram")))
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/include/dc/cache.h
+++ b/kernel/arch/dreamcast/include/dc/cache.h
@@ -38,6 +38,9 @@ __BEGIN_DECLS
 #define CCR_ICI         BIT(11) /** \< IC invalidate */
 #define CCR_IIX         BIT(15) /** \< IC INDEX enable */
 
+/** \brief  Default cache settings */
+#define CCR_DEFAULT     (CCR_ICI | CCR_ICE | CCR_OCI | CCR_CB | CCR_OCE)
+
 /** \brief  Write CCR register.
 
     This function is used internally to write the cache control register.

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -6,7 +6,9 @@
 ! Copyright (C) 2001 Megan Potter
 ! Copyright (C) 2014, 2016, 2023 Ruslan Rostovtsev
 ! Copyright (C) 2023, 2024 Andy Barajas
-! Copyright (C) 2024 Paul Cercueil
+! Copyright (C) 2024, 2025 Paul Cercueil
+! Copyright (C) 2025 Matt Slevinsky
+! Copyright (C) 2025 TapamN
 !
 ! Optimized assembler code for managing the cache.
 !
@@ -14,6 +16,7 @@
     .text
     .globl _arch_icache_inval_range
     .globl _arch_icache_sync_range
+    .globl _cache_write_ccr
 
 ! This routine goes through and flushes/invalidates the icache
 ! for a given range.
@@ -141,6 +144,64 @@ _arch_icache_sync_range:
     rts
     nop
 
+_cache_write_ccr:
+    mov.l    ccr_addr, r6
+    mov.l    @r6, r0
+
+    ! Clear mask
+    or       r4, r0
+    xor      r4, r0
+
+    ! Set bits
+    or       r5, r0
+
+    mov      r0, r4
+
+    !Block IRQs
+    mov.l    block_bit, r0
+    stc      sr, r7
+    or       r7, r0
+    ldc      r0, sr
+
+    !Jump to uncached P2 area before writing CCN
+    mova     1f, r0
+    mov      #0xa0, r1
+    shll16   r1
+    shll8    r1
+    or       r1, r0
+    jmp      @r0
+    nop
+
+.align 2
+1:
+    !Flush and invalidate data cache
+    mov.l    loc_tags, r0
+    mov      #2, r1  ! 512 >> 8 = 2
+    shll8    r1
+    mov      #0, r2
+1:
+    mov.l    r2, @r0
+    dt       r1
+    add      #32, r0   ! cache_line_size is 32
+    bf       1b
+
+    !Write to CCR
+    mov.l    r4, @r6
+
+    !Can't touch cache for a while after writing CCR
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+    !Restore SR (unblock IRQs)
+    ldc      r7, sr
+    rts
+    nop
 
 ! Variables
     .align    2
@@ -162,4 +223,9 @@ ormask:
     .long    0x100000f0
 align_mask:
     .long    ~31           ! Align address to 32-byte boundary
-
+ccr_addr:
+    .long    0xff00001c    ! Cache control register
+block_bit:
+    .long    0x10000000
+loc_tags:
+    .long    0xf4000000

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -22,6 +22,7 @@
 #include <arch/arch.h>
 #include <arch/gdb.h>
 #include <arch/rtc.h>
+#include <dc/cache.h>
 #include <dc/memory.h>
 #include <dc/perfctr.h>
 #include <dc/ubc.h>
@@ -279,6 +280,9 @@ void  __weak_symbol arch_auto_shutdown(void) {
 /* This is the entry point inside the C program */
 void arch_main(void) {
     int rv;
+
+    /* Enable caches */
+    cache_write_ccr((uint32_t)~0, CCR_DEFAULT);
 
     dma_init();
 

--- a/kernel/arch/dreamcast/kernel/startup.S
+++ b/kernel/arch/dreamcast/kernel/startup.S
@@ -34,34 +34,6 @@ start:
 	mov.l	init_sr,r0
 	ldc	r0,sr
 
-	! Run in the P2 area
-	mov.l	setup_cache_addr,r0
-	mov.l	p2_mask,r1
-	or	r1,r0
-	jmp	@r0
-	nop
-
-setup_cache:
-	! Now that we are in P2, it's safe to enable the cache
-	mov.w	ccr_data,r1
-	mov.l	ccr_addr,r0
-	mov.l	r1,@r0
-
-	! After changing CCR, eight instructions must be executed before
-	! it's safe to enter a cached area such as P1
-	nop			! 1
-	nop			! 2
-	nop			! 3
-	nop			! 4
-	nop			! 5 (d-cache now safe)
-	nop			! 6
-	mov.l	init_addr,r0	! 7
-	mov	#0,r1		! 8
-	jmp	@r0		! go
-	mov	r1,r0
-	nop
-
-init:
 	! Save old PR on old stack so we can get to it later
 	sts.l	pr,@-r15
 
@@ -207,17 +179,9 @@ new_stack_32m:
 	.long	_arch_stack_32m
 p2_mask:
 	.long	0xa0000000
-setup_cache_addr:
-	.long	setup_cache
-init_addr:
-	.long	init
 main_addr:
 	.long	_arch_main
 mmu_addr:
 	.long	0xff000010
 fpscr_addr:
 	.long	___set_fpscr	! in libgcc
-ccr_addr:
-	.long	0xff00001c
-ccr_data:
-	.word	0x090d

--- a/kernel/arch/dreamcast/kernel/startup.S
+++ b/kernel/arch/dreamcast/kernel/startup.S
@@ -43,17 +43,7 @@ start:
 
 setup_cache:
 	! Now that we are in P2, it's safe to enable the cache
-	! Check to see if we should enable OCRAM.
-	mov.l	kos_init_flags_addr, r0
-	mov.b 	@(3,r0),r0
-	tst 	#0x10,r0
-	bf	.L_setup_cache_L0
 	mov.w	ccr_data,r1
-	bra	.L_setup_cache_L1
-	nop
-.L_setup_cache_L0:
-	mov.w	ccr_data_ocram,r1
-.L_setup_cache_L1:
 	mov.l	ccr_addr,r0
 	mov.l	r1,@r0
 
@@ -227,11 +217,7 @@ mmu_addr:
 	.long	0xff000010
 fpscr_addr:
 	.long	___set_fpscr	! in libgcc
-kos_init_flags_addr:
-	.long	___kos_init_flags
 ccr_addr:
 	.long	0xff00001c
 ccr_data:
 	.word	0x090d
-ccr_data_ocram:
-	.word	0x092d


### PR DESCRIPTION
Add function cache_write_ccr(), which allows to safely toggle some bits of the CCR register.

Add function dcache_toggle_ocindex(), which can enable or disable OCINDEX mode.

Add function dcache_toggle_ocram(), which can enable or disable OCRAM mode.

Add function icache_toggle_icindex(), which can enable or disable ICINDEX mode.