### PR TITLE
Fix initialization of Broadband Adapter and LAN adapter

### DIFF
--- a/include/kos/init.h
+++ b/include/kos/init.h
@@ -52,8 +52,8 @@ __BEGIN_DECLS
     const uint32_t __kos_init_flags = (flags); \
     KOS_INIT_FLAG(flags, INIT_NET, arch_init_net); \
     KOS_INIT_FLAG(flags, INIT_NET, net_shutdown); \
-    KOS_INIT_FLAG(flags, INIT_NET, bba_la_init); \
-    KOS_INIT_FLAG(flags, INIT_NET, bba_la_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_NET, eth_init); \
+    KOS_INIT_FLAG(flags, INIT_NET, eth_shutdown); \
     KOS_INIT_FLAG(flags, INIT_FS_ROMDISK, fs_romdisk_init); \
     KOS_INIT_FLAG(flags, INIT_FS_ROMDISK, fs_romdisk_shutdown); \
     KOS_INIT_FLAG(flags, INIT_FS_NULL, fs_null_init); \


### PR DESCRIPTION
After PR #1261, the Broadband Adapter and LAN adapter were no longer properly initialized due to the wrong functions being called in the KOS_INIT_FLAGS macros. Fixes #1267