### PR TITLE
pvr_mem: Initialize pvr_mem_base in pvr_mem_initialize

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -198,7 +198,6 @@ void __weak_symbol pvr_mem_reset(void) {
 void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base, size_t available_memory) {
     (void)available_memory;
     pvr_mem_base = pvr_texture_base;
-    pvr_mem_sbrk = pvr_texture_base;
 }
 
 /* Print some statistics (like mallocstats) */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -197,6 +197,7 @@ void __weak_symbol pvr_mem_reset(void) {
 
 void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base, size_t available_memory) {
     (void)available_memory;
+    pvr_mem_base = pvr_texture_base;
     pvr_mem_sbrk = pvr_texture_base;
 }
 


### PR DESCRIPTION
### Summary

While testing DCSinge on the latest KOS master, startup was failing with:

```text
*** ASSERTION FAILURE ***
Assertion "pvr_mem_sbrk != NULL" failed at pvr_mem.c:90 in `pvr_mem_malloc':
pvr_mem_* used, but PVR hasn't been initialized yet
```

The failure occurred after `pvr_init()` had already completed and before the first FMV was loaded.

### Root Cause

`pvr_mem_initialize()` was setting `pvr_mem_sbrk` but was not initializing `pvr_mem_base`:

```c
void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base,
                                      size_t available_memory) {
    (void)available_memory;
    pvr_mem_sbrk = pvr_texture_base;
}
```

As a result, allocator state was only partially initialized.

### Fix

Initialize both allocator pointers:

```c
void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base,
                                      size_t available_memory) {
    (void)available_memory;
    pvr_mem_base = pvr_texture_base;
    pvr_mem_sbrk = pvr_texture_base;
}
```

### Verification

Before this change, DCSinge reported:

```text
pvr_free=0
```

and later aborted with the assertion above.

After this change:

```text
pvr_free=5789440
```

and texture allocation, PNG loading, and FMV initialization all proceed normally.

This appears to be an allocator initialization issue in KOS rather than an application ordering issue, since `pvr_init()` had already completed before any PVR memory queries or allocations were performed.
