### PR TITLE
dbglog: Simplify logging facility

### DIFF
--- a/include/kos/dbglog.h
+++ b/include/kos/dbglog.h
@@ -1,7 +1,8 @@
 /* KallistiOS ##version##
 
    kos/dbglog.h
-   Copyright (C)2004 Megan Potter
+   Copyright (C) 2004 Megan Potter
+   Copyright (C) 2026 Paul Cercueil
 
 */
 
@@ -23,9 +24,10 @@
 __BEGIN_DECLS
 
 #include <kos/opts.h>
+#include <stdio.h>
 
 /** \defgroup logging   Logging
-    \brief              KOS's Logging API 
+    \brief              KOS's Logging API
     \ingroup            debugging
 */
 
@@ -37,17 +39,14 @@ __BEGIN_DECLS
     info you want to see (or want your users to see).
 
     \param  level           The level of importance of this message.
-    \param  fmt             Message format string.
-    \param  ...             Format arguments
+    \param  ...             Format string + Format arguments
     \see    dbglog_levels
 */
-void __real_dbglog(int level, const char *fmt, ...) __printflike(2, 3);
-
-/* This wrapper allows for the garbage collection of unneeded debug data */
 #define dbglog(lvl, ...) \
 do { \
-  if ((lvl) <= DBGLOG_LEVEL_SUPPORT) \
-    __real_dbglog(lvl, __VA_ARGS__); \
+    int __dbglog_lvl = (lvl); \
+    if(__dbglog_lvl <= DBGLOG_LEVEL_SUPPORT && __dbglog_lvl <= dbglog_level) \
+        printf(__VA_ARGS__); \
 } while(0)
 
 /** \defgroup   dbglog_levels   Log Levels
@@ -88,6 +87,10 @@ do { \
     \see    dbglog_levels
 */
 void dbglog_set_level(int level);
+
+/** \cond */
+extern int dbglog_level;
+/** \endcond */
 
 __END_DECLS
 

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -176,7 +176,8 @@ thd_block_now
 #library_close
 
 # Low-level debug I/O
-__real_dbglog
+dbglog_level
+dbglog_set_level
 dbgio_set_irq_usage
 dbgio_enable
 dbgio_disable

--- a/kernel/libc/koslib/dbglog.c
+++ b/kernel/libc/koslib/dbglog.c
@@ -1,23 +1,14 @@
 /* KallistiOS ##version##
 
    dbglog.c
-   Copyright (C)2000,2001,2004 Megan Potter
+   Copyright (C) 2000,2001,2004 Megan Potter
+   Copyright (C) 2026 Paul Cercueil
 */
 
 #include <stdio.h>
 #include <stdarg.h>
-#include <unistd.h>
-#include <string.h>
 
 #include <kos/dbglog.h>
-#include <kos/thread.h>
-#include <kos/dbgio.h>
-#include <kos/fs.h>
-#include <kos/spinlock.h>
-
-/* Not re-entrant */
-static char printf_buf[1024];
-static spinlock_t mutex = SPINLOCK_INITIALIZER;
 
 /* Default kernel debug log level: if a message has a level higher than this,
    it won't be shown. Set to DBG_DEAD to see basically nothing, and set to
@@ -27,31 +18,4 @@ int dbglog_level = (DBGLOG_LEVEL_SUPPORT < DBG_INFO) ? DBGLOG_LEVEL_SUPPORT : DB
 /* Set debug level */
 void dbglog_set_level(int level) {
     dbglog_level = level;
-}
-
-/* Kernel debug logging facility */
-void __real_dbglog(int level, const char *fmt, ...) {
-    va_list args;
-    int i;
-
-    /* If this log level is blocked out, don't even bother */
-    if((DBGLOG_LEVEL_SUPPORT < level) || (level > dbglog_level))
-        return;
-
-    /* We only try to lock if the message isn't urgent */
-    if(level >= DBG_ERROR && !irq_inside_int())
-        spinlock_lock(&mutex);
-
-    va_start(args, fmt);
-    i = vsnprintf(printf_buf, sizeof(printf_buf), fmt, args);
-    va_end(args);
-
-    if(i > 0) {
-        if(irq_inside_int() || 
-            (fs_write(STDOUT_FILENO, printf_buf, strlen(printf_buf)) < 0))
-                dbgio_write_str(printf_buf);
-    }
-
-    if(level >= DBG_ERROR && !irq_inside_int())
-        spinlock_unlock(&mutex);
 }


### PR DESCRIPTION
Instead of calling vsnprintf() to process the format string + arguments into a non-reentrant static buffer, that then needs to be protected against concurrent accesses, just rely on the fact that the C library already provides such a mechanism.

Update dbglog() to a simple macro that will basically call printf() for standard messages, below the warning threshold, and fprintf(stderr) for the important messages.

The macro will also check that the requested log level is below the one set to KallistiOS at compilation time, and the one dynamically set with dbglog_set_level().

Note the use of __builtin_choose_expr(), this is to allow using printf() / fprintf(stderr) instead of fprintf(stdout) / fprintf(stderr). The distinction is important, as the compiler will change the calls to printf() with static strings with no format arguments to calls to puts(). On the ARM port of KallistiOS, these strings can then be transmitted to the SH4 side much more efficiently and asynchronously.