### PR TITLE
pthread: Add pthread_cleanup_{push,pop}

### DIFF
--- a/addons/libpthread/pthread_exit.c
+++ b/addons/libpthread/pthread_exit.c
@@ -2,12 +2,38 @@
 
    pthread_exit.c
    Copyright (C) 2023 Lawrence Sebald
+   Copyright (C) 2026 Paul Cercueil
 */
 
 #include "pthread-internal.h"
 #include <pthread.h>
 #include <kos/thread.h>
 
+struct pthread_cleanup_cb {
+    void (*cb)(void *d);
+    void *arg;
+};
+
+static _Thread_local struct pthread_cleanup_cb cleanups[16];
+static _Thread_local unsigned int nb_cleanups;
+
+void pthread_cleanup_push(void (*routine)(void *), void *arg) {
+    if(nb_cleanups < __array_size(cleanups))
+        cleanups[nb_cleanups++] = (struct pthread_cleanup_cb){ routine, arg };
+}
+
+void pthread_cleanup_pop(int execute) {
+    if(nb_cleanups > 0) {
+        nb_cleanups--;
+
+        if(execute)
+            cleanups[nb_cleanups].cb(cleanups[nb_cleanups].arg);
+    }
+}
+
 void pthread_exit(void *value_ptr) {
+    while(nb_cleanups > 0)
+        pthread_cleanup_pop(1);
+
     thd_exit(value_ptr);
 }

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -241,6 +241,8 @@ int pthread_getconcurrency(void);
 int pthread_setconcurrency(int new_level);
 int pthread_atfork(void (*prepare)(void), void (*parent)(void),
                    void (*child)(void));
+void pthread_cleanup_push(void (*routine)(void *), void *arg);
+void pthread_cleanup_pop(int execute);
 
 #if __GNU_VISIBLE || __BSD_VISIBLE
 /* Technically, the BSD prototype for this is to return void, not int.


### PR DESCRIPTION
Add the functions pthread_cleanup_push() and pthread_cleanup_pop().

These functions can be used to register (and respectively unregister) cleanup callbacks, that will be called when pthread_exit() is called (and *not* when the thread routine returns normally).

I don't actually have much of an use for these functions - however, autotools' "ax_pthread.m4" script, used to detect pthread, will try to compile a test program that happens to call these two functions. Adding these functions to our libpthread means that autotools will properly detect pthread now.