### PR TITLE
mutex: skip priority-restore when there is no current thread

### DIFF
--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -186,8 +186,10 @@ int mutex_unlock(mutex_t *m) {
     if (__predict_true(!--m->count)) {
         m->holder = NULL;
 
-        /* Restore real priority in case we were dynamically boosted. */
-        if (__predict_true(thd != IRQ_THREAD))
+        /* Restore real priority in case we were dynamically boosted.
+           Skip for IRQ context (IRQ_THREAD) and for the pre-scheduler
+           case where there is no current thread yet (thd_current == NULL) */
+        if (__predict_true(thd != NULL && thd != IRQ_THREAD))
             thd->prio = thd->real_prio;
 
         /* If we need to wake up a thread, do so. */


### PR DESCRIPTION
Now that malloc uses mutexes, mutex_unlock() restores the holder's pre-boost priority via `thd->prio = thd->real_prio` on the final unlock. But the first malloc runs during early boot inside thd_init -> thd_create_ex (allocating the kernel thread) before thd_current is assigned, so thd_current is NULL there. That made mutex_unlock write through a NULL pointer and crashes on some archs.