### PR TITLE
cmake: Add compatibility cmake file.

### DIFF
--- a/utils/cmake/dreamcast.cmake
+++ b/utils/cmake/dreamcast.cmake
@@ -1,0 +1,2 @@
+message(AUTHOR_WARNING "dreamcast.cmake is deprecated, please use kallistios.cmake")
+include(kallistios)

--- a/utils/cmake/dreamcast.toolchain.cmake
+++ b/utils/cmake/dreamcast.toolchain.cmake
@@ -1,0 +1,2 @@
+message(AUTHOR_WARNING "dreamcast.toolchain.cmake is deprecated, please use kallistios.toolchain.cmake")
+include($ENV{KOS_BASE}/utils/cmake/kallistios.toolchain.cmake)


### PR DESCRIPTION
We've recently changed the old `Dreamcast` to
`kallistios` toolchains. Providing a passthrough
wrapper + warning to aid compatibility.

Since the change was patched in have seen a number of people seeking help with the error due to not people not knowing they need to update their `environ.sh`. This should help some.