### PR TITLE
POSIX: Implement basic `sys/resource.h` support.

### DIFF
--- a/examples/dreamcast/basic/posix_resource/Makefile
+++ b/examples/dreamcast/basic/posix_resource/Makefile
@@ -1,0 +1,24 @@
+#
+# POSIX resource example program
+# Copyright (C) 2026 Donald Haase
+#
+
+NAME = resource
+TARGET = $(NAME).elf
+OBJS = $(NAME).o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $@ $^

--- a/examples/dreamcast/basic/posix_resource/resource.c
+++ b/examples/dreamcast/basic/posix_resource/resource.c
@@ -1,0 +1,124 @@
+/* KallistiOS ##version##
+
+   resource.c
+   Copyright (C) 2026 Donald Haase
+*/
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <sys/resource.h>
+
+#include <kos.h>
+
+struct priority_data {
+    int rv;
+    int which;
+    id_t who;
+    int value; /* Only when setting */
+};
+
+/* Samples for a plain test of getpriority() */
+static struct priority_data gp_samples[] = {
+    {0, PRIO_PROCESS, 0},
+    {0, PRIO_PGRP, 0},
+    {0, PRIO_USER, 0},
+    {-1, 42, 0},
+    {-1, PRIO_USER, 1}
+};
+
+/* Samples for testing setpriority */
+static struct priority_data sp_samples[] = {
+    {0, PRIO_PROCESS, 0, 77},
+    {-1, 42, 0, 99},
+    {-1, PRIO_USER, 1, 101}
+};
+
+int main(int argc, char **argv) {
+    int retval = EXIT_SUCCESS;
+
+    printf("First testing out getpriority()\n");
+
+    for(int i = 0; i < __array_size(gp_samples); i++) {
+        int rv = gp_samples[i].rv;
+        int which = gp_samples[i].which;
+        id_t who = gp_samples[i].who;
+
+        int actual_rv = getpriority(which, who);
+
+        if(rv != actual_rv) {
+            fprintf(stderr, "FAILED: ");
+            retval = EXIT_FAILURE;
+        }
+        else
+            printf("PASSED: ");
+
+        printf("getpriority(%i, %lu) expected %i got %i\n", which,
+            who, rv, actual_rv);
+    }
+
+    printf("Next testing out setpriority()\n");
+
+    for(int i = 0; i < __array_size(sp_samples); i++) {
+        int rv = sp_samples[i].rv;
+        int which = sp_samples[i].which;
+        id_t who = sp_samples[i].who;
+        int value = sp_samples[i].value;
+
+        int actual_rv = setpriority(which, who, value);
+
+        if(rv != actual_rv) {
+            fprintf(stderr, "FAILED: ");
+            retval = EXIT_FAILURE;
+        }
+        else
+            printf("PASSED: ");
+
+        printf("setpriority(%i, %lu, %i) expected %i got %i\n", which,
+            who, value, rv, actual_rv);
+
+        actual_rv = getpriority(which, who);
+
+        /* If the failure happens when failure is expected, it's a pass */
+        if((actual_rv != value) != (rv == -1)) {
+            fprintf(stderr, "FAILED: ");
+            retval = EXIT_FAILURE;
+        }
+        else
+            printf("PASSED: ");
+
+        printf("getpriority(%i, %lu) expected %i got %i\n", which,
+            who, value, actual_rv);
+    }
+
+    printf("Last testing out getrusage()\n");
+
+    struct rusage use;
+
+    int getrv = getrusage(RUSAGE_CHILDREN, &use);
+
+    /* Everything should be 0 for 'children' */
+    if(getrv || use.ru_utime.tv_sec || use.ru_utime.tv_usec ||
+            use.ru_stime.tv_sec || use.ru_stime.tv_usec) {
+        fprintf(stderr, "FAILED: ");
+        retval = EXIT_FAILURE;
+    }
+    else
+        printf("PASSED: ");
+
+    /* Reset our r_usage */
+    memset(&use, 0, sizeof(use));
+
+    getrv = getrusage(RUSAGE_SELF, &use);
+
+    printf("getrusage(RUSAGE_SELF, &use) times: \n"
+            "utime: %llus and %luu\n"
+            "stime: %llus and %luu\n"
+            "Total system time: %lluu\n",
+            use.ru_utime.tv_sec, use.ru_utime.tv_usec,
+            use.ru_stime.tv_sec, use.ru_stime.tv_usec,
+            timer_ns_gettime64() / 1000);
+
+    return retval;
+}

--- a/examples/dreamcast/readme.md
+++ b/examples/dreamcast/readme.md
@@ -11,6 +11,7 @@ This page serves as an index for all KallistiOS examples.
   - gdb_breaking
   - memtest32
   - mmu
+  - posix_resource
   - stackprotector
   - stacktrace
   - threading

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -667,11 +667,11 @@ struct _reent *thd_get_reent(kthread_t *thd);
     \relatesalso kthread_t
 
     Returns the amount of active CPU time the thread has consumed in
-    nanoseconds.
+    milliseconds.
 
     \param thd          The thead to retrieve the CPU time for.
 
-    \retval             Total utilized CPU time in nanoseconds.
+    \retval             Total utilized CPU time in milliseconds.
 */
 uint64_t thd_get_cpu_time(kthread_t *thd);
 
@@ -679,9 +679,9 @@ uint64_t thd_get_cpu_time(kthread_t *thd);
     \relatesalso kthread_t
 
     Returns the amount of active CPU time all threads have consumed in
-    nanoseconds.
+    milliseconds.
 
-    \retval             Total utilized CPU time in nanoseconds.
+    \retval             Total utilized CPU time in milliseconds.
 */
 uint64_t thd_get_total_cpu_time(void);
 

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -1,0 +1,155 @@
+/* KallistiOS ##version##
+
+   sys/resource.h
+   Copyright (C) 2025 Donald Haase
+*/
+
+/** \file   sys/resource.h
+    \brief  Basic definitions for resource operations
+
+    This file provides a basic implementation of the POSIX/XSI
+    standard for resource operations. These are meant to be
+    per-process, so are basically stubs for the purposes of KOS
+    which is single-process.
+*/
+
+#ifndef __SYS_RESOURCE_H
+#define __SYS_RESOURCE_H
+
+__BEGIN_DECLS
+
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+/* Possible values for the `which` argument of
+    `getpriority()` and`setpriority()` */
+enum {
+    PRIO_PROCESS,
+    PRIO_PGRP,
+    PRIO_USER
+};
+
+/** \brief  Obtain the nice value of a process, process group, or user.
+
+    In KOS we don't have a concept currently of any of these things, so
+    this is effectively a stub that will only return a value if requested
+    for the default/current id.
+
+    \param  which   Which type of ID to get the nice value of.
+    \param  who     Only 0 is currently valid.
+    \retval 0       On success.
+    \retval -1      On error, errno will be set as appropriate.
+
+    \par    Error Conditions:
+    \em     EINVAL - `which` was an invalid value.
+    \em     EINVAL - `who` was a value other than 0.
+*/
+int getpriority(int which, id_t who);
+
+/** \brief  Sets the nice value of a process, process group, or user.
+
+    In KOS we don't have a concept currently of any of these things, so
+    this is effectively a stub that will only set a value if requested
+    for the default/current id. This also currently has no impact aside
+    from changing the return of `getpriority`.
+
+    \param  which   Which type of ID to set the nice value of.
+    \param  who     Only 0 is currently valid.
+    \param  value   nice value to set.
+    \retval 0       On success.
+    \retval -1      On error, errno will be set as appropriate.
+
+    \par    Error Conditions:
+    \em     EINVAL - `which` was an invalid value.
+    \em     EINVAL - `who` was a value other than 0.
+*/
+int setpriority(int which, id_t who, int value);
+
+/* An unsigned integer type used for limit values */
+typedef unsigned int rlim_t;
+
+#define RLIM_INFINITY UINT_MAX
+#define RLIM_SAVED_MAX RLIM_INFINITY
+#define RLIM_SAVED_CUR RLIM_INFINITY
+
+struct rlimit {
+    rlim_t rlim_cur;    /* The current (soft) limit. */
+    rlim_t rlim_max;    /* The hard limit. */
+};
+
+/* Possible values for the `resource` argument of
+    `getrlimit()` and`setrlimit()` */
+enum {
+    RLIMIT_CORE,    /* Limit on size of core image. */
+    RLIMIT_CPU,     /* Limit on CPU time per process. */
+    RLIMIT_DATA,    /* Limit on data segment size. */
+    RLIMIT_FSIZE,   /* Limit on file size. */
+    RLIMIT_NOFILE,  /* Limit on number of open files. */
+    RLIMIT_STACK,   /* Limit on stack size. */
+    RLIMIT_AS       /* Limit on address space size. */
+};
+
+/** \brief  Gets the maximum resource consumption limits.
+
+    Everything will return `RLIM_INFINITY` as we impose no such
+    limits.
+
+    \param  resource   The type of resource to get the rlimit for.
+    \param  rlp        Where to place the rlimit data.
+
+    \retval 0       On success.
+    \retval -1      On error, errno will be set as appropriate.
+
+    \par    Error Conditions:
+    \em     EINVAL - `resource` was an invalid value.
+*/
+int getrlimit(int resource, struct rlimit *rlp);
+
+/** \brief  Sets the maximum resource consumption limits.
+
+    Just a stub. Errors on bad input, otherwise always succeeds.
+
+    \param  resource   The type of resource to set the rlimit for.
+    \param  rlp        Ignored.
+
+    \retval 0       On success.
+    \retval -1      On error, errno will be set as appropriate.
+
+    \par    Error Conditions:
+    \em     EINVAL - `resource` was an invalid value.
+*/
+int setrlimit(int resource, const struct rlimit *rlp);
+
+/* Possible values for the `who` argument of `getrusage()` */
+enum {
+    RUSAGE_SELF,    /* Returns information about the current process. */
+    RUSAGE_CHILDREN /* Returns information about children of the current process. */
+};
+
+struct rusage {
+    struct timeval ru_utime;    /* user time used */
+    struct timeval ru_stime;    /* system time used */
+};
+
+/** \brief  Get information about cpu utilization.
+
+    For the purposes of this function, KOS is treated as having a
+    single process that all threads are running under. As such `RUSAGE_SELF`
+    will return user time that is the sum of all living threads and
+    system time that is all the rest (IRQs + dead threads).
+    `RUSAGE_CHILDREN` will return zero.
+
+    \param  who     `RUSAGE_SELF` or `RUSAGE_CHILDREN`.
+    \param  r_usage rusage data to be filled.
+    \retval 0       On success.
+    \retval -1      On error, errno will be set as appropriate.
+
+    \par    Error Conditions:
+    \em     EINVAL - `who` was an invalid value.
+*/
+int getrusage(int who, struct rusage *r_usage);
+
+__END_DECLS
+
+#endif /* !__SYS_RESOURCE_H */

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -11,6 +11,6 @@
 #
 
 CFLAGS += -std=gnu11
-OBJS = posix_memalign.o clock_gettime.o settimeofday.o sysconf.o
+OBJS = posix_memalign.o clock_gettime.o settimeofday.o sysconf.o resource.o
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/posix/resource.c
+++ b/kernel/libc/posix/resource.c
@@ -1,0 +1,89 @@
+/* KallistiOS ##version##
+
+   resource.c
+   Copyright (C) 2025 Donald Haase
+*/
+
+#include <errno.h>
+#include <kos/thread.h>
+#include <kos/timer.h>
+#include <sys/resource.h>
+
+static int priorities[PRIO_USER + 1] = { 0 };
+
+int getpriority(int which, id_t who) {
+    if(who || (which > PRIO_USER) || (which < PRIO_PROCESS)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return priorities[which];
+}
+
+int setpriority(int which, id_t who, int value) {
+    if(who || (which > PRIO_USER) || (which < PRIO_PROCESS)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    priorities[which] = value;
+    return 0;
+}
+
+int getrlimit(int resource, struct rlimit *rlp) {
+    if((resource > RLIMIT_AS) || (resource < RLIMIT_CORE)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    rlp->rlim_cur = RLIM_INFINITY;
+    rlp->rlim_max = RLIM_INFINITY;
+    return 0;
+}
+
+int setrlimit(int resource, const struct rlimit *rlp) {
+    (void)rlp;
+
+    if((resource > RLIMIT_AS) || (resource < RLIMIT_CORE)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* Do nothing */
+    return 0;
+}
+
+/* The structure of this is based around thd_pslist */
+int getrusage(int who, struct rusage *r_usage) {
+    uint64_t ms_time, cpu_total = 0;
+
+    if((who > RUSAGE_CHILDREN) || (who < RUSAGE_SELF)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* No child processes in KOS */
+    if(who == RUSAGE_CHILDREN) {
+        r_usage->ru_utime.tv_sec  = 0;
+        r_usage->ru_utime.tv_usec = 0;
+
+        r_usage->ru_stime.tv_sec  = 0;
+        r_usage->ru_stime.tv_usec = 0;
+
+        return 0;
+    }
+
+    irq_disable_scoped();
+    ms_time = timer_ms_gettime64();
+
+    cpu_total = thd_get_total_cpu_time();
+    ms_time -= cpu_total;
+
+    r_usage->ru_utime.tv_sec  = cpu_total / 1000;
+    r_usage->ru_utime.tv_usec = (cpu_total % 1000) * 1000;
+
+    r_usage->ru_stime.tv_sec  = ms_time / 1000;
+    r_usage->ru_stime.tv_usec = (ms_time % 1000) * 1000;
+
+    return 0;
+}


### PR DESCRIPTION
The majority are merely stubs that have have no effect. `getrusage` can provide usage information. These are being added to help smooth build compatibility for projects that expect them to exist.

While creating the example noticed that some of our documentation had gone stale regarding the cpu time tracking and updated that.