### PR TITLE
cmake: Restore include dirs for compatibility.

### DIFF
--- a/utils/cmake/kallistios.toolchain.cmake
+++ b/utils/cmake/kallistios.toolchain.cmake
@@ -99,3 +99,13 @@ endif()
 if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
     set(CMAKE_INSTALL_LIBDIR ${KOS_ADDONS}/lib/${KOS_ARCH})
 endif()
+
+# Ensure our default include paths are set
+set(CMAKE_SYSTEM_INCLUDE_PATH   "${CMAKE_SYSTEM_INCLUDE_PATH} ${KOS_BASE}/include ${KOS_BASE}/kernel/arch/${KOS_ARCH}/include ${KOS_BASE}/addons/include ${KOS_PORTS}/include")
+
+include_directories(
+    ${KOS_BASE}/include
+    ${KOS_BASE}/kernel/arch/${KOS_ARCH}/include
+    ${KOS_BASE}/addons/include
+    ${KOS_PORTS}/include
+)


### PR DESCRIPTION
Before #501 core functionality of compilation required them, and after the fixing up of the toolchain they weren't needed for that anymore. But as reported in #886 this broke CLion (and may well break other functionality) that relies on these being available to be able to find includes.

I tested this with rebuilding the cmake-reliant kos-ports. Not sure though if there are downsides to readding these or if they were removed entirely as cleanup.

- Testing from @kouta-kun showed this did not correct the issue.