### PR TITLE
kernel: Set default init flags as weak symbol

### DIFF
--- a/kernel/arch/dreamcast/kernel/init_flags_default.c
+++ b/kernel/arch/dreamcast/kernel/init_flags_default.c
@@ -7,5 +7,5 @@
 #include <arch/arch.h>
 
 /* Default values which will be used if the user doesn't declare anything */
-KOS_INIT_FLAGS(INIT_DEFAULT);
+__weak_symbol KOS_INIT_FLAGS(INIT_DEFAULT);
 


### PR DESCRIPTION
If not set as a weak symbol, the linker will pick the first one it finds, which may just be KOS' default one if libkallisti.a is placed before the application's objects on the command line.