### PR TITLE
pvr+ta: avoid rendering overflown frames, fixes pvr lockups

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_irq.c
@@ -91,9 +91,17 @@ static void pvr_render_lists(void) {
         // Begin rendering from the dirty TA buffer into the clean
         // frame buffer.
         pvr_state.ta_target ^= pvr_state.vbuf_doublebuf;
-        pvr_begin_queued_render();
-        pvr_state.render_busy = 1;
-        pvr_sync_stats(PVR_SYNC_RNDSTART);
+
+        // Check if the vertex or OPB buffers have overflown
+        // NOTE: Some emulators have a bug, where PVR_TA_OPB_POS is already pre-multiplied, which we work around here.
+        if ( 
+            PVR_GET(PVR_TA_VERTBUF_POS) < PVR_GET(PVR_TA_VERTBUF_END) &&
+            (PVR_GET(PVR_TA_OPB_POS)*4 < PVR_GET(PVR_TA_OPB_END) || PVR_GET(PVR_TA_OPB_POS) == PVR_GET(PVR_TA_OPB_INIT))
+        ) {
+            pvr_begin_queued_render();
+            pvr_state.render_busy = 1;
+            pvr_sync_stats(PVR_SYNC_RNDSTART);
+        }
 
         // Switch to the clean TA buffer.
         pvr_state.lists_transferred = 0;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_misc.c
@@ -155,7 +155,7 @@ void pvr_sync_reg_buffer(void) {
     /* Set buffer pointers */
     PVR_SET(PVR_TA_OPB_START,       buf->opb);
     PVR_SET(PVR_TA_OPB_INIT,        buf->opb + buf->opb_size);
-    PVR_SET(PVR_TA_OPB_END,         buf->opb + buf->opb_size * (1 + buf->opb_overflow_count));
+    PVR_SET(PVR_TA_OPB_END,         buf->opb + buf->opb_size * (1 + buf->opb_overflow_count) - 32);  // OBP end, unlike VERTBUF_END, is inclusive
     PVR_SET(PVR_TA_VERTBUF_START,   buf->vertex);
     PVR_SET(PVR_TA_VERTBUF_END,     buf->vertex + buf->vertex_size);
 


### PR DESCRIPTION
- When TA overflows, the CORE lists in vram may be in corrupted state that lead to lockups.
- Includes workaround for buggy emulators as to not break them
- Also fixes PVR_TA_OPB_END calculation