### PR TITLE
Make init_flags_default.c include kos/init.h directly

### DIFF
--- a/kernel/init/init_flags_default.c
+++ b/kernel/init/init_flags_default.c
@@ -4,7 +4,7 @@
    (c)2002 Megan Potter
 */
 
-#include <arch/arch.h>
+#include <kos/init.h>
 
 /* Default values which will be used if the user doesn't declare anything */
 __weak_symbol KOS_INIT_FLAGS(INIT_DEFAULT);


### PR DESCRIPTION
`init_flags_default.c` includes `arch/arch.h`, but only for its inclusion of `kos/init.h`. Change to directly include `kos/init.h` instead.