### PR TITLE
pvr_mem: Don't mark prototypes __weak_symbol

### DIFF
--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
@@ -64,7 +64,7 @@ typedef void *pvr_ptr_t;
     
     \return                 A pointer to the memory on success, NULL on error
 */
-pvr_ptr_t __weak_symbol pvr_mem_malloc(size_t size);
+pvr_ptr_t pvr_mem_malloc(size_t size);
 
 /** \brief   Free a block of allocated memory in the PVR RAM pool.
     \ingroup pvr_mem_mgmt
@@ -73,14 +73,14 @@ pvr_ptr_t __weak_symbol pvr_mem_malloc(size_t size);
 
     \param  chunk           The location of the start of the block to free
 */
-void __weak_symbol pvr_mem_free(pvr_ptr_t chunk);
+void pvr_mem_free(pvr_ptr_t chunk);
 
 /** \brief   Return the number of bytes available still in the PVR RAM pool.
     \ingroup pvr_mem_mgmt
 
     \return                 The number of bytes available
 */
-size_t __weak_symbol pvr_mem_available(void);
+size_t pvr_mem_available(void);
 
 /** \brief   Reset the PVR RAM pool.
     \ingroup pvr_mem_mgmt
@@ -88,7 +88,7 @@ size_t __weak_symbol pvr_mem_available(void);
     This will essentially free any blocks allocated within the pool. There's
     generally not many good reasons for doing this.
 */
-void __weak_symbol pvr_mem_reset(void);
+void pvr_mem_reset(void);
 
 /** \brief   Set the PVR RAM base address.
     \ingroup pvr_mem_mgmt
@@ -96,14 +96,14 @@ void __weak_symbol pvr_mem_reset(void);
     This sets the base address for texture allocations.
     pvr_mem_reset should be called after calling this function.
 */
-void __weak_symbol pvr_mem_initialize(pvr_ptr_t pvr_texture_base, size_t available_memory);
+void pvr_mem_initialize(pvr_ptr_t pvr_texture_base, size_t available_memory);
 
 /** \brief   Print the list of allocated blocks in the PVR RAM pool.
     \ingroup pvr_mem_mgmt
 
     This function only works if you've enabled KM_DBG in pvr_mem.c.
 */
-void __weak_symbol pvr_mem_print_list(void);
+void pvr_mem_print_list(void);
 
 /** \brief   Print statistics about the PVR RAM pool.
     \ingroup pvr_mem_mgmt
@@ -111,7 +111,7 @@ void __weak_symbol pvr_mem_print_list(void);
     This prints out statistics like what malloc_stats() provides. Also, if
     KM_DBG is enabled in pvr_mem.c, it prints the list of allocated blocks.
 */
-void __weak_symbol pvr_mem_stats(void);
+void pvr_mem_stats(void);
 
 __END_DECLS
 


### PR DESCRIPTION
Got the latest master and found that I was having issues with my own PVR example I use to test a lot. Launched into automatic reset of the Dreamcast. I tested against dreamcast/pvr/plasma example and got the same behavior. Turns out the issue was adding __weak_symbol to the pvr_mem_* declarations in <dc/pvr/pvr_mem.h>, not just the definitions in pvr_mem.c. That makes every caller emit a *weak* undefined reference, and an ELF linker does not extract an archive member to satisfy a weak reference. As a result pvr_mem.o is never pulled out of libkallisti.a: pvr_mem_malloc(), pvr_mem_reset() and pvr_mem_initialize() all resolve to address 0, so pvr_init() jumps to 0 and the console resets the moment any textured program runs.

Keep __weak_symbol on the definitions (so a custom allocator can still override them) but use plain prototypes in the header, restoring the strong references that force archive extraction.