### PR TITLE
Attempted fix at DMA misalignment for snd stream.

### DIFF
--- a/kernel/arch/dreamcast/include/dc/sound/stream.h
+++ b/kernel/arch/dreamcast/include/dc/sound/stream.h
@@ -46,7 +46,7 @@ __BEGIN_DECLS
 #define SND_STREAM_BUFFER_MAX_PCM8  (64 << 10)
 
 /** \brief  The maximum buffer size for each channel of ADPCM stream. */
-#define SND_STREAM_BUFFER_MAX_ADPCM ((32 << 10) - 32)
+#define SND_STREAM_BUFFER_MAX_ADPCM ((32 << 10) - 64)
 
 /** \brief  The maximum buffer size for each channel of streams by default
             and for backward compatibility. */


### PR DESCRIPTION
Due to the fact that our maximum ADPCM buffer size is 32 bytes less than it used to be, now that we do split PCM, which divides the buffer into 2, our DMA-friendly buffers are no longer going to be aligned and of the right size increments for DMA transactions, which causes an assertion on an unaligned g2 DMA transfer.