### PR TITLE
Docs cleanup

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -105,16 +105,20 @@ This process should work (and has been tested) under Linux, BSD, Cygwin and
 MinGW/MSYS. It is very doubtful that it will work in any non-*nix environment.
 
 # Version Codes
-All KOS versions are composed of three sections: major, minor, micro. Major
-revisions are generally something that changes the OS fundamentally, or
+All KOS versions are composed of three sections: major, minor, and patch.
+Major revisions are generally something that changes the OS fundamentally, or
 when we wait several years between releases :smiley:. The minor version number
-is used to denote a development series. This gets incremented basically
-whenever we feel that it is relevant to do so. Finally, the micro version
-denotes a sequence in the development series. 1.1.0 would be the first
-snapshot of the 1.1 development series.
+is used to denote a stable version series. This gets incremented basically
+whenever we feel that it is relevant to do so. Finally, the patch version
+denotes a bugfixing patch to the stable version.
 
-And as always, if you want to be on the bleeding edge, use the Git
-repository hosted at SourceForge.
+Starting with v2.1.0, each stable version series will have its own branch cut
+with the format `v[major].[minor].x` and each patch version will be a tag on
+that branch. Updates to these branches should only contain bug fixes and
+should not be expected to change the API or break existing code.
+
+And as always, if you want to be on the bleeding edge, use the `master` branch
+in the Git repository hosted at GitHub.
 
 # Hacking
 If you are planning on doing your own hacking and potentially submitting

--- a/examples/dreamcast/readme.md
+++ b/examples/dreamcast/readme.md
@@ -4,37 +4,53 @@ This page serves as an index for all KallistiOS examples.
 - [**2ndmix**](2ndmix/): The flagship KallistiOS demo. It is a remixed version of _Stars_, the first publicly available homebrew Dreamcast demo!
 - basic
   - asserthnd
+  - breaking
+  - dma
   - exec
   - fpu
+  - gdb_breaking
   - memtest32
   - mmu
   - stackprotector
   - stacktrace
   - threading
   - watchdog
+- cdrom
+  - stream
 - conio
   - adventure
   - basic
+  - conio_dbgio
   - kosh
   - wump
 - cpp
   - clock
   - concurrency
   - dcplib
+  - filesystem
   - gltest
   - modplug_test
   - out_of_memory
+- dev
+  - devroot
+  - [**random**](dev/random/): Demonstrates generating random numbers using /dev/urandom
 - dreameye
   - basic
+  - sd
+- filesystem
+  - browse
+  - pty
   - sd
 - g1ata
   - atatest
 - gldc
+  - 2D_tex_quad
   - basic
   - benchmarks
   - nehe
 - [**hello**](hello/): demonstrates printing text to the console
 - keyboard
+  - keyrawtest
   - keytest
 - libdream
   - 320x240
@@ -47,6 +63,7 @@ This page serves as an index for all KallistiOS examples.
   - spu
   - ta
   - vmu
+- library
 - lightgun
   - basic
 - lua
@@ -66,6 +83,7 @@ This page serves as an index for all KallistiOS examples.
   - ntp
   - ping
   - ping6
+  - speedtest
   - udpecho6
 - objc
   - runtime
@@ -78,33 +96,42 @@ This page serves as an index for all KallistiOS examples.
   - serpent_dma
   - sinus
 - [**png**](png/): - Demonstrates the use of PNG textures, gzip decompression, and drawing text
+- pthread
+  - general
 - pvr
   - bumpmap
   - cheap_shadow
+  - fb_tex
   - modifier_volume
   - modifier_volume_tex
+  - modifier_volume_zclip
   - palette
   - plasma
+  - pvrline
   - pvrmark
   - pvrmark_strips
   - pvrmark_strips_direct
+  - strided_texture
   - texture_render
   - yuv_converter
-- [**random**](random/): Demonstrates generating random numbers using /dev/urandom
+- raylib
+  - raytris
 - [**rumble**](rumble/): Demonstrates sending raw commands to the purupuru/jump pack
 - sd
+  - ext2fs
+  - mke2fs
 - sdl
-  -sound
+  - sound
 - sound
   - cdda
   - ghettoplay-vorbis
+  - hello-adx
   - hello-mp3
   - hello-ogg
   - hello-opus
   - multi-stream
   - sfx
-- raylib
-  - raytris
+  - sfxbuf
 - tsunami
   - banner
   - font
@@ -114,6 +141,7 @@ This page serves as an index for all KallistiOS examples.
   - minifont
   - multibuffer
   - palmenu
+  - screenshot
 - vmu
   - vmu_beep
   - vmu_game

--- a/kernel/arch/dreamcast/include/arch/irq.h
+++ b/kernel/arch/dreamcast/include/arch/irq.h
@@ -60,7 +60,7 @@ __BEGIN_DECLS
     @{
 */
 
-/** \defgroup irq_context Context
+/** \ingroup irq_context
     \brief Thread execution state and accessors
 
     This API includes the structure and accessors for a


### PR DESCRIPTION
Closes #1031 

- Resolves the last current warning present (with doxygen 1.9.8) in our doxygen documentation.
- Updates the examples readme to list new examples and correct locations of ones that have moved.
- Updates doc/readme with information on our current version process.