### PR TITLE
Misc fixes

### DIFF
--- a/include/kos.h
+++ b/include/kos.h
@@ -39,6 +39,7 @@ __BEGIN_DECLS
 #include <kos/fs_dev.h>
 #include <kos/fs_pty.h>
 #include <kos/limits.h>
+#include <kos/linker.h>
 #include <kos/thread.h>
 #include <kos/sem.h>
 #include <kos/rwsem.h>

--- a/include/kos/linker.h
+++ b/include/kos/linker.h
@@ -1,0 +1,27 @@
+/* KallistiOS ##version##
+
+   include/kos/linker.h
+   Copyright (C) 2025 Paul Cercueil
+*/
+
+/** \file    kos/linker.h
+    \brief   Linker script related definitions and macros.
+    \ingroup linker
+
+    \author Paul Cercueil
+*/
+
+#ifndef __KOS_LINKER_H
+#define __KOS_LINKER_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+#include <stdint.h>
+
+extern uint8_t _bss_start[];
+extern uint8_t end[];
+
+__END_DECLS
+
+#endif /* __KOS_LINKER_H */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -304,4 +304,6 @@ int pvr_set_vertical_scale(float factor) {
     cfg |= FIELD_PREP(PVR_SCALER_CFG_VSCALE_FACTOR, f16);
 
     PVR_SET(PVR_SCALER_CFG, cfg);
+
+    return 0;
 }

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -14,6 +14,7 @@
 #include <kos/dbgio.h>
 #include <kos/dbglog.h>
 #include <kos/init.h>
+#include <kos/linker.h>
 #include <kos/platform.h>
 #include <kos/timer.h>
 #include <arch/arch.h>
@@ -29,8 +30,6 @@
 #include <dc/dcload.h>
 
 #include "initall_hdrs.h"
-
-extern uintptr_t _bss_start, end;
 
 /* ctor/dtor stuff from libgcc. */
 #if __GNUC__ == 4
@@ -281,7 +280,6 @@ void  __weak_symbol arch_auto_shutdown(void) {
 
 /* This is the entry point inside the C program */
 void arch_main(void) {
-    uint8 *bss_start = (uint8 *)(&_bss_start);
     int rv;
 
     dma_init();
@@ -297,7 +295,7 @@ void arch_main(void) {
         __kos_init_early_fn();
 
     /* Clear out the BSS area */
-    memset(bss_start, 0, (uintptr_t)(&end) - (uintptr_t)bss_start);
+    memset(_bss_start, 0, (uintptr_t)end - (uintptr_t)_bss_start);
 
     /* Do auto-init stuff */
     arch_auto_init();


### PR DESCRIPTION
- Mark linker symbols as uint8_t arrays, to avoid a compiler warning.
- Add a missing return in the new `pvr_set_vertical_scale`.