### PR TITLE
malloc: Provide missing header needed for KM_DBG

### DIFF
--- a/kernel/libc/koslib/malloc.c
+++ b/kernel/libc/koslib/malloc.c
@@ -1653,6 +1653,7 @@ static pthread_mutex_t mALLOC_MUTEx = PTHREAD_MUTEX_INITIALIZER;
 #include <stdlib.h>
 #include <kos/dbgio.h>
 #include <kos/thread.h>
+#include <arch/stack.h>
 
 #define BLOCK_MAGIC 0x1c518a74
 #define PRE_MAGIC   0x6765adb8


### PR DESCRIPTION
It looks like one of the intermediate cleanups of includes broke this. Without this, there's no access to `arch_get_ret_addr`. 