### PR TITLE
Update dcplib examples to use `pvr_filter_mode_t`.

### DIFF
--- a/examples/dreamcast/cpp/clock/clock.cc
+++ b/examples/dreamcast/cpp/clock/clock.cc
@@ -11,8 +11,6 @@
 fntRenderer *text;
 fntTexFont *font;
 
-int filter_mode = 0;
-
 const char *days[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
 const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
                          "Aug", "Sep", "Oct", "Nov", "Dec"
@@ -70,7 +68,7 @@ void drawFrame() {
     pvr_scene_begin();
     pvr_list_begin(PVR_LIST_TR_POLY);
 
-    text->setFilterMode(filter_mode);
+    text->setFilterMode(PVR_FILTER_NEAREST);
 
     text->setFont(font);
     text->setPointSize(30);

--- a/examples/dreamcast/cpp/dcplib/fnt_test.cc
+++ b/examples/dreamcast/cpp/dcplib/fnt_test.cc
@@ -35,8 +35,6 @@ fntTexFont *font_list[MAX_FONTS];
 int cur_font = 0;
 int max_font = 0;
 
-int filter_mode = 0;
-
 void switchFont() {
     cur_font++;
 
@@ -44,11 +42,24 @@ void switchFont() {
         cur_font = 0;
 }
 
-void switchFilterMode() {
-    filter_mode++;
+pvr_filter_mode_t filter_mode = PVR_FILTER_NEAREST;
 
-    if(filter_mode >= 8)
-        filter_mode = 0;
+void switchFilterMode() {
+
+    switch(filter_mode) {
+        case PVR_FILTER_NEAREST:
+            filter_mode = PVR_FILTER_BILINEAR;
+            return;
+        case PVR_FILTER_BILINEAR:
+            filter_mode = PVR_FILTER_TRILINEAR1;
+            return;
+        case PVR_FILTER_TRILINEAR1:
+            filter_mode = PVR_FILTER_TRILINEAR2;
+            return;
+        case PVR_FILTER_TRILINEAR2:
+            filter_mode = PVR_FILTER_NEAREST;
+            return;
+    }
 }
 
 void drawFrame() {


### PR DESCRIPTION
In order to update our API to use this type, it must first be updated in C++ examples to prevent illegal int->enum conversions. This will be followed by a PR to update libdcplib then to pvr.h