### PR TITLE
fix: Correct include path syntax in KOS_INC_PATHS

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -27,7 +27,7 @@ fi
 # Our includes.
 export KOS_INC_PATHS="${KOS_INC_PATHS} -I${KOS_BASE}/include \
 -I${KOS_BASE}/kernel/arch/${KOS_ARCH}/include -I${KOS_BASE}/addons/include/ \
--I${KOS_PORTS}/include"
+-isystem ${KOS_PORTS}/include"
 
 # "System" libraries.
 export KOS_LIB_PATHS="-L${KOS_BASE}/lib/${KOS_ARCH} -L${KOS_BASE}/addons/lib/${KOS_ARCH} -L${KOS_PORTS}/lib"

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -25,8 +25,8 @@ if ! expr ":$PATH:" : ".*:${KOS_BASE}/utils/build_wrappers:.*" > /dev/null ; the
 fi
 
 # Our includes.
-export KOS_INC_PATHS="${KOS_INC_PATHS} -I${KOS_BASE}/include \
--I${KOS_BASE}/kernel/arch/${KOS_ARCH}/include -I${KOS_BASE}/addons/include/ \
+export KOS_INC_PATHS="${KOS_INC_PATHS} -isystem ${KOS_BASE}/include \
+-isystem ${KOS_BASE}/kernel/arch/${KOS_ARCH}/include -isystem ${KOS_BASE}/addons/include/ \
 -isystem ${KOS_PORTS}/include"
 
 # "System" libraries.


### PR DESCRIPTION
## Summary

Change `-I${KOS_PORTS}/include` to `-isystem ${KOS_PORTS}/include` in `environ_base.sh`.

## Problem

kos-ports headers were being injected with `-I`, giving them the same priority as user project include paths. Because `kos-cc` appends these flags automatically, any user `-I` path always came second in the compiler invocation, making it impossible to override a kos-ports library with a vendored version.

For example, a project vendoring Lua 5.1 could not override the kos-ports Lua 5.5 headers, resulting in hard build errors due to API differences between the two versions (e.g. `lua_newstate` and `lua_load` signature mismatches).

## Fix

Using `-isystem` instead of `-I` for `${KOS_PORTS}/include` correctly demotes kos-ports headers to system-level search priority, below user `-I` paths. This is consistent with how third-party/port headers should be treated — it also has the side benefit of suppressing warnings from kos-ports headers in user projects.

## Testing

Verified that a project vendoring Lua 5.1 now builds correctly without requiring `-iquote` workarounds in CMake.