### PR TITLE
Update version number for current master (v2.2.2)

### DIFF
--- a/include/kos/version.h
+++ b/include/kos/version.h
@@ -99,7 +99,7 @@
 
 #define KOS_VERSION_MAJOR   2   /**< KOS's current major revision number. */
 #define KOS_VERSION_MINOR   2   /**< KOS's current minor revision number. */
-#define KOS_VERSION_PATCH   1   /**< KOS's current patch revision number. */
+#define KOS_VERSION_PATCH   2   /**< KOS's current patch revision number. */
 
 /** KOS's current version as an integer ID. */
 #define KOS_VERSION \


### PR DESCRIPTION
As with #1100 , with `v2.2.1` released, ticking up the current master version.