### PR TITLE
Fix: Format-specific AICA loop boundary in snd_stream

### DIFF
--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -561,7 +561,13 @@ static void snd_stream_start_type(snd_stream_hnd_t hnd, uint32_t type, uint32_t 
     chan->length = bytes_to_samples(hnd, streams[hnd].buffer_size);
     chan->loop = 1;
     chan->loopstart = 0;
-    chan->loopend = chan->length;
+
+    if (type == AICA_SM_ADPCM_LS) {
+        chan->loopend = chan->length - 1;
+    }
+    else {
+        chan->loopend = chan->length;
+
     chan->freq = freq;
     chan->vol = 255;
     chan->pan = streams[hnd].channels == 2 ? 0 : 128;

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -561,7 +561,7 @@ static void snd_stream_start_type(snd_stream_hnd_t hnd, uint32_t type, uint32_t 
     chan->length = bytes_to_samples(hnd, streams[hnd].buffer_size);
     chan->loop = 1;
     chan->loopstart = 0;
-    chan->loopend = chan->length - 1;
+    chan->loopend = chan->length;
     chan->freq = freq;
     chan->vol = 255;
     chan->pan = streams[hnd].channels == 2 ? 0 : 128;


### PR DESCRIPTION
Issue:

    PCM (AICA_SM_16BIT, AICA_SM_8BIT): Requires an inclusive boundary (length). The length - 1 offset drops a sample on every buffer wrap-around, causing a periodic clicking artifact.

    ADPCM (AICA_SM_ADPCM_LS): Requires the length - 1 offset to prevent stream corruption during wrap-around.

Solution:
Apply the offset exclusively for ADPCM streams.