### PR TITLE
arch: Move `args.h` to `dc` API layer

### DIFF
--- a/kernel/arch/dreamcast/include/arch/args.h
+++ b/kernel/arch/dreamcast/include/arch/args.h
@@ -1,58 +1,9 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/include/arch/args.h
-   Copyright (C) 2023 Paul Cercueil <paul@crapouillou.net>
+   kernel/arch/dreamcast/include/arch/args.h
 
 */
 
-/** \file   arch/args.h
-    \brief  Macros for getting argument registers in inline assembly
+#include <dc/args.h>
 
-    This file contains the KOS_FPARG(n) macro, which resolves to the register
-    name that corresponds to the nth floating-point argument of a function.
-
-    \author Paul Cercueil
-*/
-
-#ifndef __ARCH_ARGS_H
-#define __ARCH_ARGS_H
-
-#include <kos/cdefs.h>
-__BEGIN_DECLS
-
-#ifdef __SH4_SINGLE_ONLY__
-#define KOS_SH4_SINGLE_ONLY 1
-#else
-#define KOS_SH4_SINGLE_ONLY 0
-#endif
-
-#define __KOS_FPARG_0_1 "fr4"
-#define __KOS_FPARG_0_0 "fr5"
-#define __KOS_FPARG_1_1 "fr5"
-#define __KOS_FPARG_1_0 "fr4"
-#define __KOS_FPARG_2_1 "fr6"
-#define __KOS_FPARG_2_0 "fr7"
-#define __KOS_FPARG_3_1 "fr7"
-#define __KOS_FPARG_3_0 "fr6"
-#define __KOS_FPARG_4_1 "fr8"
-#define __KOS_FPARG_4_0 "fr9"
-#define __KOS_FPARG_5_1 "fr9"
-#define __KOS_FPARG_5_0 "fr8"
-#define __KOS_FPARG_6_1 "fr10"
-#define __KOS_FPARG_6_0 "fr11"
-#define __KOS_FPARG_7_1 "fr11"
-#define __KOS_FPARG_7_0 "fr10"
-
-#define __KOS_FPARG(n,single) __KOS_FPARG_##n##_##single
-#define _KOS_FPARG(n,single) __KOS_FPARG(n,single)
-
-/** \brief  Get the name of the nth floating-point argument register
- *
- *  This macro resolves to the register name that corresponds to the nth
- *  floating-point argument of a function (starting from n=0).
- */
-#define KOS_FPARG(n) _KOS_FPARG(n, KOS_SH4_SINGLE_ONLY)
-
-__END_DECLS
-
-#endif /* __ARCH_ARGS_H */
+#warning "The `<arch/args.h>` header has been moved to `<dc/args.h>`."

--- a/kernel/arch/dreamcast/include/dc/args.h
+++ b/kernel/arch/dreamcast/include/dc/args.h
@@ -1,0 +1,58 @@
+/* KallistiOS ##version##
+
+   arch/dreamcast/include/dc/args.h
+   Copyright (C) 2023 Paul Cercueil <paul@crapouillou.net>
+
+*/
+
+/** \file   dc/args.h
+    \brief  Macros for getting argument registers in inline assembly
+
+    This file contains the KOS_FPARG(n) macro, which resolves to the register
+    name that corresponds to the nth floating-point argument of a function.
+
+    \author Paul Cercueil
+*/
+
+#ifndef __ARCH_ARGS_H
+#define __ARCH_ARGS_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+#ifdef __SH4_SINGLE_ONLY__
+#define KOS_SH4_SINGLE_ONLY 1
+#else
+#define KOS_SH4_SINGLE_ONLY 0
+#endif
+
+#define __KOS_FPARG_0_1 "fr4"
+#define __KOS_FPARG_0_0 "fr5"
+#define __KOS_FPARG_1_1 "fr5"
+#define __KOS_FPARG_1_0 "fr4"
+#define __KOS_FPARG_2_1 "fr6"
+#define __KOS_FPARG_2_0 "fr7"
+#define __KOS_FPARG_3_1 "fr7"
+#define __KOS_FPARG_3_0 "fr6"
+#define __KOS_FPARG_4_1 "fr8"
+#define __KOS_FPARG_4_0 "fr9"
+#define __KOS_FPARG_5_1 "fr9"
+#define __KOS_FPARG_5_0 "fr8"
+#define __KOS_FPARG_6_1 "fr10"
+#define __KOS_FPARG_6_0 "fr11"
+#define __KOS_FPARG_7_1 "fr11"
+#define __KOS_FPARG_7_0 "fr10"
+
+#define __KOS_FPARG(n,single) __KOS_FPARG_##n##_##single
+#define _KOS_FPARG(n,single) __KOS_FPARG(n,single)
+
+/** \brief  Get the name of the nth floating-point argument register
+ *
+ *  This macro resolves to the register name that corresponds to the nth
+ *  floating-point argument of a function (starting from n=0).
+ */
+#define KOS_FPARG(n) _KOS_FPARG(n, KOS_SH4_SINGLE_ONLY)
+
+__END_DECLS
+
+#endif /* __ARCH_ARGS_H */

--- a/kernel/arch/dreamcast/include/dc/fmath_base.h
+++ b/kernel/arch/dreamcast/include/dc/fmath_base.h
@@ -18,7 +18,7 @@
 #ifndef __DC_FMATH_BASE_H
 #define __DC_FMATH_BASE_H
 
-#include <arch/args.h>
+#include <dc/args.h>
 
 #include <kos/cdefs.h>
 __BEGIN_DECLS


### PR DESCRIPTION
These are something only used within the `dc` API layer and per #1155 are being moved to the appropriate place.