### PR TITLE
Replace frame-pointer stack tracing with heuristic SP scanning

### DIFF
--- a/doc/environ.sh.sample
+++ b/doc/environ.sh.sample
@@ -169,12 +169,10 @@ export KOS_CFLAGS="${KOS_CFLAGS} -fno-PIC -fno-PIE"
 
 # Frame Pointers
 #
-# Controls whether frame pointers are emitted or not. Disabled by default, as
-# they use an extra register. Enable them if you plan to use GDB for debugging
-# or need additional stack trace
+# Frame pointers are always disabled — they use an extra register and do not
+# work reliably on SH4. Stack tracing uses heuristic SP scanning instead.
 #
 export KOS_CFLAGS="${KOS_CFLAGS} -fomit-frame-pointer"
-#export KOS_CFLAGS="${KOS_CFLAGS} -fno-omit-frame-pointer -DFRAME_POINTERS"
 
 # Stack Protector
 #

--- a/examples/dreamcast/basic/stacktrace/stacktrace.c
+++ b/examples/dreamcast/basic/stacktrace/stacktrace.c
@@ -1,25 +1,138 @@
 /* KallistiOS ##version##
 
    stacktrace.c
-   (c)2002 Megan Potter
+   Copyright (c) 2002 Megan Potter
+   Copyright (c) 2026 Andy Barajas
+
+   -------------------
+   Demonstrates arch_stk_trace() by printing stack traces from three
+   different call scenarios:
+
+   1. Directly from main() -- a shallow trace.
+   2. From inside a recursive function (depth_recurse, 6 levels deep).
+   3. From inside a function called through a function pointer.
+
+   The volatile arrays and fill loops in these functions are intentional
+   -- they force the compiler to create real stack frames that save PR
+   (the return address register) to the stack. Without them, GCC for
+   SH4 keeps everything in registers and the stack scanner has nothing
+   to find.
+
+   Expected output (addresses will vary):
+
+   -------- Stack Trace (innermost first) ---------
+      8c010088
+   -------------- End Stack Trace -----------------
+   -------- Stack Trace (innermost first) ---------
+      8c010152
+      8c010152
+      8c010152
+      8c010152
+      8c010196
+      8c01024a
+      8c010684
+      8c010088
+   -------------- End Stack Trace -----------------
+   -------- Stack Trace (innermost first) ---------
+      8c01022c
+      8c010250
+      8c010684
+      8c010088
+   -------------- End Stack Trace -----------------
 */
 
 #include <kos.h>
 
-/*  This is marked as __noinline to ensure the compiler
-    doesn't try to get smart and inline it which would
-    defeat the purpose of the example.
-*/
-__noinline void func(void) {
+/* A simple function that sums its input with an array.
+   Called through a function pointer to test indirect calls (JSR).
+   The volatile array and loop force a real stack frame.
+   The stack trace is taken here so the full indirect call chain
+   (do_work -> call_indirect -> test_indirect -> main) is visible. */
+__noinline static int do_work(int x) {
+    volatile int buf[12];
+    int i;
+
+    for(i = 0; i < 12; ++i)
+        buf[i] = x + i;
+
     arch_stk_trace(0);
+    return buf[0] + buf[11];
+}
+
+/* Function pointer type for do_work. */
+typedef int (*work_fn)(int);
+
+/* Calls a function through a function pointer and returns the result.
+   Tests that indirect calls show up in traces. */
+__noinline static int call_indirect(work_fn fn, int v) {
+    volatile int buf[12];
+    int i;
+
+    for(i = 0; i < 12; ++i)
+        buf[i] = v + i;
+
+    buf[0] = fn(buf[0]);
+    return buf[0] + buf[11];
+}
+
+/* A recursive function that calls itself `depth` times, then prints
+   a stack trace at the deepest level. The volatile array ensures each
+   recursion level gets a real stack frame with a saved PR value. The
+   addition after the recursive call prevents tail-call optimization. */
+__noinline static int depth_recurse(int depth, int value) {
+    volatile int buf[12];
+    int i;
+
+    for(i = 0; i < 12; ++i)
+        buf[i] = value + depth + i;
+
+    if(depth == 0) {
+        arch_stk_trace(0);
+        return buf[0];
+    }
+
+    return depth_recurse(depth - 1, buf[0]) + buf[1];
+}
+
+/* Trigger a stack trace from 6 levels of recursion. */
+__noinline static void test_recursive(void) {
+    volatile int buf[12];
+    int i;
+
+    for(i = 0; i < 12; ++i)
+        buf[i] = i;
+
+    buf[0] = depth_recurse(5, buf[0]);
+    (void)buf[0];
+}
+
+/* Call a function through a function pointer. The stack trace is
+   taken inside do_work so the full call chain is on the stack. */
+__noinline static void test_indirect(void) {
+    volatile int buf[12];
+    int i;
+
+    for(i = 0; i < 12; ++i)
+        buf[i] = i * 2;
+
+    buf[0] = call_indirect(do_work, buf[0]);
+    (void)buf[0];
 }
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+
+    /* Stack trace directly from main. */
     arch_stk_trace(0);
 
-    func();
+    /* Stack trace from deep recursion. */
+    test_recursive();
+
+    /* Stack trace from inside a function called through a pointer. */
+    test_indirect();
+
+    printf("stacktrace example done.\n");
 
     return 0;
 }
-
-

--- a/kernel/arch/dreamcast/include/arch/stack.h
+++ b/kernel/arch/dreamcast/include/arch/stack.h
@@ -12,9 +12,10 @@
 
     This file contains arch-specific stack implementations, including defining
     stack sizes and alignments, as well as functions for stack tracing and
-    debugging. On Dreamcast, the stack tracing functions only work if frame
-    pointers have been enabled at compile time (-DFRAME_POINTERS and no
-    -fomit-frame-pointer flag).
+    debugging. On Dreamcast, the stack tracing functions use heuristic stack
+    pointer scanning rather than frame pointer chains, because GCC for SH4
+    does not reliably maintain r14-based frame pointers, even with
+    -fno-omit-frame-pointer.
 
     \author Megan Potter
     \author Eric Fradella
@@ -100,6 +101,20 @@ static inline uintptr_t arch_fptr_next(uintptr_t fptr) {
     return arch_fptr_ret_addr(fptr + 4);
 }
 
+/** \brief   Find the next return address by scanning the stack.
+
+    Scans upward from the given stack pointer for saved PR values
+    validated as return addresses from call instructions.
+
+    \param  sp              Stack pointer to start scanning from.
+    \param  ret_addr_out    On success, receives the found return address.
+    \param  next_sp_out     On success, receives the stack position to
+                            continue scanning from.
+    \return                 `true` if a return address was found.
+*/
+bool arch_stk_unwind_step(uintptr_t sp, uintptr_t *ret_addr_out,
+                      uintptr_t *next_sp_out);
+
 /** \brief  Set up new stack before running.
 
     This function does nothing as it is unnecessary on Dreamcast.
@@ -118,23 +133,24 @@ void arch_stk_setup(kthread_t *nt);
     \param  n               The number of frames to leave off. Each frame is a
                             jump to subroutine or branch to subroutine. assert()
                             leaves off 2 frames, for reference.
+
+    \see    arch_stk_trace_at
 */
 void arch_stk_trace(int n);
 
-/** \brief  Do a stack trace from the current function.
+/** \brief  Do a stack trace from the given stack pointer.
 
-    This function does a stack trace from the the specified frame pointer,
+    This function does a stack trace from the specified stack pointer,
     printing the results to stdout. This could be used for doing something like
     stack tracing a main thread from inside an IRQ handler.
 
-    \param  fp              The frame pointer to start from.
+    \param  sp              The stack pointer to start scanning from.
     \param  n               The number of frames to leave off.
 */
-void arch_stk_trace_at(uint32_t fp, size_t n);
+void arch_stk_trace_at(uintptr_t sp, size_t n);
 
 /** @} */
 
 __END_DECLS
 
 #endif  /* __ARCH_EXEC_H */
-

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -130,8 +130,9 @@ static char *irq_exception_string(irq_t evt) {
 /* Print a kernel panic reg dump */
 extern irq_context_t *irq_srt_addr;
 void irq_dump_regs(int code, irq_t evt) {
-    uint32_t fp;
-    uint32_t ret_addr;
+    uintptr_t sp;
+    uintptr_t ret_addr;
+    uintptr_t next_sp;
     uint32_t *regs = irq_srt_addr->r;
     bool valid_pc;
     bool valid_pr;
@@ -143,8 +144,8 @@ void irq_dump_regs(int code, irq_t evt) {
     dbglog(DBG_DEAD, " R8-R15: %08lx %08lx %08lx %08lx %08lx %08lx %08lx %08lx\n",
            regs[8], regs[9], regs[10], regs[11], regs[12], regs[13], regs[14], regs[15]);
     dbglog(DBG_DEAD, " SR %08lx PR %08lx\n", irq_srt_addr->sr, irq_srt_addr->pr);
-    fp = regs[14];
-    arch_stk_trace_at(fp, 0);
+    sp = regs[15];
+    arch_stk_trace_at(sp, 0);
 
     if(code == 1) {
         dbglog(DBG_DEAD, "\nEncountered %s. ", irq_exception_string(evt));
@@ -162,20 +163,9 @@ void irq_dump_regs(int code, irq_t evt) {
             if(valid_pr)
                 dbglog(DBG_DEAD, " %08lx", irq_srt_addr->pr);
 
-            while(__is_defined(FRAME_POINTERS) && fp != 0xffffffff) {
-                /* Validate the function pointer (fp) */
-                if((fp & 3) || (fp < 0x8c000000) || (fp > _arch_mem_top))
-                    break;
-
-                /* Get the return address from the function pointer */
-                ret_addr = arch_fptr_ret_addr(fp);
-
-                /* Validate the return address */
-                if(!arch_valid_text_address(ret_addr))
-                    break;
-
-                dbglog(DBG_DEAD, " %08lx", ret_addr);
-                fp = arch_fptr_next(fp);
+            while(arch_stk_unwind_step(sp, &ret_addr, &next_sp)) {
+                dbglog(DBG_DEAD, " %08x", ret_addr);
+                sp = next_sp;
             }
         }
 

--- a/kernel/arch/dreamcast/kernel/stack.c
+++ b/kernel/arch/dreamcast/kernel/stack.c
@@ -13,12 +13,114 @@
 #include <arch/arch.h>
 #include <arch/stack.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 static uintptr_t arch_stack_16m_dft = 0x8d000000;
 static uintptr_t arch_stack_32m_dft = 0x8e000000;
 
 extern uintptr_t arch_stack_16m __attribute__((weak,alias("arch_stack_16m_dft")));
 extern uintptr_t arch_stack_32m __attribute__((weak,alias("arch_stack_32m_dft")));
+
+/* Resolve the scan end for a stack walk.
+
+   When SP falls within the current thread's stack, use the actual end of that
+   stack so repeated unwind steps remain within one fixed stack window.
+   Otherwise, fall back to a conservative kernel-stack-sized scan. */
+static uintptr_t arch_stk_scan_end(uintptr_t sp) {
+    uintptr_t scan_end = sp + THD_KERNEL_STACK_SIZE;
+
+    if(thd_current && thd_current->stack && thd_current->stack_size) {
+        uintptr_t stack_base = (uintptr_t)thd_current->stack;
+        uintptr_t stack_end = stack_base + thd_current->stack_size;
+
+        if(sp >= stack_base && sp < stack_end)
+            scan_end = stack_end;
+    }
+
+    if(scan_end > _arch_mem_top)
+        scan_end = _arch_mem_top;
+
+    return scan_end;
+}
+
+/* Check if an address looks like a SH4 return address from a call.
+
+   Validates that the instruction at (ret_addr - 4) is a BSR, BSRF, or JSR.
+   This filters out false positives when scanning for saved PR values on
+   the stack. */
+static bool arch_is_call_return(uintptr_t ret_addr) {
+    uint16_t insn;
+    uintptr_t text_start = (uintptr_t)&_executable_start;
+    uintptr_t text_end = (uintptr_t)&_etext;
+
+    /* Must be aligned, within .text, and far enough in to read the
+       preceding call instruction at ret_addr - 4. */
+    if((ret_addr & 1) || ret_addr < text_start + 4 || ret_addr >= text_end)
+        return false;
+
+    /* Grab call instruction */
+    insn = *(const uint16_t *)(ret_addr - 4);
+
+    return ((insn & 0xf000) == 0xb000)      /* BSR */
+        || ((insn & 0xf0ff) == 0x0003)      /* BSRF */
+        || ((insn & 0xf0ff) == 0x400b);     /* JSR */
+}
+
+/* Find the next return address by scanning the stack upward from sp.
+
+   Searches for saved PR values validated by arch_is_call_return().
+   On success, sets *ret_addr_out to the found return address and
+   *next_sp_out to the stack position to continue scanning from. */
+static bool arch_stk_unwind_step_bounded(uintptr_t sp, uintptr_t scan_end,
+                                         uintptr_t *ret_addr_out,
+                                         uintptr_t *next_sp_out) {
+    uintptr_t addr;
+
+    if(!ret_addr_out || !next_sp_out)
+        return false;
+
+    /* Initialize outputs to safe defaults. */
+    *ret_addr_out = 0;
+    *next_sp_out = 0xffffffff;
+
+    /* 0xffffffff is the sentinel for end-of-chain. */
+    if(sp == 0xffffffff)
+        return false;
+
+    /* SP must be word-aligned and within usable Dreamcast RAM. */
+    if((sp & 3) || sp < page_phys_base || sp > _arch_mem_top)
+        return false;
+
+    if(scan_end > _arch_mem_top)
+        scan_end = _arch_mem_top;
+
+    if(sp >= scan_end)
+        return false;
+
+    /* Walk each word on the stack looking for a saved PR value that
+       points to just after a call instruction. */
+    for(addr = sp; addr < scan_end; addr += 4) {
+        uintptr_t candidate = *(uintptr_t *)addr;
+
+        if(!arch_is_call_return(candidate))
+            continue;
+
+        /* Found a valid return address; report it and tell the caller
+           where to resume scanning. */
+        *ret_addr_out = candidate;
+        *next_sp_out = addr + 4;
+        return true;
+    }
+
+    /* Exhausted the scan range without finding a return address. */
+    return false;
+}
+
+bool arch_stk_unwind_step(uintptr_t sp, uintptr_t *ret_addr_out,
+                      uintptr_t *next_sp_out) {
+    return arch_stk_unwind_step_bounded(sp, arch_stk_scan_end(sp),
+                                        ret_addr_out, next_sp_out);
+}
 
 /* This function is unnecessary and does nothing on Dreamcast */
 void arch_stk_setup(kthread_t *nt) {
@@ -28,43 +130,44 @@ void arch_stk_setup(kthread_t *nt) {
 /* Do a stack trace from the current function; leave off the first n frames
    (i.e., in assert()). */
 __noinline void arch_stk_trace(int n) {
-    arch_stk_trace_at(arch_get_fptr(), n + 1);
+    register uintptr_t sp asm("r15");
+
+    /* Keep previous behaviour: arch_stk_trace skipped one extra frame
+       (the tracer itself), so pass n+1 to arch_stk_trace_at. */
+    arch_stk_trace_at(sp, n + 1);
 }
 
-/* Do a stack trace from the given frame pointer (useful for things like
-   tracing from an ISR); leave off the first n frames. */
-void arch_stk_trace_at(uint32_t fp, size_t n) {
-    uint32_t ret_addr;
-    if(!__is_defined(FRAME_POINTERS)) {
-        dbgio_printf("Stack Trace: frame pointers not enabled!\n");
-        return;
-    }
+/* Do a stack trace from the given stack pointer. Leave off the first
+   n frames. */
+void arch_stk_trace_at(uintptr_t sp, size_t n) {
+    const uint32_t max_frames = 25;
+    uintptr_t ret_addr;
+    uintptr_t next_sp;
+    uintptr_t scan_end = arch_stk_scan_end(sp);
+    uint32_t printed = 0;
 
     dbgio_printf("-------- Stack Trace (innermost first) ---------\n");
 
-    while(fp != 0xffffffff) {
-        /* Validate the function pointer (fp) */
-        if((fp & 3) || (fp < 0x8c000000) || (fp > _arch_mem_top)) {
-            dbgio_printf("   %08lx   (invalid frame pointer)\n", fp);
+    while(arch_stk_unwind_step_bounded(sp, scan_end, &ret_addr, &next_sp)) {
+        if(n) {
+            --n;
+            sp = next_sp;
+            continue;
+        }
+
+        dbgio_printf("   %08lx\n", (unsigned long)ret_addr);
+        ++printed;
+
+        if(printed >= max_frames) {
+            dbgio_printf("   ... (stack scan truncated)\n");
             break;
         }
 
-        if(n == 0) {
-            /* Get the return address from the function pointer */
-            ret_addr = arch_fptr_ret_addr(fp);
-
-            /* Validate the return address */
-            if(!arch_valid_address(ret_addr)) {
-                dbgio_printf("   %08lx   (invalid return address)\n", ret_addr);
-                break;
-            } else
-                dbgio_printf("   %08lx\n", ret_addr);
-        }
-        else n--;
-
-        fp = arch_fptr_next(fp);
+        sp = next_sp;
     }
+
+    if(printed == 0)
+        dbgio_printf("   (no frames found)\n");
 
     dbgio_printf("-------------- End Stack Trace -----------------\n");
 }
-

--- a/kernel/arch/dreamcast/kernel/startup.S
+++ b/kernel/arch/dreamcast/kernel/startup.S
@@ -122,10 +122,6 @@ memchk_done:
 	shll16	r4
 #endif
 
-	! Setup a sentinel value for frame pointer in case we're using
-	! FRAME_POINTERS for stack tracing.
-	mov	#-1,r14
-
 	! Jump to the kernel main
 	mov.l	main_addr,r0
 	jsr	@r0

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -222,6 +222,7 @@ rtc_boot_time
 # Stack tracing
 arch_stk_trace
 arch_stk_trace_at
+arch_stk_unwind_step
 
 # Timers
 timer_ms_gettime


### PR DESCRIPTION
GCC does not reliably maintain r14-based frame pointers, even with `-fno-omit-frame-pointer`, resulting in incomplete or empty stack traces. This has been the case for many years. 

Using the algorithm that SKMP proposed here: https://discord.com/channels/488332893324836864/614912396460556298/1347632664408101026 I replace the FP-chain walker with a stack pointer scanner that walks upward from SP, validating saved PR values against preceding BSR/BSRF/JSR instructions. This removes the `FRAME_POINTERS` build-time dependency so stack traces work unconditionally! 

I also expanded the stracktrace example to demonstrate recursive and indirect (function pointer) call scenarios.