### PR TITLE
fs: Add workaround for fs_stat() on mount points

### DIFF
--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -868,6 +868,13 @@ int fs_stat(const char *path, struct stat *buf, int flag) {
         return vfs->stat(vfs, fullpath + strlen(vfs->nmmgr.pathname), buf,
                          flag);
     }
+    else if(!strcmp(path, vfs->nmmgr.pathname)) {
+        /* no vfs->stat - handle stat() on the mount folder */
+        *buf = (struct stat){
+            .st_mode = S_IFDIR | S_IRWXU | S_IRWXG | S_IRWXO,
+        };
+        return 0;
+    }
     else {
         errno = ENOSYS;
         return -1;


### PR DESCRIPTION
The various VFS handlers may not implement a .stat backend function. For instance, the socket VFS does not implement any. However, we still want to be able to tell that /sock is a directory and not a file.

Add a workaround, so that if we're trying to fs_stat() a mount point, and the corresponding VFS does not provide a .stat backend function, we just return it as a 0777 directory.

(This commit fixes Bloom crashing in C++'s `filesystem::is_regular_file("/sock")`).