### PR TITLE
libkosfat: fix fat_search_long longname_buf for LFN

### DIFF
--- a/addons/libkosfat/directory.c
+++ b/addons/libkosfat/directory.c
@@ -284,7 +284,8 @@ static int fat_search_long(fat_fs_t *fs, const char *fn, uint32_t cluster,
             memcpy(&longname_buf[fnlen], lent->name1, 10);
             memcpy(&longname_buf[fnlen + 5], lent->name2, 12);
             memcpy(&longname_buf[fnlen + 11], lent->name3, 4);
-            longname_buf[fnlen + 14] = 0;
+            /* Make sure the string is null-terminated at longname_buf[fnlen + 11 + 4 / sizeof(uint16_t)] */
+            longname_buf[fnlen + 13] = 0;
 
             /* XXXX: Calculate the checksum here. */
 


### PR DESCRIPTION
This patch fixes the longname_buf null character offset which was set at the end of the non null-terminated string + 2. As the buffer contains ucs2 data from previous iterations, if a non-null char ends up there, the memcmp test fails.

Notes to reviewers:
* 1st contrib so please let me know if there is something missing or wrong :)
* It may not be 100% reproductible but here is how I tested it: with a fat32 formated sdcard on windows, create a file named "ABCDEFGHI.123" at the root of the sdcard and try to load it --> file not found.