### PR TITLE
Ignore .cache/, .clangd, .envrc, and compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,11 @@
 *~
 .*.swp
 .DS_Store
+.cache/
 .vscode/
+.clangd
+.envrc
+compile_commands.json
 environ.sh
 romdisk.img
 /doc/reference/


### PR DESCRIPTION
For users of language servers, these files are used to specify compilation parameters or are generated for use by the language server. They should be ignored by git as they are not relevant to the repo itself.