### PR TITLE
net: Fix checksum, part 3

### DIFF
--- a/kernel/net/net_ipv4.c
+++ b/kernel/net/net_ipv4.c
@@ -35,6 +35,8 @@ static inline uint16_t checksum_one(uint16_t val, uint16_t sum) {
 
 /* Perform an IP-style checksum on a block of data */
 uint16_t __pure net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t sum) {
+    typedef uint16_t __attribute__((may_alias)) alias_u16_t;
+
     /* Make sure we don't do any unaligned memory accesses */
     if((uintptr_t)data & 1) {
         sum = checksum_one(*data, sum);
@@ -44,7 +46,7 @@ uint16_t __pure net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t su
 
     /* Compute checksum two bytes at a time */
     for(; bytes > 1; bytes -= 2, data += 2)
-        sum = checksum_one(*(const uint16_t *)data, sum);
+        sum = checksum_one(*(const alias_u16_t *)data, sum);
 
     /* Handle the last byte, if we have an odd byte count */
     if(bytes)


### PR DESCRIPTION
The code was breaking aliasing rules when called from net_ipv4_checksum_pseudo(), as the struct address was indirectly casted to a uint16_t pointer, causing GCC to not bother emit the proper code for the undefined behaviour.

Address this issue by using a locally defined uint16_t type that is allowed to alias.