### PR TITLE
Don't link dcplib for cpp/filesystem example

### DIFF
--- a/examples/dreamcast/cpp/filesystem/Makefile
+++ b/examples/dreamcast/cpp/filesystem/Makefile
@@ -21,7 +21,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS)
-	kos-c++ -o $(TARGET) $(OBJS) -ldcplib
+	kos-c++ -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)


### PR DESCRIPTION
This example accidentally links in dcplib unnecessarily.