### PR TITLE
examples: Prevent race condition in reentrant mutex thread labels.

### DIFF
--- a/examples/dreamcast/basic/threading/reentrant_mutex/reentrant_mutex.c
+++ b/examples/dreamcast/basic/threading/reentrant_mutex/reentrant_mutex.c
@@ -168,6 +168,9 @@ static void *thread_func(void *arg) {
 
 int main(int argc, const char* argv[]) {
     kthread_t *threads[THREAD_COUNT];
+
+    char thd_label[16];
+    kthread_attr_t attrs = { .label = thd_label };
     
     /* Initialize our mutex */
     reentrant_mutex_init(&rmutex);
@@ -175,12 +178,10 @@ int main(int argc, const char* argv[]) {
     /* Spawn a bunch of threads, potentially yielding the main thread after
        each one gets spawned. */
     for(size_t i = 0; i < THREAD_COUNT; ++i) {
-        threads[i] = thd_create(false, thread_func, NULL);
-
-        char thd_label[16];
         snprintf(thd_label, sizeof(thd_label), "%u", i);
-        thd_set_label(threads[i], thd_label);
- 
+
+        threads[i] = thd_create_ex(&attrs, thread_func, NULL);
+
         maybe_pass();
     }
  


### PR DESCRIPTION
Before the output would print `Hello from thread unnamed!` if it happened to be that the thread routine ran before the call to set the thread label. By having that be passed in on thread creation the label is guaranteed to always be present at the time of that print.

Because it's a thing I had to double check: https://github.com/KallistiOS/KallistiOS/blob/de597f67ecd691074c2b843b14db6a2cb2132a66/kernel/thread/thread.c#L462 `thread_create_ex` does copy the label data rather than just taking the pointer, so it's safe to reuse the buffer in a loop.