### PR TITLE
thread: Constify accessor params.

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -531,7 +531,7 @@ int thd_set_prio(kthread_t *thd, prio_t prio);
 
     \sa thd_set_prio
 */
-prio_t thd_get_prio(kthread_t *thd);
+prio_t thd_get_prio(const kthread_t *thd);
 
 /** \brief       Retrieve a thread's numeric identifier.
     \relatesalso kthread_t
@@ -541,7 +541,7 @@ prio_t thd_get_prio(kthread_t *thd);
 
     \return                 The identifier of the thread
 */
-tid_t thd_get_id(kthread_t *thd);
+tid_t thd_get_id(const kthread_t *thd);
 
 /** \brief       Retrieve the current thread's kthread struct.
     \relatesalso kthread_t
@@ -559,7 +559,7 @@ kthread_t *thd_get_current(void);
 
     \sa thd_set_label
 */
-const char *thd_get_label(kthread_t *thd);
+const char *thd_get_label(const kthread_t *thd);
 
 /** \brief       Set the thread's label.
     \relatesalso kthread_t
@@ -590,7 +590,7 @@ void thd_set_label(kthread_t *__RESTRICT thd, const char *__RESTRICT label);
 
     \sa thd_set_pd
 */
-const char *thd_get_pwd(kthread_t *thd);
+const char *thd_get_pwd(const kthread_t *thd);
 
 /** \brief       Set the thread's current working directory.
     \relatesalso kthread_t

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -568,14 +568,14 @@ int thd_set_prio(kthread_t *thd, prio_t prio) {
     return 0;
 }
 
-prio_t thd_get_prio(kthread_t *thd) {
+prio_t thd_get_prio(const kthread_t *thd) {
     if(!thd)
         thd = thd_current;
 
     return thd->prio;
 }
 
-tid_t thd_get_id(kthread_t *thd) {
+tid_t thd_get_id(const kthread_t *thd) {
     if(!thd)
         thd = thd_current;
 
@@ -873,7 +873,7 @@ int thd_detach(kthread_t *thd) {
 
 /*****************************************************************************/
 /* Retrieve / set thread label */
-const char *thd_get_label(kthread_t *thd) {
+const char *thd_get_label(const kthread_t *thd) {
     if(!thd)
         thd = thd_current;
 
@@ -893,7 +893,7 @@ kthread_t *thd_get_current(void) {
 }
 
 /* Retrieve / set thread pwd */
-const char *thd_get_pwd(kthread_t *thd) {
+const char *thd_get_pwd(const kthread_t *thd) {
     if(!thd)
         thd = thd_current;
 


### PR DESCRIPTION
None modify the contents of what is being accessed.

Note that `thd_get_cpu_time` doesn't qualify as it will attempt to update the time if being called on the current thread. Neither do `thd_get_errno` or `thd_get_reent` as the return would discard the qualifier.