### PR TITLE
New cache ARCH API

### DIFF
--- a/examples/dreamcast/cdrom/stream/cd-stream-test.c
+++ b/examples/dreamcast/cdrom/stream/cd-stream-test.c
@@ -18,8 +18,7 @@
 #include <dc/maple/controller.h>
 #include <dc/cdrom.h>
 
-#include <arch/cache.h>
-
+#include <kos/cache.h>
 #include <kos/init.h>
 #include <kos/dbgio.h>
 #include <kos/dbglog.h>

--- a/include/kos.h
+++ b/include/kos.h
@@ -33,6 +33,7 @@ __BEGIN_DECLS
 #include <unistd.h>
 
 #include <kos/version.h>
+#include <kos/cache.h>
 #include <kos/fs.h>
 #include <kos/fs_romdisk.h>
 #include <kos/fs_ramdisk.h>
@@ -64,7 +65,6 @@ __BEGIN_DECLS
 #include <kos/spinlock.h>
 
 #include <arch/arch.h>
-#include <arch/cache.h>
 #include <arch/irq.h>
 #include <arch/timer.h>
 #include <arch/types.h>

--- a/include/kos/cache.h
+++ b/include/kos/cache.h
@@ -1,0 +1,303 @@
+/* KallistiOS ##version##
+
+   include/kos/cache.h
+   Copyright (C) 2001 Megan Potter
+   Copyright (C) 2014, 2016, 2023 Ruslan Rostovtsev
+   Copyright (C) 2023 Andy Barajas
+   Copyright (C) 2025 Eric Fradella
+   Copyright (C) 2026 Falco Girgis
+*/
+
+/** \file    include/kos/cache.h
+    \brief   Cache management functionality.
+    \ingroup system_cache
+
+    This file contains definitions for functions that manage the caches,
+    including functions to flush, invalidate, purge, prefetch and allocate
+    individual cache lines or address ranges.
+
+    \author Megan Potter
+    \author Ruslan Rostovtsev
+    \author Andy Barajas
+    \author Falco Girgis
+*/
+
+#ifndef __KOS_CACHE_H
+#define __KOS_CACHE_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+#include <arch/cache.h>
+
+#include <stdint.h>
+
+/** \defgroup system_cache Cache
+    \brief                 Driver and API for managing the SH4's cache
+    \ingroup               system
+
+    @{
+*/
+
+/** \brief  Level 1 instruction cache size.
+
+    The capacity of the L1 instruction cache in bytes.
+*/
+#define CACHE_L1_ICACHE_SIZE \
+    ARCH_CACHE_L1_ICACHE_SIZE
+
+/** \brief  Level 1 instruction cache associativity.
+
+    Number of ways in the L1 instruction cache.
+*/
+#define CACHE_L1_ICACHE_ASSOC \
+    ARCH_CACHE_L1_ICACHE_ASSOC
+
+/** \brief  L1 instruction cache line size.
+
+    The size of each cache line in the L1 instruction cache.
+*/
+#define CACHE_L1_ICACHE_LINESIZE \
+    ARCH_CACHE_L1_ICACHE_LINESIZE
+
+/** \brief  Level 1 data cache size.
+
+    The capacity of the L1 data cache in bytes.
+*/
+#define CACHE_L1_DCACHE_SIZE \
+    ARCH_CACHE_L1_DCACHE_SIZE
+
+/** \brief  Level 1 data cache associativity.
+
+    Number of ways in the L1 data cache.
+*/
+#define CACHE_L1_DCACHE_ASSOC \
+    ARCH_CACHE_L1_DCACHE_ASSOC
+
+/** \brief  L1 data cache line size.
+
+    The size of each cache line in the L1 data cache.
+*/
+#define CACHE_L1_DCACHE_LINESIZE \
+    ARCH_CACHE_L1_DCACHE_LINESIZE
+
+/** \brief  Level 2 cache size.
+
+    The capacity of the L2 cache in bytes.
+*/
+#define CACHE_L2_CACHE_SIZE \
+    ARCH_CACHE_L2_CACHE_SIZE
+
+/** \brief  Level 2 cache associativity.
+
+    Number of ways in the L2 cache.
+*/
+#define CACHE_L2_CACHE_ASSOC \
+    ARCH_CACHE_L2_CACHE_ASSOC
+
+/** \brief  Level 2 cache line size.
+
+    The size of each cache line in the L2 cache.
+*/
+#define CACHE_L2_CACHE_LINESIZE \
+    ARCH_CACHE_L2_CACHE_LINESIZE
+
+/** \brief Invalidate the instruction cache.
+
+    This instruction invalidates a range of the instruction cache.
+
+    \param  start           The physical address to begin invalidation at.
+    \param  count           The number of bytes to invalidate.
+*/
+static inline void icache_inval_range(uintptr_t start, size_t count) {
+    arch_icache_inval_range(start, count);
+}
+
+/** \brief Synchronize the instruction cache.
+
+    This function ensures that the instruction cache is synchronized with the
+    data/operand cache. It is functionally  the same as calling
+    dcache_wback_range() followed by icache_inval_range(), but may be
+    implemented in a more optimized way.
+
+    \param  start           The physical address to begin invalidation at.
+    \param  count           The number of bytes to invalidate.
+*/
+static inline void icache_sync_range(uintptr_t start, size_t count) {
+    arch_icache_sync_range(start, count);
+}
+
+/** \brief  Invalidate the data/operand cache.
+
+    This function invalidates a range of the data/operand cache. If you care
+    about the contents of the cache that have not been written back yet, use
+    dcache_wback_range() before using this function.
+
+    \param  start           The physical address to begin invalidating at.
+    \param  count           The number of bytes to invalidate.
+*/
+static inline void dcache_inval_range(uintptr_t start, size_t count) {
+    arch_dcache_inval_range(start, count);
+}
+
+/** \brief  Perform a write-back on the data/operand cache.
+
+    This function flushes a range of the data/operand cache, forcing a write-
+    back on all of the data in the specified range. This does not invalidate
+    the cache in the process (meaning the blocks will still be in the cache,
+    just not marked as dirty after this has completed). If you wish to
+    invalidate the cache as well, call dcache_inval_range() after calling this
+    function or use dcache_purge_range() instead of dcache_wback_range().
+
+    \param  start           The physical address to begin flushing at.
+    \param  count           The number of bytes to write back.
+*/
+static inline void dcache_wback_range(uintptr_t start, size_t count) {
+    arch_dcache_wback_range(start, count);
+}
+
+/** \brief  Perform a write-back on the the whole data/operand cache.
+
+    This function flushes all the data/operand cache, forcing a write-
+    back on all of the cache blocks that are marked as dirty.
+*/
+static inline void dcache_wback_all(void) {
+    arch_dcache_wback_all();
+}
+
+/** \brief  Purge the data/operand cache.
+
+    This function flushes a range of the data/operand cache, forcing a write-
+    back and then invalidates all of the data in the specified range.
+
+    \param  start           The physical address to begin purging at.
+    \param  count           The number of bytes to purge.
+*/
+static inline void dcache_purge_range(uintptr_t start, size_t count) {
+    arch_dcache_purge_range(start, count);
+}
+
+/** \brief  Purge all the data/operand cache.
+
+    This function flushes the entire data/operand cache, ensuring that all
+    cache blocks marked as dirty are written back to memory and all cache
+    entries are invalidated. It does not require an additional buffer and is
+    preferred when memory resources are constrained.
+*/
+static inline void dcache_purge_all(void) {
+    arch_dcache_purge_all();
+}
+
+/** \brief  Prefetch one block to the data/operand cache.
+
+    This function prefetch a block of the data/operand cache.
+
+    \param  src             The physical address to prefetch.
+*/
+static inline void dcache_pref_line(const void *src) {
+    arch_dcache_pref_line(src);
+}
+
+/** \brief  Allocate one cache line of the data/operand cache.
+
+    This function allocates a cache line of the data/operand cache.
+    The initial content of the allocated cache line is undefined.
+
+    \param  src             The address to allocate (32-byte aligned)
+*/
+static inline void dcache_alloc_line(void *src) {
+    arch_dcache_alloc_line(src);
+}
+
+/** \brief  Zero-allocate one cache line of the data/operand cache.
+
+    This function allocates a cache line of the data/operand cache.
+    The allocated cache line will be zeroed.
+
+    \param  src             The address to allocate (32-byte aligned)
+*/
+static inline void dcache_zero_alloc_line(void *src) {
+    arch_dcache_zero_alloc_line(src);
+}
+
+/** \brief  Allocate one cache line of the data/operand cache with a value.
+
+    This function allocates a cache line of the data/operand cache.
+    The specified value is written at the beginning of the cache line.
+    The initial content of the rest of the cache line is undefined.
+
+    \param  src             The address to allocate (32-byte aligned)
+    \param  value           The value written to the beginning of the cache line.
+*/
+static inline void dcache_alloc_line_with_value(void *src, uintptr_t value) {
+    arch_dcache_alloc_line_with_value(src, value);
+}
+
+/** \brief  Invalidate one cache line of the data/operand cache.
+
+    This function invalidates a cache line of the data/operand cache.
+    The data inside the cache line is not written back to memory, and
+    the cache line is marked as free.
+
+    \param  src             The address to invalidate
+*/
+static inline void dcache_inval_line(void *src) {
+    arch_dcache_inval_line(src);
+}
+
+/** \brief  Purge one cache line of the data/operand cache.
+
+    This function purges a cache line of the data/operand cache.
+    If the cache line is dirty, the data is written back to memory, and
+    then the cache line is marked as free.
+
+    \param  src             The address to purge
+*/
+static inline void dcache_purge_line(void *src) {
+    arch_dcache_purge_line(src);
+}
+
+/** \brief  Write-back one cache line of the data/operand cache.
+
+    This function flushes a cache line of the data/operand cache.
+    If the cache line is dirty, the data is written back to memory.
+    The cache line is not invalidated.
+
+    \param  src             The address to flush
+*/
+static inline void dcache_wback_line(void *src) {
+    arch_dcache_wback_line(src);
+}
+
+/** \cond */
+__depr("icache_flush_range() has been renamed to icache_sync_range()")
+static inline void icache_flush_range(uintptr_t start, size_t count) {
+    icache_sync_range(start, count);
+}
+
+__depr("dcache_flush_range() has been renamed to dcache_wback_range()")
+static inline void dcache_flush_range(uintptr_t start, size_t count) {
+    dcache_wback_range(start, count);
+}
+
+__depr("dcache_flush_all() has been renamed to dcache_wback_all()")
+static inline void dcache_flush_all(void) {
+    dcache_wback_all();
+}
+
+__depr("dcache_pref_block() has been renamed to dcache_pref_line()")
+static inline void dcache_pref_block(const void *src) {
+    dcache_pref_line(src);
+}
+
+__depr("dcache_alloc_block() has been renamed to dcache_alloc_line_with_value()")
+static inline void dcache_alloc_block(void *src, uint32_t value) {
+    dcache_alloc_line_with_value(src, value);
+}
+/** \endcond */
+
+/** @} */
+
+__END_DECLS
+
+#endif  /* __KOS_CACHE_H */

--- a/kernel/arch/dreamcast/exports.txt
+++ b/kernel/arch/dreamcast/exports.txt
@@ -4,11 +4,6 @@ include dc/sound/sound.h
 # Cache management
 arch_icache_inval_range
 arch_icache_sync_range
-arch_dcache_inval_range
-arch_dcache_wback_range
-arch_dcache_purge_range
-arch_dcache_wback_all
-arch_dcache_purge_all
 
 # ASIC
 asic_evt_set_handler

--- a/kernel/arch/dreamcast/exports.txt
+++ b/kernel/arch/dreamcast/exports.txt
@@ -1,6 +1,15 @@
 include kos.h
 include dc/sound/sound.h
 
+# Cache management
+arch_icache_inval_range
+arch_icache_sync_range
+arch_dcache_inval_range
+arch_dcache_wback_range
+arch_dcache_purge_range
+arch_dcache_wback_all
+arch_dcache_purge_all
+
 # ASIC
 asic_evt_set_handler
 asic_evt_disable_all

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -11,8 +11,6 @@
  */
 #include <assert.h>
 
-#include <arch/cache.h>
-
 #include <dc/asic.h>
 #include <dc/cdrom.h>
 #include <dc/g1ata.h>
@@ -20,6 +18,7 @@
 #include <dc/syscalls.h>
 #include <dc/vblank.h>
 
+#include <kos/cache.h>
 #include <kos/irq.h>
 #include <kos/timer.h>
 #include <kos/thread.h>

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -755,7 +755,7 @@ static void unlock_dma_memory(void) {
     if(patched) {
         flush_size = (patch_addr[1] - patch_addr[0]) + CACHE_L1_ICACHE_LINESIZE;
         flush_size &= ~(CACHE_L1_ICACHE_LINESIZE - 1);
-        icache_flush_range(patch_addr[0] | MEM_AREA_P1_BASE, flush_size);
+        icache_sync_range(patch_addr[0] | MEM_AREA_P1_BASE, flush_size);
     }
     *prot_reg = G1_ATA_DMA_UNLOCK_ALLMEM;
 }

--- a/kernel/arch/dreamcast/hardware/dmac.c
+++ b/kernel/arch/dreamcast/hardware/dmac.c
@@ -4,11 +4,11 @@
 
    Copyright (C) 2025 Paul Cercueil
 */
-#include <arch/cache.h>
 #include <arch/dmac.h>
 
 #include <dc/memory.h>
 
+#include <kos/cache.h>
 #include <kos/dbglog.h>
 #include <kos/genwait.h>
 #include <kos/irq.h>

--- a/kernel/arch/dreamcast/hardware/dmac.c
+++ b/kernel/arch/dreamcast/hardware/dmac.c
@@ -83,7 +83,7 @@ static dma_addr_t dma_map_src_dst(uintptr_t addr, size_t len, bool is_dst) {
         if(is_dst)
             dcache_inval_range(addr, len);
         else
-            dcache_flush_range(addr, len);
+            dcache_wback_range(addr, len);
         break;
 
     default:

--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -13,6 +13,7 @@
 #include <dc/asic.h>
 #include <dc/memory.h>
 
+#include <kos/cache.h>
 #include <kos/dbglog.h>
 #include <kos/irq.h>
 #include <kos/sem.h>
@@ -21,7 +22,6 @@
 #include <kos/timer.h>
 
 #include <arch/arch.h>
-#include <arch/cache.h>
 
 /*
    This file implements support for accessing devices over the G1 bus by the

--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -895,7 +895,7 @@ int g1_ata_write_lba_dma(uint64_t sector, size_t count, const void *buf,
     */
     if((addr & MEM_AREA_P2_BASE) != MEM_AREA_P2_BASE) {
         /* Flush the dcache over the range of the data. */
-        dcache_flush_range(addr, count * 512);
+        dcache_wback_range(addr, count * 512);
     }
 
     /* Use the physical memory address. */

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -18,8 +18,8 @@
 #include <dc/g2bus.h>
 #include <dc/sq.h>
 #include <dc/flashrom.h>
-#include <arch/cache.h>
 #include <dc/memory.h>
+#include <kos/cache.h>
 #include <kos/dbglog.h>
 #include <kos/irq.h>
 #include <kos/net.h>

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -8,7 +8,6 @@
 #include <assert.h>
 #include <dc/pvr.h>
 #include <dc/asic.h>
-#include <arch/cache.h>
 #include "pvr_internal.h"
 
 #include <kos/dbglog.h>

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
@@ -7,7 +7,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include <arch/cache.h>
+#include <kos/cache.h>
 #include <dc/pvr.h>
 #include "pvr_internal.h"
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_prim.c
@@ -46,7 +46,7 @@ void pvr_poly_compile(pvr_poly_hdr_t *dst, const pvr_poly_cxt_t *src) {
 
     /* pvr_poly_hdr_t is cacheline-aligned and we're writing all 32 bytes:
      * we can allocate a dirty cache line */
-    dcache_alloc_block(dst, cmd);
+    dcache_alloc_line_with_value(dst, cmd);
 
     /* Polygon mode 1 */
     dst->mode1 = FIELD_PREP(PVR_TA_PM1_DEPTHCMP, src->depth.comparison)
@@ -280,7 +280,7 @@ void pvr_sprite_compile(pvr_sprite_hdr_t *dst, const pvr_sprite_cxt_t *src) {
 
     /* pvr_sprite_hdr_t is cacheline-aligned and we're writing all 32 bytes:
      * we can allocate a dirty cache line */
-    dcache_alloc_block(dst, cmd);
+    dcache_alloc_line_with_value(dst, cmd);
 
     /* Polygon mode 1 */
     dst->mode1 = FIELD_PREP(PVR_TA_PM1_DEPTHCMP, src->depth.comparison)
@@ -347,7 +347,7 @@ void pvr_mod_compile(pvr_mod_hdr_t *dst, pvr_list_t list, uint32_t mode,
 
     /* pvr_mod_hdr_t is cacheline-aligned and we're writing all 32 bytes:
      * we can allocate a dirty cache line */
-    dcache_alloc_block(dst, cmd);
+    dcache_alloc_line_with_value(dst, cmd);
 
     dst->mode1 = FIELD_PREP(PVR_TA_PM1_MODIFIERINST, mode)
         | FIELD_PREP(PVR_TA_PM1_CULLING, cull);
@@ -376,7 +376,7 @@ void pvr_poly_mod_compile(pvr_poly_mod_hdr_t *dst, const pvr_poly_cxt_t *src) {
 
     /* pvr_poly_mod_hdr_t is cacheline-aligned and we're writing all 32 bytes:
      * we can allocate a dirty cache line */
-    dcache_alloc_block(dst, cmd);
+    dcache_alloc_line_with_value(dst, cmd);
 
     /* Polygon mode 1 */
     dst->mode1 = FIELD_PREP(PVR_TA_PM1_DEPTHCMP, src->depth.comparison)

--- a/kernel/arch/dreamcast/hardware/sci.c
+++ b/kernel/arch/dreamcast/hardware/sci.c
@@ -7,7 +7,6 @@
 #include <dc/sci.h>
 #include <dc/math.h>
 #include <arch/arch.h>
-#include <arch/cache.h>
 #include <arch/dmac.h>
 #include <kos/timer.h>
 

--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -10,9 +10,9 @@
 
 #include <assert.h>
 
-#include <arch/cache.h>
 #include <arch/mmu.h>
 #include <dc/sq.h>
+#include <kos/cache.h>
 #include <kos/dbglog.h>
 #include <kos/mutex.h>
 

--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -144,7 +144,7 @@ __noinline void *sq_cpy(void *dest, const void *src, size_t n) {
         /* If src is not 8-byte aligned, slow path */
         if(!__is_aligned(src, 8)) {
             while(nb--) {
-                dcache_pref_block(s + 8); /* Prefetch 32 bytes for next loop */
+                dcache_pref_line(s + 8); /* Prefetch 32 bytes for next loop */
                 d[0] = *(s++);
                 d[1] = *(s++);
                 d[2] = *(s++);

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -33,6 +33,7 @@ __BEGIN_DECLS
 
 #include <kos/regfield.h>
 
+#include <stdalign.h>
 #include <stdint.h>
 
 #define ARCH_CACHE_L1_ICACHE_SIZE       (8 * 1024)
@@ -174,11 +175,24 @@ static inline void arch_dcache_wback_range(uintptr_t start, size_t count) {
 }
 
 static inline void arch_dcache_purge_all(void) {
-    volatile uint32_t *dca = (volatile uint32_t *)0xf4000008;
     unsigned int i;
 
-    for (i = 0; i < 512; i++, dca += 8)
-        *dca = 0;
+    if(__is_defined(__OPTIMIZE_SIZE__)) {
+        volatile uint32_t *dca = (volatile uint32_t *)0xf4000008;
+
+        for (i = 0; i < 512; i++, dca += 8)
+            *dca = 0;
+    }
+    else {
+        alignas(32) static char buffer[ARCH_CACHE_L1_DCACHE_SIZE];
+        char *buf = buffer;
+
+        for(i = 0; i < ARCH_CACHE_L1_DCACHE_SIZE / 32; i++) {
+            arch_dcache_alloc_line(buf);
+            arch_dcache_inval_line(buf);
+            buf += 32;
+        }
+    }
 }
 
 static inline void arch_dcache_purge_range(uintptr_t start, size_t count) {

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -209,12 +209,7 @@ static __always_inline void dcache_pref_block(const void *src) {
     );
 }
 
-/** \brief  Write-back Store Queue buffer to external memory
-
-    This function initiates write-back for one Store Queue.
-
-    \param  src             The SQ mapped address to write-back.
-*/
+__depr("dcache_wback_sq is deprecated. Use sq_flush() from <dc/sq.h>")
 static __always_inline void dcache_wback_sq(void *src) {
     __asm__ __volatile__("pref @%0\n"
                          : /* No outputs */

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -31,6 +31,8 @@
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
+#include <kos/regfield.h>
+
 #include <stdint.h>
 
 #define ARCH_CACHE_L1_ICACHE_SIZE       (8 * 1024)
@@ -47,13 +49,6 @@ __BEGIN_DECLS
 
 void arch_icache_inval_range(uintptr_t start, size_t count);
 void arch_icache_sync_range(uintptr_t start, size_t count);
-
-void arch_dcache_inval_range(uintptr_t start, size_t count);
-void arch_dcache_wback_range(uintptr_t start, size_t count);
-void arch_dcache_purge_range(uintptr_t start, size_t count);
-
-void arch_dcache_wback_all(void);
-void arch_dcache_purge_all(void);
 
 __depr("dcache_wback_sq is deprecated. Use sq_flush() from <dc/sq.h>")
 static __always_inline void dcache_wback_sq(void *src) {
@@ -144,6 +139,61 @@ static inline void arch_dcache_wback_line(void *src) {
                "=m"(ptr[7])
              : "r" (ptr)
     );
+}
+
+static inline void arch_dcache_inval_range(uintptr_t start, size_t count) {
+    uintptr_t end = start + count;
+
+    start &= ~0x1f;
+
+    for(; start < end; start += 32)
+        arch_dcache_inval_line((void *)start);
+}
+
+static inline void arch_dcache_wback_all(void) {
+    unsigned int i;
+    volatile uint32_t *dca = (volatile uint32_t *)0xf4000008;
+
+    for (i = 0; i < 512; i++, dca += 8)
+        *dca &= ~BIT(1); /* Zero out U bit */
+}
+
+static inline void arch_dcache_wback_range(uintptr_t start, size_t count) {
+    uintptr_t end = start + count;
+
+    if(count >= 65560) {
+        /* Above this magic threshold, it's just faster to flush the whole cache. */
+        arch_dcache_wback_all();
+    }
+    else {
+        start &= ~0x1f;
+
+        for(; start < end; start += 32)
+            arch_dcache_wback_line((void *)start);
+    }
+}
+
+static inline void arch_dcache_purge_all(void) {
+    volatile uint32_t *dca = (volatile uint32_t *)0xf4000008;
+    unsigned int i;
+
+    for (i = 0; i < 512; i++, dca += 8)
+        *dca = 0;
+}
+
+static inline void arch_dcache_purge_range(uintptr_t start, size_t count) {
+    uintptr_t end = start + count;
+
+    if(count >= 39936) {
+        /* Above this magic threshold, it's just faster to purge the whole cache. */
+        arch_dcache_purge_all();
+    }
+    else {
+        start &= ~0x1f;
+
+        for(; start < end; start += 32)
+            arch_dcache_purge_line((void *)start);
+    }
 }
 
 __END_DECLS

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -81,7 +81,12 @@ static inline void arch_dcache_alloc_line_with_value(void *src, uintptr_t value)
 }
 
 static inline void arch_dcache_alloc_line(void *src) {
+#if __GNUC__ <= 9
+    /* Avoid ICE on GCC 9 */
+    uint32_t r0 = 0;
+#else
     register uint32_t r0 __asm__("r0");
+#endif
 
     arch_dcache_alloc_line_with_value(src, r0);
 }

--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -1,7 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/include/cache.h
-
+   arch/dreamcast/include/arch/cache.h
    Copyright (C) 2001 Megan Potter
    Copyright (C) 2014, 2016, 2023 Ruslan Rostovtsev
    Copyright (C) 2023 Andy Barajas
@@ -23,6 +22,9 @@
     \author Falco Girgis
 */
 
+/* Keep this include above the macro guards */
+#include <kos/cache.h>
+
 #ifndef __ARCH_CACHE_H
 #define __ARCH_CACHE_H
 
@@ -31,183 +33,27 @@ __BEGIN_DECLS
 
 #include <stdint.h>
 
-/** \defgroup system_cache Cache
-    \brief                 Driver and API for managing the SH4's cache
-    \ingroup               system
+#define ARCH_CACHE_L1_ICACHE_SIZE       (8 * 1024)
+#define ARCH_CACHE_L1_ICACHE_ASSOC      1
+#define ARCH_CACHE_L1_ICACHE_LINESIZE   32
 
-    @{
-*/
+#define ARCH_CACHE_L1_DCACHE_SIZE       (16 * 1024)
+#define ARCH_CACHE_L1_DCACHE_ASSOC      1
+#define ARCH_CACHE_L1_DCACHE_LINESIZE   32
 
-/** \brief  Level 1 instruction cache size.
+#define ARCH_CACHE_L2_CACHE_SIZE        0
+#define ARCH_CACHE_L2_CACHE_ASSOC       0
+#define ARCH_CACHE_L2_CACHE_LINESIZE    0
 
-    The capacity of the L1 instruction cache in bytes.
-*/
-#define CACHE_L1_ICACHE_SIZE 8 * 1024
+void arch_icache_inval_range(uintptr_t start, size_t count);
+void arch_icache_sync_range(uintptr_t start, size_t count);
 
-/** \brief  Level 1 instruction cache associativity.
+void arch_dcache_inval_range(uintptr_t start, size_t count);
+void arch_dcache_wback_range(uintptr_t start, size_t count);
+void arch_dcache_purge_range(uintptr_t start, size_t count);
 
-    Number of ways in the L1 instruction cache.
-*/
-#define CACHE_L1_ICACHE_ASSOC 1
-
-/** \brief  L1 instruction cache line size.
-
-    The size of each cache line in the L1 instruction cache.
-*/
-#define CACHE_L1_ICACHE_LINESIZE 32
-
-/** \brief  Level 1 data cache size.
-
-    The capacity of the L1 data cache in bytes.
-*/
-#define CACHE_L1_DCACHE_SIZE 16 * 1024
-
-/** \brief  Level 1 data cache associativity.
-
-    Number of ways in the L1 data cache.
-*/
-#define CACHE_L1_DCACHE_ASSOC 1
-
-/** \brief  L1 data cache line size.
-
-    The size of each cache line in the L1 data cache.
-*/
-#define CACHE_L1_DCACHE_LINESIZE 32
-
-/** \brief  Level 2 cache size.
-
-    The capacity of the L2 cache in bytes.
-*/
-#define CACHE_L2_CACHE_SIZE 0
-
-/** \brief  Level 2 cache associativity.
-
-    Number of ways in the L2 cache.
-*/
-#define CACHE_L2_CACHE_ASSOC 0
-
-/** \brief  Level 2 cache line size.
-
-    The size of each cache line in the L2 cache.
-*/
-#define CACHE_L2_CACHE_LINESIZE 0
-
-/** \brief Invalidate the instruction cache.
-
-    This instruction invalidates a range of the instruction cache.
-
-    \warning
-    If you care aobut the contents of the cache that have not been written
-    back yet, use icache_flush_range() instead!
-
-    \param  start           The physical address to begin invalidation at.
-    \param  count           The number of bytes to invalidate.
-*/
-void icache_inval_range(uintptr_t start, size_t count);
-
-/** \brief  Flush the instruction cache.
-
-    This function flushes a range of the instruction cache.
-
-    \param  start           The physical address to begin flushing at.
-    \param  count           The number of bytes to flush.
-*/
-void icache_flush_range(uintptr_t start, size_t count);
-
-/** \brief  Invalidate the data/operand cache.
-
-    This function invalidates a range of the data/operand cache. If you care
-    about the contents of the cache that have not been written back yet, use
-    dcache_flush_range() before using this function.
-
-    \param  start           The physical address to begin invalidating at.
-    \param  count           The number of bytes to invalidate.
-*/
-void dcache_inval_range(uintptr_t start, size_t count);
-
-/** \brief  Flush the data/operand cache.
-
-    This function flushes a range of the data/operand cache, forcing a write-
-    back on all of the data in the specified range. This does not invalidate 
-    the cache in the process (meaning the blocks will still be in the cache, 
-    just not marked as dirty after this has completed). If you wish to 
-    invalidate the cache as well, call dcache_inval_range() after calling this
-    function or use dcache_purge_range() instead of dcache_flush_range().
-
-    \param  start           The physical address to begin flushing at.
-    \param  count           The number of bytes to flush.
-*/
-void dcache_flush_range(uintptr_t start, size_t count);
-
-/** \brief  Flush all the data/operand cache.
-
-    This function flushes all the data/operand cache, forcing a write-
-    back on all of the cache blocks that are marked as dirty.
-
-    \note
-    dcache_flush_range() is faster than dcache_flush_all() if the count
-    param is 66560 or less.
-*/
-void dcache_flush_all(void);
-
-/** \brief  Purge the data/operand cache.
-
-    This function flushes a range of the data/operand cache, forcing a write-
-    back and then invalidates all of the data in the specified range.
-
-    \param  start           The physical address to begin purging at.
-    \param  count           The number of bytes to purge.
-*/
-void dcache_purge_range(uintptr_t start, size_t count);
-
-/** \brief  Purge all the data/operand cache.
-
-    This function flushes the entire data/operand cache, ensuring that all 
-    cache blocks marked as dirty are written back to memory and all cache 
-    entries are invalidated. It does not require an additional buffer and is 
-    preferred when memory resources are constrained.
-
-    \note
-    dcache_purge_range() is faster than dcache_purge_all() if the count
-    param is 39936 or less.
-*/
-void dcache_purge_all(void);
-
-/** \brief  Purge all the data/operand cache with buffer.
-
-    This function performs a purge of all data/operand cache blocks by 
-    utilizing an external buffer to speed up the write-back and invalidation 
-    process. It is always faster than dcache_purge_all() and is recommended 
-    where maximum speed is required.
-
-    \note While this function offers a superior purge rate, it does require
-    the use of a temporary buffer. So use this function if you have an extra 
-    8/16 kb of memory laying around that you can utilize for no other purpose 
-    than for this function.
-
-    \param  start           The physical address for temporary buffer (32-byte 
-                            aligned)
-    \param  count           The size of the temporary buffer, which can be 
-                            either 8 KB or 16 KB, depending on cache 
-                            configuration - 8 KB buffer with OCRAM enabled, 
-                            otherwise 16 KB.
-
-*/
-void dcache_purge_all_with_buffer(uintptr_t start, size_t count);
-
-/** \brief  Prefetch one block to the data/operand cache.
-
-    This function prefetch a block of the data/operand cache.
-
-    \param  src             The physical address to prefetch.
-*/
-static __always_inline void dcache_pref_block(const void *src) {
-    __asm__ __volatile__("pref @%0\n"
-                         : /* No outputs */
-                         : "r" (src)
-                         : /* No clobbers */
-    );
-}
+void arch_dcache_wback_all(void);
+void arch_dcache_purge_all(void);
 
 __depr("dcache_wback_sq is deprecated. Use sq_flush() from <dc/sq.h>")
 static __always_inline void dcache_wback_sq(void *src) {
@@ -218,30 +64,87 @@ static __always_inline void dcache_wback_sq(void *src) {
     );
 }
 
-/** \brief  Allocate one block of the data/operand cache.
+static inline void arch_dcache_pref_line(const void *src) {
+    __builtin_prefetch(src);
+}
 
-    This function allocate a block of the data/operand cache.
-
-    \param  src             The address to allocate (32-byte aligned)
-    \param  value           The value written to first 4-byte.
-*/
-static __always_inline void dcache_alloc_block(void *src, uint32_t value) {
-    uint32_t *src32 = (uint32_t *)src;
+static inline void arch_dcache_alloc_line_with_value(void *src, uintptr_t value) {
+    uintptr_t *ptr = (uintptr_t *)src;
 
     __asm__ ("movca.l r0, @%8\n\t"
-             : "=m"(src32[0]),
-               "=m"(src32[1]),
-               "=m"(src32[2]),
-               "=m"(src32[3]),
-               "=m"(src32[4]),
-               "=m"(src32[5]),
-               "=m"(src32[6]),
-               "=m"(src32[7])
-             : "r" (src32), "z" (value)
+             : "=m"(ptr[0]),
+               "=m"(ptr[1]),
+               "=m"(ptr[2]),
+               "=m"(ptr[3]),
+               "=m"(ptr[4]),
+               "=m"(ptr[5]),
+               "=m"(ptr[6]),
+               "=m"(ptr[7])
+             : "r" (ptr), "z"(value)
     );
 }
 
-/** @} */
+static inline void arch_dcache_alloc_line(void *src) {
+    register uint32_t r0 __asm__("r0");
+
+    arch_dcache_alloc_line_with_value(src, r0);
+}
+
+static inline void arch_dcache_zero_alloc_line(void *src) {
+    uint32_t *ptr = (uint32_t *)((uintptr_t)src & ~0x1f);
+
+    arch_dcache_alloc_line_with_value(src, 0);
+
+    ptr[1] = ptr[2] = ptr[3] = ptr[4] = ptr[5] = ptr[6] = ptr[7] = 0;
+}
+
+static inline void arch_dcache_inval_line(void *src) {
+    uintptr_t *ptr = (uintptr_t *)src;
+
+    __asm__ ("ocbi @%8\n\t"
+             : "=m"(ptr[0]),
+               "=m"(ptr[1]),
+               "=m"(ptr[2]),
+               "=m"(ptr[3]),
+               "=m"(ptr[4]),
+               "=m"(ptr[5]),
+               "=m"(ptr[6]),
+               "=m"(ptr[7])
+             : "r" (ptr)
+    );
+}
+
+static inline void arch_dcache_purge_line(void *src) {
+    uintptr_t *ptr = (uintptr_t *)src;
+
+    __asm__ ("ocbp @%8\n\t"
+             : "=m"(ptr[0]),
+               "=m"(ptr[1]),
+               "=m"(ptr[2]),
+               "=m"(ptr[3]),
+               "=m"(ptr[4]),
+               "=m"(ptr[5]),
+               "=m"(ptr[6]),
+               "=m"(ptr[7])
+             : "r" (ptr)
+    );
+}
+
+static inline void arch_dcache_wback_line(void *src) {
+    uintptr_t *ptr = (uintptr_t *)src;
+
+    __asm__ ("ocbwb @%8\n\t"
+             : "=m"(ptr[0]),
+               "=m"(ptr[1]),
+               "=m"(ptr[2]),
+               "=m"(ptr[3]),
+               "=m"(ptr[4]),
+               "=m"(ptr[5]),
+               "=m"(ptr[6]),
+               "=m"(ptr[7])
+             : "r" (ptr)
+    );
+}
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -45,7 +45,6 @@ __BEGIN_DECLS
 
 #include <dc/memory.h>
 #include <arch/types.h>
-#include <arch/cache.h>
 #include <dc/sq.h>
 #include <kos/img.h>
 #include <kos/regfield.h>

--- a/kernel/arch/dreamcast/include/dc/sq.h
+++ b/kernel/arch/dreamcast/include/dc/sq.h
@@ -43,7 +43,6 @@ __BEGIN_DECLS
 
 #include <stdint.h>
 #include <dc/memory.h>
-#include <arch/cache.h>
 
 /** \brief   Mask dest to Store Queue area as address
     \ingroup store_queues

--- a/kernel/arch/dreamcast/include/dc/sq.h
+++ b/kernel/arch/dreamcast/include/dc/sq.h
@@ -110,7 +110,13 @@ void sq_wait(void);
 
     \sa sq_wait()
 */
-#define sq_flush(dest) dcache_wback_sq(dest)
+static inline void sq_flush(void *src) {
+    __asm__ __volatile__("pref @%0\n"
+                         : /* No outputs */
+                         : "r" (src)
+                         : "memory"
+    );
+}
 
 /** \brief   Copy a block of memory.
     \ingroup store_queues

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -121,7 +121,7 @@ _arch_icache_sync_range:
     or       r1, r6        ! CACHE_IC_ADDRESS_ARRAY | (v & CACHE_IC_ENTRY_MASK)
     ocbwb    @r7           ! Write back D cache
     and      r3, r7        ! v & 0xfffffc00
-    bt/s     .iinval_loop
+    bt/s     .iflush_loop
     mov.l    r7, @r6       ! Invalidate cache entry
 
     ! make sure we have enough instrs before returning to P1

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -85,7 +85,7 @@ _icache_inval_range:
     rts
     nop
 
-! This routine goes through and flushes/invalidates the icache 
+! This routine goes through and flushes/invalidates the icache
 ! for a given range.
 !
 ! r4 is starting address
@@ -149,7 +149,7 @@ _icache_flush_range:
     nop
 
 
-! This routine goes through and invalidates the dcache for a given 
+! This routine goes through and invalidates the dcache for a given
 ! range of RAM. Make sure that you've called dcache_flush_range first
 ! if you care about the contents.
 !
@@ -158,11 +158,11 @@ _icache_flush_range:
     .align 2
 _dcache_inval_range:
     tst      r5, r5         ! Test if size is 0
-    mov.l    align_mask, r0   
+    mov.l    align_mask, r0
 
     bt       .dinval_exit   ! Exit early if no blocks to inval
     add      r4, r5         ! Get ending address from size
-    
+
     and      r0, r4         ! Align start address
 
 .dinval_loop:
@@ -189,13 +189,13 @@ _dcache_flush_range:
     ! Check that 0 < size < flush_check
     tst      r5, r5
     mov.l    flush_check, r2
-    
+
     bt       .dflush_exit       ! Exit early if no blocks to flush
     mov.l    align_mask, r0
 
     cmp/hi   r2, r5             ! Compare with flush_check
     add      r4, r5             ! Get ending address from size
-    
+
     bt       _dcache_flush_all  ! If size > flush_check, jump to _dcache_flush_all
     and      r0, r4             ! Align start address
 
@@ -242,12 +242,12 @@ _dcache_flush_all:
 ! r5 is size
     .align 2
 _dcache_purge_range:
-    ! Check that 0 < size < purge_check  
+    ! Check that 0 < size < purge_check
     tst      r5, r5
     mov.l    purge_check, r2
-    
+
     bt       .dpurge_exit       ! Exit early if no blocks to purge
-    mov.l    align_mask, r0 
+    mov.l    align_mask, r0
 
     cmp/hi   r2, r5             ! Compare with purge_check
     add      r4, r5             ! Get ending address from size
@@ -275,7 +275,7 @@ _dcache_purge_all:
     mov.l    dca_addr, r1
     mov.w    cache_lines, r2
     mov      #0, r3
-    
+
 .dpurge_all_loop:
     mov.l    r3, @r1     ! Update dcache entry
     dt       r2
@@ -318,7 +318,7 @@ ic_entry_mask:
     .long    0x1fe0        ! CACHE_IC_ENTRY_MASK
 ic_valid_mask:
     .long    0xfffffc00
-ifr_addr:    
+ifr_addr:
     .long    .iflush_real
 iir_addr:
     .long    .iinval_real
@@ -329,18 +329,18 @@ dca_addr:
 dc_ubit_mask:
     .long    0xfffffffd    ! Mask to zero out U bit
 
-! _dcache_flush_range can have size param set up to 66560 bytes 
+! _dcache_flush_range can have size param set up to 66560 bytes
 ! and still be faster than dcache_flush_all.
 flush_check:
     .long    66560
-    
-! _dcache_purge_range can have size param set up to 39936 bytes 
+
+! _dcache_purge_range can have size param set up to 39936 bytes
 ! and still be faster than dcache_purge_all.
 purge_check:
-    .long    39936 
+    .long    39936
 
-! Shared    
-p2_mask:    
+! Shared
+p2_mask:
     .long    0xa0000000
 ormask:
     .long    0x100000f0
@@ -348,5 +348,4 @@ align_mask:
     .long    ~31           ! Align address to 32-byte boundary
 cache_lines:
     .word    512           ! Total number of cache lines in dcache
-       
 

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -14,13 +14,6 @@
     .text
     .globl _arch_icache_inval_range
     .globl _arch_icache_sync_range
-    .globl _arch_dcache_inval_range
-    .globl _arch_dcache_wback_range
-    .globl _arch_dcache_wback_all
-    .globl _arch_dcache_purge_range
-    .globl _arch_dcache_purge_all
-    .globl _dcache_purge_all_with_buffer
-
 
 ! This routine goes through and flushes/invalidates the icache
 ! for a given range.
@@ -149,165 +142,6 @@ _arch_icache_sync_range:
     nop
 
 
-! This routine goes through and invalidates the dcache for a given
-! range of RAM. Make sure that you've called dcache_flush_range first
-! if you care about the contents.
-!
-! r4 is starting address
-! r5 is size
-    .align 2
-_arch_dcache_inval_range:
-    tst      r5, r5         ! Test if size is 0
-    mov.l    align_mask, r0
-
-    bt       .dinval_exit   ! Exit early if no blocks to inval
-    add      r4, r5         ! Get ending address from size
-
-    and      r0, r4         ! Align start address
-
-.dinval_loop:
-    ! Invalidate the dcache
-    ocbi     @r4
-    add      #32, r4        ! Move on to next cache block
-    cmp/hi   r4, r5
-    bt       .dinval_loop
-
-.dinval_exit:
-    rts
-    nop
-
-
-! This routine goes through and forces a write-back on the
-! specified data range. Use prior to dcache_inval_range if you
-! care about the contents. If the range is bigger than the dcache,
-! we flush the whole cache instead.
-!
-! r4 is starting address
-! r5 is size
-    .align 2
-_arch_dcache_wback_range:
-    ! Check that 0 < size < flush_check
-    tst      r5, r5
-    mov.l    flush_check, r2
-
-    bt       .dflush_exit       ! Exit early if no blocks to flush
-    mov.l    align_mask, r0
-
-    cmp/hi   r2, r5             ! Compare with flush_check
-    add      r4, r5             ! Get ending address from size
-
-    bt       _arch_dcache_wback_all  ! If size > flush_check, jump to _arch_dcache_wback_all
-    and      r0, r4             ! Align start address
-
-.dflush_loop:
-    ! Write back the dcache
-    ocbwb    @r4
-    add      #32, r4        ! Move on to next cache block
-    cmp/hi   r4, r5
-    bt       .dflush_loop
-
-.dflush_exit:
-    rts
-    nop
-
-
-! This routine uses the OC address array to have direct access to the
-! dcache entries.  It forces a write-back on all dcache entries where
-! the U bit and V bit are set to 1.  Then updates the entry with
-! U bit cleared.
-    .align 2
-_arch_dcache_wback_all:
-    mov.l    dca_addr, r1
-    mov.w    cache_lines, r2
-    mov.l    dc_ubit_mask, r3
-
-.dflush_all_loop:
-    mov.l    @r1, r0     ! Get dcache array entry value
-    and      r3, r0      ! Zero out U bit
-    dt       r2
-    mov.l    r0, @r1     ! Update dcache entry
-
-    bf/s     .dflush_all_loop
-    add      #32, r1     ! Move on to next entry
-
-    rts
-    nop
-
-
-! This routine goes through and forces a write-back and invalidate
-! on the specified data range. If the range is bigger than the dcache,
-! we purge the whole cache instead.
-!
-! r4 is starting address
-! r5 is size
-    .align 2
-_arch_dcache_purge_range:
-    ! Check that 0 < size < purge_check
-    tst      r5, r5
-    mov.l    purge_check, r2
-
-    bt       .dpurge_exit       ! Exit early if no blocks to purge
-    mov.l    align_mask, r0
-
-    cmp/hi   r2, r5             ! Compare with purge_check
-    add      r4, r5             ! Get ending address from size
-
-    bt       _arch_dcache_purge_all  ! If size > purge_check, jump to _arch_dcache_purge_all
-    and      r0, r4             ! Align start address
-
-.dpurge_loop:
-    ! Write back and invalidate the D cache
-    ocbp     @r4
-    add      #32, r4     ! Move on to next cache block
-    cmp/hi   r4, r5
-    bt       .dpurge_loop
-
-.dpurge_exit:
-    rts
-    nop
-
-
-! This routine uses the OC address array to have direct access to the
-! dcache entries.  It goes through and forces a write-back and invalidate
-! on all of the dcache.
-    .align 2
-_arch_dcache_purge_all:
-    mov.l    dca_addr, r1
-    mov.w    cache_lines, r2
-    mov      #0, r3
-
-.dpurge_all_loop:
-    mov.l    r3, @r1     ! Update dcache entry
-    dt       r2
-    bf/s     .dpurge_all_loop
-    add      #32, r1     ! Move on to next entry
-
-    rts
-    nop
-
-
-! This routine forces a write-back and invalidate all dcache
-! using a 8kb or 16kb 32-byte aligned buffer.
-!
-! r4 is address for temporary buffer 32-byte aligned
-! r5 is size of temporary buffer (8 KB or 16 KB)
-    .align 2
-_dcache_purge_all_with_buffer:
-    mov      #0, r0
-    add      r4, r5
-
-.dpurge_all_buffer_loop:
-    ! Allocate and then invalidate the dcache line
-    movca.l  r0, @r4
-    cmp/hi   r4, r5
-    ocbi     @r4
-    bt.s    .dpurge_all_buffer_loop
-    add      #32, r4        ! Move on to next cache block
-
-    rts
-    nop
-
-
 ! Variables
     .align    2
 
@@ -322,30 +156,10 @@ ifr_addr:
     .long    .iflush_real
 iir_addr:
     .long    .iinval_real
-
-! D-cache (Data cache)
-dca_addr:
-    .long    0xf4000008    ! dcache array address
-dc_ubit_mask:
-    .long    0xfffffffd    ! Mask to zero out U bit
-
-! _arch_dcache_flush_range can have size param set up to 66560 bytes
-! and still be faster than dcache_wback_all.
-flush_check:
-    .long    66560
-
-! _arch_dcache_purge_range can have size param set up to 39936 bytes
-! and still be faster than arch_dcache_purge_all.
-purge_check:
-    .long    39936
-
-! Shared
 p2_mask:
     .long    0xa0000000
 ormask:
     .long    0x100000f0
 align_mask:
     .long    ~31           ! Align address to 32-byte boundary
-cache_lines:
-    .word    512           ! Total number of cache lines in dcache
 

--- a/kernel/arch/dreamcast/kernel/cache.s
+++ b/kernel/arch/dreamcast/kernel/cache.s
@@ -12,13 +12,13 @@
 !
 
     .text
-    .globl _icache_inval_range
-    .globl _icache_flush_range
-    .globl _dcache_inval_range
-    .globl _dcache_flush_range
-    .globl _dcache_flush_all
-    .globl _dcache_purge_range
-    .globl _dcache_purge_all
+    .globl _arch_icache_inval_range
+    .globl _arch_icache_sync_range
+    .globl _arch_dcache_inval_range
+    .globl _arch_dcache_wback_range
+    .globl _arch_dcache_wback_all
+    .globl _arch_dcache_purge_range
+    .globl _arch_dcache_purge_all
     .globl _dcache_purge_all_with_buffer
 
 
@@ -28,7 +28,7 @@
 ! r4 is starting address
 ! r5 is size
     .align 2
-_icache_inval_range:
+_arch_icache_inval_range:
     tst      r5, r5          ! Test if size is 0
     mov.l    iir_addr, r0
 
@@ -91,7 +91,7 @@ _icache_inval_range:
 ! r4 is starting address
 ! r5 is size
     .align 2
-_icache_flush_range:
+_arch_icache_sync_range:
     tst      r5, r5          ! Test if size is 0
     mov.l    ifr_addr, r0
 
@@ -156,7 +156,7 @@ _icache_flush_range:
 ! r4 is starting address
 ! r5 is size
     .align 2
-_dcache_inval_range:
+_arch_dcache_inval_range:
     tst      r5, r5         ! Test if size is 0
     mov.l    align_mask, r0
 
@@ -185,7 +185,7 @@ _dcache_inval_range:
 ! r4 is starting address
 ! r5 is size
     .align 2
-_dcache_flush_range:
+_arch_dcache_wback_range:
     ! Check that 0 < size < flush_check
     tst      r5, r5
     mov.l    flush_check, r2
@@ -196,7 +196,7 @@ _dcache_flush_range:
     cmp/hi   r2, r5             ! Compare with flush_check
     add      r4, r5             ! Get ending address from size
 
-    bt       _dcache_flush_all  ! If size > flush_check, jump to _dcache_flush_all
+    bt       _arch_dcache_wback_all  ! If size > flush_check, jump to _arch_dcache_wback_all
     and      r0, r4             ! Align start address
 
 .dflush_loop:
@@ -216,7 +216,7 @@ _dcache_flush_range:
 ! the U bit and V bit are set to 1.  Then updates the entry with
 ! U bit cleared.
     .align 2
-_dcache_flush_all:
+_arch_dcache_wback_all:
     mov.l    dca_addr, r1
     mov.w    cache_lines, r2
     mov.l    dc_ubit_mask, r3
@@ -241,7 +241,7 @@ _dcache_flush_all:
 ! r4 is starting address
 ! r5 is size
     .align 2
-_dcache_purge_range:
+_arch_dcache_purge_range:
     ! Check that 0 < size < purge_check
     tst      r5, r5
     mov.l    purge_check, r2
@@ -252,7 +252,7 @@ _dcache_purge_range:
     cmp/hi   r2, r5             ! Compare with purge_check
     add      r4, r5             ! Get ending address from size
 
-    bt       _dcache_purge_all  ! If size > purge_check, jump to _dcache_purge_all
+    bt       _arch_dcache_purge_all  ! If size > purge_check, jump to _arch_dcache_purge_all
     and      r0, r4             ! Align start address
 
 .dpurge_loop:
@@ -271,7 +271,7 @@ _dcache_purge_range:
 ! dcache entries.  It goes through and forces a write-back and invalidate
 ! on all of the dcache.
     .align 2
-_dcache_purge_all:
+_arch_dcache_purge_all:
     mov.l    dca_addr, r1
     mov.w    cache_lines, r2
     mov      #0, r3
@@ -329,13 +329,13 @@ dca_addr:
 dc_ubit_mask:
     .long    0xfffffffd    ! Mask to zero out U bit
 
-! _dcache_flush_range can have size param set up to 66560 bytes
-! and still be faster than dcache_flush_all.
+! _arch_dcache_flush_range can have size param set up to 66560 bytes
+! and still be faster than dcache_wback_all.
 flush_check:
     .long    66560
 
-! _dcache_purge_range can have size param set up to 39936 bytes
-! and still be faster than dcache_purge_all.
+! _arch_dcache_purge_range can have size param set up to 39936 bytes
+! and still be faster than arch_dcache_purge_all.
 purge_check:
     .long    39936
 

--- a/kernel/arch/dreamcast/kernel/exec.c
+++ b/kernel/arch/dreamcast/kernel/exec.c
@@ -7,9 +7,9 @@
 #include <assert.h>
 
 #include <arch/arch.h>
-#include <arch/cache.h>
 #include <arch/exec.h>
 #include <dc/memory.h>
+#include <kos/cache.h>
 #include <kos/irq.h>
 
 /* Pull the shutdown function in from init.c */

--- a/kernel/arch/dreamcast/kernel/exec.c
+++ b/kernel/arch/dreamcast/kernel/exec.c
@@ -42,7 +42,7 @@ void arch_exec_at(const void *image, uint32_t length, uint32_t address) {
     irq_disable();
 
     /* Flush the data cache for the source area */
-    dcache_flush_range((uintptr_t)image, length);
+    dcache_wback_range((uintptr_t)image, length);
 
     /* Copy over the trampoline */
     for(i = 0; i < tcount; i++)
@@ -55,8 +55,8 @@ void arch_exec_at(const void *image, uint32_t length, uint32_t address) {
     values[3] = _arch_old_stack;    /* Patch in old R15 */
 
     /* Flush both caches for the trampoline area */
-    dcache_flush_range((uintptr_t)buffer, tcount * 4);
-    icache_flush_range((uintptr_t)buffer, tcount * 4);
+    dcache_wback_range((uintptr_t)buffer, tcount * 4);
+    icache_sync_range((uintptr_t)buffer, tcount * 4);
 
     /* Shut us down */
     arch_shutdown();

--- a/kernel/arch/dreamcast/kernel/gdb_stub.c
+++ b/kernel/arch/dreamcast/kernel/gdb_stub.c
@@ -150,8 +150,8 @@
 #include <dc/dcload.h>
 #include <arch/gdb.h>
 #include <arch/arch.h>
-#include <arch/cache.h>
 
+#include <kos/cache.h>
 #include <kos/irq.h>
 
 #include <stddef.h>

--- a/kernel/arch/dreamcast/kernel/gdb_stub.c
+++ b/kernel/arch/dreamcast/kernel/gdb_stub.c
@@ -590,7 +590,7 @@ static void doSStep(void) {
     instrBuffer.memAddr = instrMem;
     instrBuffer.oldInstr = *instrMem;
     *instrMem = SSTEP_INSTR;
-    icache_flush_range((uint32_t)instrMem, 2);
+    icache_sync_range((uint32_t)instrMem, 2);
 }
 
 
@@ -602,7 +602,7 @@ static void undoSStep(void) {
         short *instrMem;
         instrMem = instrBuffer.memAddr;
         *instrMem = instrBuffer.oldInstr;
-        icache_flush_range((uint32_t)instrMem, 2);
+        icache_sync_range((uint32_t)instrMem, 2);
     }
 
     stepped = 0;
@@ -785,7 +785,7 @@ static void gdb_handle_exception(int exceptionVector) {
                         if(hexToInt(&ptr, &length))
                             if(*(ptr++) == ':') {
                                 hex2mem(ptr, (char *) addr, length);
-                                icache_flush_range(addr, length);
+                                icache_sync_range(addr, length);
                                 ptr = 0;
                                 strcpy(remcomOutBuffer, "OK");
                             }

--- a/kernel/arch/dreamcast/kernel/mmu.c
+++ b/kernel/arch/dreamcast/kernel/mmu.c
@@ -12,10 +12,10 @@
 
 #include <arch/arch.h>
 #include <arch/mmu.h>
-#include <arch/cache.h>
 
 #include <dc/memory.h>
 
+#include <kos/cache.h>
 #include <kos/dbgio.h>
 #include <kos/irq.h>
 #include <kos/regfield.h>

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -18,10 +18,10 @@
 #include <sys/cdefs.h>
 #include <sys/queue.h>
 
+#include <kos/cache.h>
 #include <kos/dbglog.h>
 #include <kos/sem.h>
 #include <kos/thread.h>
-#include <arch/cache.h>
 #include <kos/timer.h>
 #include <dc/g2bus.h>
 #include <dc/sq.h>

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -209,7 +209,7 @@ static void snd_pcm16_split_unaligned(void *buffer, void *left, void *right, siz
     uint32_t right_val;
 
     for(; len >= 8; len -= 8) {
-        dcache_pref_block(buf + 8);
+        dcache_pref_line(buf + 8);
 
         data = *buf++;
         left_val = (data >> 16);
@@ -220,8 +220,8 @@ static void snd_pcm16_split_unaligned(void *buffer, void *left, void *right, siz
         right_val |= (data & 0xffff) << 16;
 
         if(__is_aligned(left_ptr, 32)) {
-            dcache_alloc_block(left_ptr++, left_val);
-            dcache_alloc_block(right_ptr++, right_val);
+            dcache_alloc_line_with_value(left_ptr++, left_val);
+            dcache_alloc_line_with_value(right_ptr++, right_val);
         }
         else {
             *left_ptr++ = left_val;
@@ -250,7 +250,7 @@ void snd_pcm16_split_sq(uint32_t *data, uintptr_t left, uintptr_t right, size_t 
     masked_right = SQ_MASK_DEST(right);
 
     sq_lock((void *)left);
-    dcache_pref_block(s);
+    dcache_pref_line(s);
 
     g2_lock_scoped();
 

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -175,13 +175,6 @@ thd_block_now
 #library_open
 #library_close
 
-# Cache management
-icache_flush_range
-dcache_inval_range
-dcache_flush_range
-dcache_purge_range
-dcache_purge_all
-
 # Low-level debug I/O
 __real_dbglog
 dbgio_set_irq_usage

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -407,7 +407,7 @@ int elf_load(const char *fn, klibrary_t *shell, elf_prog_t *out) {
     dbglog(DBG_SOURCE(ELF_DBG_VERBOSE), "elf_load final ELF stats: memory image at %p, size %08lx\n", out->data, out->size);
 
     /* Flush the icache for that zone */
-    icache_flush_range((uint32_t)out->data, out->size);
+    icache_sync_range((uint32_t)out->data, out->size);
 
     return 0;
 

--- a/kernel/fs/elf.c
+++ b/kernel/fs/elf.c
@@ -8,8 +8,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <arch/cache.h>
 #include <arch/arch.h>
+#include <kos/cache.h>
 #include <kos/fs.h>
 #include <kos/elf.h>
 #include <kos/exports.h>

--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -9,10 +9,10 @@
    build flag.
 */
 
+#include <kos/cache.h>
 #include <kos/irq.h>
 #include <kos/mutex.h>
 #include <arch/arch.h>
-#include <arch/cache.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>

--- a/kernel/libc/posix/sysconf.c
+++ b/kernel/libc/posix/sysconf.c
@@ -6,8 +6,8 @@
 */
 
 #include <arch/arch.h>
-#include <arch/cache.h>
 #include <sys/uio.h>
+#include <kos/cache.h>
 #include <kos/netcfg.h>
 #include <kos/fs.h>
 #include <kos/thread.h>


### PR DESCRIPTION
Add a new cache ARCH API, compatible with existing code but with slightly different names.

Note that some functions have been introduced, e.g. functions to invalidate / flush / purge individual cache lines.

This PR also rewrites most of the cache code from ASM to C, because it really does not need this level of complexity.