### PR TITLE
Optimized and fixed buggy/slow IPv4 checksum alg.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,7 +43,7 @@ Joe Fenton: 2016
 Stefan Galowicz: 2016, 2017
 Luke Benstead: 2020, 2021, 2022, 2023
 Eric Fradella: 2023, 2024, 2025, 2026
-Falco Girgis: 2023, 2024, 2025
+Falco Girgis: 2023, 2024, 2025, 2026
 Ruslan Rostovtsev: 2014, 2016, 2023, 2024, 2025
 Colton Pawielski: 2023
 Andy Barajas: 2023, 2024

--- a/kernel/net/net_ipv4.c
+++ b/kernel/net/net_ipv4.c
@@ -30,7 +30,6 @@ static net_ipv4_stats_t ipv4_stats = { 0 };
 /* Perform an IP-style checksum on a block of data */
 uint16_t __pure net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t start) {
     uint32_t sum = start;
-    size_t i = bytes;
     uintptr_t end = (uintptr_t)data + bytes;
 
     /* Make sure we don't do any unaligned memory accesses */
@@ -50,10 +49,8 @@ uint16_t __pure net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t st
         }
     }
 
-    i &= 0x1;
-
     /* Handle the last byte, if we have an odd byte count */
-    if(i)
+    if(bytes & 0x1)
         sum += data[bytes - 1];
 
     /* Take care of any carry bits */


### PR DESCRIPTION
I've taken the liberty of gifting KOS back my hand-optimized ipv4 checksum that was previously part of SH4ZAM. It was written in C, but optimized by hand within Compiler Explorer.

1) net_ipv4.c
    - net_ipv4_checksum() was calculating the checksum extremely inefficiently, doing byte-wise masking + shifting within a loop for every 16-bit word. The algorithm is now directly summing each 16-bit word and is only doing the shifty loop for carry bits once at the end.
    - net_ipv4_checksum() was also TOTALLY INCORRECT for the unaligned path, due to a bug on line 38 (*ptr + 1): which is adding one to the dereferenced value, not using the value of the next byte address... So basically this whole path is wrong and we've gotten lucky that the "data" has always been at least 2 byte aligned. 
2) AUTHORS
    - added 2026 copyright date, since this is my first contribution this year.

Tested by running all network examples. Everything passed and seems to be in working order.