### PR TITLE
maple: Correct shutdown device count.

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -151,7 +151,6 @@ static void maple_hw_init(void) {
 void maple_hw_shutdown(void) {
     int p, u, cnt;
     uint32_t  ptr;
-    maple_device_t *dev;
 
     /* Reset all devices to leave them as we found them */
     maple_dev_reset_all();
@@ -184,12 +183,9 @@ void maple_hw_shutdown(void) {
     /* Free any attached devices */
     for(cnt = 0, p = 0; p < MAPLE_PORT_COUNT; p++) {
         for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-            cnt += !!maple_driver_detach(p, u);
+            cnt += !maple_driver_detach(p, u);
 
-            dev = maple_state.ports[p].units[u];
-            if(dev)
-                free(dev->status);
-            free(dev);
+            free(maple_state.ports[p].units[u]);
         }
     }
 


### PR DESCRIPTION
This was working just plain wrong. It was treating `maple_driver_detach` as if it was 0 for no device which is backwards. Now it appropriately counts the number of devices that were still attached on shutdown.

Additionally remove the unnecessary freeing of `dev->status`. `maple_driver_detach` already does such a check and frees it if needed.