### PR TITLE
Fix and update pvr_set_presort_mode()

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
@@ -30,6 +30,8 @@
 
 #define LIST_ENABLED(i) (pvr_state.lists_enabled & BIT(i))
 
+#define PVR_TILE_MATRIX_HEADER_SIZE 0x48
+
 
 /* Fill Tile Matrix buffers. This function takes a base address and sets up
    the rendering structures there. Each tile of the screen (32x32) receives
@@ -56,9 +58,9 @@ static void pvr_init_tile_matrix(int which, bool presort) {
     */
 
     /* Header of zeros */
-    vr += BYTES_TO_WORDS(buf->tile_matrix);
+    vr += BYTES_TO_WORDS(buf->tile_matrix - PVR_TILE_MATRIX_HEADER_SIZE);
 
-    for(x = 0; x < 0x48; x += 4)
+    for(x = 0; x < PVR_TILE_MATRIX_HEADER_SIZE; x += 4)
         * vr++ = 0;
 
     /* Initial init tile */
@@ -69,9 +71,6 @@ static void pvr_init_tile_matrix(int which, bool presort) {
     vr[4] = 0x80000000;
     vr[5] = 0x80000000;
     vr += 6;
-
-    /* Must skip over zeroed header for actual usage */
-    buf->tile_matrix += 0x48;
 
     /* Now the main tile matrix */
 #if 0
@@ -270,9 +269,12 @@ void pvr_allocate_buffers(const pvr_init_params_t *params) {
         /* N-byte align */
         outaddr = __align_up(outaddr, 128);
 
+        /* Tile Matrix header */
+        outaddr += PVR_TILE_MATRIX_HEADER_SIZE;
+
         /* Tile Matrix */
         buf->tile_matrix = outaddr;
-        buf->tile_matrix_size = WORDS_TO_BYTES(18 + 6 * pvr_state.tw * pvr_state.th);
+        buf->tile_matrix_size = WORDS_TO_BYTES(6 + 6 * pvr_state.tw * pvr_state.th);
         outaddr += buf->tile_matrix_size;
 
         /* N-byte align */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
@@ -136,6 +136,9 @@ void pvr_set_presort_mode(bool presort) {
     uint32_t *vr;
     int x, y;
 
+    if(__predict_false(!pvr_state.vbuf_doublebuf))
+	    pvr_wait_render_done();
+
     tile_matrix = pvr_state.ta_buffers[pvr_state.ta_target].tile_matrix;
     vr = (uint32_t *)PVR_RAM_BASE + BYTES_TO_WORDS(tile_matrix) + 6;
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_buffers.c
@@ -132,7 +132,21 @@ void pvr_init_tile_matrices(bool presort) {
 }
 
 void pvr_set_presort_mode(bool presort) {
-    pvr_init_tile_matrix(pvr_state.ta_target, presort);
+    uint32_t tile_matrix;
+    uint32_t *vr;
+    int x, y;
+
+    tile_matrix = pvr_state.ta_buffers[pvr_state.ta_target].tile_matrix;
+    vr = (uint32_t *)PVR_RAM_BASE + BYTES_TO_WORDS(tile_matrix) + 6;
+
+    for(x = 0; x < pvr_state.tw; x++) {
+        for(y = 0; y < pvr_state.th; y++) {
+            vr[0] = (y << 8) | (x << 2) | (presort << 29);
+            vr += 6;
+        }
+    }
+
+    vr[-6] |= BIT(31);
 }
 
 


### PR DESCRIPTION
`pvr_set_presort_mode()` was just not working, as it would call `pvr_init_tile_matrix()`, causing the tile matrix offset to be modified to an invalid value.

Update pvr_init_tile_matrix() so that the tile matrix offset is not modified, and update pvr_set_presort_mode() so that it can be used at any time during the scene, and not just at the very beginning.