### PR TITLE
Expand @-style parameters to fix CLion compatibility (#886)

### DIFF
--- a/utils/build_wrappers/kos-cc
+++ b/utils/build_wrappers/kos-cc
@@ -5,6 +5,13 @@ ARGS=$*
 USEMODE=0
 for i in $ARGS; do
 	case "${i}" in
+		@*)
+			ARGS="${ARGS} $(cat ${i:1})"
+		;;
+	esac
+done
+for i in $ARGS; do
+	case "${i}" in
 		-o)
 			if [ $USEMODE != 2 -a $USEMODE != 3 ]; then
 				# Link


### PR DESCRIPTION
This commit fixes issue #886.

When CLion processes a CMake file, it executes CMAKE_C_COMPILER and CMAKE_CXX_COMPILER with `-xc++ --sysroot=/opt/toolchains/dc/kos-ports -g -std=gnu++20 -DFRAME_POINTERS -fno-omit-frame-pointer -fpch-preprocess -v -dD -E -D___CIDR_DEFINITIONS_END`, but it passes these arguments through a file in /tmp using @-parameter (https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html#Overall-Options). Since the kos-cc wrapper was not expanding this file, it did not correctly detect it and thus did not include the import directories in the parameter list.

Expanding these kinds of parameters allows CLion to correctly detect the include directories configured in the CMakeLists both of the project itself and the toolchain.