### PR TITLE
Reduce and clean up spinlock usage

### DIFF
--- a/include/machine/malloc.h
+++ b/include/machine/malloc.h
@@ -44,7 +44,7 @@ __BEGIN_DECLS
 
 /** \brief  Determine if it is safe to call malloc() in an IRQ context.
 
-    This function checks the value of the internal spinlock that is used for
+    This function checks the value of the internal mutex that is used for
     malloc() to ensure that a call to it will not freeze the running process.
     This is only really useful in an IRQ context to ensure that a call to
     malloc() (or some other memory allocation function) won't cause a deadlock.

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
@@ -95,13 +95,21 @@ static struct mallinfo mALLINFo();
 
 #ifdef USE_MALLOC_LOCK
 
-#include <kos/spinlock.h>
+#include <kos/mutex.h>
 
-static spinlock_t mALLOC_MUTEx = SPINLOCK_INITIALIZER;
-
-/* This is pretty GCC dependent ^_^; */
-#define MALLOC_PREACTION   ({ spinlock_lock(&mALLOC_MUTEx); 0; })
-#define MALLOC_POSTACTION  ({ spinlock_unlock(&mALLOC_MUTEx); 0; })
+/* Enable thread locking. Because spin locks can cause priority inversion,
+   we use mutexes here. */
+static mutex_t mALLOC_MUTEx = MUTEX_INITIALIZER;
+#define MALLOC_PREACTION ({                         \
+    int result = mutex_lock_irqsafe(&mALLOC_MUTEx); \
+    assert(result == 0);                            \
+    result;                                         \
+})
+#define MALLOC_POSTACTION ({                  \
+    int result = mutex_unlock(&mALLOC_MUTEx); \
+    assert(result == 0);                      \
+    result;                                   \
+})
 
 #else
 

--- a/kernel/arch/dreamcast/sound/snd_mem.c
+++ b/kernel/arch/dreamcast/sound/snd_mem.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <errno.h>
 #include <sys/queue.h>
@@ -58,11 +59,11 @@ typedef struct snd_block_str {
     size_t  size;
 
     /* Is this block in use? */
-    int inuse;
+    bool inuse;
 } snd_block_t;
 
 /* Our SPU RAM pool */
-static int initted = 0;
+static bool initted = false;
 static TAILQ_HEAD(snd_block_q, snd_block_str) pool = {0};
 static mutex_t snd_mem_mutex = MUTEX_INITIALIZER;
 
@@ -80,7 +81,7 @@ int snd_mem_init(uint32_t reserve) {
     }
 
     // Make sure our base is 32-byte aligned
-    reserve = (reserve + 0x1f) & ~0x1f;
+    reserve = __align_up(reserve, 32);
 
     /* Make sure our tailq is initted */
     TAILQ_INIT(&pool);
@@ -101,13 +102,12 @@ int snd_mem_init(uint32_t reserve) {
     else
         blk->size = 8 * 1024 * 1024 - reserve;
 
-    blk->inuse = 0;
+    blk->inuse = false;
     TAILQ_INSERT_HEAD(&pool, blk, qent);
 
-    if(__is_defined(SNDMEMDEBUG))
-        dbglog(DBG_DEBUG, "snd_mem_init: %d bytes available\n", blk->size);
+    dbglog(DBG_SOURCE(SNDMEMDEBUG), "snd_mem_init: %d bytes available\n", blk->size);
 
-    initted = 1;
+    initted = true;
     mutex_unlock(&snd_mem_mutex);
 
     return 0;
@@ -122,21 +122,15 @@ void snd_mem_shutdown(void) {
     if(mutex_lock_irqsafe(&snd_mem_mutex))
         return;
 
-    e = TAILQ_FIRST(&pool);
+    TAILQ_FOREACH_SAFE(e, &pool, qent, n) {
+        dbglog(DBG_SOURCE(SNDMEMDEBUG), "snd_mem_shutdown: %s block at %08lx (size %d)\n",
+               e->inuse ? "in-use" : "unused", e->addr, e->size);
 
-    while(e) {
-        n = TAILQ_NEXT(e, qent);
-
-        if(__is_defined(SNDMEMDEBUG)) {
-            dbglog(DBG_DEBUG, "snd_mem_shutdown: %s block at %08lx (size %d)\n",
-                   e->inuse ? "in-use" : "unused", e->addr, e->size);
-        }
-
+        TAILQ_REMOVE(&pool, e, qent);
         free(e);
-        e = n;
     }
 
-    initted = 0;
+    initted = false;
     mutex_unlock(&snd_mem_mutex);
 }
 
@@ -156,7 +150,7 @@ uint32_t snd_mem_malloc(size_t size) {
     }
 
     // Make sure the size is a multiple of 32 bytes to maintain alignment
-    size = (size + 0x1f) & ~0x1f;
+    size = __align_up(size, 32);
 
     /* Look for a block */
     TAILQ_FOREACH(e, &pool, qent) {
@@ -174,12 +168,10 @@ uint32_t snd_mem_malloc(size_t size) {
 
     /* Is the block the exact size? */
     if(best->size == size) {
-        if(__is_defined(SNDMEMDEBUG)) {
-            dbglog(DBG_DEBUG, "snd_mem_malloc: allocating perfect-fit at %08lx for size %d\n",
-                   best->addr, best->size);
-        }
+        dbglog(DBG_SOURCE(SNDMEMDEBUG), "snd_mem_malloc: allocating perfect-fit at %08lx for size %d\n",
+               best->addr, best->size);
 
-        best->inuse = 1;
+        best->inuse = true;
         mutex_unlock(&snd_mem_mutex);
         return best->addr;
     }
@@ -196,16 +188,14 @@ uint32_t snd_mem_malloc(size_t size) {
     memset(e, 0, sizeof(snd_block_t));
     e->addr = best->addr + size;
     e->size = best->size - size;
-    e->inuse = 0;
+    e->inuse = false;
     TAILQ_INSERT_AFTER(&pool, best, e, qent);
 
-    if(__is_defined(SNDMEMDEBUG)) {
-        dbglog(DBG_DEBUG, "snd_mem_malloc: allocating block %08lx for size %d, and leaving %d at %08lx\n",
+    dbglog(DBG_SOURCE(SNDMEMDEBUG), "snd_mem_malloc: allocating block %08lx for size %d, and leaving %d at %08lx\n",
                best->addr, size, e->size, e->addr);
-    }
 
     best->size = size;
-    best->inuse = 1;
+    best->inuse = true;
 
     mutex_unlock(&snd_mem_mutex);
     return best->addr;
@@ -237,17 +227,15 @@ void snd_mem_free(uint32_t addr) {
     }
 
     /* Set this block as unused */
-    e->inuse = 0;
+    e->inuse = false;
 
-    if(__is_defined(SNDMEMDEBUG))
-        dbglog(DBG_DEBUG, "snd_mem_free: freeing block at %08lx\n", e->addr);
+    dbglog(DBG_SOURCE(SNDMEMDEBUG), "snd_mem_free: freeing block at %08lx\n", e->addr);
 
     /* Can we coalesce with the block before us? */
     o = TAILQ_PREV(e, snd_block_q, qent);
 
     if(o && !o->inuse) {
-        if(__is_defined(SNDMEMDEBUG))
-            dbglog(DBG_DEBUG, "   coalescing with block at %08lx\n", o->addr);
+        dbglog(DBG_SOURCE(SNDMEMDEBUG), "   coalescing with block at %08lx\n", o->addr);
 
         o->size += e->size;
         TAILQ_REMOVE(&pool, e, qent);
@@ -259,8 +247,7 @@ void snd_mem_free(uint32_t addr) {
     o = TAILQ_NEXT(e, qent);
 
     if(o && !o->inuse) {
-        if(__is_defined(SNDMEMDEBUG))
-            dbglog(DBG_DEBUG, "   coalescing with block at %08lx\n", o->addr);
+        dbglog(DBG_SOURCE(SNDMEMDEBUG), "   coalescing with block at %08lx\n", o->addr);
 
         e->size += o->size;
         TAILQ_REMOVE(&pool, o, qent);

--- a/kernel/arch/dreamcast/sound/snd_mem.c
+++ b/kernel/arch/dreamcast/sound/snd_mem.c
@@ -15,7 +15,7 @@
 #include <dc/sound/sound.h>
 #include <arch/arch.h>
 #include <kos/dbglog.h>
-#include <kos/spinlock.h>
+#include <kos/mutex.h>
 
 /*
 
@@ -64,7 +64,7 @@ typedef struct snd_block_str {
 /* Our SPU RAM pool */
 static int initted = 0;
 static TAILQ_HEAD(snd_block_q, snd_block_str) pool = {0};
-static spinlock_t snd_mem_mutex = SPINLOCK_INITIALIZER;
+static mutex_t snd_mem_mutex = MUTEX_INITIALIZER;
 
 
 /* Reinitialize the pool with the given RAM base offset */
@@ -74,7 +74,7 @@ int snd_mem_init(uint32_t reserve) {
     if(initted)
         snd_mem_shutdown();
 
-    if(!spinlock_lock_irqsafe(&snd_mem_mutex)) {
+    if(mutex_lock_irqsafe(&snd_mem_mutex)) {
         errno = EAGAIN;
         return -1;
     }
@@ -88,7 +88,7 @@ int snd_mem_init(uint32_t reserve) {
     blk = (snd_block_t *)malloc(sizeof(snd_block_t));
 
     if(!blk) {
-        spinlock_unlock(&snd_mem_mutex);
+        mutex_unlock(&snd_mem_mutex);
         errno = ENOMEM;
         return -1;
     }
@@ -108,7 +108,7 @@ int snd_mem_init(uint32_t reserve) {
         dbglog(DBG_DEBUG, "snd_mem_init: %d bytes available\n", blk->size);
 
     initted = 1;
-    spinlock_unlock(&snd_mem_mutex);
+    mutex_unlock(&snd_mem_mutex);
 
     return 0;
 }
@@ -119,7 +119,7 @@ void snd_mem_shutdown(void) {
 
     if(!initted) return;
 
-    if(!spinlock_lock_irqsafe(&snd_mem_mutex))
+    if(mutex_lock_irqsafe(&snd_mem_mutex))
         return;
 
     e = TAILQ_FIRST(&pool);
@@ -137,7 +137,7 @@ void snd_mem_shutdown(void) {
     }
 
     initted = 0;
-    spinlock_unlock(&snd_mem_mutex);
+    mutex_unlock(&snd_mem_mutex);
 }
 
 /* Allocate a chunk of SPU RAM; we will return an offset into SPU RAM. */
@@ -150,7 +150,7 @@ uint32_t snd_mem_malloc(size_t size) {
     if(size == 0)
         return 0;
 
-    if(!spinlock_lock_irqsafe(&snd_mem_mutex)) {
+    if(mutex_lock_irqsafe(&snd_mem_mutex)) {
         errno = EAGAIN;
         return 0;
     }
@@ -168,7 +168,7 @@ uint32_t snd_mem_malloc(size_t size) {
 
     if(best == NULL) {
         dbglog(DBG_ERROR, "snd_mem_malloc: no chunks big enough for alloc(%d)\n", size);
-        spinlock_unlock(&snd_mem_mutex);
+        mutex_unlock(&snd_mem_mutex);
         return 0;
     }
 
@@ -180,7 +180,7 @@ uint32_t snd_mem_malloc(size_t size) {
         }
 
         best->inuse = 1;
-        spinlock_unlock(&snd_mem_mutex);
+        mutex_unlock(&snd_mem_mutex);
         return best->addr;
     }
 
@@ -189,7 +189,7 @@ uint32_t snd_mem_malloc(size_t size) {
 
     if(e == NULL) {
         dbglog(DBG_ERROR, "snd_mem_malloc: not enough main memory to alloc(%d)\n", size);
-        spinlock_unlock(&snd_mem_mutex);
+        mutex_unlock(&snd_mem_mutex);
         return 0;
     }
 
@@ -207,7 +207,7 @@ uint32_t snd_mem_malloc(size_t size) {
     best->size = size;
     best->inuse = 1;
 
-    spinlock_unlock(&snd_mem_mutex);
+    mutex_unlock(&snd_mem_mutex);
     return best->addr;
 }
 
@@ -221,7 +221,7 @@ void snd_mem_free(uint32_t addr) {
     if(addr == 0)
         return;
 
-    if(!spinlock_lock_irqsafe(&snd_mem_mutex))
+    if(mutex_lock_irqsafe(&snd_mem_mutex))
         return;
 
     /* Look for the block */
@@ -232,7 +232,7 @@ void snd_mem_free(uint32_t addr) {
 
     if(!e) {
         dbglog(DBG_ERROR, "snd_mem_free: attempt to free non-existent block at %08lx\n", (uint32_t)e);
-        spinlock_unlock(&snd_mem_mutex);
+        mutex_unlock(&snd_mem_mutex);
         return;
     }
 
@@ -266,7 +266,7 @@ void snd_mem_free(uint32_t addr) {
         TAILQ_REMOVE(&pool, o, qent);
         free(o);
     }
-    spinlock_unlock(&snd_mem_mutex);
+    mutex_unlock(&snd_mem_mutex);
 }
 
 uint32_t snd_mem_available(void) {
@@ -276,7 +276,7 @@ uint32_t snd_mem_available(void) {
     if(!initted)
         return 0;
 
-    if(!spinlock_lock_irqsafe(&snd_mem_mutex)) {
+    if(mutex_lock_irqsafe(&snd_mem_mutex)) {
         errno = EAGAIN;
         return 0;
     }
@@ -286,6 +286,6 @@ uint32_t snd_mem_available(void) {
             largest = e->size;
     }
 
-    spinlock_unlock(&snd_mem_mutex);
+    mutex_unlock(&snd_mem_mutex);
     return (uint32_t)largest;
 }

--- a/kernel/libc/c11/atomics.c
+++ b/kernel/libc/c11/atomics.c
@@ -195,7 +195,7 @@ bool __atomic_compare_exchange(size_t size,
 }
 
 /* All atomics for builtin types are lock-free, while our
-   generic atomics back-end utilizes spinlocks. */
+   generic atomics back-end utilizes mutexes. */
 bool __atomic_is_lock_free(size_t size, const volatile void *ptr) {
     (void)ptr;
     (void)size;

--- a/kernel/thread/tls.c
+++ b/kernel/thread/tls.c
@@ -15,7 +15,6 @@
 
 #include <kos/irq.h>
 #include <kos/tls.h>
-#include <kos/spinlock.h>
 #include <kos/thread.h>
 #include <kos/mutex.h>
 


### PR DESCRIPTION
Furthering #1180 , reduce the usage of spinlocks and clean up mentions of them that had already been migrated to mutexes. This migrates the usage of spinlocks to mutexes for the PVR and AICA memory managers ~~as well as newlib's generic locks~~.

Additionally performed some minor cleanups while there.