### PR TITLE
Vmu game fix

### DIFF
--- a/examples/dreamcast/vmu/vmu_game/vmu_game.c
+++ b/examples/dreamcast/vmu/vmu_game/vmu_game.c
@@ -9,7 +9,7 @@
 
 #include <kos.h>
 
-void draw_findings(void) {
+static void draw_findings(void) {
     file_t d;
 
     d = fs_open("/vmu/a1", O_RDONLY | O_DIR);
@@ -22,29 +22,32 @@ void draw_findings(void) {
     fs_close(d);
 }
 
-int dev_checked = 0;
-void new_vmu(void) {
-    maple_device_t * dev;
-
-    dev = maple_enum_dev(0, 1);
-
-    if(dev == NULL) {
-        if(dev_checked) {
-            memset(vram_s + 88 * 640, 0, 640 * (480 - 64) * 2);
-            bfont_draw_str_vram_fmt(10, 88, false, "No VMU");
-            dev_checked = 0;
-        }
-    }
-    else if(dev_checked) {
-    }
-    else {
-        memset(vram_s + 88 * 640, 0, 640 * (480 - 88));
-        draw_findings();
-        dev_checked = 1;
-    }
+static void clear_status_area(void) {
+    memset(vram_s + 88 * 640, 0, 640 * BFONT_HEIGHT * sizeof(*vram_s));
 }
 
-int wait_start(void) {
+static bool dev_checked = false;
+static void new_vmu(void) {
+    maple_device_t *dev;
+    bool present;
+
+    dev = maple_enum_dev(0, 1);
+    present = (dev != NULL);
+
+    if(present == dev_checked)
+        return;
+
+    clear_status_area();
+
+    if(present)
+        draw_findings();
+    else
+        bfont_draw_str_vram_fmt(10, 88, false, "No VMU");
+
+    dev_checked = present;
+}
+
+static int wait_start(void) {
     maple_device_t *cont;
     cont_state_t *state;
 
@@ -66,7 +69,7 @@ int wait_start(void) {
 }
 
 /* Here's the actual meat of it */
-void write_game_entry(void) {
+static void write_game_entry(void) {
     file_t f;
     int data_size;
     uint8_t *data;
@@ -106,5 +109,3 @@ int main(int argc, char **argv) {
 
     return 0;
 }
-
-

--- a/examples/dreamcast/vmu/vmu_game/vmu_game.c
+++ b/examples/dreamcast/vmu/vmu_game/vmu_game.c
@@ -1,7 +1,7 @@
 /* KallistiOS ##version##
 
    vmu_game.c
-   (c)2020 BBHoodsta
+   Copyright (C) 2020 Andy Barajas
 */
 
 /* This simple example shows how to use the vmufs_write function to write
@@ -10,16 +10,16 @@
 #include <kos.h>
 
 void draw_findings(void) {
-    file_t      d;
+    file_t d;
 
     d = fs_open("/vmu/a1", O_RDONLY | O_DIR);
-
     if(!d) {
         bfont_draw_str_vram_fmt(10, 88, false, "Can't read VMU");
+        return;
     }
-    else {
-        bfont_draw_str_vram_fmt(10, 88, false, "VMU found. Press Start.");
-    }
+
+    bfont_draw_str_vram_fmt(10, 88, false, "VMU found. Press Start.");
+    fs_close(d);
 }
 
 int dev_checked = 0;
@@ -73,21 +73,27 @@ void write_game_entry(void) {
     maple_device_t *dev;
 
     f = fs_open("/rd/TETRIS.VMS", O_RDONLY);
-
     if(!f) {
         printf("Error reading Tetris game from romdisk\n");
         return;
     }
 
     data_size = fs_total(f);
-    data = (uint8_t*) malloc(data_size + 1);
+    data = (uint8_t *)malloc(data_size + 1);
+    if(!data) {
+        printf("Error allocating memory for game data\n");
+        fs_close(f);
+        return;
+    }
+
     fs_read(f, data, data_size);
     fs_close(f);
 
     dev = maple_enum_type(0, MAPLE_FUNC_MEMCARD);
-    
     if(dev)
         vmufs_write(dev, "Tetris", data, data_size, VMUFS_VMUGAME);
+
+    free(data);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Fixed a couple of issues in this example.

1. The VMU file was never closed and that would cause an ASSERTION FAILURE during shutdown.
2. Free the memory we allocate.
3. Format changes and refactor new_vmu() to make it easier to read.