### PR TITLE
utils/pvrtex: fix file corruption on Windows

### DIFF
--- a/utils/pvrtex/approvaltest/Makefile
+++ b/utils/pvrtex/approvaltest/Makefile
@@ -7,7 +7,7 @@ RUN_DIR = $(TEST_DIR)/run
 PVRTEX = ../pvrtex
 
 # Default target
-all: test
+all: compare
 
 # Define the array of commands
 TESTS = \
@@ -59,4 +59,4 @@ approve:
 clean:
 	@rm -rf $(RECEIVED_DIR)
 
-.PHONY: all test approve clean
+.PHONY: all compare approve clean

--- a/utils/pvrtex/file_common.c
+++ b/utils/pvrtex/file_common.c
@@ -63,7 +63,7 @@ void WritePvrTexEncoder(const PvrTexEncoder *pte, FILE *f, ptewSmallVQType svq, 
 int FileSize(const char *fname) {
 	assert(fname);
 
-	FILE *f = fopen(fname, "r");
+	FILE *f = fopen(fname, "rb");
 	if (f == NULL)
 		return -1;
 	fseek(f, 0, SEEK_END);
@@ -75,7 +75,7 @@ int FileSize(const char *fname) {
 size_t Slurp(const char *fname, void **data) {
 	assert(fname);
 
-	FILE *f = fopen(fname, "r");
+	FILE *f = fopen(fname, "rb");
 	if (f == NULL)
 		return 0;
 

--- a/utils/pvrtex/file_dctex.c
+++ b/utils/pvrtex/file_dctex.c
@@ -28,7 +28,7 @@ static int convert_size(int size) {
 void fDtWrite(const PvrTexEncoder *pte, const char *outfname) {
 	assert(pte);
 
-	FILE *f = fopen(outfname, "w");
+	FILE *f = fopen(outfname, "wb");
 	assert(f);
 
 	unsigned textype = 0;
@@ -74,7 +74,7 @@ void fDtWrite(const PvrTexEncoder *pte, const char *outfname) {
 	unsigned resultsize = FileSize(outfname);
 	ErrorExitOn(resultsize != size, "Size of file written for \"%s\" was incorrect. Expected file to be %u bytes, but result was %u bytes.\n", outfname, size, resultsize);
 
-	f = fopen(outfname, "r");
+	f = fopen(outfname, "rb");
 	void *readbuff = malloc(size);
 	if (fread(readbuff, size, 1, f) == 1) {
 		if (!fDtValidateHeader(readbuff)) {

--- a/utils/pvrtex/file_pvr.c
+++ b/utils/pvrtex/file_pvr.c
@@ -21,7 +21,7 @@ void fPvrWrite(const PvrTexEncoder *pte, const char *outfname) {
 	assert(pte->pvr_tex);
 	assert(outfname);
 
-	FILE *f = fopen(outfname, "w");
+	FILE *f = fopen(outfname, "wb");
 	assert(f);
 
 	//Write header

--- a/utils/pvrtex/file_tex.c
+++ b/utils/pvrtex/file_tex.c
@@ -8,7 +8,7 @@
 void fTexWrite(const PvrTexEncoder *pte, const char *outfname) {
 	assert(pte);
 
-	FILE *f = fopen(outfname, "w");
+	FILE *f = fopen(outfname, "wb");
 	assert(f);
 
 	unsigned textype = 0;
@@ -61,7 +61,7 @@ void fTexWritePalette(const PvrTexEncoder *pte, const char *outfname) {
 
 	pteLog(LOG_COMPLETION, "Writing .PAL to \"%s\"...\n", outfname);
 
-	FILE *f = fopen(outfname, "w");
+	FILE *f = fopen(outfname, "wb");
 	assert(f);
 
 	WriteFourCC("DPAL", f);


### PR DESCRIPTION
Use 'rb'/'wb' in fopen calls to prevent CRLF substitution in binary files on Windows.

Fix approvaltest makefile to actually run the test by default. Looks like it was always intended to, but then just didn't - default target 'test' was specified but absent.

before change: approvaltest on Windows fails;
after change: approvaltest succeeds.

Fixes https://github.com/KallistiOS/KallistiOS/issues/1339