### PR TITLE
thd: Enable thread ageing support

### DIFF
--- a/include/kos/intmath.h
+++ b/include/kos/intmath.h
@@ -1,0 +1,40 @@
+/* KallistiOS ##version##
+
+   kos/intmath.h
+   Copyright (C) 2026 Paul Cercueil
+
+   Integer math helper functions
+*/
+
+/** \file    kos/intmath.h
+    \brief   Functions to help with integer math.
+    \ingroup intmath
+
+    \author Paul Cercueil
+*/
+
+#ifndef __KOS_INTMATH_H
+#define __KOS_INTMATH_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+#include <stdbool.h>
+
+static inline bool is_power_of_two(unsigned int val)
+{
+    return (val & (val - 1)) == 0;
+}
+
+static inline unsigned int log2_rdown(unsigned int val)
+{
+    return 31 - __builtin_clz(val);
+}
+
+static inline unsigned int log2_rup(unsigned int val)
+{
+    return log2_rdown(val) + !is_power_of_two(val);
+}
+
+__END_DECLS
+#endif /* __KOS_INTMATH_H */

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -216,7 +216,7 @@ typedef struct __attribute__((aligned(32))) kthread {
     */
     uint64_t wait_timeout;
 
-    /** \brief Per-Thread CPU Time. */
+    /** \brief Per-Thread CPU Time, in milliseconds. */
     struct {
         uint64_t scheduled; /**< \brief time when the thread became active */
         uint64_t total;     /**< \brief total running CPU time for thread */

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -89,6 +89,9 @@ __BEGIN_DECLS
 
     This macro defines the maximum value for a thread's priority. Note that the
     larger this number, the lower the priority of the thread.
+
+    Priority values above this threshold are still supported, with the caveat
+    that the scheduler might not give any CPU time to the thread.
 */
 #define PRIO_MAX 4096
 

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -9,6 +9,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <limits.h>
 #include <malloc.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -20,6 +21,7 @@
 #include <kos/thread.h>
 #include <kos/dbgio.h>
 #include <kos/dbglog.h>
+#include <kos/intmath.h>
 #include <kos/irq.h>
 #include <kos/sem.h>
 #include <kos/rwsem.h>
@@ -52,7 +54,15 @@ static alignas(THD_STACK_ALIGNMENT) uint8_t thd_idle_stack[512];
 /* Thread scheduler data */
 
 /* Scheduler timer interrupt frequency (Hertz) */
-static unsigned int thd_sched_ms = 1000 / THD_SCHED_HZ;
+static unsigned int thd_sched_ms;
+
+/* log2() of the time interval in milliseconds since a thread's last preemption,
+ * after which the thread's priority is doubled */
+static unsigned int thd_ageing_ms_log2;
+
+/* The number of ticks since its last preemption after which a thread's priority
+ * will be doubled. */
+#define THD_AGEING_THRESHOLD 8
 
 /* Thread list. This includes all threads except dead ones. */
 static struct ktlist thd_list;
@@ -632,6 +642,15 @@ static inline void thd_schedule_inner(kthread_t *thd, uint64_t now) {
     irq_set_context(&thd_current->context);
 }
 
+static inline prio_t thd_calc_prio(const kthread_t *thd, uint32_t now) {
+    prio_t prio = thd->prio;
+
+    if(__predict_true(prio < PRIO_MAX))
+       prio >>= (now - (uint32_t)thd->cpu_time.scheduled) >> thd_ageing_ms_log2;
+
+    return prio;
+}
+
 /* Thread scheduler; this function will find a new thread to run when a
    context switch is requested. No work is done in here except to change
    out the thd_current variable contents. Assumed that we are in an
@@ -649,7 +668,8 @@ static inline void thd_schedule_inner(kthread_t *thd, uint64_t now) {
    don't want a full context switch inside the same priority group.
 */
 void thd_schedule(bool front_of_line) {
-    kthread_t *thd;
+    kthread_t *thd, *next_thd = NULL;
+    prio_t prio, max_prio = INT_MAX;
     uint64_t now;
     int ret;
 
@@ -694,8 +714,14 @@ void thd_schedule(bool front_of_line) {
         }
 
         /* Is it runnable? If not, keep going */
-        if(thd->state == STATE_READY)
-            break;
+        if(thd->state != STATE_READY)
+            continue;
+
+        prio = thd_calc_prio(thd, now);
+        if(prio < max_prio) {
+            next_thd = thd;
+            max_prio = prio;
+        }
     }
 
     /* If we didn't already re-enqueue the thread and we are supposed to do so,
@@ -706,22 +732,22 @@ void thd_schedule(bool front_of_line) {
 
         /* Make sure we have a thread, just in case we couldn't find anything
            above. */
-        if(thd == NULL || thd == thd_idle_thd)
-            thd = thd_current;
+        if(next_thd == NULL || next_thd == thd_idle_thd)
+            next_thd = thd_current;
     }
     else if(__predict_false(thd_current->state == STATE_POLLING)) {
         thd_add_to_runnable(thd_current, front_of_line);
     }
 
     /* Didn't find one? Big problem here... */
-    if(thd == NULL) {
+    if(next_thd == NULL) {
         thd_pslist(printf);
         arch_panic("couldn't find a runnable thread");
     }
 
     /* We should now have a runnable thread, so remove it from the
        run queue and switch to it. */
-    thd_schedule_inner(thd, now);
+    thd_schedule_inner(next_thd, now);
 }
 
 /* Temporary priority boosting function: call this from within an interrupt
@@ -1023,6 +1049,7 @@ int thd_set_hz(unsigned int hertz) {
         return -1;
 
     thd_sched_ms = 1000 / hertz;
+    thd_ageing_ms_log2 = log2_rup(thd_sched_ms * THD_AGEING_THRESHOLD);
 
     return 0;
 }
@@ -1049,7 +1076,7 @@ int thd_init(void) {
     const kthread_attr_t idle_attr = {
         .stack_size  = sizeof(thd_idle_stack),
         .stack_ptr   = thd_idle_stack,
-        .prio        = PRIO_MAX,
+        .prio        = PRIO_MAX + 1, /* disable ageing */
         .label       = "[idle]",
         .disable_tls = true
     };
@@ -1080,6 +1107,9 @@ int thd_init(void) {
 
     /* Reinitialize thread counter */
     thd_count = 0;
+
+    /* Set default HZ value */
+    thd_set_hz(THD_SCHED_HZ);
 
     /* Setup a kernel task for the currently running "main" thread */
     kern = thd_create_ex(&kern_attr, NULL, NULL);


### PR DESCRIPTION
Until now, a low-priority thread could be completely starved when the scheduler always had higher-priority running threads to preempt.

Address this issue by implementing thread ageing. This mechanism increases a thread priority at every given time interval (harcoded to 32 milliseconds here) since the last preemption, giving it a chance to eventually run.

Note that this means we're now parsing the entire run queue to find the thread that will eventually be preempted. This should be fine, KallistiOS is not Linux and the number of running threads is generally minimal.

Fixes #1295.