### PR TITLE
Tls cleanup (no more spinlocks)

### DIFF
--- a/include/kos/tls.h
+++ b/include/kos/tls.h
@@ -117,11 +117,6 @@ int kthread_setspecific(kthread_key_t key, const void *value);
 */
 int kthread_key_delete(kthread_key_t key);
 
-/** \cond */
-/* Delete the destructor for a given key. This function is for internal use
-   only! */
-void kthread_key_delete_destructor(kthread_key_t key);
-
 /* Initialization and shutdown. Once again, internal use only. */
 int kthread_tls_init(void);
 void kthread_tls_shutdown(void);

--- a/kernel/thread/tls.c
+++ b/kernel/thread/tls.c
@@ -73,7 +73,8 @@ int kthread_key_create(kthread_key_t *key, void (*destructor)(void *)) {
     kthread_tls_dest_t *dest;
 
     if(irq_inside_int() &&
-       (spinlock_is_locked(&mutex) || !malloc_irq_safe())) {
+       (spinlock_is_locked(&mutex) ||
+       (destructor && !malloc_irq_safe()))) {
         errno = EPERM;
         return -1;
     }

--- a/kernel/thread/tls.c
+++ b/kernel/thread/tls.c
@@ -122,7 +122,8 @@ int kthread_setspecific(kthread_key_t key, const void *value) {
     kthread_t *cur = thd_get_current();
     kthread_tls_kv_t *i;
 
-    if(irq_inside_int() && spinlock_is_locked(&mutex)) {
+    if(irq_inside_int() &&
+       (spinlock_is_locked(&mutex) || !malloc_irq_safe())) {
         errno = EPERM;
         return -1;
     }

--- a/kernel/thread/tls.c
+++ b/kernel/thread/tls.c
@@ -173,12 +173,8 @@ int kthread_tls_init(void) {
 void kthread_tls_shutdown(void) {
     kthread_tls_dest_t *n1, *n2;
 
-    /* Tear down the destructor list. */
-    n1 = LIST_FIRST(&dest_list);
-
-    while(n1 != NULL) {
-        n2 = LIST_NEXT(n1, dest_list);
+    LIST_FOREACH_SAFE(n1, &dest_list, dest_list, n2) {
+        LIST_REMOVE(n1, dest_list);
         free(n1);
-        n1 = n2;
     }
 }

--- a/kernel/thread/tls.c
+++ b/kernel/thread/tls.c
@@ -38,7 +38,7 @@ static struct kthread_tls_dest_list dest_list;
 static mutex_t dlist_mtx;
 
 /* What is the next key that will be given out? */
-kthread_key_t kthread_key_next(void) {
+static kthread_key_t kthread_key_next(void) {
     return next_key;
 }
 


### PR DESCRIPTION
- Add a check for possible malloc use in IRQ that was missing in key setting.
- Update check for possible malloc use in IRQ for key creation to only apply if malloc will be needed.
- Use `LIST_FOREACH_SAFE` rather than replicating the macro by pieces.
- Move `kthread_key_delete` from thread.c to tls.c.
- Replace spinlock with an atomic to protect the key counter and a mutex to protect the destructor list.
- Clean up and update documentation, reduce unnecessary exposure of internal API.