### PR TITLE
example: gdb usage

### DIFF
--- a/examples/dreamcast/basic/gdb_breaking/Makefile
+++ b/examples/dreamcast/basic/gdb_breaking/Makefile
@@ -1,0 +1,30 @@
+# KallistiOS ##version##
+#
+# examples/dreamcast/basic/gdb_breaking/Makefile
+# Copyright (c) 2025 Donald Haase
+#
+
+NAME = gdb_breaking
+TARGET = $(NAME).elf
+OBJS = $(NAME).o
+
+
+include $(KOS_BASE)/Makefile.rules
+
+all: rm-elf $(TARGET)
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist: $(TARGET)
+	-rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/basic/gdb_breaking/gdb_breaking.c
+++ b/examples/dreamcast/basic/gdb_breaking/gdb_breaking.c
@@ -1,0 +1,42 @@
+/* KallistiOS ##version##
+
+   gdb_breaking.c
+   Copyright (C) 2025 Donald Haase
+
+*/
+
+/*  This program demonstrates setting up a debugging connection with KOS to
+    a host-side gdb server. If sending using dc-tool, you must pass the `-g`
+    flag to enable connection to the gdb server. Alternatively, this will
+    attempt to establish the gdb connection over the scif port directly.
+
+    Once this program is sent to the DC or emulator, you'd start up `kos-gdb`
+    or gdb-multiarch and pass it the elf to the program so that it can see
+    symbols in it. gdb will inform of each of the two breakpoints below and
+    allow you to inspect the local variables and states by using commands like
+    `where full` and moving on from the breakpoint with `continue`.
+*/
+
+#include <arch/gdb.h>
+#include <kos/dbglog.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdalign.h>
+
+int main(int argc, char* argv[]) {
+    size_t step = 0;
+
+    /* Initialize the connection. This informs dc-tool to connect in
+    gdb, or sets up the scif connection, then installs the various IRQ
+    handlers needed for monitoring and breaking. Then it breaks. */
+    dbglog(DBG_INFO, "Step %u: call gdb_init()\n", ++step);
+    gdb_init();
+
+    /* Now try a manual gdb breakpoint */
+    dbglog(DBG_INFO, "Step %u: call gdb_breakpoint()\n", ++step);
+    gdb_breakpoint();
+
+    return step;
+}


### PR DESCRIPTION
Simple example showing how to initialize gdb and trigger a manual breakpoint in code.

Sample output on console + gdb output:

```
KallistiOS v2.2.2 [dreamcast/pristine]
  Git revision: 9c150b5b
  Thu Dec 25 08:31:01 PM EST 2025
  quzar@Centurion-IV.localdomain:/home/quzar/dcdev/KallistiOS
  sh-elf-gcc (GCC) 14.3.0
maple: active drivers:
    Dreameye (Camera): Camera
    Sound Input Peripheral: Microphone
    PuruPuru (Vibration) Pack: JumpPack
    VMU Driver: Clock, LCD, MemoryCard
    Mouse Driver: Mouse
    Keyboard Driver: Keyboard
    Controller Driver: Controller
    Lightgun: LightGun
  DMA Buffer at ac074f00
vid_set_mode: 640x480 VGA with 1 framebuffers.
dc-load console support enabled
maple: attached devices:
  A0: Dreamcast Controller           (01000000: Controller)
  A1: Visual Memory                  (0e000000: Clock, LCD, MemoryCard)
  A2: Puru Puru Pack                 (00010000: JumpPack)

Step 1: call gdb_init()
waiting for gdb client connection...
Step 2: call gdb_breakpoint()

arch: exit return code 2
arch: shutting down kernel
vid_set_mode: 640x480 VGA with 1 framebuffers.
```

```
quzar@Centurion-IV:~/dcdev/KallistiOS/examples/dreamcast/basic/gdb_breaking$ kos-gdb ./gdb_breaking.elf
GNU gdb (GDB) 16.3
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-pc-linux-gnu --target=sh-elf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
The target architecture is set to "sh4".
Remote debugging using 127.0.0.1:2159

warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
0x2c35018c in ?? ()
Reading symbols from /home/quzar/dcdev/KallistiOS/examples/dreamcast/basic/gdb_breaking/gdb_breaking.elf...
(gdb) where full
#0  gdb_init () at gdb_stub.c:950
No locals.
#1  0x8c01014e in main (argc=<optimized out>, argv=<optimized out>) at gdb_breaking.c:35
        step = 1
(gdb) continue
Continuing.

Program received signal SIGTRAP, Trace/breakpoint trap.
gdb_breakpoint () at gdb_stub.c:853
853         BREAKPOINT();
(gdb) where full
#0  gdb_breakpoint () at gdb_stub.c:853
No locals.
#1  0x8c01015e in main (argc=<optimized out>, argv=<optimized out>) at gdb_breaking.c:39
        step = 2
(gdb) continue
Continuing.
Remote connection closed