### PR TITLE
Check results of `mutex_lock_irqsafe`

### DIFF
--- a/include/kos/mutex.h
+++ b/include/kos/mutex.h
@@ -143,7 +143,7 @@ int mutex_destroy(mutex_t *m) __nonnull_all;
                      function was called inside an interrupt and the mutex was
                      already locked \n
 */
-int mutex_lock_irqsafe(mutex_t *m) __nonnull_all;
+__result_use_check int mutex_lock_irqsafe(mutex_t *m) __nonnull_all;
 
 /** \brief  Lock a mutex (with a timeout).
 

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -210,7 +210,8 @@ static void pty_destroy_unused(void) {
 
     /* Make sure no one else is messing with the list and then disable
        everything for a bit */
-    mutex_lock_irqsafe(&list_mutex);
+    if(mutex_lock_irqsafe(&list_mutex))
+        return;
 
     old = irq_disable();
 
@@ -427,7 +428,8 @@ static int pty_close(void *h) {
 
     if(fdobj->type == PF_PTY) {
         /* De-ref this end of it */
-        mutex_lock_irqsafe(&fdobj->d.p->mutex);
+        if(mutex_lock_irqsafe(&fdobj->d.p->mutex))
+            return -1;
 
         fdobj->d.p->refcnt--;
 
@@ -842,7 +844,8 @@ void fs_pty_shutdown(void) {
     if(!initted)
         return;
 
-    mutex_lock_irqsafe(&list_mutex);
+    /* If we fail, we proceed anyways */
+    mutex_trylock(&list_mutex);
 
     /* Go through and free all the pty entries */
     c = LIST_FIRST(&ptys);

--- a/kernel/thread/tls.c
+++ b/kernel/thread/tls.c
@@ -221,7 +221,7 @@ void kthread_tls_shutdown(void) {
     kthread_tls_dest_t *n1, *n2;
 
     /* If we can't get it, shut down anyways */
-    mutex_lock_irqsafe(&dlist_mtx);
+    mutex_trylock(&dlist_mtx);
 
     LIST_FOREACH_SAFE(n1, &dest_list, dest_list, n2) {
         LIST_REMOVE(n1, dest_list);


### PR DESCRIPTION
Following up on #1371 adjust other instances where we were not checking the result of `mutex_lock_irqsafe` to determine if it had succeeded or not. Then add an attribute to the function so that a warning is generated if the return value from it is unused.

We may want to set up `__result_use_check` on other core functions like this to help root out any missing checks and prevent new ones from being introduced in the future.