### PR TITLE
examples: Fix stackprotector with builtins.

### DIFF
--- a/examples/dreamcast/basic/stackprotector/Makefile
+++ b/examples/dreamcast/basic/stackprotector/Makefile
@@ -6,6 +6,9 @@
 
 TARGET = stackprotector.elf
 OBJS = stackprotector.o
+#Disable optimization that might avoid the overflow and the warning the intentional error would create
+KOS_CFLAGS += -O0 -Wno-stringop-overflow -Wno-analyzer-out-of-bounds
+#Foce stack protector on
 KOS_CFLAGS += -fstack-protector-all
 KOS_GCCVER_MIN = 4.0.0
 

--- a/examples/dreamcast/basic/stackprotector/stackprotector.c
+++ b/examples/dreamcast/basic/stackprotector/stackprotector.c
@@ -49,18 +49,10 @@ __used void __stack_chk_fail(void) {
     exit(EXIT_SUCCESS);
 }
 
-/* Make sure the compiler doesn't complain about the bad thing 
-we are doing intentionally */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wanalyzer-out-of-bounds"
-
 __noinline void badfunc(void) {
     char buffer[8];
     strcpy(buffer, "This string is entirely too long and will overflow.");
 }
-
-/* Turn the warning back on */
-#pragma GCC diagnostic pop
 
 int main(int argc, char **argv) {
     printf("Stack protector test....\n");


### PR DESCRIPTION
With builtins and lto enabled, `strcpy` would optimize better and it seems as though `badfunc` would just not get called at all. Forced optimization off for the example and disabled the new warning it can produce. Due to it being related to a builtins/lto having the warnings disabled in the context of the one function wasn't sufficient anymore.