### PR TITLE
elf: Adjust debug verbosity.

### DIFF
--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -59,6 +59,9 @@ __BEGIN_DECLS
 /* Enable debugging in fs_vmu. */
 /* #define VMUFS_DEBUG 1 */
 
+/* Enable verbose debugging in elf loading. */
+/* #define ELF_DBG_VERBOSE 1 */
+
 /* Enable to allow extra debugging checks in the malloc code itself. This
    sometimes catches corrupted blocks. Recommended during debugging phases. */
 /* #define MALLOC_DEBUG 1 */


### PR DESCRIPTION
Prior to #1116 this debug output had been gated by a define in the elf.c source. Now that we have the dbg source option for dbglog, leverage that to prevent the overly verbose debug from being outputted even in KDEBUG.

Edit: per feedback via discord, dropped the change of the summary outputs to `DBG_INFO`.