### PR TITLE
Removed #define for static_assert in C23.

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -41,8 +41,13 @@ __BEGIN_DECLS
 /** \cond */
 #define _assert(e) assert(e)
 
-#if __STDC_VERSION__ >= 201112L && !defined __cplusplus
-#define static_assert _Static_assert
+/* 1) C11-C17: _Static_assert is a reserved word, and <assert.h> adds a macro,
+               static_assert which maps to it.
+   2) C23+:    static_assert becomes a reserved word, _Static_assert becomes deprecated.
+   3) C++11+:  static_assert is a reserved word.
+*/
+#if __STDC_VERSION__ >= 201112L && __STDC_VERSION__ <= 201710L && !defined __cplusplus
+#   define static_assert _Static_assert
 #endif
 /** \endcond */
 


### PR DESCRIPTION
1) assert.h
    - Adding another conditional check for C language revisions being less than or equal to C17 before defining the static_assert macro.
    - C23 introduced static_assert as a builtin keyword and no longer requires <assert.h> inclusion in order to use it. Furthemore, it deprecates the _Static_assert builtin we were defining it to.