### PR TITLE
git: Add `subarch_exports.c` to `.gitignore`.

### DIFF
--- a/kernel/arch/dreamcast/kernel/.gitignore
+++ b/kernel/arch/dreamcast/kernel/.gitignore
@@ -1,1 +1,2 @@
 arch_exports.c
+subarch_exports.c


### PR DESCRIPTION
As a generated file, we should ensure git can see it.