### PR TITLE
sound_stream: Prevent dropping last sample on loop.

### DIFF
--- a/kernel/arch/dreamcast/include/dc/sound/stream.h
+++ b/kernel/arch/dreamcast/include/dc/sound/stream.h
@@ -46,7 +46,7 @@ __BEGIN_DECLS
 #define SND_STREAM_BUFFER_MAX_PCM8  (64 << 10)
 
 /** \brief  The maximum buffer size for each channel of ADPCM stream. */
-#define SND_STREAM_BUFFER_MAX_ADPCM (32 << 10)
+#define SND_STREAM_BUFFER_MAX_ADPCM ((32 << 10) - 32)
 
 /** \brief  The maximum buffer size for each channel of streams by default
             and for backward compatibility. */

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -559,7 +559,7 @@ static void snd_stream_start_type(snd_stream_hnd_t hnd, uint32_t type, uint32_t 
     chan->length = bytes_to_samples(hnd, streams[hnd].buffer_size);
     chan->loop = 1;
     chan->loopstart = 0;
-    chan->loopend = chan->length - 1;
+    chan->loopend = chan->length;
     chan->freq = freq;
     chan->vol = 255;
     chan->pan = streams[hnd].channels == 2 ? 0 : 128;


### PR DESCRIPTION
Discussed in more detail in #1353. Reducing the loopend size by one was required for ADPCM but would cause the loss of one sample at the end of a loop for other formats.

The issue had to do with the AICA loop register overflowing the sample count with the amount of ADPCM samples that can fit in a single buffer as the 4-bits in 32kb allowed a max of 0x10000 samples.

The fix is to remove the dropping of the last sample from loopend and adjust the maximum ADPCM buffer size to prevent it from being able to overflow (while still keeping 32-byte alignment).

@KatanaDreamsDev - This what you were describing by the end of #1353 ? If you'd like to update it there, that's fine too.