### PR TITLE
CI: Ignore removed whitespaces in whitespace check

### DIFF
--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -13,6 +13,4 @@ jobs:
     - name: Whitespace check
       run: |
         git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-        git diff ${{ github.base_ref }} >/tmp/diff1.txt
-        git diff --ignore-space-at-eol ${{ github.base_ref }} >/tmp/diff2.txt
-        diff /tmp/diff1.txt /tmp/diff2.txt >/dev/null
+        ! git diff ${{ github.base_ref }} |grep '^\+.* $' >/dev/null

--- a/kernel/libc/koslib/pathconf.c
+++ b/kernel/libc/koslib/pathconf.c
@@ -28,7 +28,7 @@ long pathconf(const char *path, int name) {
         break;
     case _PC_NO_TRUNC:
         return 1;
-        break;    
+        break;
     default:
         errno = EINVAL;
         return -1;


### PR DESCRIPTION
A PR that removes errorneous whitespaces shouldn't trigger the whitespace check.
    
Update the whitespace check to only consider the whitespaces that were added by a PR.
