### PR TITLE
Fix assert stack tracing

### DIFF
--- a/examples/dreamcast/basic/asserthnd/Makefile
+++ b/examples/dreamcast/basic/asserthnd/Makefile
@@ -17,7 +17,7 @@ rm-elf:
 	-rm -f $(TARGET)
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS)
+	kos-cc -Og -o $(TARGET) $(OBJS)
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/basic/asserthnd/asserthnd.c
+++ b/examples/dreamcast/basic/asserthnd/asserthnd.c
@@ -12,26 +12,25 @@
 This example shows off how to setup an assert handler (for example for
 a custom crash screen, or some other debug method, or even ignoring
 asserts selectively). It also demonstrates the default assert handler.
-If you compiled with -DFRAME_POINTERS and without -fomit-frame-pointer
-then you'll get something like this:
+You'll get something like this:
 
 *** ASSERTION FAILURE ***
 Assertion "a != 5" failed at asserthnd.c:40 in `func2': This is a test message!
 
 -------- Stack Trace (innermost first) ---------
-   8c01016a
-   8c0101e0
-   8c010478
-   8c010062
+   8c010170
+   8c0101ca
+   8c0111f2
+   8c010086
 -------------- End Stack Trace -----------------
 
 You can punch those numbers into addr2line to get a nice stack traceback,
 assuming you compiled your program with -g:
 
->] dc-addr2line -e asserthnd.elf 8c01016a 8c0101e0 8c010478
-/usr/local/home/bard/prj/kos/examples/dreamcast/basic/asserthnd/asserthnd.c:46
-/usr/local/home/bard/prj/kos/examples/dreamcast/basic/asserthnd/asserthnd.c:69
-/usr/local/home/bard/prj/kos/kernel/arch/dreamcast/kernel/main.c:129
+>] $KOS_ADDR2LINE -e asserthnd.elf 8c010170 8c0101ca 8c0111f2
+/opt/toolchains/dc/kos/examples/dreamcast/basic/asserthnd/asserthnd.c:45 (discriminator 1)
+/opt/toolchains/dc/kos/examples/dreamcast/basic/asserthnd/asserthnd.c:73
+/opt/toolchains/dc/kos/kernel/arch/dreamcast/kernel/init.c:311
 
 */
 

--- a/kernel/arch/dreamcast/kernel/stack.c
+++ b/kernel/arch/dreamcast/kernel/stack.c
@@ -4,10 +4,7 @@
    (c)2002 Megan Potter
 */
 
-/* Functions to tinker with the stack, including obtaining a stack
-   trace when frame pointers are enabled. If frame pointers are enabled,
-   then you'll need to also define FRAME_POINTERS to get support for stack
-   traces. */
+/* Functions to tinker with the stack, including obtaining a stack trace. */
 
 #include <kos/dbgio.h>
 #include <arch/arch.h>
@@ -129,12 +126,10 @@ void arch_stk_setup(kthread_t *nt) {
 
 /* Do a stack trace from the current function; leave off the first n frames
    (i.e., in assert()). */
-__noinline void arch_stk_trace(int n) {
+void arch_stk_trace(int n) {
     register uintptr_t sp asm("r15");
 
-    /* Keep previous behaviour: arch_stk_trace skipped one extra frame
-       (the tracer itself), so pass n+1 to arch_stk_trace_at. */
-    arch_stk_trace_at(sp, n + 1);
+    arch_stk_trace_at(sp, n);
 }
 
 /* Do a stack trace from the given stack pointer. Leave off the first

--- a/kernel/libc/koslib/assert.c
+++ b/kernel/libc/koslib/assert.c
@@ -5,8 +5,8 @@
 
 */
 
-// In both the newlib and KOS libc cases, we use our own assert. The
-// assert_msg and assert hooking functionality is just too useful.
+/* In both the newlib and KOS libc cases, we use our own assert. The
+   assert_msg and assert hooking functionality is just too useful. */
 
 #include <assert.h>
 #include <stdio.h>
@@ -27,8 +27,7 @@ __noinline static void __noreturn assert_handler_default(const char *file, int l
         dbglog(DBG_CRITICAL, "Assertion \"%s\" failed at %s:%d in `%s': %s\n\n",
                expr, file, line, func, msg);
 
-    if(__is_defined(FRAME_POINTERS))
-        arch_stk_trace(2);
+    arch_stk_trace(0);
 
     abort();
     /* NOT REACHED */


### PR DESCRIPTION
Following #1359 , remove further references that had been left in around the frame-pointers based stack tracing.

Additionally remove the places where we were intentionally ignoring layers of the tracing in order to avoid things like `arch_stk_trace` or `assert` showing up in the trace. While this might lead to some extra lines to trace, it prevents the bigger problem of accidentally skipping layers when something gets inlined