### PR TITLE
atomics: Ensure builtins unavailable before declaring.

### DIFF
--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -92,17 +92,39 @@
         return ret;  \
     }
 
-/* GCC provides us with all primitive atomics except for 64-bit types. */
-ATOMIC_LOAD_N_(unsigned long long, 8)
-ATOMIC_STORE_N_(unsigned long long, 8)
-ATOMIC_EXCHANGE_N_(unsigned long long, 8)
-ATOMIC_COMPARE_EXCHANGE_N_(unsigned long long, 8)
-ATOMIC_FETCH_N_(unsigned long long, 8, add, +=)
-ATOMIC_FETCH_N_(unsigned long long, 8, sub, -=)
-ATOMIC_FETCH_N_(unsigned long long, 8, and, &=)
-ATOMIC_FETCH_N_(unsigned long long, 8, or, |=)
-ATOMIC_FETCH_N_(unsigned long long, 8, xor, ^=)
-ATOMIC_FETCH_NAND_N_(unsigned long long, 8)
+/* GCC, for some targets (such as SH4), is missing 64-bit types. 
+    provide them if they aren't already defined.
+*/
+#if !__has_builtin(__atomic_load_8)
+    ATOMIC_LOAD_N_(unsigned long long, 8)
+#endif
+#if !__has_builtin(__atomic_store_8)
+    ATOMIC_STORE_N_(unsigned long long, 8)
+#endif
+#if !__has_builtin(__atomic_exchange_8)
+    ATOMIC_EXCHANGE_N_(unsigned long long, 8)
+#endif
+#if !__has_builtin(__atomic_compare_exchange_8)
+    ATOMIC_COMPARE_EXCHANGE_N_(unsigned long long, 8)
+#endif
+#if !__has_builtin(__atomic_fetch_add_8)
+    ATOMIC_FETCH_N_(unsigned long long, 8, add, +=)
+#endif
+#if !__has_builtin(__atomic_fetch_sub_8)
+    ATOMIC_FETCH_N_(unsigned long long, 8, sub, -=)
+#endif
+#if !__has_builtin(__atomic_fetch_and_8)
+    ATOMIC_FETCH_N_(unsigned long long, 8, and, &=)
+#endif
+#if !__has_builtin(__atomic_fetch_or_8)
+    ATOMIC_FETCH_N_(unsigned long long, 8, or, |=)
+#endif
+#if !__has_builtin(__atomic_fetch_xor_8)
+    ATOMIC_FETCH_N_(unsigned long long, 8, xor, ^=)
+#endif
+#if !__has_builtin(__atomic_fetch_nand_8)
+    ATOMIC_FETCH_NAND_N_(unsigned long long, 8)
+#endif
 
 /* Provide GCC with symbols and logic required to implement
    generically sized atomics. Rather than disabling an enabling


### PR DESCRIPTION
On non-sh4 based platforms, these may be available, and defining them unconditionally would lead to a conflict. This was found by trying to build for x86-64 on the [`null_arch`](https://github.com/KallistiOS/KallistiOS/commits/null_arch/) branch

@darcagn not sure how these have worked out for PPC so far. It seems though that they can normally be overridden without gcc complaining, and I only noticed it was happening because the prototypes were different for x86-64 and gave a warning. It may be the case that the whole file should be gated or moved over into the dc arch.

@gyrovorbis do you happen to know on the dc how these interact with a non soft-imask model? It *might* be that these are overriding or doubling up with the gusa system when that's being used, both adding the gusa guardrails *and* disabling irqs by calling these. I think we missed raising the question when we switched. Hopefully it's not a problem but would be good to be sure and at least maybe update the comments in this atomics file too.

Edit: Addressed in #1314 