### PR TITLE
exports: Ensure subarch exports removed on clean.

### DIFF
--- a/kernel/arch/dreamcast/kernel/Makefile
+++ b/kernel/arch/dreamcast/kernel/Makefile
@@ -32,4 +32,4 @@ subarch_exports.c: ../exports-$(KOS_SUBARCH).txt
 	$(KOS_BASE)/utils/genexports/genexports.sh $< $@ subarch_symtab
 
 clean:
-	-rm -f arch_exports.c
+	-rm -f arch_exports.c subarch_exports.c


### PR DESCRIPTION
Without this `make clean` does not remove the temp generated file, and one can't switch from pristine to naomi builds and back.