### PR TITLE
pvr: Fix modifier volumes

### DIFF
--- a/examples/dreamcast/pvr/modifier_volume_zclip/example.c
+++ b/examples/dreamcast/pvr/modifier_volume_zclip/example.c
@@ -117,7 +117,6 @@ static void draw_modifier(matrix_t *pvm)
         vol[i].cz = transform[index[i][2]][2];
     }
     pvr_mod_compile(&hdr, PVR_LIST_OP_MOD, PVR_MODIFIER_INCLUDE_LAST_POLY, PVR_CULLING_SMALL);
-    hdr.cmd |= (1 << 6); /* Last poly */
     pvr_modifier_commit_zclip(&hdr, vol, 12);
 }
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
@@ -340,6 +340,13 @@ void pvr_mod_compile(pvr_mod_hdr_t *dst, pvr_list_t list, uint32_t mode,
     cmd = PVR_CMD_MODIFIER
         | FIELD_PREP(PVR_TA_CMD_TYPE, list);
 
+    /* For modifier volumes, the PVR_TA_CMD_MODIFIERMODE flag specifies that
+     * the next polygon is the last one in the volume. */
+    if(mode == PVR_MODIFIER_INCLUDE_LAST_POLY
+       || mode == PVR_MODIFIER_EXCLUDE_LAST_POLY) {
+        cmd |= PVR_TA_CMD_MODIFIERMODE;
+    }
+
     /* pvr_mod_hdr_t is cacheline-aligned and we're writing all 32 bytes:
      * we can allocate a dirty cache line */
     dcache_alloc_block(dst, cmd);


### PR DESCRIPTION
The header of the modifier volume has a bit to specify that the next polygon is the last one. Until now, this bit was never set.

The examples happened to work because
- for 2D examples, the hardware seems to work if this bit isn't set for the last modifier volume in the list;
- for the 3D example, the code was manually setting that bit.