### PR TITLE
C++ std::chrono precision toolchain fixes + clock example upgrade.

### DIFF
--- a/examples/dreamcast/cpp/clock/Makefile
+++ b/examples/dreamcast/cpp/clock/Makefile
@@ -1,18 +1,22 @@
 #
 # DC Clock App
 # Based on Peter Hatch's Font Test
-# (c)2002 Megan Potter
-#   
+#
+# Copyright (C) 2002 Megan Potter
+# Copyright (C) 2026 Falco Girgis
+#
 
 TARGET = clock.elf
 OBJS = clock.o romdisk.o
 KOS_ROMDISK_DIR = romdisk
-
-KOS_CPPFLAGS += -std=gnu++17
-
-all: rm-elf $(TARGET)
+KOS_CPPFLAGS += -std=gnu++23
+KOS_GCCVER_MIN = 13.0.0
 
 include $(KOS_BASE)/Makefile.rules
+
+ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
+
+all: rm-elf $(TARGET)
 
 clean: rm-elf
 	-rm -f $(OBJS) 
@@ -30,3 +34,7 @@ dist: $(TARGET)
 	-rm -f $(OBJS) romdisk.img
 	$(KOS_STRIP) $(TARGET)
 
+else
+  all $(TARGET) clean rm-elf run dist:
+	$(KOS_GCCVER_MIN_WARNING)
+endif

--- a/examples/dreamcast/cpp/clock/clock.cc
+++ b/examples/dreamcast/cpp/clock/clock.cc
@@ -1,76 +1,85 @@
-// Originally from plib_examples
-// Ported to Dreamcast/KOS by Peter Hatch
-// read_input () code from KOS examples
-// Converted to a clock by Megan Potter
-// Resolution enhanced by Falco Girgis
+/* KallistiOS ##version##
+
+   examples/dreamcast/cpp/clock/clock.cc
+
+   Copyright (C) Peter Hatch
+   Copyright (C) Megan Pottter
+   Copyright (C) 2023, 2026 Falco Girgis
+
+*/
+
+/*
+    This example displays the following information, updating in real-time:
+        - Current Unix timestamp
+        - Current date
+        - Current timestamp (nanosecond resolution)
+
+    It uses C++'s std::chrono timing API for all of this, and additionally
+    leverages as much modern functioanlity from C++23 as is possible, both
+    to provide examples to users and to serve as a sanity test for modern
+    C++ features in the toolchain for us KOS devs. :)
+*/
 
 #include <kos.h>
-#include <time.h>
 #include <dcplib/fnt.h>
 
-fntRenderer *text;
-fntTexFont *font;
+#include <cmath>
+#include <cstdlib>
 
-const char *days[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
-const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
-                         "Aug", "Sep", "Oct", "Nov", "Dec"
-                       };
+#include <array>
+#include <algorithm>
+#include <functional>
+#include <chrono>
+#include <print>
+#include <format>
 
-float bg[3];                        /* Current bg */
-float bg_delta[3] = { 0.01f };      /* bg per-frame delta */
-int   bg_cur = 1;
-float bgarray[][3] = {
-    { 0.0f, 0.0f, 0.0f },
-    { 0.5f, 0.0f, 0.0f },
-    { 0.0f, 0.5f, 0.0f },
-    { 0.0f, 0.0f, 0.5f },
-    { 0.5f, 0.0f, 0.5f },
-    { 0.0f, 0.5f, 0.5f },
-    { 0.5f, 0.5f, 0.0f },
-    { 0.5f, 0.5f, 0.5f }
+namespace {
+
+struct bg_state {
+    std::array<float, 3> color = { 0.0f };
+    std::array<float, 3> delta = { 0.01f };
+    size_t index = 1;
+
+    constexpr static const
+    std::array<std::array<float, 3>, 8> presets = {{
+        { 0.0f, 0.0f, 0.0f },
+        { 0.5f, 0.0f, 0.0f },
+        { 0.0f, 0.5f, 0.0f },
+        { 0.0f, 0.0f, 0.5f },
+        { 0.5f, 0.0f, 0.5f },
+        { 0.0f, 0.5f, 0.5f },
+        { 0.5f, 0.5f, 0.0f },
+        { 0.5f, 0.5f, 0.5f }
+    }};
 };
-#define BG_COUNT 8
 
-#define fabs(a) ( (a) < 0 ? -(a) : (a) )
-void bgframe() {
-    pvr_set_bg_color(bg[0], bg[1], bg[2]);
+void update_bg(bg_state* bg) {
+    pvr_set_bg_color(bg->color[0], bg->color[1], bg->color[2]);
 
-    bg[0] += bg_delta[0];
-    bg[1] += bg_delta[1];
-    bg[2] += bg_delta[2];
+    std::ranges::transform(bg->color, bg->delta, bg->color.begin(), std::plus<float>());
 
-    if(fabs(bg[0] - bgarray[bg_cur][0]) < 0.01f
-            && fabs(bg[1] - bgarray[bg_cur][1]) < 0.01f
-            && fabs(bg[2] - bgarray[bg_cur][2]) < 0.01f) {
-        bg_cur++;
+    if(std::ranges::equal(bg->color, bg->presets[bg->index],
+                          [](float a, float b) { return std::abs(a - b) < 0.01f; }))
+    {
+        if(++bg->index >= bg->presets.size())
+            bg->index = 0;
 
-        if(bg_cur >= BG_COUNT)
-            bg_cur = 0;
-
-        bg_delta[0] = (bgarray[bg_cur][0] - bg[0]) / (0.5f / 0.01f);
-        bg_delta[1] = (bgarray[bg_cur][1] - bg[1]) / (0.5f / 0.01f);
-        bg_delta[2] = (bgarray[bg_cur][2] - bg[2]) / (0.5f / 0.01f);
+        std::ranges::transform(bg->presets[bg->index], bg->color, bg->delta.begin(),
+                               [](float a, float b) { return (a - b) / (0.5f / 0.01f); });
     }
 }
 
-void drawFrame() {
-    struct timespec spec;
-    struct tm tm;
-    char tmpbuf[256];
+void draw_scene(fntRenderer* text) {
     int y = 50;
 
-    bgframe();
-
-    timespec_get(&spec, TIME_UTC);
-    localtime_r(&spec.tv_sec, &tm);
+    auto timestamp = std::chrono::high_resolution_clock::now();
+    auto duration  = timestamp.time_since_epoch();
+    auto seconds   = std::chrono::duration_cast<std::chrono::seconds>(duration);
+    auto unix_secs = std::chrono::system_clock::to_time_t(timestamp);
+    auto nanosecs  = std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds);
 
     pvr_scene_begin();
     pvr_list_begin(PVR_LIST_TR_POLY);
-
-    text->setFilterMode(PVR_FILTER_NEAREST);
-
-    text->setFont(font);
-    text->setPointSize(30);
 
     text->begin();
     text->setColor(1, 1, 1);
@@ -79,82 +88,71 @@ void drawFrame() {
     text->end();
     y += 50;
 
-    sprintf(tmpbuf, "Unix: %lld", spec.tv_sec);
+    text->begin();
+    text->setColor(1, 1, 1);
+    text->start2f(20, y);
+    text->puts(std::format("Unix: {}", unix_secs).c_str());
+    text->end();
+    y += 50;
 
     text->begin();
     text->setColor(1, 1, 1);
     text->start2f(20, y);
-    text->puts(tmpbuf);
+    text->puts(std::format("{0:%A} {0:%B} {0:%d}, {0:%Y}", timestamp).c_str());
     text->end();
     y += 50;
-
-    sprintf(tmpbuf, "%s %s %02d %04d",
-            days[tm.tm_wday], months[tm.tm_mon], tm.tm_mday, 1900 + tm.tm_year);
 
     text->begin();
     text->setColor(1, 1, 1);
     text->start2f(20, y);
-    text->puts(tmpbuf);
+    text->puts(std::format("{:%H:%M:%S}", timestamp).c_str());
     text->end();
     y += 50;
 
-    sprintf(tmpbuf, "%02d:%02d:%02d.%lu",
-            tm.tm_hour, tm.tm_min, tm.tm_sec, spec.tv_nsec);
-
-    text->begin();
-    text->setColor(1, 1, 1);
-    text->start2f(20, y);
-    text->puts(tmpbuf);
-    text->end();
-    y += 50;
-
-    pvr_list_finish();
     pvr_scene_finish();
 }
 
+bool read_input() {
+    if(auto *cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER); cont) {
+        /* Check for start on the controller */
+        auto *state = static_cast<cont_state_t *>(maple_dev_status(cont));
 
-/* This is really more complicated than it needs to be in this particular
-   case, but it's nice and verbose. */
-int read_input() {
-    maple_device_t *cont;
-    cont_state_t *state;
+        if(!state) {
+            std::println(stderr, "Error getting controller status.");
+            return true;
+        }
 
-    cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
-
-    if(!cont) {
-        return 0;
+        if(state->start) {
+            std::println("Pressed start.");
+            return true;
+        }
     }
 
-    /* Check for start on the controller */
-    state = (cont_state_t *)maple_dev_status(cont);
+    return false;
+}
 
-    if(!state) {
-        printf("Error getting controller status\n");
-        return 1;
-    }
-
-    if(state->buttons & CONT_START) {
-        printf("Pressed start\n");
-        return 1;
-    }
-
-    return 0;
 }
 
 int main(int argc, char **argv) {
-    pvr_init_params_t pvrInit = {
-        {PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_32, PVR_BINSIZE_0, PVR_BINSIZE_0},
+    const pvr_init_params_t pvrInit = {
+        { PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_32, PVR_BINSIZE_0, PVR_BINSIZE_0 },
         512 * 1024, 0, 0, 0, 0, 0
     };
 
     pvr_init(&pvrInit);
 
-    text = new fntRenderer();
-    font = new fntTexFont("/rd/default.txf");
+    fntRenderer text;
+    fntTexFont font("/rd/default.txf");
+    bg_state bg;
+
+    text.setFilterMode(PVR_FILTER_NEAREST);
+    text.setFont(&font);
+    text.setPointSize(30);
 
     while(!read_input()) {
-        drawFrame();
+        update_bg(&bg);
+        draw_scene(&text);
     }
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/include/kos/timer.h
+++ b/include/kos/timer.h
@@ -35,7 +35,7 @@ typedef struct timespec timespec_t;
 
     \return                 The current uptime of the system as a timespec struct.
 */
-static inline timespec_t timer_gettime(void) {
+static inline timespec_t timer_gettimespec(void) {
     return arch_timer_gettime();
 }
 
@@ -49,7 +49,7 @@ static inline timespec_t timer_gettime(void) {
     \return                 The number of milliseconds since KOS started.
 */
 static inline uint64_t timer_ms_gettime64(void) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     return (uint64_t)time.tv_sec * 1000 + (uint64_t)(time.tv_nsec / 1000000);
 }
@@ -62,7 +62,7 @@ static inline uint64_t timer_ms_gettime64(void) {
     \return                 The uptime in microseconds.
 */
 static inline uint64_t timer_us_gettime64(void) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     return (uint64_t)time.tv_sec * 1000000 + (uint64_t)(time.tv_nsec / 1000);
 }
@@ -75,7 +75,7 @@ static inline uint64_t timer_us_gettime64(void) {
     \return                 The uptime in nanoseconds.
 */
 static inline uint64_t timer_ns_gettime64(void) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     return (uint64_t)time.tv_sec * 1000000000 + (uint64_t)time.tv_nsec;
 }
@@ -95,7 +95,7 @@ static inline uint64_t timer_ns_gettime64(void) {
                             timer_ms_gettime64() function.
 */
 static inline void timer_ms_gettime(uint32_t *secs, uint32_t *msecs) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     if(secs)  *secs = time.tv_sec;
     if(msecs) *msecs = (uint32_t)(time.tv_nsec / 1000000);
@@ -117,7 +117,7 @@ static inline void timer_ms_gettime(uint32_t *secs, uint32_t *msecs) {
                             a second since boot.
 */
 static inline void timer_us_gettime(uint32_t *secs, uint32_t *usecs) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     if(secs)  *secs = time.tv_sec;
     if(usecs) *usecs = (uint32_t)(time.tv_nsec / 1000);
@@ -139,7 +139,7 @@ static inline void timer_us_gettime(uint32_t *secs, uint32_t *usecs) {
                             a second since boot.
 */
 static inline void timer_ns_gettime(uint32_t *secs, uint32_t *nsecs) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     if(secs)  *secs = time.tv_sec;
     if(nsecs) *nsecs = (uint32_t)time.tv_nsec;

--- a/include/machine/time.h
+++ b/include/machine/time.h
@@ -2,7 +2,7 @@
 
    machine/time.h
    Copyright (C) 2023 Lawrence Sebald
-   Copyright (C) 2024 Falco Girgis
+   Copyright (C) 2024, 2026 Falco Girgis
 */
 
 /** \file    machine/time.h
@@ -14,10 +14,6 @@
     \remark
     This will probably go away at some point in the future, if/when Newlib gets
     an implementation of this function. But for now, it's here.
-
-    \todo
-    - Implement _POSIX_TIMERS, which requires POSIX signals back-end.
-    - Implement thread-specific CPU time
 
     \author Lawrence Sebald
     \author Falco Girgis
@@ -89,37 +85,6 @@ extern struct tm *localtime_r(const __time_t *timer, struct tm *timeptr);
 
 /* C23 added POSIX gmtime() for UTC broken-down time to a Unix timestamp. */
 extern __time_t timegm(struct tm *timeptr);
-
-#endif
-
-/* =========== Enable the following for POSIX POSIX.1b (1993) =========== */
-#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 199309L)
-
-/* We do not support POSIX timers!
-#ifndef _POSIX_TIMERS
-#define _POSIX_TIMERS 1
-#endif */
-
-#ifndef _POSIX_MONOTONIC_CLOCK
-#define _POSIX_MONOTONIC_CLOCK 1
-#endif
-
-#ifndef _POSIX_CPUTIME
-#define _POSIX_CPUTIME 1
-#endif
-
-#ifndef _POSIX_THREAD_CPUTIME
-#define _POSIX_THREAD_CPUTIME 1
-#endif
-
-/* Explicitly provided function declarations for POSIX clock API, since
-   getting them from Newlib requires supporting the rest of the _POSIX_TIMERS
-   API, which is not implemented yet. */
-extern int clock_settime(__clockid_t clock_id, const struct timespec *ts);
-extern int clock_gettime(__clockid_t clock_id, struct timespec *ts);
-extern int clock_getres(__clockid_t clock_id, struct timespec *res);
-
-extern int nanosleep(const struct timespec *req, struct timespec *rem);
 
 #endif
 

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -1,7 +1,7 @@
 # KallistiOS ##version##
 #
 # kernel/libc/posix/Makefile
-# Copyright (C) 2023 Falco Girgis
+# Copyright (C) 2023, 2026 Falco Girgis
 #
 
 #
@@ -11,6 +11,6 @@
 #
 
 CFLAGS += -std=gnu11
-OBJS = posix_memalign.o clock_gettime.o settimeofday.o sysconf.o
+OBJS = clock_gettime.o posix_timer.o posix_memalign.o settimeofday.o sysconf.o
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/posix/posix_timer.c
+++ b/kernel/libc/posix/posix_timer.c
@@ -1,0 +1,45 @@
+/* KallistiOS ##version##
+
+   posix_timer.c
+   Copyright (C) 2026 Falco Girgis
+*/
+
+#include <time.h>
+#include <errno.h>
+
+int timer_create(clockid_t clock_id, struct sigevent *evp, timer_t *timerid) {
+    (void)clock_id;
+    (void)evp;
+    (void)timerid;
+
+    return ENOTSUP;
+}
+
+int timer_delete(timer_t timerid) {
+    (void)timerid;
+
+    return EINVAL;
+}
+
+int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
+                  struct itimerspec *ovalue) {
+    (void)timerid;
+    (void)flags;
+    (void)value;
+    (void)ovalue;
+    
+    return EINVAL;
+}
+
+int timer_gettime(timer_t timerid, struct itimerspec *value) {
+    (void)timerid;
+    (void)value;
+
+    return EINVAL;
+}
+
+int timer_getoverrun(timer_t timerid) {
+    (void)timerid;
+
+    return EINVAL;
+}

--- a/utils/kos-chain/patches/targets/gcc-15.2.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-15.2.0-kos.diff
@@ -144,4 +144,16 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0-kos/libstdc++-v3/configur
 +    kos)	thread_header=gthr-kos.h ;;
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
- 
+
+@@ -21307,6 +21308,11 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then

--- a/utils/kos-chain/patches/targets/gcc-15.2.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-15.2.1-kos.diff
@@ -144,4 +144,16 @@ diff -ruN gcc-15.2.1/libstdc++-v3/configure gcc-15.2.1-kos/libstdc++-v3/configur
 +    kos)	thread_header=gthr-kos.h ;;
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
- 
+
+@@ -21307,6 +21308,11 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then

--- a/utils/kos-chain/patches/targets/gcc-16.0.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.0.1-kos.diff
@@ -146,3 +146,15 @@ diff -ruN gcc-16.0.1/libstdc++-v3/configure gcc-16.0.1-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
+@@ -21489,6 +21490,11 @@
+         ac_has_clock_realtime=yes
+         ac_has_nanosleep=yes
+         ;;
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then

--- a/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
+++ b/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
@@ -287,3 +287,22 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/libc/stdlib/assert.c newlib-4.6.0
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
 +
+diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/sys/features.h newlib-4.6.0.20260123-kos/newlib/libc/include/sys/features.h
+--- newlib-4.6.0.20260123/newlib/libc/include/sys/features.h	2024-02-10 09:30:58.772247624 -0600
++++ newlib-4.6.0.20260123-kos/newlib/libc/include/sys/features.h	2024-02-10 09:31:16.329331366 -0600
+@@ -440,6 +440,15 @@
+ #endif
+ 
+ 
++#ifdef __sh__
++/* KallistiOS provides POSIX timer support via clock_gettime() */
++#define _POSIX_TIMERS           200809L
++#define _POSIX_MONOTONIC_CLOCK  200809L
++#define _POSIX_CPUTIME          200809L
++#define _POSIX_THREAD_CPUTIME   200809L
++#endif
++
++
+ #ifdef __svr4__
+ # define _POSIX_JOB_CONTROL     1
+ # define _POSIX_SAVED_IDS       1


### PR DESCRIPTION
This PR is a series of commits which works its  way up to fixing the horrible 1 second maximum resolution of C++'s `std::chrono` API in addition to revamping the C++ clock example to... y'know... actually use real C++ code and not just be C++98 calling into C APIs for date/time.

Basically `std::chrono` went from utterly useless for C++ developers to having the full 80ns granularity of `clock_gettime()` and `timespec_get()`, which is awesome. Plus, the clock example now actually flexes `std::chrono` for a cleaner implementation that also validates modern C++ APIs and features for our toolchains.

Here are the highlights of the commits:

1.  First I had to break our arch/timer API... because SOMEONE named a public API routine, `timer_gettime()` which is literally the name of a POSIX Timer API routine, which I have had to stub out as part of this PR... This could be seen as an API break, sorta, technically, but there's just no way around this. That routine should've never been named that to begin with, and we should absolutely rename it ASAP before more damage is done.

2. I had to stub out the entirety of the POSIX asynchronous timer API routines, such as the *real* `timer_gettime()`, which are just returning EINVAL/ENOSUP atm as stubs. These are needed, because libstdc++ REQUIRES `_POSIX_TIMERS` feature support in order to back `std::chrono` with `clock_gettime()` for its full resolution.

3. I had to remove our declarations for the little bit of the POSIX timer API that we do support from `machine/time.h` and instead get those declarations plus the rest of the POSIX timer API declarations handled by Newlib, by patching its top-level `sys/features.h` header, which is where each platform supported by Newlib conditionally enables the POSIX API features which it supports.

4. I had to finally patch GCC versions 15 and 16 so that `libstdc++`'s configure script which tests for routines to back `std::chrono` with would properly find and use `clock_gettime()` from POSIX, which offers full 80ns resolution, rather than the fallthrough implementation that just uses C89's `time()` routine, with only 1 second resolution.

5. I up-ported the C++ clock example to unapologetically modern AF C++23 code for god, glory, toolchain testing, and educational purposes. :kekw:

EDIT: Oh yeah, I rebuilt both a GCC16 and a GCC15 toolchain with those patches and confirmed everything works great with the new `std::chrono`-based C++ clock example:


https://github.com/user-attachments/assets/c71cbafa-50b6-4e90-8205-ed5419eecdce