### PR TITLE
Add Remote Procedure Call (RPC) API

### DIFF
--- a/include/kos/rpc.h
+++ b/include/kos/rpc.h
@@ -1,0 +1,159 @@
+/* KallistiOS ##version##
+
+   include/kos/rpc.h
+   Copyright (C) 2026 Paul Cercueil
+*/
+
+/** \file    kos/rpc.h
+    \brief   Remote procedure call support
+
+    This file contains an API that can be used for sending RPC messages to a
+    remote processor and handling RPC messages from a remote processor.
+
+    \author Paul Cercueil
+*/
+#ifndef __KOS_RPC_H
+#define __KOS_RPC_H
+
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
+#include <kos/regfield.h>
+#include <stdint.h>
+
+/** \brief  RPC command code.
+
+    A RPC command code identifies a command that can be executed on the remote
+    processor.
+
+    \headerfile kos/rpc.h
+*/
+typedef unsigned char rpc_code_t;
+
+/** \brief  Special command code that represents a response to a command
+    received from the remote. */
+#define RPC_CMD_RESP    0xff
+
+/** \brief  RPC command structure.
+
+    This structure packs the details of a remote procedure call. */
+typedef struct rpc_cmd {
+    rpc_code_t cmd;             /**< \brief Command code */
+    uint8_t flags;              /**< \brief Command flags */
+    uint16_t id;                /**< \brief Command ID (leave it blank) */
+    uint32_t params[3];         /**< \brief Command parameters (12 bytes total) */
+} rpc_cmd_t;
+
+/** \name   RPC command flags
+    \brief  Flags supported for the rpc_cmd_t.flags field. */
+#define RPC_CMD_FLAG_ASYNC      BIT(0)  /**< \brief Command is asynchronous */
+
+/** \name   Command queue
+    \brief  RPC command queue structure.
+
+    The RPC mechanism has two of these; one used for passing the data
+    from the remote processor to the local processor, and the second
+    is used for the other way.
+*/
+typedef struct rpc_cmd_queue {
+    uint32_t head;              /**< \brief Insertion point offset (in commands) */
+    uint32_t tail;              /**< \brief Removal point offset (in commands) */
+    uint32_t size;              /**< \brief Queue size (in commands) */
+    rpc_cmd_t *addr;            /**< \brief Addresses of the commands buffer */
+} rpc_queue_t;
+
+/** \name   RPC data structure.
+
+    This structure should be populated by the user program, before being passed
+    to rpc_init(). */
+typedef struct rpc {
+    /** \brief  Pointer to the inbound queue */
+    rpc_queue_t *inbound;
+
+    /** \brief  Pointer to the outbound queue */
+    rpc_queue_t *outbound;
+
+    /** \brief  RPC callback to read from queue
+
+        \param  dst         A pointer to the local destination buffer
+        \param  rpc_src     The source address in the remote address space
+        \param  len         The length of the transfer
+    */
+    void (*rpc_read)(void *dst, const void *rpc_src, size_t len);
+
+    /** \brief  RPC callback to write to the queue
+
+        \param  rpc_dst     The destination address in the remote address space
+        \param  src         A pointer to the local source buffer
+        \param  len         The length of the transfer
+    */
+    void (*rpc_write)(void *rpc_dst, const void *src, size_t len);
+
+    /** \brief  RPC callback to wake up the remote processor
+
+        This function will be called to notify the remote processor that one
+        or more commands have been added to its inbound queue. */
+    void (*rpc_notify)(void);
+} rpc_t;
+
+/** \brief  Initialize the RPC mechanism.
+
+    \param  rpc             A pointer to an (initialized) rpc structure
+
+    \retval 0               On success.
+    \retval -1              If the RPC structure hasn't been properly
+                            initialized.
+*/
+int rpc_init(rpc_t *rpc);
+
+/** \brief  Shutdown the RPC mechanism. */
+void rpc_shutdown(void);
+
+/** \brief  Execute a command on the remote processor
+
+    This function enqueues a command onto the RPC's outbound queue.
+
+    \param  rpc             A pointer to the rpc structure
+    \param  cmd             A pointer to the command to be sent
+
+    \returns                For asynchronous commands, 0 is returned.
+                            Otherwise, the return value of the remote function
+                            is returned.
+*/
+int rpc_execute(rpc_t *rpc, rpc_cmd_t *cmd);
+
+/** \brief  Request processing of the inbound queue
+
+    This function should be called when any new inbound commands should be
+    processed.
+
+    \param  rpc             A pointer to the rpc structure
+*/
+void rpc_process_inbound(rpc_t *rpc);
+
+/** \brief  Callback type for rpc_register(). */
+typedef int (*rpc_cb_t)(const rpc_cmd_t *cmd, void *cb_data);
+
+/** \brief  Assign a function to a given command code.
+
+    This function should be used to register a function that will be then
+    called when receiving a given command, identified by its code, in the
+    inbound queue.
+
+    \param  code            The command code identifier
+    \param  cb              The callback function to call
+    \param  cb_data         A user pointer to pass to the callback
+*/
+void rpc_register(rpc_code_t code, rpc_cb_t cb, void *cb_data);
+
+/** \brief  Unregister a function for a given command code.
+
+    \param  code            The command code identifier
+*/
+static inline void rpc_unregister(rpc_code_t code) {
+    rpc_register(code, NULL, NULL);
+}
+
+__END_DECLS
+
+#endif /* __KOS_RPC_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -6,7 +6,7 @@
 #
 
 OBJS = banner.o version.o
-SUBDIRS = arch debug fs thread mm net libc exports romdisk init
+SUBDIRS = arch debug fs thread mm net libc exports romdisk init misc
 STUBS = stubs/kernel_export_stubs.o stubs/arch_export_stubs.o stubs/subarch_export_stubs.o
 
 # Everything from here up should be plain old C.

--- a/kernel/misc/Makefile
+++ b/kernel/misc/Makefile
@@ -1,0 +1,9 @@
+# KallistiOS ##version##
+#
+# misc/Makefile
+# (c)2026 Paul Cercueil
+#
+
+OBJS = rpc.o
+
+include $(KOS_BASE)/Makefile.prefab

--- a/kernel/misc/rpc.c
+++ b/kernel/misc/rpc.c
@@ -1,0 +1,169 @@
+/* KallistiOS ##version##
+
+   rpc.c
+   Copyright (C) 2026 Paul Cercueil
+*/
+
+#include <kos/dbglog.h>
+#include <kos/genwait.h>
+#include <kos/mutex.h>
+#include <kos/rpc.h>
+#include <kos/thread.h>
+#include <kos/worker_thread.h>
+
+#include <errno.h>
+#include <stdint.h>
+
+typedef struct rpc_cb_data {
+    rpc_cb_t cb;
+    void *data;
+} rpc_cb_data_t;
+
+static rpc_cb_data_t rpc_cb_data[256];
+
+static kthread_worker_t *worker;
+static kthread_worker_t *notifier;
+
+static uint16_t next_cmd_id;
+
+static mutex_t rpc_lock = MUTEX_INITIALIZER;
+
+static kthread_attr_t rpc_worker_thread_attr = {
+    .prio = 9, /* slightly below default */
+    .label = "[rpc]",
+};
+
+static inline void * rpc_id_to_addr(uint16_t id) {
+    /* Generate a fake address that will be used with genwait, so that
+     * clients can wait on a particular command ID. */
+    return (void *)(0xFFFF0000 + id);
+}
+
+static void rpc_notifier(void *d) {
+    rpc_t *rpc = d;
+
+    rpc->rpc_notify();
+}
+
+static void rpc_worker(void *d) {
+    rpc_queue_t queue;
+    rpc_t *rpc = d;
+    rpc_cmd_t cmd;
+    int ret;
+
+    /* Read the queue structure */
+    rpc->rpc_read(&queue, rpc->inbound, sizeof(queue));
+
+    while(queue.head != queue.tail) {
+        /* Read one command */
+        rpc->rpc_read(&cmd, &queue.addr[queue.tail], sizeof(cmd));
+
+        if(!rpc_cb_data[cmd.cmd].cb) {
+            dbglog(DBG_WARNING, "No handler for RPC command %hhu\n", cmd.cmd);
+        } else {
+            ret = rpc_cb_data[cmd.cmd].cb(&cmd, rpc_cb_data[cmd.cmd].data);
+
+            /* The command is not async? send the response */
+            if(!(cmd.flags & RPC_CMD_FLAG_ASYNC)) {
+                rpc_cmd_t resp = {
+                    .cmd = RPC_CMD_RESP,
+                    .flags = RPC_CMD_FLAG_ASYNC,
+                    .params = {
+                        [0] = cmd.id,
+                        [1] = ret,
+                    },
+                };
+
+                rpc_execute(rpc, &resp);
+            }
+        }
+
+        if(++queue.tail == queue.size)
+            queue.tail = 0;
+    }
+
+    /* Update to the new TAIL */
+    rpc->rpc_write((void *)rpc->inbound + offsetof(rpc_queue_t, tail),
+                   &queue.tail, sizeof(queue.tail));
+}
+
+static int rpc_has_response(const rpc_cmd_t *cmd, void *d) {
+    (void)d;
+
+    genwait_wake_all_err(rpc_id_to_addr(cmd->params[0]), (int)cmd->params[1]);
+
+    return 0;
+}
+
+int rpc_init(rpc_t *rpc) {
+    if(!rpc || !rpc->rpc_read || !rpc->rpc_write || !rpc->rpc_notify) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    worker = thd_worker_create_ex(&rpc_worker_thread_attr, rpc_worker, rpc);
+    if(!worker)
+        return -1;
+
+    notifier = thd_worker_create(rpc_notifier, rpc);
+    if(!notifier) {
+        thd_worker_destroy(worker);
+        return -1;
+    }
+
+    rpc_register(RPC_CMD_RESP, rpc_has_response, rpc);
+
+    return 0;
+}
+
+void rpc_shutdown(void) {
+    thd_worker_destroy(notifier);
+    thd_worker_destroy(worker);
+}
+
+int rpc_execute(rpc_t *rpc, rpc_cmd_t *cmd) {
+    rpc_queue_t queue;
+    int ret = 0;
+
+    mutex_lock(&rpc_lock);
+
+    /* Get a command ID */
+    cmd->id = next_cmd_id++;
+
+    /* Read the queue structure */
+    rpc->rpc_read(&queue, rpc->outbound, sizeof(queue));
+
+    /* Write our command at the current HEAD */
+    rpc->rpc_write(&queue.addr[queue.head], cmd, sizeof(*cmd));
+
+    if(++queue.head == queue.size)
+        queue.head = 0;
+
+    /* Update to the new HEAD */
+    rpc->rpc_write((void *)rpc->outbound + offsetof(rpc_queue_t, head),
+                   &queue.head, sizeof(queue.head));
+
+    mutex_unlock(&rpc_lock);
+
+    /* Notify the remote processor that a new message has been euqueued */
+    thd_worker_wakeup(notifier);
+
+    if(!(cmd->flags & RPC_CMD_FLAG_ASYNC)) {
+        /* Wait until we have a response */
+        genwait_wait(rpc_id_to_addr(cmd->id), "RPC", 0);
+
+        ret = thd_get_current()->thd_errno;
+    }
+
+    return ret;
+}
+
+void rpc_process_inbound(rpc_t *rpc) {
+    (void)rpc;
+
+    thd_worker_wakeup(worker);
+}
+
+void rpc_register(rpc_code_t code, rpc_cb_t cb, void *cb_data) {
+    rpc_cb_data[code] = (rpc_cb_data_t){ cb, cb_data };
+}


### PR DESCRIPTION
Introduce a new API that can be used for sending RPC messages to a remote processor, and handling RPC messages from a remote processor.

This will be used for the communication between the SH4 and the ARM on the Dreamcast, when the ARM will be running KallistiOS. It will allow the ARM to output debug messages, access files, or anything really.

It will also allow the SH4 and the ARM to work better together; for instance, by having the ARM processor responsible for managing the sound RAM, and have commands to request memory.