### PR TITLE
`fs_ramdisk`: cleanup and dynamic file table

### DIFF
--- a/include/kos/fs_ramdisk.h
+++ b/include/kos/fs_ramdisk.h
@@ -53,7 +53,7 @@ void fs_ramdisk_shutdown(void);
     \retval 0               On success
     \retval -1              On failure
 */
-int fs_ramdisk_attach(const char * fn, void * obj, size_t size);
+int fs_ramdisk_attach(const char *fn, void *obj, size_t size);
 
 /** \brief  Detach a file from the ramdisk.
 
@@ -67,7 +67,7 @@ int fs_ramdisk_attach(const char * fn, void * obj, size_t size);
     \retval 0               On success
     \retval -1              On failure
 */
-int fs_ramdisk_detach(const char * fn, void ** obj, size_t * size);
+int fs_ramdisk_detach(const char *fn, void **obj, size_t *size);
 
 /** @} */
 

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -130,11 +130,6 @@ __BEGIN_DECLS
 #define VMUFS_DEBUG 1
 #endif
 
-/** \brief  The maximum number of ramdisk files that can be open at a time. */
-#ifndef FS_RAMDISK_MAX_FILES
-#define FS_RAMDISK_MAX_FILES 8
-#endif
-
 /** \brief  The number of distinct file descriptors, including files and
             network sockets, that can be in use at a time. Decreasing this
             value can reduce memory usage.  */

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -865,14 +865,11 @@ void fs_ramdisk_shutdown(void) {
 
     /* For now assume there's only the root dir, since mkdir and
        rmdir aren't even implemented... */
-    f1 = LIST_FIRST(rootdir);
-
-    while(f1) {
-        f2 = LIST_NEXT(f1, dirlist);
+    LIST_FOREACH_SAFE(f1, rootdir, dirlist, f2) {
+        LIST_REMOVE(f1, dirlist);
         free(f1->name);
         free(f1->data);
         free(f1);
-        f1 = f2;
     }
 
     free(rootdir);

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -38,6 +38,7 @@ cache data from disk rather than as a general purpose file system.
 
 #include <string.h>
 #include <strings.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -122,7 +123,7 @@ static rd_file_t *ramdisk_find(rd_dir_t *parent, const char *name, size_t namele
 
 /* Find a path-named file in the ramdisk. There should not be a
    slash at the beginning, nor at the end. Assumes we hold rd_mutex. */
-static rd_file_t *ramdisk_find_path(rd_dir_t *parent, const char *fn, int dir) {
+static rd_file_t *ramdisk_find_path(rd_dir_t *parent, const char *fn, bool dir) {
     rd_file_t *f = NULL;
     char *cur;
 
@@ -187,7 +188,7 @@ static int ramdisk_get_parent(rd_dir_t *parent, const char *fn, rd_dir_t **dout,
         strncpy(pname, fn, p - fn);
         pname[p - fn] = 0;
 
-        f = ramdisk_find_path(parent, pname, 1);
+        f = ramdisk_find_path(parent, pname, true);
         free(pname);
 
         if(!f)
@@ -203,7 +204,7 @@ static int ramdisk_get_parent(rd_dir_t *parent, const char *fn, rd_dir_t **dout,
 
 /* Create a path-named file in the ramdisk. There should not be a
    slash at the beginning, nor at the end. Assumes we hold rd_mutex. */
-static rd_file_t *ramdisk_create_file(rd_dir_t *parent, const char *fn, int dir) {
+static rd_file_t *ramdisk_create_file(rd_dir_t *parent, const char *fn, bool dir) {
     rd_file_t   *f;
     rd_dir_t    *pdir;
     const char  *p;
@@ -558,7 +559,7 @@ static int ramdisk_unlink(vfs_handler_t *vfs, const char *fn) {
     mutex_lock_scoped(&rd_mutex);
 
     /* Find the file */
-    f = ramdisk_find_path(rootdir, fn, 0);
+    f = ramdisk_find_path(rootdir, fn, false);
 
     if(f) {
         /* Make sure it's not in use */
@@ -612,7 +613,7 @@ static int ramdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     mutex_lock_scoped(&rd_mutex);
 
     /* Find the file */
-    f = ramdisk_find_path(rootdir, path, 0);
+    f = ramdisk_find_path(rootdir, path, false);
     if(!f) {
         errno = ENOENT;
         return -1;

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -838,9 +838,9 @@ int fs_ramdisk_detach(const char *fn, void **obj, size_t *size) {
     *size = f->size;
 
     /* Ditch the data block we had and replace it with a fake one. */
-    f->data = malloc(64);
-    f->datasize = 64;
-    f->size = 64;
+    f->data = NULL;
+    f->datasize = 0;
+    f->size = 0;
 
     /* Close the file */
     ramdisk_close(fd);

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -103,6 +103,9 @@ static struct {
 /* Mutex for file system structs */
 static mutex_t rd_mutex;
 
+/* Data used for stat->st_dev's dev_t */
+static const dev_t rd_dev = (dev_t)('r' | ('a' << 8) | ('m' << 16));
+
 /* Test if an file_t is invalid, presumes mutex is already held. */
 static inline bool ramdisk_fd_invalid(file_t fd) {
     return((fd >= FS_RAMDISK_MAX_FILES) || (!fh[fd].file));
@@ -602,7 +605,7 @@ static int ramdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     /* Root directory of ramdisk */
     if(len == 0 || (len == 1 && *path == '/')) {
         memset(st, 0, sizeof(struct stat));
-        st->st_dev = (dev_t)('r' | ('a' << 8) | ('m' << 16));
+        st->st_dev = rd_dev;
         st->st_mode = S_IFDIR | S_IRWXU | S_IRWXG | S_IRWXO;
         st->st_size = -1;
         st->st_nlink = 2;
@@ -620,7 +623,7 @@ static int ramdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     }
 
     memset(st, 0, sizeof(struct stat));
-    st->st_dev = (dev_t)('r' | ('a' << 8) | ('m' << 16));
+    st->st_dev = rd_dev;
     st->st_mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
     st->st_mode |= (f->isdir) ?
         (S_IFDIR | S_IXUSR | S_IXGRP | S_IXOTH) : S_IFREG;
@@ -697,7 +700,7 @@ static int ramdisk_fstat(void *h, struct stat *st) {
 
     /* Fill in the structure. */
     memset(st, 0, sizeof(struct stat));
-    st->st_dev = (dev_t)('r' | ('a' << 8) | ('m' << 16));
+    st->st_dev = rd_dev;
     st->st_mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
     st->st_mode |= (f->isdir) ? S_IFDIR : S_IFREG;
     st->st_size = (f->isdir) ? -1 : (int)f->datasize;

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -188,8 +188,10 @@ static int ramdisk_get_parent(rd_dir_t *parent, const char *fn, rd_dir_t **dout,
     else {
         pname = (char *)malloc((p - fn) + 1);
 
-        if(!pname)
+        if(!pname) {
+            errno = ENOMEM;
             return -2;
+        }
 
         strncpy(pname, fn, p - fn);
         pname[p - fn] = 0;
@@ -197,8 +199,10 @@ static int ramdisk_get_parent(rd_dir_t *parent, const char *fn, rd_dir_t **dout,
         f = ramdisk_find_path(parent, pname, true);
         free(pname);
 
-        if(!f)
+        if(!f) {
+            errno = ENOENT;
             return -1;
+        }
 
         *dout = (rd_dir_t *)f->data;
         *fnout = p + 1;
@@ -220,12 +224,15 @@ static rd_file_t *ramdisk_create_file(rd_dir_t *parent, const char *fn, bool dir
         return NULL;
 
     /* Now add a file to the parent */
-    if(!(f = (rd_file_t *)malloc(sizeof(rd_file_t))))
+    if(!(f = (rd_file_t *)malloc(sizeof(rd_file_t)))) {
+        errno = ENOMEM;
         return NULL;
+    }
 
     f->name = strdup(p);
     if(f->name == NULL) {
         free(f);
+        errno = ENOMEM;
         return NULL;
     }
 
@@ -247,6 +254,7 @@ static rd_file_t *ramdisk_create_file(rd_dir_t *parent, const char *fn, bool dir
     if(f->data == NULL) {
         free(f->name);
         free(f);
+        errno = ENOMEM;
         return NULL;
     }
 
@@ -269,8 +277,10 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
     mutex_lock_scoped(&rd_mutex);
 
     /* Are we trying to do something stupid? */
-    if((mode & O_DIR) && mm != O_RDONLY)
+    if((mode & O_DIR) && mm != O_RDONLY) {
+        errno = EISDIR;
         goto error_out;
+    }
 
     /* Look for the file */
     assert(root != NULL);
@@ -282,7 +292,7 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
         f = ramdisk_find_path(rootdir, fn, mode & O_DIR);
 
         if(f == NULL) {
-            /* Are we planning to write anyway? */
+            /* Are we planning to write to a file anyway? */
             if(mm != O_RDONLY && !(mode & O_DIR)) {
                 /* Create a new file */
                 f = ramdisk_create_file(rootdir, fn, mode & O_DIR);
@@ -290,14 +300,19 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
                 if(f == NULL)
                     goto error_out;
             }
-            else
+            /* Must be read only mode as we tested for non-read DIR earlier. */
+            else /* if(mm == O_RDONLY) */ {
+                errno = ENOENT;
                 goto error_out;
+            }
         }
     }
 
-    /* Check for more stupid things */
-    if(f->isdir && (!(mode & O_DIR) || mm != O_RDONLY))
+    /* Did we ask for a dir as a file? */
+    if(f->isdir && !(mode & O_DIR)) {
+        errno = EINVAL;
         goto error_out;
+    }
 
     /* Find a free file handle */
     for(fd = 1; fd < FS_RAMDISK_MAX_FILES; fd++)
@@ -307,6 +322,7 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
     /* Did we find it? */
     if(fd >= FS_RAMDISK_MAX_FILES) {
         fd = -1;
+        errno = EMFILE;
         goto error_out;
     }
 
@@ -375,7 +391,10 @@ static int ramdisk_close(void *h) {
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid */
-    if(ramdisk_fd_invalid(fd)) return 0;
+    if(ramdisk_fd_invalid(fd)) {
+        errno = EBADF;
+        return 0;
+    }
 
     f = fh[fd].file;
     fh[fd].file = NULL;
@@ -399,7 +418,10 @@ static ssize_t ramdisk_read(void *h, void *buf, size_t bytes) {
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or a dir */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return (ssize_t)-1;
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir) {
+        errno = EBADF;
+        return (ssize_t)-1;
+    }
 
     /* Is there enough left? */
     if((fh[fd].ptr + bytes) > fh[fd].file->size)
@@ -418,19 +440,22 @@ static ssize_t ramdisk_write(void *h, const void *buf, size_t bytes) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    /* Check that the fd is invalid or a dir */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return (ssize_t)-1;
-
-    /* Check that the fd is open for writing */
-    if(fh[fd].file->openfor != OPENFOR_WRITE) return (ssize_t)-1;
+    /* Check that the fd is invalid or a dir or not open for writing */
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir ||
+        (fh[fd].file->openfor != OPENFOR_WRITE)) {
+        errno = EBADF;
+        return (ssize_t)-1;
+    }
 
     /* Is there enough left? */
     if((fh[fd].ptr + bytes) > fh[fd].file->datasize) {
         /* We need to realloc the block */
         void *np = realloc(fh[fd].file->data, (fh[fd].ptr + bytes) + (rd_blksize * 4));
 
-        if(np == NULL)
+        if(np == NULL) {
+            errno = ENOSPC;
             return -1;
+        }
 
         fh[fd].file->data = np;
         fh[fd].file->datasize = (fh[fd].ptr + bytes) + (rd_blksize * 4);
@@ -507,7 +532,10 @@ static off_t ramdisk_tell(void *h) {
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or a dir */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return -1;
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir) {
+        errno = EBADF;
+        return -1;
+    }
 
     return fh[fd].ptr;
 }
@@ -519,7 +547,10 @@ static size_t ramdisk_total(void *h) {
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or a dir */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return -1;
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir) {
+        errno = EBADF;
+        return -1;
+    }
 
     return fh[fd].file->size;
 }
@@ -559,7 +590,6 @@ static const dirent_t *ramdisk_readdir(void *h) {
 
 static int ramdisk_unlink(vfs_handler_t *vfs, const char *fn) {
     rd_file_t    *f;
-    int     rv = -1;
 
     (void)vfs;
 
@@ -568,23 +598,29 @@ static int ramdisk_unlink(vfs_handler_t *vfs, const char *fn) {
     /* Find the file */
     f = ramdisk_find_path(rootdir, fn, false);
 
-    if(f) {
-        /* Make sure it's not in use */
-        if(f->usage == 0) {
-            /* Free its data */
-            free(f->name);
-            free(f->data);
-
-            /* Remove it from the parent list */
-            LIST_REMOVE(f, dirlist);
-
-            /* Free the entry itself */
-            free(f);
-            rv = 0;
-        }
+    /* No entry found to unlink */
+    if(!f) {
+        errno = ENOENT;
+        return -1;
     }
 
-    return rv;
+    /* Make sure it's not in use */
+    if(f->usage) {
+        errno = EBUSY;
+        return -1;
+    }
+
+    /* Free its data */
+    free(f->name);
+    free(f->data);
+
+    /* Remove it from the parent list */
+    LIST_REMOVE(f, dirlist);
+
+    /* Free the entry itself */
+    free(f);
+
+    return 0;
 }
 
 static void *ramdisk_mmap(void *h) {

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -388,7 +388,7 @@ static int ramdisk_close(void *h) {
     /* Check that the fd is invalid */
     if(ramdisk_fd_invalid(fd)) {
         errno = EBADF;
-        return 0;
+        return -1;
     }
 
     f = fd->file;

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -94,10 +94,10 @@ static rd_dir_t  *rootdir = NULL;
    too lazy right now. =) */
 static struct {
     rd_file_t   *file;      /* ramdisk file struct */
-    int         dir;        /* >0 if a directory */
-    int         omode;      /* Open mode */
     uintptr_t   ptr;        /* Current read position in bytes */
+    int         omode;      /* Open mode */
     dirent_t    dirent;     /* A static dirent to pass back to clients */
+    bool        dir;        /* true if a directory */
 } fh[FS_RAMDISK_MAX_FILES];
 
 /* Mutex for file system structs */
@@ -312,7 +312,7 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
 
     /* Fill the basic fd structure */
     fh[fd].file = f;
-    fh[fd].dir = mode & O_DIR;
+    fh[fd].dir = !!(mode & O_DIR);
     fh[fd].omode = mode;
 
     /* The rest require a bit more thought */

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -56,9 +56,9 @@ char *strdup(const char *);
 typedef struct rd_file {
     char      *name;    /* File name -- allocated */
     uint32_t  size;     /* Actual file size */
-    int type;       /* File type */
-    int openfor;    /* Lock constant */
-    int usage;      /* Usage count (unopened is 0) */
+    bool      isdir;    /* Dir or not */
+    int       openfor;  /* Lock constant */
+    int       usage;    /* Usage count (unopened is 0) */
 
     /* For the following two members:
       - In files, this is a block of allocated memory containing the
@@ -136,7 +136,7 @@ static rd_file_t *ramdisk_find_path(rd_dir_t *parent, const char *fn, bool dir) 
                itself, something is wrong. */
             f = ramdisk_find(parent, fn, cur - fn);
 
-            if(f == NULL || f->type != STAT_TYPE_DIR)
+            if(f == NULL || !f->isdir)
                 return NULL;
 
             /* Pull out the rd_dir_t pointer */
@@ -155,7 +155,7 @@ static rd_file_t *ramdisk_find_path(rd_dir_t *parent, const char *fn, bool dir) 
     if(fn[0] != 0) {
         f = ramdisk_find(parent, fn, strlen(fn));
 
-        if((f == NULL) || (!dir && f->type == STAT_TYPE_DIR) || (dir && f->type != STAT_TYPE_DIR))
+        if((f == NULL) || (!dir && f->isdir) || (dir && !f->isdir))
             return NULL;
     }
     else {
@@ -224,7 +224,7 @@ static rd_file_t *ramdisk_create_file(rd_dir_t *parent, const char *fn, bool dir
     }
 
     f->size = 0;
-    f->type = dir ? STAT_TYPE_DIR : STAT_TYPE_FILE;
+    f->isdir = dir;
     f->openfor = OPENFOR_NOTHING;
     f->usage = 0;
 
@@ -289,7 +289,7 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
     }
 
     /* Check for more stupid things */
-    if(f->type == STAT_TYPE_DIR && (!(mode & O_DIR) || mm != O_RDONLY))
+    if(f->isdir && (!(mode & O_DIR) || mm != O_RDONLY))
         goto error_out;
 
     /* Find a free file handle */
@@ -538,7 +538,7 @@ static const dirent_t *ramdisk_readdir(void *h) {
     strcpy(fh[fd].dirent.name, f->name);
     fh[fd].dirent.time = 0;
 
-    if(f->type == STAT_TYPE_DIR) {
+    if(f->isdir) {
         fh[fd].dirent.attr = O_DIR;
         fh[fd].dirent.size = -1;
     }
@@ -622,10 +622,10 @@ static int ramdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     memset(st, 0, sizeof(struct stat));
     st->st_dev = (dev_t)('r' | ('a' << 8) | ('m' << 16));
     st->st_mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
-    st->st_mode |= (f->type == STAT_TYPE_DIR) ? 
+    st->st_mode |= (f->isdir) ?
         (S_IFDIR | S_IXUSR | S_IXGRP | S_IXOTH) : S_IFREG;
-    st->st_size = (f->type == STAT_TYPE_DIR) ? -1 : (int)f->datasize;
-    st->st_nlink = (f->type == STAT_TYPE_DIR) ? 2 : 1;
+    st->st_size = (f->isdir) ? -1 : (int)f->datasize;
+    st->st_nlink = (f->isdir) ? 2 : 1;
     st->st_blksize = 1024;
     st->st_blocks = f->datasize >> 10;
 
@@ -699,9 +699,9 @@ static int ramdisk_fstat(void *h, struct stat *st) {
     memset(st, 0, sizeof(struct stat));
     st->st_dev = (dev_t)('r' | ('a' << 8) | ('m' << 16));
     st->st_mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
-    st->st_mode |= (f->type == STAT_TYPE_DIR) ? S_IFDIR : S_IFREG;
-    st->st_size = (f->type == STAT_TYPE_DIR) ? -1 : (int)f->datasize;
-    st->st_nlink = (f->type == STAT_TYPE_DIR) ? 2 : 1;
+    st->st_mode |= (f->isdir) ? S_IFDIR : S_IFREG;
+    st->st_size = (f->isdir) ? -1 : (int)f->datasize;
+    st->st_nlink = (f->isdir) ? 2 : 1;
     st->st_blksize = 1024;
     st->st_blocks = f->datasize >> 10;
 
@@ -838,7 +838,7 @@ void fs_ramdisk_init(void) {
     }
 
     root->size = 0;
-    root->type = STAT_TYPE_DIR;
+    root->isdir = true;
     root->openfor = OPENFOR_NOTHING;
     root->usage = 0;
     root->data = rootdir;

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -53,7 +53,7 @@ char *strdup(const char *);
 
 /* File definition */
 typedef struct rd_file {
-    char    * name;     /* File name -- allocated */
+    char      *name;    /* File name -- allocated */
     uint32_t  size;     /* Actual file size */
     int type;       /* File type */
     int openfor;    /* Lock constant */
@@ -68,7 +68,7 @@ typedef struct rd_file {
       - In directories, this is just a pointer to an rd_dir struct,
         which is defined below. datasize has no meaning for a
         directory. */
-    void    * data;     /* Data block pointer */
+    void      *data;    /* Data block pointer */
     uint32_t  datasize; /* Size of data block pointer */
 
     LIST_ENTRY(rd_file) dirlist;    /* Directory list entry */
@@ -122,9 +122,9 @@ static rd_file_t *ramdisk_find(rd_dir_t *parent, const char *name, size_t namele
 
 /* Find a path-named file in the ramdisk. There should not be a
    slash at the beginning, nor at the end. Assumes we hold rd_mutex. */
-static rd_file_t * ramdisk_find_path(rd_dir_t * parent, const char * fn, int dir) {
-    rd_file_t * f = NULL;
-    char * cur;
+static rd_file_t *ramdisk_find_path(rd_dir_t *parent, const char *fn, int dir) {
+    rd_file_t *f = NULL;
+    char *cur;
 
     /* If the object is in a sub-tree, traverse the tree looking
        for the right directory */
@@ -167,10 +167,10 @@ static rd_file_t * ramdisk_find_path(rd_dir_t * parent, const char * fn, int dir
 }
 
 /* Find the parent directory and file name in the path-named file */
-static int ramdisk_get_parent(rd_dir_t * parent, const char * fn, rd_dir_t ** dout, const char **fnout) {
-    const char  * p;
-    char        * pname;
-    rd_file_t   * f;
+static int ramdisk_get_parent(rd_dir_t *parent, const char *fn, rd_dir_t **dout, const char **fnout) {
+    const char  *p;
+    char        *pname;
+    rd_file_t   *f;
 
     p = strrchr(fn, '/');
 
@@ -203,10 +203,10 @@ static int ramdisk_get_parent(rd_dir_t * parent, const char * fn, rd_dir_t ** do
 
 /* Create a path-named file in the ramdisk. There should not be a
    slash at the beginning, nor at the end. Assumes we hold rd_mutex. */
-static rd_file_t * ramdisk_create_file(rd_dir_t * parent, const char * fn, int dir) {
-    rd_file_t   * f;
-    rd_dir_t    * pdir;
-    const char  * p;
+static rd_file_t *ramdisk_create_file(rd_dir_t *parent, const char *fn, int dir) {
+    rd_file_t   *f;
+    rd_dir_t    *pdir;
+    const char  *p;
 
     /* First, find the parent dir */
     if(ramdisk_get_parent(parent, fn, &pdir, &p) < 0)
@@ -248,7 +248,7 @@ static rd_file_t * ramdisk_create_file(rd_dir_t * parent, const char * fn, int d
 }
 
 /* Open a file or directory */
-static void * ramdisk_open(vfs_handler_t * vfs, const char *fn, int mode) {
+static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
     file_t      fd = -1;
     rd_file_t   *f;
     int     mm = mode & O_MODE_MASK;
@@ -360,7 +360,7 @@ error_out:
 }
 
 /* Close a file or directory */
-static int ramdisk_close(void * h) {
+static int ramdisk_close(void *h) {
     rd_file_t   *f;
     file_t      fd = (file_t)h;
 
@@ -385,7 +385,7 @@ static int ramdisk_close(void * h) {
 }
 
 /* Read from a file */
-static ssize_t ramdisk_read(void * h, void *buf, size_t bytes) {
+static ssize_t ramdisk_read(void *h, void *buf, size_t bytes) {
     file_t  fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
@@ -405,7 +405,7 @@ static ssize_t ramdisk_read(void * h, void *buf, size_t bytes) {
 }
 
 /* Write to a file */
-static ssize_t ramdisk_write(void * h, const void *buf, size_t bytes) {
+static ssize_t ramdisk_write(void *h, const void *buf, size_t bytes) {
     file_t  fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
@@ -419,7 +419,7 @@ static ssize_t ramdisk_write(void * h, const void *buf, size_t bytes) {
     /* Is there enough left? */
     if((fh[fd].ptr + bytes) > fh[fd].file->datasize) {
         /* We need to realloc the block */
-        void * np = realloc(fh[fd].file->data, (fh[fd].ptr + bytes) + 4096);
+        void *np = realloc(fh[fd].file->data, (fh[fd].ptr + bytes) + 4096);
 
         if(np == NULL)
             return -1;
@@ -440,7 +440,7 @@ static ssize_t ramdisk_write(void * h, const void *buf, size_t bytes) {
 }
 
 /* Seek elsewhere in a file */
-static off_t ramdisk_seek(void * h, off_t offset, int whence) {
+static off_t ramdisk_seek(void *h, off_t offset, int whence) {
     file_t  fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
@@ -493,7 +493,7 @@ static off_t ramdisk_seek(void * h, off_t offset, int whence) {
 }
 
 /* Tell where in the file we are */
-static off_t ramdisk_tell(void * h) {
+static off_t ramdisk_tell(void *h) {
     file_t  fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
@@ -505,7 +505,7 @@ static off_t ramdisk_tell(void * h) {
 }
 
 /* Tell how big the file is */
-static size_t ramdisk_total(void * h) {
+static size_t ramdisk_total(void *h) {
     file_t  fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
@@ -517,8 +517,8 @@ static size_t ramdisk_total(void * h) {
 }
 
 /* Read a directory entry */
-static const dirent_t *ramdisk_readdir(void * h) {
-    rd_file_t   * f;
+static const dirent_t *ramdisk_readdir(void *h) {
+    rd_file_t   *f;
     file_t      fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
@@ -549,8 +549,8 @@ static const dirent_t *ramdisk_readdir(void * h) {
     return &fh[fd].dirent;
 }
 
-static int ramdisk_unlink(vfs_handler_t * vfs, const char *fn) {
-    rd_file_t   * f;
+static int ramdisk_unlink(vfs_handler_t *vfs, const char *fn) {
+    rd_file_t    *f;
     int     rv = -1;
 
     (void)vfs;
@@ -579,7 +579,7 @@ static int ramdisk_unlink(vfs_handler_t * vfs, const char *fn) {
     return rv;
 }
 
-static void * ramdisk_mmap(void * h) {
+static void *ramdisk_mmap(void *h) {
     file_t  fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
@@ -662,7 +662,7 @@ static int ramdisk_fcntl(void *h, int cmd, va_list ap) {
     }
 }
 
-static int ramdisk_rewinddir(void * h) {
+static int ramdisk_rewinddir(void *h) {
     file_t fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
@@ -755,7 +755,7 @@ static vfs_handler_t vh = {
 /* Attach a piece of memory to a file. This works somewhat like open for
    writing, but it doesn't actually attach the file to an fd, and it starts
    out with data instead of being blank. */
-int fs_ramdisk_attach(const char * fn, void * obj, size_t size) {
+int fs_ramdisk_attach(const char *fn, void *obj, size_t size) {
     void        *fd;
     rd_file_t   *f;
 
@@ -780,7 +780,7 @@ int fs_ramdisk_attach(const char * fn, void * obj, size_t size) {
 }
 
 /* Does the opposite of attach. This again piggybacks on open. */
-int fs_ramdisk_detach(const char * fn, void ** obj, size_t * size) {
+int fs_ramdisk_detach(const char *fn, void **obj, size_t *size) {
     void        *fd;
     rd_file_t   *f;
 

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -102,6 +102,11 @@ static struct {
 /* Mutex for file system structs */
 static mutex_t rd_mutex;
 
+/* Test if an file_t is invalid, presumes mutex is already held. */
+static inline bool ramdisk_fd_invalid(file_t fd) {
+    return((fd >= FS_RAMDISK_MAX_FILES) || (!fh[fd].file));
+}
+
 /* Search a directory for the named file; return the struct if
    we find it. Assumes we hold rd_mutex. */
 static rd_file_t *ramdisk_find(rd_dir_t *parent, const char *name, size_t namelen) {
@@ -361,80 +366,77 @@ static int ramdisk_close(void * h) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    /* Check that the fd is valid */
-    if(fd < FS_RAMDISK_MAX_FILES && fh[fd].file != NULL) {
-        f = fh[fd].file;
-        fh[fd].file = NULL;
+    /* Check that the fd is invalid */
+    if(ramdisk_fd_invalid(fd)) return 0;
 
-        /* Decrease the usage count */
-        f->usage--;
-        assert(f->usage >= 0);
+    f = fh[fd].file;
+    fh[fd].file = NULL;
 
-        /* If the usage count is back to 0, then no one has the file
-           open. Remove the openfor status. */
-        if(f->usage == 0)
-            f->openfor = OPENFOR_NOTHING;
-    }
+    /* Decrease the usage count */
+    f->usage--;
+    assert(f->usage >= 0);
+
+    /* If the usage count is back to 0, then no one has the file
+       open. Remove the openfor status. */
+    if(f->usage == 0)
+        f->openfor = OPENFOR_NOTHING;
 
     return 0;
 }
 
 /* Read from a file */
 static ssize_t ramdisk_read(void * h, void *buf, size_t bytes) {
-    ssize_t rv = -1;
     file_t  fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
 
-    /* Check that the fd is valid */
-    if(fd < FS_RAMDISK_MAX_FILES && fh[fd].file != NULL && !fh[fd].dir) {
-        /* Is there enough left? */
-        if((fh[fd].ptr + bytes) > fh[fd].file->size)
-            bytes = fh[fd].file->size - fh[fd].ptr;
+    /* Check that the fd is invalid or a dir */
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return (ssize_t)-1;
 
-        /* Copy out the requested amount */
-        memcpy(buf, ((uint8_t *)fh[fd].file->data) + fh[fd].ptr, bytes);
-        fh[fd].ptr += bytes;
+    /* Is there enough left? */
+    if((fh[fd].ptr + bytes) > fh[fd].file->size)
+        bytes = fh[fd].file->size - fh[fd].ptr;
 
-        rv = bytes;
-    }
+    /* Copy out the requested amount */
+    memcpy(buf, ((uint8_t *)fh[fd].file->data) + fh[fd].ptr, bytes);
+    fh[fd].ptr += bytes;
 
-    return rv;
+    return bytes;
 }
 
 /* Write to a file */
 static ssize_t ramdisk_write(void * h, const void *buf, size_t bytes) {
-    ssize_t rv = -1;
     file_t  fd = (file_t)h;
 
     mutex_lock_scoped(&rd_mutex);
 
-    /* Check that the fd is valid */
-    if(fd < FS_RAMDISK_MAX_FILES && fh[fd].file != NULL && !fh[fd].dir && fh[fd].file->openfor == OPENFOR_WRITE) {
-        /* Is there enough left? */
-        if((fh[fd].ptr + bytes) > fh[fd].file->datasize) {
-            /* We need to realloc the block */
-            void * np = realloc(fh[fd].file->data, (fh[fd].ptr + bytes) + 4096);
+    /* Check that the fd is invalid or a dir */
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return (ssize_t)-1;
 
-            if(np == NULL)
-                return -1;
+    /* Check that the fd is open for writing */
+    if(fh[fd].file->openfor != OPENFOR_WRITE) return (ssize_t)-1;
 
-            fh[fd].file->data = np;
-            fh[fd].file->datasize = (fh[fd].ptr + bytes) + 4096;
-        }
+    /* Is there enough left? */
+    if((fh[fd].ptr + bytes) > fh[fd].file->datasize) {
+        /* We need to realloc the block */
+        void * np = realloc(fh[fd].file->data, (fh[fd].ptr + bytes) + 4096);
 
-        /* Copy out the requested amount */
-        memcpy(((uint8_t *)fh[fd].file->data) + fh[fd].ptr, buf, bytes);
-        fh[fd].ptr += bytes;
+        if(np == NULL)
+            return -1;
 
-        if(fh[fd].file->size < fh[fd].ptr) {
-            fh[fd].file->size = fh[fd].ptr;
-        }
-
-        rv = bytes;
+        fh[fd].file->data = np;
+        fh[fd].file->datasize = (fh[fd].ptr + bytes) + 4096;
     }
 
-    return rv;
+    /* Copy out the requested amount */
+    memcpy(((uint8_t *)fh[fd].file->data) + fh[fd].ptr, buf, bytes);
+    fh[fd].ptr += bytes;
+
+    if(fh[fd].file->size < fh[fd].ptr) {
+        fh[fd].file->size = fh[fd].ptr;
+    }
+
+    return bytes;
 }
 
 /* Seek elsewhere in a file */
@@ -443,8 +445,8 @@ static off_t ramdisk_seek(void * h, off_t offset, int whence) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    /* Check that the fd is valid */
-    if(fd >= FS_RAMDISK_MAX_FILES || !fh[fd].file || fh[fd].dir) {
+    /* Check that the fd is invalid or a dir */
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir) {
         errno = EBADF;
         return -1;
     }
@@ -496,10 +498,10 @@ static off_t ramdisk_tell(void * h) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    if(fd < FS_RAMDISK_MAX_FILES && fh[fd].file != NULL && !fh[fd].dir)
-        return fh[fd].ptr;
+    /* Check that the fd is invalid or a dir */
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return -1;
 
-    return -1;
+    return fh[fd].ptr;
 }
 
 /* Tell how big the file is */
@@ -508,10 +510,10 @@ static size_t ramdisk_total(void * h) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    if(fd < FS_RAMDISK_MAX_FILES && fh[fd].file != NULL && !fh[fd].dir)
-        return fh[fd].file->size;
+    /* Check that the fd is invalid or a dir */
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return -1;
 
-    return -1;
+    return fh[fd].file->size;
 }
 
 /* Read a directory entry */
@@ -521,30 +523,30 @@ static const dirent_t *ramdisk_readdir(void * h) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    if(fd < FS_RAMDISK_MAX_FILES && fh[fd].file != NULL && fh[fd].ptr != 0 && fh[fd].dir) {
-        /* Find the current file and advance to the next */
-        f = (rd_file_t *)fh[fd].ptr;
-        fh[fd].ptr = (uintptr_t)LIST_NEXT(f, dirlist);
-
-        /* Copy out the requested data */
-        strcpy(fh[fd].dirent.name, f->name);
-        fh[fd].dirent.time = 0;
-
-        if(f->type == STAT_TYPE_DIR) {
-            fh[fd].dirent.attr = O_DIR;
-            fh[fd].dirent.size = -1;
-        }
-        else {
-            fh[fd].dirent.attr = 0;
-            fh[fd].dirent.size = f->size;
-        }
-
-        return &fh[fd].dirent;
-    }
-    else {
+    /* Check that the fd is invalid, NOT a dir, or empty */
+    if(ramdisk_fd_invalid(fd) || !fh[fd].dir || !fh[fd].ptr) {
         errno = EBADF;
         return NULL;
     }
+
+    /* Find the current file and advance to the next */
+    f = (rd_file_t *)fh[fd].ptr;
+    fh[fd].ptr = (uintptr_t)LIST_NEXT(f, dirlist);
+
+    /* Copy out the requested data */
+    strcpy(fh[fd].dirent.name, f->name);
+    fh[fd].dirent.time = 0;
+
+    if(f->type == STAT_TYPE_DIR) {
+        fh[fd].dirent.attr = O_DIR;
+        fh[fd].dirent.size = -1;
+    }
+    else {
+        fh[fd].dirent.attr = 0;
+        fh[fd].dirent.size = f->size;
+    }
+
+    return &fh[fd].dirent;
 }
 
 static int ramdisk_unlink(vfs_handler_t * vfs, const char *fn) {
@@ -582,10 +584,10 @@ static void * ramdisk_mmap(void * h) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    if(fd < FS_RAMDISK_MAX_FILES && fh[fd].file != NULL && !fh[fd].dir)
-        return fh[fd].file->data;
+    /* Check that the fd is invalid or a dir */
+    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return NULL;
 
-    return NULL;
+    return fh[fd].file->data;
 }
 
 static int ramdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
@@ -639,7 +641,8 @@ static int ramdisk_fcntl(void *h, int cmd, va_list ap) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    if(fd >= FS_RAMDISK_MAX_FILES || !fh[fd].file) {
+    /* Check that the fd is invalid */
+    if(ramdisk_fd_invalid(fd)) {
         errno = EBADF;
         return -1;
     }
@@ -664,7 +667,8 @@ static int ramdisk_rewinddir(void * h) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    if(fd >= FS_RAMDISK_MAX_FILES || !fh[fd].file || !fh[fd].dir) {
+    /* Check that the fd is invalid or NOT a dir */
+    if(ramdisk_fd_invalid(fd) || !fh[fd].dir) {
         errno = EBADF;
         return -1;
     }
@@ -681,7 +685,8 @@ static int ramdisk_fstat(void *h, struct stat *st) {
 
     mutex_lock_scoped(&rd_mutex);
 
-    if(fd >= FS_RAMDISK_MAX_FILES || !fh[fd].file) {
+    /* Check that the fd is invalid */
+    if(ramdisk_fd_invalid(fd)) {
         errno = EBADF;
         return -1;
     }

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -90,15 +90,17 @@ static rd_dir_t  *rootdir = NULL;
 /********************************************************************************/
 /* File primitives */
 
-/* File handles.. I could probably do this with a linked list, but I'm just
-   too lazy right now. =) */
-static struct {
+/* Entries in the fd list. Pointers of this type are passed out to ref files. */
+typedef struct rd_fd {
     rd_file_t   *file;      /* ramdisk file struct */
     uintptr_t   ptr;        /* Current read position in bytes */
     int         omode;      /* Open mode */
+    TAILQ_ENTRY(rd_fd)  next;   /* Next handle in the linked list */
     dirent_t    dirent;     /* A static dirent to pass back to clients */
     bool        dir;        /* true if a directory */
-} fh[FS_RAMDISK_MAX_FILES];
+} rd_fd_t;
+
+static TAILQ_HEAD(rd_fd_queue, rd_fd) rd_fd_queue;
 
 /* Mutex for file system structs */
 static mutex_t rd_mutex;
@@ -110,8 +112,8 @@ static const dev_t rd_dev = (dev_t)('r' | ('a' << 8) | ('m' << 16));
 static const blksize_t rd_blksize = 1024;
 
 /* Test if an file_t is invalid, presumes mutex is already held. */
-static inline bool ramdisk_fd_invalid(file_t fd) {
-    return((fd >= FS_RAMDISK_MAX_FILES) || (!fh[fd].file));
+static inline bool ramdisk_fd_invalid(rd_fd_t *fd) {
+    return(!fd || (!fd->file));
 }
 
 /* Search a directory for the named file; return the struct if
@@ -265,7 +267,7 @@ static rd_file_t *ramdisk_create_file(rd_dir_t *parent, const char *fn, bool dir
 
 /* Open a file or directory */
 static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
-    file_t      fd = -1;
+    rd_fd_t     *fd;
     rd_file_t   *f;
     int     mm = mode & O_MODE_MASK;
 
@@ -279,7 +281,7 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
     /* Are we trying to do something stupid? */
     if((mode & O_DIR) && mm != O_RDONLY) {
         errno = EISDIR;
-        goto error_out;
+        return NULL;
     }
 
     /* Look for the file */
@@ -298,12 +300,12 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
                 f = ramdisk_create_file(rootdir, fn, mode & O_DIR);
 
                 if(f == NULL)
-                    goto error_out;
+                    return NULL;
             }
             /* Must be read only mode as we tested for non-read DIR earlier. */
             else /* if(mm == O_RDONLY) */ {
                 errno = ENOENT;
-                goto error_out;
+                return NULL;
             }
         }
     }
@@ -311,53 +313,51 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
     /* Did we ask for a dir as a file? */
     if(f->isdir && !(mode & O_DIR)) {
         errno = EINVAL;
-        goto error_out;
-    }
-
-    /* Find a free file handle */
-    for(fd = 1; fd < FS_RAMDISK_MAX_FILES; fd++)
-        if(fh[fd].file == NULL)
-            break;
-
-    /* Did we find it? */
-    if(fd >= FS_RAMDISK_MAX_FILES) {
-        fd = -1;
-        errno = EMFILE;
-        goto error_out;
+        return NULL;
     }
 
     /* Is the file already open for write? */
     if(f->openfor == OPENFOR_WRITE)
-        goto error_out;
+        return NULL;
+    /* Or already open for reading and you want to write */
+    else if((f->openfor == OPENFOR_READ) &&
+            ((mm & O_RDWR) || (mm & O_WRONLY)))
+        return NULL;
+
+    /* Create a new file handle */
+    fd = (rd_fd_t *)calloc(1, sizeof(*fd));
+
+    /* Did we get memory? */
+    if(!fd) {
+        errno = ENOMEM;
+        return NULL;
+    }
 
     /* Fill the basic fd structure */
-    fh[fd].file = f;
-    fh[fd].dir = !!(mode & O_DIR);
-    fh[fd].omode = mode;
+    fd->file = f;
+    fd->dir = !!(mode & O_DIR);
+    fd->omode = mode;
 
     /* The rest require a bit more thought */
     if(mm == O_RDONLY) {
         f->openfor = OPENFOR_READ;
-        fh[fd].ptr = 0;
+        fd->ptr = 0;
     }
     else if((mm & O_RDWR) || (mm & O_WRONLY)) {
-        if(f->openfor == OPENFOR_READ)
-            goto error_out;
-
         f->openfor = OPENFOR_WRITE;
 
         if(mode & O_APPEND)
-            fh[fd].ptr = f->size;
+            fd->ptr = f->size;
         /* If we're opening with O_TRUNC, kill the existing contents */
         else if(mode & O_TRUNC) {
             free(f->data);
             f->datasize = rd_blksize;
             f->data = malloc(f->datasize);
             f->size = 0;
-            fh[fd].ptr = 0;
+            fd->ptr = 0;
         }
         else
-            fh[fd].ptr = 0;
+            fd->ptr = 0;
     }
     else {
         assert_msg(0, "Unknown file mode");
@@ -365,28 +365,23 @@ static void *ramdisk_open(vfs_handler_t *vfs, const char *fn, int mode) {
 
     /* If we opened a dir, then ptr is actually a pointer to the first
        file entry. */
-    if(mode & O_DIR) {
-        fh[fd].ptr = (uintptr_t)LIST_FIRST((rd_dir_t *)f->data);
-    }
+    if(mode & O_DIR)
+        fd->ptr = (uintptr_t)LIST_FIRST((rd_dir_t *)f->data);
 
     /* Increase the usage count */
     f->usage++;
 
+    /* Now insert the fd into our fd list */
+    TAILQ_INSERT_TAIL(&rd_fd_queue, fd, next);
+
     /* Should do it... */
-    return (void *)fd;
-
-error_out:
-
-    if(fd != -1)
-        fh[fd].file = NULL;
-
-    return NULL;
+    return fd;
 }
 
 /* Close a file or directory */
 static int ramdisk_close(void *h) {
     rd_file_t   *f;
-    file_t      fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     mutex_lock_scoped(&rd_mutex);
 
@@ -396,8 +391,8 @@ static int ramdisk_close(void *h) {
         return 0;
     }
 
-    f = fh[fd].file;
-    fh[fd].file = NULL;
+    f = fd->file;
+    fd->file = NULL;
 
     /* Decrease the usage count */
     f->usage--;
@@ -408,65 +403,69 @@ static int ramdisk_close(void *h) {
     if(f->usage == 0)
         f->openfor = OPENFOR_NOTHING;
 
+    /* Remove fd from the queue, and free it. */
+    TAILQ_REMOVE(&rd_fd_queue, fd, next);
+    free(fd);
+
     return 0;
 }
 
 /* Read from a file */
 static ssize_t ramdisk_read(void *h, void *buf, size_t bytes) {
-    file_t  fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or a dir */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir) {
+    if(ramdisk_fd_invalid(fd) || fd->dir) {
         errno = EBADF;
         return (ssize_t)-1;
     }
 
     /* Is there enough left? */
-    if((fh[fd].ptr + bytes) > fh[fd].file->size)
-        bytes = fh[fd].file->size - fh[fd].ptr;
+    if((fd->ptr + bytes) > fd->file->size)
+        bytes = fd->file->size - fd->ptr;
 
     /* Copy out the requested amount */
-    memcpy(buf, ((uint8_t *)fh[fd].file->data) + fh[fd].ptr, bytes);
-    fh[fd].ptr += bytes;
+    memcpy(buf, ((uint8_t *)fd->file->data) + fd->ptr, bytes);
+    fd->ptr += bytes;
 
     return bytes;
 }
 
 /* Write to a file */
 static ssize_t ramdisk_write(void *h, const void *buf, size_t bytes) {
-    file_t  fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or a dir or not open for writing */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir ||
-        (fh[fd].file->openfor != OPENFOR_WRITE)) {
+    if(ramdisk_fd_invalid(fd) || fd->dir ||
+        (fd->file->openfor != OPENFOR_WRITE)) {
         errno = EBADF;
         return (ssize_t)-1;
     }
 
     /* Is there enough left? */
-    if((fh[fd].ptr + bytes) > fh[fd].file->datasize) {
+    if((fd->ptr + bytes) > fd->file->datasize) {
         /* We need to realloc the block */
-        void *np = realloc(fh[fd].file->data, (fh[fd].ptr + bytes) + (rd_blksize * 4));
+        void *np = realloc(fd->file->data, (fd->ptr + bytes) + (rd_blksize * 4));
 
         if(np == NULL) {
             errno = ENOSPC;
             return -1;
         }
 
-        fh[fd].file->data = np;
-        fh[fd].file->datasize = (fh[fd].ptr + bytes) + (rd_blksize * 4);
+        fd->file->data = np;
+        fd->file->datasize = (fd->ptr + bytes) + (rd_blksize * 4);
     }
 
     /* Copy out the requested amount */
-    memcpy(((uint8_t *)fh[fd].file->data) + fh[fd].ptr, buf, bytes);
-    fh[fd].ptr += bytes;
+    memcpy(((uint8_t *)fd->file->data) + fd->ptr, buf, bytes);
+    fd->ptr += bytes;
 
-    if(fh[fd].file->size < fh[fd].ptr) {
-        fh[fd].file->size = fh[fd].ptr;
+    if(fd->file->size < fd->ptr) {
+        fd->file->size = fd->ptr;
     }
 
     return bytes;
@@ -474,12 +473,12 @@ static ssize_t ramdisk_write(void *h, const void *buf, size_t bytes) {
 
 /* Seek elsewhere in a file */
 static off_t ramdisk_seek(void *h, off_t offset, int whence) {
-    file_t  fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or a dir */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir) {
+    if(ramdisk_fd_invalid(fd) || fd->dir) {
         errno = EBADF;
         return -1;
     }
@@ -492,25 +491,25 @@ static off_t ramdisk_seek(void *h, off_t offset, int whence) {
                 return -1;
             }
 
-            fh[fd].ptr = offset;
+            fd->ptr = offset;
             break;
 
         case SEEK_CUR:
-            if(offset < 0 && ((uint32_t)-offset) > fh[fd].ptr) {
+            if(offset < 0 && ((uint32_t)-offset) > fd->ptr) {
                 errno = EINVAL;
                 return -1;
             }
 
-            fh[fd].ptr += offset;
+            fd->ptr += offset;
             break;
 
         case SEEK_END:
-            if(offset < 0 && ((uint32_t)-offset) > fh[fd].file->size) {
+            if(offset < 0 && ((uint32_t)-offset) > fd->file->size) {
                 errno = EINVAL;
                 return -1;
             }
 
-            fh[fd].ptr = fh[fd].file->size + offset;
+            fd->ptr = fd->file->size + offset;
             break;
 
         default:
@@ -520,72 +519,72 @@ static off_t ramdisk_seek(void *h, off_t offset, int whence) {
 
     /* Check bounds */
     // XXXX: Technically this isn't correct. Fix it sometime.
-    if(fh[fd].ptr > fh[fd].file->size) fh[fd].ptr = fh[fd].file->size;
+    if(fd->ptr > fd->file->size) fd->ptr = fd->file->size;
 
-    return fh[fd].ptr;
+    return fd->ptr;
 }
 
 /* Tell where in the file we are */
 static off_t ramdisk_tell(void *h) {
-    file_t  fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or a dir */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir) {
+    if(ramdisk_fd_invalid(fd) || fd->dir) {
         errno = EBADF;
         return -1;
     }
 
-    return fh[fd].ptr;
+    return fd->ptr;
 }
 
 /* Tell how big the file is */
 static size_t ramdisk_total(void *h) {
-    file_t  fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or a dir */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir) {
+    if(ramdisk_fd_invalid(fd) || fd->dir) {
         errno = EBADF;
         return -1;
     }
 
-    return fh[fd].file->size;
+    return fd->file->size;
 }
 
 /* Read a directory entry */
 static const dirent_t *ramdisk_readdir(void *h) {
     rd_file_t   *f;
-    file_t      fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid, NOT a dir, or empty */
-    if(ramdisk_fd_invalid(fd) || !fh[fd].dir || !fh[fd].ptr) {
+    if(ramdisk_fd_invalid(fd) || !fd->dir || !fd->ptr) {
         errno = EBADF;
         return NULL;
     }
 
     /* Find the current file and advance to the next */
-    f = (rd_file_t *)fh[fd].ptr;
-    fh[fd].ptr = (uintptr_t)LIST_NEXT(f, dirlist);
+    f = (rd_file_t *)fd->ptr;
+    fd->ptr = (uintptr_t)LIST_NEXT(f, dirlist);
 
     /* Copy out the requested data */
-    strcpy(fh[fd].dirent.name, f->name);
-    fh[fd].dirent.time = 0;
+    strcpy(fd->dirent.name, f->name);
+    fd->dirent.time = 0;
 
     if(f->isdir) {
-        fh[fd].dirent.attr = O_DIR;
-        fh[fd].dirent.size = -1;
+        fd->dirent.attr = O_DIR;
+        fd->dirent.size = -1;
     }
     else {
-        fh[fd].dirent.attr = 0;
-        fh[fd].dirent.size = f->size;
+        fd->dirent.attr = 0;
+        fd->dirent.size = f->size;
     }
 
-    return &fh[fd].dirent;
+    return &fd->dirent;
 }
 
 static int ramdisk_unlink(vfs_handler_t *vfs, const char *fn) {
@@ -624,14 +623,14 @@ static int ramdisk_unlink(vfs_handler_t *vfs, const char *fn) {
 }
 
 static void *ramdisk_mmap(void *h) {
-    file_t  fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or a dir */
-    if(ramdisk_fd_invalid(fd) || fh[fd].dir) return NULL;
+    if(ramdisk_fd_invalid(fd) || fd->dir) return NULL;
 
-    return fh[fd].file->data;
+    return fd->file->data;
 }
 
 static int ramdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
@@ -676,7 +675,7 @@ static int ramdisk_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
 }
 
 static int ramdisk_fcntl(void *h, int cmd, va_list ap) {
-    file_t fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     (void)ap;
 
@@ -690,7 +689,7 @@ static int ramdisk_fcntl(void *h, int cmd, va_list ap) {
 
     switch(cmd) {
         case F_GETFL:
-            return fh[fd].omode;
+            return fd->omode;
 
         case F_SETFL:
         case F_GETFD:
@@ -704,24 +703,24 @@ static int ramdisk_fcntl(void *h, int cmd, va_list ap) {
 }
 
 static int ramdisk_rewinddir(void *h) {
-    file_t fd = (file_t)h;
+    rd_fd_t     *fd = h;
 
     mutex_lock_scoped(&rd_mutex);
 
     /* Check that the fd is invalid or NOT a dir */
-    if(ramdisk_fd_invalid(fd) || !fh[fd].dir) {
+    if(ramdisk_fd_invalid(fd) || !fd->dir) {
         errno = EBADF;
         return -1;
     }
 
     /* Rewind to the first file. */
-    fh[fd].ptr = (uintptr_t)LIST_FIRST((rd_dir_t *)fh[fd].file->data);
+    fd->ptr = (uintptr_t)LIST_FIRST((rd_dir_t *)fd->file->data);
 
     return 0;
 }
 
 static int ramdisk_fstat(void *h, struct stat *st) {
-    file_t fd = (file_t)h;
+    rd_fd_t     *fd = h;
     rd_file_t *f;
 
     mutex_lock_scoped(&rd_mutex);
@@ -733,7 +732,7 @@ static int ramdisk_fstat(void *h, struct stat *st) {
     }
 
     /* Grab the file itself... */
-    f = fh[fd].file;
+    f = fd->file;
 
     /* Fill in the structure. */
     memset(st, 0, sizeof(struct stat));
@@ -794,7 +793,7 @@ static vfs_handler_t vh = {
    writing, but it doesn't actually attach the file to an fd, and it starts
    out with data instead of being blank. */
 int fs_ramdisk_attach(const char *fn, void *obj, size_t size) {
-    void        *fd;
+    rd_fd_t     *fd;
     rd_file_t   *f;
 
     /* First of all, open a file for writing. This'll save us a bunch
@@ -805,7 +804,7 @@ int fs_ramdisk_attach(const char *fn, void *obj, size_t size) {
         return -1;
 
     /* Ditch the data block we had and replace it with the user one. */
-    f = fh[(uintptr_t)fd].file;
+    f = fd->file;
     free(f->data);
     f->data = obj;
     f->datasize = size;
@@ -819,7 +818,7 @@ int fs_ramdisk_attach(const char *fn, void *obj, size_t size) {
 
 /* Does the opposite of attach. This again piggybacks on open. */
 int fs_ramdisk_detach(const char *fn, void **obj, size_t *size) {
-    void        *fd;
+    rd_fd_t     *fd;
     rd_file_t   *f;
 
     /* First of all, open a file for reading. This'll save us a bunch
@@ -833,7 +832,7 @@ int fs_ramdisk_detach(const char *fn, void **obj, size_t *size) {
     assert(obj != NULL);
     assert(size != NULL);
 
-    f = fh[(uintptr_t)fd].file;
+    f = fd->file;
     *obj = f->data;
     *size = f->size;
 
@@ -883,8 +882,8 @@ void fs_ramdisk_init(void) {
 
     LIST_INIT(rootdir);
 
-    /* Reset fd's */
-    memset(fh, 0, sizeof(fh));
+    /* Init the list of file descriptors */
+    TAILQ_INIT(&rd_fd_queue);
 
     /* Init thread mutexes */
     mutex_init(&rd_mutex, MUTEX_TYPE_NORMAL);
@@ -895,11 +894,17 @@ void fs_ramdisk_init(void) {
 
 /* De-init the file system */
 void fs_ramdisk_shutdown(void) {
-    rd_file_t *f1, *f2;
+    rd_file_t   *f1, *f2;
+    rd_fd_t     *fd1, *fd2;
 
     /* Test if initted */
     if(rootdir == NULL)
         return;
+
+    /* First free up the open handles */
+    TAILQ_FOREACH_SAFE(fd1, &rd_fd_queue, next, fd2) {
+        ramdisk_close(fd1);
+    }
 
     /* For now assume there's only the root dir, since mkdir and
        rmdir aren't even implemented... */


### PR DESCRIPTION
General cleanup along with a transition to dynamic file handles like #1112 and #973.

- Use `bools` rather than ints where appropriate.
- Cleanups to spacing.
- Refactoring of validity checks.
- De-magic some constants.
- Fixup usage of LIST macros.
- Provide more complete coverage of errno settings to match posix.
- Correct error return for `close`.