### PR TITLE
pvr: Correct setting of `txr::alpha`

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
@@ -159,15 +159,14 @@ void pvr_poly_cxt_txr(pvr_poly_cxt_t *dst, pvr_list_t list,
     dst->txr.enable = true;
 
     dst->gen.alpha = alpha;
+    dst->txr.alpha = false;
 
     if(!alpha) {
-        dst->txr.alpha = true;
         dst->blend.src = PVR_BLEND_ONE;
         dst->blend.dst = PVR_BLEND_ZERO;
         dst->txr.env = PVR_TXRENV_MODULATE;
     }
     else {
-        dst->txr.alpha = true;
         dst->blend.src = PVR_BLEND_SRCALPHA;
         dst->blend.dst = PVR_BLEND_INVSRCALPHA;
         dst->txr.env = PVR_TXRENV_MODULATEALPHA;
@@ -236,15 +235,14 @@ void pvr_sprite_cxt_txr(pvr_sprite_cxt_t *dst, pvr_list_t list,
     dst->gen.culling = PVR_CULLING_CCW;
 
     dst->gen.alpha = alpha;
+    dst->txr.alpha = false;
 
     if(!alpha) {
-        dst->txr.alpha = true;
         dst->blend.src = PVR_BLEND_ONE;
         dst->blend.dst = PVR_BLEND_ZERO;
         dst->txr.env = PVR_TXRENV_MODULATE;
     }
     else {
-        dst->txr.alpha = true;
         dst->blend.src = PVR_BLEND_SRCALPHA;
         dst->blend.dst = PVR_BLEND_INVSRCALPHA;
         dst->txr.env = PVR_TXRENV_MODULATEALPHA;
@@ -540,23 +538,21 @@ void pvr_poly_cxt_txr_mod(pvr_poly_cxt_t *dst, pvr_list_t list,
 
     dst->gen.alpha = alpha;
     dst->gen.alpha2 = alpha;
+    dst->txr.alpha = false;
+    dst->txr2.alpha = false;
 
     if(!alpha) {
-        dst->txr.alpha = true;
         dst->blend.src = PVR_BLEND_ONE;
         dst->blend.dst = PVR_BLEND_ZERO;
         dst->txr.env = PVR_TXRENV_MODULATE;
-        dst->txr2.alpha = true;
         dst->blend.src2 = PVR_BLEND_ONE;
         dst->blend.dst2 = PVR_BLEND_ZERO;
         dst->txr2.env = PVR_TXRENV_MODULATE;
     }
     else {
-        dst->txr.alpha = true;
         dst->blend.src = PVR_BLEND_SRCALPHA;
         dst->blend.dst = PVR_BLEND_INVSRCALPHA;
         dst->txr.env = PVR_TXRENV_MODULATEALPHA;
-        dst->txr2.alpha = true;
         dst->blend.src2 = PVR_BLEND_SRCALPHA;
         dst->blend.dst2 = PVR_BLEND_INVSRCALPHA;
         dst->txr2.env = PVR_TXRENV_MODULATEALPHA;

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -210,7 +210,7 @@ typedef struct {
         pvr_mip_bias_t      mipmap_bias;    /**< \brief Mipmap bias */
         pvr_uv_flip_t       uv_flip;        /**< \brief Enable/disable U/V flipping */
         pvr_uv_clamp_t      uv_clamp;       /**< \brief Enable/disable U/V clamping */
-        bool                alpha;          /**< \brief Enable/disable texture alpha */
+        bool                alpha;          /**< \brief True to _disable_ texture alpha */
         pvr_txr_shading_mode_t  env;        /**< \brief Texture color contribution */
         int     width;          /**< \brief Texture width (requires a power of 2) */
         int     height;         /**< \brief Texture height (requires a power of 2) */
@@ -261,7 +261,7 @@ typedef struct {
         pvr_mip_bias_t      mipmap_bias;    /**< \brief Mipmap bias */
         pvr_uv_flip_t       uv_flip;        /**< \brief Enable/disable U/V flipping */
         pvr_uv_clamp_t      uv_clamp;       /**< \brief Enable/disable U/V clamping */
-        bool                alpha;          /**< \brief Enable/disable texture alpha */
+        bool                alpha;          /**< \brief True to _disable_ texture alpha */
         pvr_txr_shading_mode_t  env;        /**< \brief Texture color contribution */
         int     width;          /**< \brief Texture width (requires a power of 2) */
         int     height;         /**< \brief Texture height (requires a power of 2) */


### PR DESCRIPTION
This member has inverted meaning and is actually 'alpha disabled?'. In #1288 was accidentally flipped around.