### PR TITLE
nmmgr cleanups

### DIFF
--- a/include/kos/nmmgr.h
+++ b/include/kos/nmmgr.h
@@ -39,7 +39,7 @@ struct nmmgr_handler;
 
     Contrary to what doxygen may think, this is not a function.
 */
-typedef LIST_HEAD(nmmgr_list, nmmgr_handler) nmmgr_list_t;
+typedef SLIST_HEAD(nmmgr_list, nmmgr_handler) nmmgr_list_t;
 
 /** \brief   List entry initializer for static structs.
     \ingroup system_namemgr
@@ -64,7 +64,7 @@ typedef struct nmmgr_handler {
     uint32_t  version;        /* Version code */
     uint32_t  flags;          /* Bitmask of flags */
     uint32_t  type;           /* Type of handler */
-    LIST_ENTRY(nmmgr_handler)   list_ent;   /* Linked list entry */
+    SLIST_ENTRY(nmmgr_handler)  list_ent;   /* Linked list entry */
 } nmmgr_handler_t;
 
 /** \brief   Alias handler interface.

--- a/kernel/exports/exports.c
+++ b/kernel/exports/exports.c
@@ -73,7 +73,7 @@ export_sym_t *export_lookup(const char *name) {
     nmmgrs = nmmgr_get_list();
 
     /* Go through and look at each symtab entry */
-    LIST_FOREACH(nmmgr, nmmgrs, list_ent) {
+    SLIST_FOREACH(nmmgr, nmmgrs, list_ent) {
         /* Not a symtab -> ignore */
         if(nmmgr->type != NMMGR_TYPE_SYMTAB)
             continue;
@@ -127,7 +127,7 @@ export_sym_t *export_lookup_addr(uintptr_t addr) {
     nmmgrs = nmmgr_get_list();
 
     /* Go through and look at each symtab entry */
-    LIST_FOREACH(nmmgr, nmmgrs, list_ent) {
+    SLIST_FOREACH(nmmgr, nmmgrs, list_ent) {
         /* Not a symtab -> ignore */
         if(nmmgr->type != NMMGR_TYPE_SYMTAB)
             continue;

--- a/kernel/exports/nmmgr.c
+++ b/kernel/exports/nmmgr.c
@@ -39,7 +39,7 @@ nmmgr_handler_t * nmmgr_lookup(const char *fn) {
     size_t          cur_len = 0, tmp_len;
 
     /* Scan the handler table and look for the best path match */
-    LIST_FOREACH(tmp, &nmmgr_handlers, list_ent) {
+    SLIST_FOREACH(tmp, &nmmgr_handlers, list_ent) {
         tmp_len = strlen(tmp->pathname);
         if(!strncasecmp(tmp->pathname, fn, tmp_len)) {
             if(cur_len < tmp_len) {
@@ -70,7 +70,7 @@ nmmgr_list_t * nmmgr_get_list(void) {
 int nmmgr_handler_add(nmmgr_handler_t *hnd) {
     mutex_lock(&mutex);
 
-    LIST_INSERT_HEAD(&nmmgr_handlers, hnd, list_ent);
+    SLIST_INSERT_HEAD(&nmmgr_handlers, hnd, list_ent);
 
     mutex_unlock(&mutex);
 
@@ -79,19 +79,21 @@ int nmmgr_handler_add(nmmgr_handler_t *hnd) {
 
 /* Remove a name handler */
 int nmmgr_handler_remove(nmmgr_handler_t *hnd) {
-    nmmgr_handler_t *c, *tmp;
+    nmmgr_handler_t *tmp;
     int rv = -1;
 
     if(mutex_lock_irqsafe(&mutex) < 0)
         return -1;
 
     /* Verify that it's actually in there */
-    LIST_FOREACH_SAFE(c, &nmmgr_handlers, list_ent, tmp) {
-        if(c == hnd) {
-            LIST_REMOVE(hnd, list_ent);
-            rv = 0;
+    SLIST_FOREACH(tmp, &nmmgr_handlers, list_ent) {
+        if(tmp == hnd)
             break;
-        }
+    }
+
+    if(tmp) {
+        SLIST_REMOVE(&nmmgr_handlers, hnd, nmmgr_handler, list_ent);
+        rv = 0;
     }
 
     mutex_unlock(&mutex);
@@ -104,7 +106,7 @@ KOS_INIT_FLAG_WEAK(export_init, false);
 /* Initialize structures */
 void nmmgr_init(void) {
     /* Start with no handlers */
-    LIST_INIT(&nmmgr_handlers);
+    SLIST_INIT(&nmmgr_handlers);
 
     /* Initialize our internal exports */
     KOS_INIT_FLAG_CALL(export_init);
@@ -113,10 +115,10 @@ void nmmgr_init(void) {
 void nmmgr_shutdown(void) {
     nmmgr_handler_t *c, *n;
 
-    c = LIST_FIRST(&nmmgr_handlers);
+    c = SLIST_FIRST(&nmmgr_handlers);
 
     while(c != NULL) {
-        n = LIST_NEXT(c, list_ent);
+        n = SLIST_NEXT(c, list_ent);
 
         if(c->flags & NMMGR_FLAGS_NEEDSFREE)
             free(c);

--- a/kernel/exports/nmmgr.c
+++ b/kernel/exports/nmmgr.c
@@ -82,7 +82,8 @@ int nmmgr_handler_remove(nmmgr_handler_t *hnd) {
     nmmgr_handler_t *c, *tmp;
     int rv = -1;
 
-    mutex_lock_irqsafe(&mutex);
+    if(mutex_lock_irqsafe(&mutex) < 0)
+        return -1;
 
     /* Verify that it's actually in there */
     LIST_FOREACH_SAFE(c, &nmmgr_handlers, list_ent, tmp) {

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -68,7 +68,7 @@ static dirent_t *fs_root_readdir(fs_hnd_t *handle) {
 
     nmhead = nmmgr_get_list();
 
-    LIST_FOREACH(nmhnd, nmhead, list_ent) {
+    SLIST_FOREACH(nmhnd, nmhead, list_ent) {
         if((nmhnd->flags & NMMGR_FLAGS_INDEV))
             continue;
 

--- a/kernel/fs/fs_dev.c
+++ b/kernel/fs/fs_dev.c
@@ -34,7 +34,7 @@ static dirent_t *dev_root_readdir(dev_hnd_t * handle) {
 
     nmhead = nmmgr_get_list();
 
-    LIST_FOREACH(nmhnd, nmhead, list_ent) {
+    SLIST_FOREACH(nmhnd, nmhead, list_ent) {
         if(!(nmhnd->flags & NMMGR_FLAGS_INDEV))
             continue;
 


### PR DESCRIPTION
Check for the return code of a `mutex_lock_irqsafe()`, and switch to using a single-linked list.