### PR TITLE
exports: drop arch_stk_unwind_step from the export table

### DIFF
--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -222,7 +222,6 @@ rtc_boot_time
 # Stack tracing
 arch_stk_trace
 arch_stk_trace_at
-arch_stk_unwind_step
 
 # Timers
 timer_ms_gettime


### PR DESCRIPTION
I unknowningly exported DC specific arch_stk_unwind_step(), which forces every arch to define the symbol. Drop it so the build doesn't require a stub on arches that don't implement it.