### PR TITLE
environ: Move default setting of SUBARCH to `environ_dreamcast.sh`

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -23,15 +23,13 @@ export KOS_ARCH="dreamcast"
 # is targeting or uses an existing value that
 # can be set externally via your IDE.
 #
+# Only needs to be set if not using default.
+#
 # Valid values:
 #   "pristine" - Dreamcast console or HKT-0120 devkit (default)
 #   "naomi"    - NAOMI or NAOMI 2 arcade board
 #
-if [ -z "${KOS_SUBARCH}" ] ; then
-    export KOS_SUBARCH="pristine"
-else
-    export KOS_SUBARCH
-fi
+#export KOS_SUBARCH="naomi"
 
 # KOS Root Path
 #

--- a/environ_dreamcast.sh
+++ b/environ_dreamcast.sh
@@ -1,6 +1,11 @@
 # KallistiOS environment variable settings. These are the shared pieces
 # for the Dreamcast(tm) platform.
 
+# Add the default subarch (DC) if one hasn't already been set.
+if [ -z "${KOS_SUBARCH}" ] ; then
+    export KOS_SUBARCH="pristine"
+fi
+
 # Add the default external DC tools path if it isn't already set.
 if [ -z "${DC_TOOLS_BASE}" ] ; then
     export DC_TOOLS_BASE="${KOS_CC_BASE}/../bin"


### PR DESCRIPTION
All the other default setting tests happen at this level. Now the value can more clearly be simply set in environ or by IDE. 


This was spurned on by me being a clueless user and just changing the instance of `pristine` in the sample to `naomi` in order to switch back and forth. That was super problematic though because re-sourcing `environ.sh` with that would not have any effect since `KOS_SUBARCH` was already sourced in the environment so the value wasn't being updated. This should make `KOS_SUBARCH` work more like the rest of the other settings where the environ sample shows how to override the default rather than enforcing the default.