### PR TITLE
PTY related filesystem fixes

### DIFF
--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -194,7 +194,7 @@ static int fs_hnd_assign(fs_hnd_t *hnd) {
 
     fs_hnd_ref(hnd);
 
-    for(i = 0; i < FD_SETSIZE; i++) {
+    for(i = 3; i < FD_SETSIZE; i++) {
         fs_hnd_t *old = NULL;
 
         if(atomic_compare_exchange_strong(&fd_table[i], &old, hnd))

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -309,6 +309,9 @@ file_t fs_dup2(file_t oldfd, file_t newfd) {
         return -1;
     }
 
+    if(oldfd == newfd)
+        goto out_get_ref;
+
     do {
         prev = fd_table[newfd];
         if(prev) {
@@ -319,6 +322,7 @@ file_t fs_dup2(file_t oldfd, file_t newfd) {
     } while(!atomic_compare_exchange_strong(&fd_table[newfd],
                                             &prev, fd_table[oldfd]));
 
+out_get_ref:
     fs_hnd_ref(fd_table[newfd]);
 
     return newfd;

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -39,7 +39,6 @@ something like this:
 #include <kos/thread.h>
 #include <kos/mutex.h>
 #include <kos/nmmgr.h>
-#include <kos/dbgio.h>
 #include <kos/dbglog.h>
 
 /* File handle structure; this is an entirely internal structure so it does

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -180,7 +180,8 @@ int fs_pty_create(char *buffer, int maxbuflen, file_t *master_out, file_t *slave
 
     if(boot) {
         /* Get the slave channel setup first, and dup it across
-           our stdout and stderr. */
+           our stdin, stdout and stderr. */
+        fs_dup2(*slave_out, STDIN_FILENO);
         fs_dup2(*slave_out, STDOUT_FILENO);
         fs_dup2(*slave_out, STDERR_FILENO);
     }


### PR DESCRIPTION
This PR addresses a few issues relative to the file descriptors. Until now, the filesystem core would allocate file descriptors starting from 0. This does not work well alongside the C library, which reserves FDs 0/1/2 for stdin/stdout/stderr.

What happened then, is that the PTY driver would open `/pty/sl00` as the FD 0, and dup2 that FD to 1 and 2 (aka. stdout / stderr). As a result, this file descriptor was also used implictly as the stdin, without it being actually dup2'd.

This was worse on the ARM side, as another file is opened as FD 0, causing the PTY driver's `/pty/sl00` to be opened as FD 1. Then the dup2() call that maps it to stdout would actually be a `dup2(1, 1)`, causing the file descriptor to be closed because of a bug in the dup2 implementation.

Address these issues by handling the case where oldfd == newfd in dup2(), and start the FD values at 3 in the core filesystem code.