### PR TITLE
Fix double-free in wav2adpcm

### DIFF
--- a/utils/wav2adpcm/wav2adpcm.c
+++ b/utils/wav2adpcm/wav2adpcm.c
@@ -307,7 +307,6 @@ int straight_copy(FILE *in, const char *outfile) {
 
     if(fread(buffer, filesize, 1, in) != 1) {
         fprintf(stderr, "Cannot read file.\n");
-        free(buffer);
         result = -1;
         goto cleanup;
     }


### PR DESCRIPTION
In `straight_copy()`, if `fread()` fails it frees `buffer` then jumps to `cleanup` where it frees once more, resulting in a crash.