### PR TITLE
`maple`: Add attribute to non-NUL-terminated strings.

### DIFF
--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -229,7 +229,7 @@ typedef struct maple_frame {
     This structure is used by the hardware to deliver the response to the device
     info request.
 
-    \note product_name and product_license are not guaranteed to be NULL terminated.
+    \note product_name and product_license are not guaranteed to be NUL terminated.
 
     \headerfile dc/maple.h
 */
@@ -238,8 +238,8 @@ typedef struct maple_devinfo {
     uint32  function_data[3];       /**< \brief Additional data per function */
     uint8   area_code;              /**< \brief Region code */
     uint8   connector_direction;    /**< \brief 0: UP (most controllers), 1: DOWN (lightgun, microphones) */
-    char    product_name[30];       /**< \brief Name of device */
-    char    product_license[60];    /**< \brief License statement */
+    char    product_name[30] __attribute__ ((nonstring));       /**< \brief Name of device */
+    char    product_license[60] __attribute__ ((nonstring));    /**< \brief License statement */
     uint16  standby_power;          /**< \brief Power consumption (standby) */
     uint16  max_power;              /**< \brief Power consumption (max) */
 } maple_devinfo_t;


### PR DESCRIPTION
`maple_devinfo_t::product_*` are stored in the device and are not guaranteed to be NUL-terminated. Since #551 these haven't been force-truncated to ensure that. The attribute should help produce more appropriate warnings when using the struct members.

Additionally adjusted the documentation warning to use the name of the character `NUL` rather than the value `NULL`.

The attribute has been available since at least gcc 9.3 so there shouldn't be any toolchain issues: https://gcc.gnu.org/onlinedocs/gcc-9.3.0/gcc/Common-Variable-Attributes.html#index-nonstring-variable-attribute