### PR TITLE
Added " MIL CD" as a valid input for DEVICE_INFO

### DIFF
--- a/utils/makeip/CHANGELOG.md
+++ b/utils/makeip/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-01-20
+### Added
+- `" MIL CD"` is now a valid input for **Device Info**.
+
 ## [2.0.0] - 2020-06-24
 ### Added
 - All the fields may now be filled directly from the command-line. Use the `-u`

--- a/utils/makeip/README.md
+++ b/utils/makeip/README.md
@@ -200,8 +200,8 @@ disc of three, the **Device Information** field might be something like
 `"8B40 CD-ROM2/3  "`.
 
 Please note, commercial `IP.BIN` files (which aren't produced by **IP creator**)
-supports the `" GD-ROM"` type. Also, the **CRC** value doesn't need to be
-provided as it's computed automatically by the **IP creator** program.
+supports the `" GD-ROM"` and `" MIL CD"` type. Also, the **CRC** value doesn't
+need to be provided as it's computed automatically by the **IP creator** program.
 
 In clear, you just have to pass `CD-ROMx/y` to that field, where `x` is the disc
 number and `y` the total discs in the set. The default value is `CD-ROM1/1`.

--- a/utils/makeip/src/Makefile
+++ b/utils/makeip/src/Makefile
@@ -1,6 +1,6 @@
 TARGET = makeip
 
-VERSION = 2.0.0
+VERSION = 2.0.1
 
 OBJECTS = utils.o vector.o crc.o mr.o field.o ip.o main.o
 

--- a/utils/makeip/src/field.c
+++ b/utils/makeip/src/field.c
@@ -346,7 +346,8 @@ _check_deviceinfo(field_t *f, char *value)
   long dummy;
   result = result && (strlen(deviceinfo) == 9)
     && ((!strncmp(deviceinfo, "CD-ROM", 6)) ||
-        (!strncmp(deviceinfo, "GD-ROM", 6)))
+        (!strncmp(deviceinfo, "GD-ROM", 6)) ||
+        (!strncmp(deviceinfo, "MIL CD", 6)))
     && substr_long_parse(deviceinfo, 6, 1, &dummy) && (deviceinfo[7] == '/')
 	&& substr_long_parse(deviceinfo, 8, 1, &dummy);
 


### PR DESCRIPTION
I modified the makeip utility to allow for " MIL CD" as a valid input for the Device Info field. " MIL CD" is an officially supported string for this field, as that's what's used on the commercial MIL-CDs.

Now, the utility accepts " CD-ROM", " GD-ROM", and " MIL CD"