### PR TITLE
Skmp/replaceable texture allocator

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -200,7 +200,7 @@ int pvr_init(const pvr_init_params_t *params) {
     pvr_state.valid = 1;
 
     /* Validate our memory pool */
-    pvr_mem_initialize((pvr_ptr_t)(PVR_RAM_INT_BASE + pvr_state.texture_base));
+    pvr_mem_initialize((pvr_ptr_t)(PVR_RAM_INT_BASE + pvr_state.texture_base), PVR_RAM_SIZE - pvr_state.texture_base);
     pvr_mem_reset();
     /* This doesn't work right now... */
     /*#ifndef NDEBUG
@@ -243,7 +243,7 @@ int pvr_shutdown(void) {
     pvr_dma_shutdown();
 
     /* Invalidate our memory pool */
-    pvr_mem_initialize((pvr_ptr_t)NULL);
+    pvr_mem_initialize((pvr_ptr_t)NULL, 0);
     pvr_mem_reset();
 
     /* Destroy the mutex */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -200,6 +200,7 @@ int pvr_init(const pvr_init_params_t *params) {
     pvr_state.valid = 1;
 
     /* Validate our memory pool */
+    pvr_mem_initialize((pvr_ptr_t)(PVR_RAM_INT_BASE + pvr_state.texture_base));
     pvr_mem_reset();
     /* This doesn't work right now... */
     /*#ifndef NDEBUG
@@ -242,6 +243,7 @@ int pvr_shutdown(void) {
     pvr_dma_shutdown();
 
     /* Invalidate our memory pool */
+    pvr_mem_initialize((pvr_ptr_t)NULL);
     pvr_mem_reset();
 
     /* Destroy the mutex */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -56,8 +56,9 @@ static LIST_HEAD(memctl_list, memctl) block_list;
 
 /* PVR RAM base; NULL is considered invalid */
 static pvr_ptr_t pvr_mem_base = NULL;
-#define CHECK_MEM_BASE \
-    assert_msg(pvr_mem_base != NULL, \
+static pvr_ptr_t pvr_mem_sbrk = NULL;
+#define CHECK_MEM_SBRK \
+    assert_msg(pvr_mem_sbrk != NULL, \
                "pvr_mem_* used, but PVR hasn't been initialized yet")
 
 /* Used in pvr_mem_core.c */
@@ -65,10 +66,10 @@ void *pvr_int_sbrk(size_t amt) {
     uint32_t old, n;
 
     /* Are we valid? */
-    CHECK_MEM_BASE;
+    CHECK_MEM_SBRK;
 
     /* Try to increment it */
-    old = (uint32_t)pvr_mem_base;
+    old = (uint32_t)pvr_mem_sbrk;
     n = old + amt;
 
     /* Did we run over? */
@@ -76,7 +77,7 @@ void *pvr_int_sbrk(size_t amt) {
         return (void *) - 1;
 
     /* Nope, everything's cool */
-    pvr_mem_base = (pvr_ptr_t)n;
+    pvr_mem_sbrk = (pvr_ptr_t)n;
     return (pvr_ptr_t)old;
 }
 
@@ -86,7 +87,7 @@ pvr_ptr_t __weak_symbol pvr_mem_malloc(size_t size) {
     uint32_t rv32;
     memctl_t    *ctl;
 
-    CHECK_MEM_BASE;
+    CHECK_MEM_SBRK;
 
     rv32 = (uint32_t)pvr_int_malloc(size);
     assert_msg((rv32 & 0x1f) == 0,
@@ -119,7 +120,7 @@ void __weak_symbol pvr_mem_free(pvr_ptr_t chunk) {
     if(__is_defined(PVR_KM_DBG))
         ra = arch_get_ret_addr();
 
-    CHECK_MEM_BASE;
+    CHECK_MEM_SBRK;
 
     if(__is_defined(PVR_KM_DBG_VERBOSE)) {
         printf("Thread %d/%08lx freeing block @ %08lx\n",
@@ -175,11 +176,11 @@ static size_t pvr_mem_available_int(void) {
 }
 
 size_t __weak_symbol pvr_mem_available(void) {
-    if(!pvr_mem_base)
+    if(!pvr_mem_sbrk)
         return 0;
 
     return pvr_mem_available_int() + 
-        (PVR_RAM_INT_TOP - (size_t)pvr_mem_base);
+        (PVR_RAM_INT_TOP - (size_t)pvr_mem_sbrk);
 }
 
 /* Reset the memory pool, equivalent to freeing all textures currently
@@ -187,18 +188,21 @@ size_t __weak_symbol pvr_mem_available(void) {
    change, etc. */
 void __weak_symbol pvr_mem_reset(void) {    
     if (pvr_mem_base != NULL) {
+        pvr_mem_sbrk = pvr_mem_base;
         pvr_int_mem_reset();
+    } else {
+        pvr_mem_sbrk = NULL;
     }
 }
 
 void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base) {
-    pvr_mem_base = pvr_texture_base;
+    pvr_mem_sbrk = pvr_texture_base;
 }
 
 /* Print some statistics (like mallocstats) */
 void __weak_symbol pvr_mem_stats(void) {
     printf("pvr_mem_stats():\n");
     pvr_int_malloc_stats();
-    printf("max sbrk base: %08lx\n", (uint32_t)pvr_mem_base);
+    printf("max sbrk base: %08lx\n", (uint32_t)pvr_mem_sbrk);
     pvr_mem_print_list();
 }

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -7,7 +7,6 @@
 
 #include <assert.h>
 #include <dc/pvr.h>
-#include "pvr_internal.h"
 #include <stdio.h>
 
 #include <malloc.h> /* For the struct mallinfo defs */
@@ -83,7 +82,7 @@ void *pvr_int_sbrk(size_t amt) {
 
 /* Allocate a chunk of memory from texture space; the returned value
    will be relative to the base of texture memory (zero-based) */
-pvr_ptr_t pvr_mem_malloc(size_t size) {
+pvr_ptr_t __weak_symbol pvr_mem_malloc(size_t size) {
     uint32_t rv32;
     memctl_t    *ctl;
 
@@ -112,7 +111,7 @@ pvr_ptr_t pvr_mem_malloc(size_t size) {
 }
 
 /* Free a previously allocated chunk of memory */
-void pvr_mem_free(pvr_ptr_t chunk) {
+void __weak_symbol pvr_mem_free(pvr_ptr_t chunk) {
     uint32_t    ra;
     memctl_t    *ctl, *tmp;
     int     found;
@@ -151,7 +150,7 @@ void pvr_mem_free(pvr_ptr_t chunk) {
 }
 
 /* Check the memory block list to see what's allocated */
-void pvr_mem_print_list(void) {
+void __weak_symbol pvr_mem_print_list(void) {
     memctl_t    *ctl;
 
     if(!__is_defined(PVR_KM_DBG))
@@ -175,7 +174,7 @@ static size_t pvr_mem_available_int(void) {
     return mi.arena - mi.uordblks;
 }
 
-size_t pvr_mem_available(void) {
+size_t __weak_symbol pvr_mem_available(void) {
     if(!pvr_mem_base)
         return 0;
 
@@ -186,17 +185,18 @@ size_t pvr_mem_available(void) {
 /* Reset the memory pool, equivalent to freeing all textures currently
    residing in RAM. This _must_ be done on a mode change, configuration
    change, etc. */
-void pvr_mem_reset(void) {
-    if(!pvr_state.valid)
-        pvr_mem_base = NULL;
-    else {
-        pvr_mem_base = (pvr_ptr_t)(PVR_RAM_INT_BASE + pvr_state.texture_base);
+void __weak_symbol pvr_mem_reset(void) {    
+    if (pvr_mem_base != NULL) {
         pvr_int_mem_reset();
     }
 }
 
+void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base) {
+    pvr_mem_base = pvr_texture_base;
+}
+
 /* Print some statistics (like mallocstats) */
-void pvr_mem_stats(void) {
+void __weak_symbol pvr_mem_stats(void) {
     printf("pvr_mem_stats():\n");
     pvr_int_malloc_stats();
     printf("max sbrk base: %08lx\n", (uint32_t)pvr_mem_base);

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -195,7 +195,8 @@ void __weak_symbol pvr_mem_reset(void) {
     }
 }
 
-void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base) {
+void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base, size_t available_memory) {
+    (void)available_memory;
     pvr_mem_sbrk = pvr_texture_base;
 }
 

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
@@ -64,7 +64,7 @@ typedef void *pvr_ptr_t;
     
     \return                 A pointer to the memory on success, NULL on error
 */
-pvr_ptr_t pvr_mem_malloc(size_t size);
+pvr_ptr_t __weak_symbol pvr_mem_malloc(size_t size);
 
 /** \brief   Free a block of allocated memory in the PVR RAM pool.
     \ingroup pvr_mem_mgmt
@@ -73,14 +73,14 @@ pvr_ptr_t pvr_mem_malloc(size_t size);
 
     \param  chunk           The location of the start of the block to free
 */
-void pvr_mem_free(pvr_ptr_t chunk);
+void __weak_symbol pvr_mem_free(pvr_ptr_t chunk);
 
 /** \brief   Return the number of bytes available still in the PVR RAM pool.
     \ingroup pvr_mem_mgmt
 
     \return                 The number of bytes available
 */
-size_t pvr_mem_available(void);
+size_t __weak_symbol pvr_mem_available(void);
 
 /** \brief   Reset the PVR RAM pool.
     \ingroup pvr_mem_mgmt
@@ -88,14 +88,22 @@ size_t pvr_mem_available(void);
     This will essentially free any blocks allocated within the pool. There's
     generally not many good reasons for doing this.
 */
-void pvr_mem_reset(void);
+void __weak_symbol pvr_mem_reset(void);
+
+/** \brief   Set the the PVR RAM base address.
+    \ingroup pvr_mem_mgmt
+
+    This sets the base address for texture allocations.
+    pvr_mem_reset should be called after calling this function.
+*/
+void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base);
 
 /** \brief   Print the list of allocated blocks in the PVR RAM pool.
     \ingroup pvr_mem_mgmt
 
     This function only works if you've enabled KM_DBG in pvr_mem.c.
 */
-void pvr_mem_print_list(void);
+void __weak_symbol pvr_mem_print_list(void);
 
 /** \brief   Print statistics about the PVR RAM pool.
     \ingroup pvr_mem_mgmt
@@ -103,7 +111,7 @@ void pvr_mem_print_list(void);
     This prints out statistics like what malloc_stats() provides. Also, if
     KM_DBG is enabled in pvr_mem.c, it prints the list of allocated blocks.
 */
-void pvr_mem_stats(void);
+void __weak_symbol pvr_mem_stats(void);
 
 __END_DECLS
 

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
@@ -96,7 +96,7 @@ void __weak_symbol pvr_mem_reset(void);
     This sets the base address for texture allocations.
     pvr_mem_reset should be called after calling this function.
 */
-void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base);
+void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base, size_t available_memory);
 
 /** \brief   Print the list of allocated blocks in the PVR RAM pool.
     \ingroup pvr_mem_mgmt

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
@@ -90,7 +90,7 @@ size_t __weak_symbol pvr_mem_available(void);
 */
 void __weak_symbol pvr_mem_reset(void);
 
-/** \brief   Set the the PVR RAM base address.
+/** \brief   Set the PVR RAM base address.
     \ingroup pvr_mem_mgmt
 
     This sets the base address for texture allocations.


### PR DESCRIPTION
- Marks the pvr_mem api __weak_symbol so that it can be overridden by the application
- Adds pvr_mem_initialize so that pvr_mem (or other allocators) don't need pull in `pvr_internals.h`
- splits pvr sbrk base to its own variable, to allow resets

This closes #1373 and is identical to it but with the gcc 9.5 error corrected as mentioned in the feedback there.