### PR TITLE
dc-chain: Update docs and mingw patch for sys/sched.h removal

### DIFF
--- a/utils/dc-chain/doc/mingw/packages/fixup-sh4-newlib.sh
+++ b/utils/dc-chain/doc/mingw/packages/fixup-sh4-newlib.sh
@@ -17,4 +17,3 @@ cp -r $kos_base/kernel/arch/dreamcast/include/dc $newlib_inc
 # they are already "cp" instructions.
 cp $kos_base/include/pthread.h $newlib_inc
 cp $kos_base/include/sys/_pthread.h $newlib_inc/sys
-cp $kos_base/include/sys/sched.h $newlib_inc/sys

--- a/utils/dc-chain/patches/README.md
+++ b/utils/dc-chain/patches/README.md
@@ -25,7 +25,6 @@ Generic `newlib` fixups (applied directly after `newlib` is installed):
 ```
 cp $(kos_base)/include/pthread.h $(newlib_inc)                       # KOS pthread.h is modified
 cp $(kos_base)/include/sys/_pthread.h $(newlib_inc)/sys              # to define _POSIX_THREADS
-cp $(kos_base)/include/sys/sched.h $(newlib_inc)/sys                 # pthreads to kthreads mapping
 ln -nsf $(kos_base)/include/kos $(newlib_inc)                        # so KOS includes are available as kos/file.h
 ln -nsf $(kos_base)/kernel/arch/dreamcast/include/arch $(newlib_inc) # kos/thread.h requires arch/arch.h
 ln -nsf $(kos_base)/kernel/arch/dreamcast/include/dc   $(newlib_inc) # arch/arch.h requires dc/video.h


### PR DESCRIPTION
Cleaning up after the removal of the patch in #1208. The default `sys/sched.h` from newlib is used instead.