### PR TITLE
fs: Fix use of uninitialized variable

### DIFF
--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -155,6 +155,7 @@ static fs_hnd_t * fs_hnd_open(const char *fn, int mode) {
     hnd->handler = cur;
     hnd->hnd = h;
     hnd->refcnt = 0;
+    hnd->idx = 0;
 
     return hnd;
 }


### PR DESCRIPTION
The 'idx' field was not initialized when opening a directory, which caused fs_readdir() to behave erratically.