### PR TITLE
CI: Temporarily disable exclusion rule for Markdown files

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -52,7 +52,6 @@ jobs:
             - .github/workflows/build-kos.sh
             - .github/workflows/list-profiles.sh
             - utils/dc-chain/**
-            - '!**/*.md'
 
     - name: build-toolchain
       if: steps.filter.outputs.paths == 'true'


### PR DESCRIPTION
This was added late and is buggy as it causes the toolchain to be built always, even for pull requests that don't touch any toolchain-related or CI-related files.