### PR TITLE
libkosfat: Partial LFN entry filename fix.

### DIFF
--- a/addons/libkosfat/directory.c
+++ b/addons/libkosfat/directory.c
@@ -1323,7 +1323,8 @@ int fat_add_dentry(fat_fs_t *fs, const char *fn, fat_dentry_t *parent,
         /* Make things easier later... */
         if(len % 13) {
             ++dents;
-            memset(longname_buf2 + len, 0, 13 * sizeof(uint16_t));
+            memset(longname_buf2 + len, 0xFF, 13 * sizeof(uint16_t));
+            longname_buf2[len] = 0x0000;
         }
 
         /* Come up with the short name the file will have. */


### PR DESCRIPTION
When fat_add_dentry() creates long filename entries, partial LFN entries (where the filename doesn't fill all 13 UCS-2 character slots) are padded with 0x0000 after the null terminator. The FAT specification requires these positions to be 0xFFFF.

This causes host operating systems with conformant FAT implementations (which likely includes Windows, Linux, macOS, and others) to ignore the LFN entries and fall back to displaying the 8.3 short filename (e.g. MK5115~1.VMU instead of MK5115450-1.VMU). Filenames that exactly fill one or more LFN entries with no partial trailing entry are unaffected.

Closes #1326 