### PR TITLE
RFC: Support for reading argc/argv

### DIFF
--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -74,6 +74,7 @@ __BEGIN_DECLS
     KOS_INIT_FLAG(flags, INIT_LIBRARY, library_init); \
     KOS_INIT_FLAG(flags, INIT_LIBRARY, library_shutdown); \
     KOS_INIT_FLAG_NONE(flags, INIT_NO_SHUTDOWN, kos_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_ARGS, args_init); \
     KOS_INIT_FLAGS_ARCH(flags)
 
 #define __KOS_INIT_FLAGS_1(flags) \
@@ -166,6 +167,7 @@ extern const void * __kos_romdisk;
 #define INIT_FS_RND      0x00000200  /**< Enable support for /dev/urandom VFS */
 
 #define INIT_NO_SHUTDOWN 0x00000400  /**< Disable hardware shutdown */
+#define INIT_ARGS        0x00000800  /**< Enable reading argc/argv */
 /** @} */
 
 __END_DECLS

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -154,12 +154,48 @@ KOS_INIT_FLAG_WEAK(fs_rnd_shutdown, true);
 KOS_INIT_FLAG_WEAK(library_init, true);
 KOS_INIT_FLAG_WEAK(library_shutdown, true);
 
+struct args_data {
+    size_t args_size;
+    int argc;
+    char **argv;
+};
+
+static struct args_data __default_args = { 0, 0, NULL };
+static struct args_data *__args = &__default_args;
+
+/* Look for argc/argv. It's expected that a loader will pass a size_t
+at `end` which will set the amount of bytes to follow that needs to be
+set aside on the heap after the program data. 0 indicates none. */
+void args_init(void) {
+    /* Start by setting this up to test if it has data */
+    __args = (struct args_data *)end;
+
+    /* Try to set aside memory for the args */
+    if((__args->args_size == 0) ||
+        (mm_sbrk(__args->args_size) == (void *)-1)) {
+        /* Currently there's no error response we can provide. dbgio_init
+            has the chance of needing to malloc for serial cable. So we just
+            set ourselves back to the default. */
+            __args = &__default_args;
+            return;
+    }
+
+    /* We were able to set the heap to start after all the args data, so
+        nothing more to do. */
+    return;
+}
+
+KOS_INIT_FLAG_WEAK(args_init, true);
+
 /* Auto-init stuff: override with a non-weak symbol if you don't want all of
    this to be linked into your code (and do the same with the
    arch_auto_shutdown function too). */
 int  __weak_symbol arch_auto_init(void) {
     /* Initialize memory management */
     mm_init();
+
+    /* Prepare argc/argv if available */
+    KOS_INIT_FLAG_CALL(args_init);
 
     /* Do this immediately so we can receive exceptions for init code
        and use ints for dbgio receive. */
@@ -308,7 +344,7 @@ void arch_main(void) {
     _init();
 
     /* Call the user's main function */
-    rv = main(0, NULL);
+    rv = main(__args->argc, __args->argv);
 
     /* Call kernel exit */
     exit(rv);


### PR DESCRIPTION
This required a tiny cleanup in mm.c (and I went ahead and did a full cleanup instead). The basic idea is that a loader would follow the loaded program data with at least one 4-byte value at `end` that will describe the total number of bytes after the program data that will be taken up by arg data. We then adjust sbrk so that this memory region is safe from being overwritten.

There's probably some much better way to do this, but I wanted to open the discussion with something that seemed workable (if a bit manual). In order to be useful this would also require some updating to `exec` and `dcload` and would support #865  as we could then define any number of kos or arch level command line inputs that a loader could pass in.

Some alternatives I'd considered:
- Drop the data at the very top of memory ahead of the initial stack, but this would mean a lot of fiddling around in sensitive parts of the code, and (as far as I can see) be basically the same as this just swapping `arch_mem_top` for `end` and not being able to reuse `sbrk`.
- Have a new 'syscall' that could be polled and would return just argc/argv, but that would still leave the problem of where the data would be so that it would be safe from interfering with internal memory management.
- Have a new 'syscall' that requested the data and received the full contents of the arguments. This would avoid the memory management issues as it could be done much later in startup and just be malloc'd data, but would basically require dcload. A self-contained loader (like a compilation disc, one the main potential use cases) would have to be as sophisticated, and would still have to have it's own way to pull the data from somewhere like a vfs.
- Have the args data stored in vfs. This would avoid a lot of the other issues above, but just didn't seem right. It could have the effect of not allowing vfs remapping which would be a key kind of use case, and unless it was baked into the user-side (which would somewhat defeat the purpose) there would have to be a whole 'find the file' process of searching through all the vfses and such.