### PR TITLE
Newlib 4.6.0 Patch: Weak ASM memory symbols.

### DIFF
--- a/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
+++ b/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
@@ -287,3 +287,15 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/libc/stdlib/assert.c newlib-4.6.0
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
 +
+diff --color -ruN newlib-4.6.0.20260123/newlib/libc/machine/sh/asm.h newlib-4.6.0.20260123-kos/newlib/libc/machine/sh/asm.h
+--- newlib-4.6.0.20260123/newlib/libc/machine/sh/asm.h	2026-01-23 16:12:49.000000000 -0600
++++ newlib-4.6.0.20260123-kos/newlib/libc/machine/sh/asm.h	2026-01-23 16:12:49.000000000 -0600
+@@ -16,7 +16,7 @@
+ 	TEXT; .balign 8; .globl name; name:
+ #else
+ #define _ENTRY(name)	\
+-	.text; .align 2; .globl name; name:
++	.text; .align 2; .globl name; .weak name; .type name, %function; name:
+ #endif /* __SH5__ */
+ 
+ #define ENTRY(name)	\


### PR DESCRIPTION
This patch is the result of my evil experimentation with testing my shz_memcpy() routines as the toolchain's default implementation.

So how can I achieve such a thing while still being able to iterate on my implementation? How can I use it for system memcpy() but not have to commit to a particular implementation and keep control over my own implementation, as I iterate on it?

...this PR was my idea. All of the standard C memory routines from Newlib that are implemented in out-of-line ASM: memcpy(), memmove(), memset(), strlen(), etc, are all declared via the same macro. This PR modifies that macro so that all of these routines which get declared with it are now declared WEAK symbols.

So now, simply add a memcpy, memset, memmove, or whatever function into your project and forward it on to shz_memcpy() or libfastmem or whatever you want to back it with!