### PR TITLE
malloc: Fix priority inversion

### DIFF
--- a/kernel/libc/koslib/malloc.c
+++ b/kernel/libc/koslib/malloc.c
@@ -24,7 +24,7 @@
 
 #include <kos/dbglog.h>
 #include <kos/opts.h>
-#include <kos/spinlock.h>
+#include <kos/mutex.h>
 
 #undef DEBUG
 
@@ -41,17 +41,24 @@
 #define malloc_getpagesize PAGESIZE
 #define HAVE_USR_INCLUDE_MALLOC_H
 
-/* Enable thread locking. Because mutexes actually require malloc themselves,
-   we use spinlocks here. They are also MUCH faster. As a general rule this
-   shouldn't be a big problem. */
-static spinlock_t mALLOC_MUTEx = SPINLOCK_INITIALIZER;
-#define MALLOC_PREACTION   ({ spinlock_lock(&mALLOC_MUTEx); 0; })
-#define MALLOC_POSTACTION  ({ spinlock_unlock(&mALLOC_MUTEx); 0; })
+/* Enable thread locking. Because spin locks can cause priority inversion,
+   we use mutexes here. */
+static mutex_t mALLOC_MUTEx = MUTEX_INITIALIZER;
+#define MALLOC_PREACTION ({                         \
+    int result = mutex_lock_irqsafe(&mALLOC_MUTEx); \
+    assert(result == 0);                            \
+    result;                                         \
+})
+#define MALLOC_POSTACTION ({                  \
+    int result = mutex_unlock(&mALLOC_MUTEx); \
+    assert(result == 0);                      \
+    result;                                   \
+})
 
 /* Use this from within an IRQ to determine if it's safe
    to do memory allocation stuff */
 int malloc_irq_safe(void) {
-    return !spinlock_is_locked(&mALLOC_MUTEx);
+    return !mutex_is_locked(&mALLOC_MUTEx);
 }
 
 /* <unistd.h> doesn't define this in strict standard-compliant mode, so do so


### PR DESCRIPTION
Incorporates the feedback from #1351 in a clean commit.

If the application is multithreaded with high and
low priority threads, and the low priority thread
gets preempted during a malloc/free, then the high priority thread will block indefinitely on malloc.

Resolves #1350