### PR TITLE
Add a color selection method to the minifont system

### DIFF
--- a/kernel/arch/dreamcast/include/dc/minifont.h
+++ b/kernel/arch/dreamcast/include/dc/minifont.h
@@ -29,7 +29,6 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
-#include <arch/types.h>
 #include <stdint.h>
 
 /** \defgroup video_fonts_mini Mini
@@ -49,7 +48,7 @@ __BEGIN_DECLS
 
     \return                 Amount of width covered in 16-bit increments.
 */
-int minifont_draw(uint16 *buffer, uint32 bufwidth, uint32 c);
+int minifont_draw(uint16_t *buffer, uint32_t bufwidth, uint32_t c);
 
 /** \brief  Draw a full string to any sort of buffer.
 
@@ -63,7 +62,7 @@ int minifont_draw(uint16 *buffer, uint32 bufwidth, uint32 c);
 
     \return                 Amount of width covered in 16-bit increments.
 */
-int minifont_draw_str(uint16 *b, uint32 bufwidth, const char *str);
+int minifont_draw_str(uint16_t *b, uint32_t bufwidth, const char *str);
 
 /** \brief  Set the color for the mini font.
     \param  r               Red component (0-255)

--- a/kernel/arch/dreamcast/util/minifont.c
+++ b/kernel/arch/dreamcast/util/minifont.c
@@ -21,10 +21,10 @@ void minifont_set_color(uint8_t r, uint8_t g, uint8_t b) {
     textcolor = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b & 0xF8) >> 3;
 }
 
-int minifont_draw(uint16 *buffer, uint32 bufwidth, uint32 c) {
+int minifont_draw(uint16_t *buffer, uint32_t bufwidth, uint32_t c) {
     int pos, i, j, k;
-    uint8 byte;
-    uint16 *cur;
+    uint8_t byte;
+    uint16_t *cur;
 
     if(c < 33 || c > 126)
         return CHAR_WIDTH;
@@ -51,7 +51,7 @@ int minifont_draw(uint16 *buffer, uint32 bufwidth, uint32 c) {
     return CHAR_WIDTH;
 }
 
-int minifont_draw_str(uint16 *buffer, uint32 bufwidth, const char *str) {
+int minifont_draw_str(uint16_t *buffer, uint32_t bufwidth, const char *str) {
     char c;
     int adv = 0;
 


### PR DESCRIPTION
Since I've done some rumble work on Star Fox 64 and Doom 64, I'd like to work on or help #1185 but the way it is structured makes it difficult, so I'm splitting it up.

This is @dfchil 's commit for adding a color selection to the minifont system, introduced as its own distinct PR, and since it left half of the file using standard types and the other half using old KOS types, I also updated the source to just use standard types now.