### PR TITLE
Add C11's static_assert() to <assert.h>

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -40,6 +40,10 @@ __BEGIN_DECLS
    error message. */
 /** \cond */
 #define _assert(e) assert(e)
+
+#if __STDC_VERSION__ >= 201112L && !defined __cplusplus
+#define static_assert _Static_assert
+#endif
 /** \endcond */
 
 #ifdef NDEBUG


### PR DESCRIPTION
C11 adds the _Static_assert keyword, and a static_assert macro in <assert.h>.

Add the static_assert() macro to our <assert.h> copy.