### PR TITLE
Provide 1/2/4/8-byte atomic fallbacks + switch to mutexes

### DIFF
--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -10,7 +10,7 @@
 */
 
 #include <kos/irq.h>
-#include <kos/spinlock.h>
+#include <kos/mutex.h>
 #include <arch/arch.h>
 #include <arch/cache.h>
 #include <stdint.h>
@@ -119,7 +119,7 @@ ATOMIC_OPS_N_(unsigned long long, 8)
 
 /* Provide GCC with symbols and logic required to implement
    generically sized atomics. Rather than disabling an enabling
-   interrupts around primitive assignments, we use spinlocks
+   interrupts around primitive assignments, we use mutexes
    around memcpy() calls. */
 
 /* Size of each memory region covered by an individual lock. */
@@ -131,13 +131,13 @@ ATOMIC_OPS_N_(unsigned long long, 8)
 #define GENERIC_LOCK_COUNT          (PAGESIZE / GENERIC_LOCK_BLOCK_SIZE)
 
 /* Create a hash table mapping a region of memory to a lock. */
-static spinlock_t locks[GENERIC_LOCK_COUNT] = {
-    [0 ... (GENERIC_LOCK_COUNT - 1)] = SPINLOCK_INITIALIZER
+static mutex_t locks[GENERIC_LOCK_COUNT] = {
+    [0 ... (GENERIC_LOCK_COUNT - 1)] = MUTEX_INITIALIZER
 };
 
 /* Our hash function which maps an address to its corresponding lock index. */
 inline static uintptr_t
-address_to_spinlock(const volatile void *ptr) {
+address_to_mutex(const volatile void *ptr) {
     return ((uintptr_t)ptr / GENERIC_LOCK_BLOCK_SIZE) % GENERIC_LOCK_COUNT;
 }
 
@@ -145,11 +145,11 @@ void __atomic_load(size_t size,
                    const volatile void *ptr,
                    void *ret,
                    int memorder) {
-    const uintptr_t lock = address_to_spinlock(ptr);
+    const uintptr_t lock = address_to_mutex(ptr);
 
     (void)memorder;
 
-    spinlock_lock_scoped(&locks[lock]);
+    mutex_lock_scoped(&locks[lock]);
     memcpy(ret, (const void *)ptr, size);
 }
 
@@ -157,11 +157,11 @@ void __atomic_store(size_t size,
                     volatile void *ptr,
                     void *val,
                     int memorder) {
-    const uintptr_t lock = address_to_spinlock(ptr);
+    const uintptr_t lock = address_to_mutex(ptr);
 
     (void)memorder;
 
-    spinlock_lock_scoped(&locks[lock]);
+    mutex_lock_scoped(&locks[lock]);
     memcpy((void *)ptr, val, size);
 }
 
@@ -170,11 +170,11 @@ void __atomic_exchange(size_t size,
                        void *val,
                        void *ret,
                        int memorder) {
-    const uintptr_t lock = address_to_spinlock(ptr);
+    const uintptr_t lock = address_to_mutex(ptr);
 
     (void)memorder;
 
-    spinlock_lock_scoped(&locks[lock]);
+    mutex_lock_scoped(&locks[lock]);
     memcpy(ret, (const void *)ptr, size);
     memcpy((void *)ptr, val, size);
 }
@@ -185,12 +185,12 @@ bool __atomic_compare_exchange(size_t size,
                                void* desired,
                                int success_memorder,
                                int fail_memorder) {
-    const uintptr_t lock = address_to_spinlock(ptr);
+    const uintptr_t lock = address_to_mutex(ptr);
 
     (void)success_memorder;
     (void)fail_memorder;
 
-    spinlock_lock_scoped(&locks[lock]);
+    mutex_lock_scoped(&locks[lock]);
 
     if(memcmp((const void *)ptr, expected, size) == 0) {
         memcpy((void *)ptr, desired, size);


### PR DESCRIPTION
Provide fallback functions for 1/2/4/8-byte atomics, that are used only when GCC does not already provide the corresponding builtin.

Switch the > 8-byte atomics to using mutexes instead of spinlocks.