### PR TITLE
kos-cc: Don't apply verbose output to version check.

### DIFF
--- a/utils/build_wrappers/kos-cc
+++ b/utils/build_wrappers/kos-cc
@@ -20,6 +20,11 @@ for i in $ARGS; do
 			# a better way to do this. (scan for any .c?)
 			USEMODE=3
 		;;
+		-dumpversion)
+			# Used for our gcc version test which expects
+			# *just* the output and no verbose output.
+			USEMODE=4
+		;;
 		*)
 		;;
 	esac
@@ -56,5 +61,10 @@ case $USEMODE in
 			echo ${KOS_CC} ${KOS_CFLAGS} "$@"
 		fi
 		exec ${KOS_CC} ${KOS_CFLAGS} "$@"
+	;;
+
+	4)
+		# -dumpversion mode. Ignore verbose.
+		exec ${KOS_CC} "$@"
 	;;
 esac


### PR DESCRIPTION
As `KOS_GCCVER` relies on the output of `kos-cc -dumpversion` being just the singular value, enabling `KOS_WRAPPERS_VERBOSE` breaks the checking that it does by echoing the call ahead of the output. To avoid this we have a separate use mode for the dumpversion flag which ignores the request for verbose output.

This might be better done by having `KOS_GCCVER` test for `KOS_WRAPPERS_VERBOSE` or some other method.