### PR TITLE
examples: Fix dangling reference in concurrency.cpp

### DIFF
--- a/examples/dreamcast/cpp/concurrency/concurrency.cpp
+++ b/examples/dreamcast/cpp/concurrency/concurrency.cpp
@@ -650,7 +650,7 @@ namespace {
     };
 
     template<typename FF>
-    defer_raii(FF &&ff) -> defer_raii<decltype(ff)>;
+    defer_raii(FF &&ff) -> defer_raii<std::decay_t<FF>>;
 }  // anonymous namespace
 
 auto defer(auto &&f) {


### PR DESCRIPTION
Using `decltype(ff)` here creates a dangling reference, which can cause a crash (seems to always happen on GameCube). Switching this to `std::decay_t<FF>` passes the value which fixes the crash. Verified by @gyrovorbis this is necessary to fix.