### PR TITLE
thd: Add function thd_get_idle()

### DIFF
--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -550,6 +550,13 @@ tid_t thd_get_id(const kthread_t *thd);
 */
 kthread_t *thd_get_current(void);
 
+/** \brief       Retrieve the idle thread's kthread struct.
+    \relatesalso kthread_t
+
+    \return                 The idle thread's structure.
+*/
+kthread_t *thd_get_idle(void);
+
 /** \brief       Retrieve the thread's label.
     \relatesalso kthread_t
 

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -892,6 +892,10 @@ kthread_t *thd_get_current(void) {
     return thd_current;
 }
 
+kthread_t *thd_get_idle(void) {
+    return thd_idle_thd;
+}
+
 /* Retrieve / set thread pwd */
 const char *thd_get_pwd(const kthread_t *thd) {
     if(!thd)


### PR DESCRIPTION
Combined with thd_get_cpu_time(), this function allows me to get the time spent by the CPU in the idle thread on a given time interval, and therefore the CPU usage of my application on that time interval.