### PR TITLE
Docs v2.2.2

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,12 +2,24 @@
 
 Platform-specific changes are prefixed with the platform name, otherwise the change is platform-independent. The name/initials of the person who is responsible for the change are listed in [square brackets] for most versions (where they are missing from early versions, assume that they should be attributed to Megan Potter).
 
+## KallistiOS version 2.2.2
+- **Dreamcast**: Add missing header to `snd_stream.h` [Donald Haase ==DH]
+- Fix bug causing erratic behavior in `readdir` [Paul Cercueil == PC]
+- No longer build GDB by default with toolchain [Eric Fradella == EF]
+- Fix building older toolchains with newer host GCC [PC]
+- Correct cmake include path for addons [DH]
+- **Dreamcast**: Prevent controller from unregistering if sub-devices still active [PC]
+- Improved support for C static asserts [Falco Girgis == FG][PC]
+- Correct errors in doxygen processing [DH][PC]
+- Improve thread safety of fs operations [PC]
+- Fix CLion compatibility with kos-cc wrappers [kouta]
+
 ## KallistiOS version 2.2.1
 - **Dreamcast**: Fine-tune timer rate to avoid clock drift [Paul Cercueil == PC]
 - **Dreamcast**: Update keyboard LED/mod status handling, add new example to demonstrate [Troy Davis == GPF]
 - **Dreamcast**: Detect 3rd party memory cards and disable sending screen/clock commands to them [Donald Haase == DH]
 - **Dreamcast**: Support for 1st party rumble packs [DH]
-- **Dreamcast**: Various fixes and expansions to the cmake environment [Falco Girgis ==FG][PC]
+- **Dreamcast**: Various fixes and expansions to the cmake environment [Falco Girgis == FG][PC]
 
 ## KallistiOS version 2.2.0
 - Added . & .. directories to filesystems that lack it [Andress Barajas == AB]

--- a/doc/RELNOTES.md
+++ b/doc/RELNOTES.md
@@ -1,8 +1,16 @@
 KallistiOS ##version##  
 Copyright (C) 2002, 2003 Megan Potter  
 Copyright (C) 2012-2019 Lawrence Sebald  
-Copyright (C) 2024-2025 Donald Haase  
+Copyright (C) 2024-2026 Donald Haase  
 Copyright (C) 2025 Eric Fradella  
+
+RELEASE NOTES for 2.2.2
+-----------------------
+
+Another minor patch version to collect ~20 PRs of bug fixes. Notably GDB is no
+longer built by default with the toolchain as it was frequently breaking,
+further improvements to rumble support, and fixes to allow CLion to function
+again with our build wrappers.
 
 RELEASE NOTES for 2.2.1
 -----------------------


### PR DESCRIPTION
Update the docs to have the relnotes and changelog for v2.2.1 (which was missed the last time around) and the newest for v2.2.2.