### PR TITLE
`file_t` and general fs cleanups

### DIFF
--- a/addons/libkosutils/netcfg.c
+++ b/addons/libkosutils/netcfg.c
@@ -264,7 +264,7 @@ int netcfg_load(netcfg_t *out) {
     /* Scan for VMUs */
     f = fs_open("/vmu", O_RDONLY | O_DIR);
 
-    if(f >= 0) {
+    if(f != FILEHND_INVALID) {
         for(; ;) {
             d = fs_readdir(f);
 
@@ -391,7 +391,7 @@ int netcfg_save(const netcfg_t *cfg) {
     /* Scan for a VMU */
     f = fs_open("/vmu", O_RDONLY | O_DIR);
 
-    if(f < 0)
+    if(f == FILEHND_INVALID)
         return -1;
 
     d = fs_readdir(f);

--- a/addons/libkosutils/pcx_small.c
+++ b/addons/libkosutils/pcx_small.c
@@ -43,7 +43,7 @@ int pcx_load_flat(const char *fn, int *w_out, int *h_out, void *pic_out) {
     /* Open the file */
     fd = fs_open(fn, O_RDONLY);
 
-    if(fd == 0) {
+    if(fd == FILEHND_INVALID) {
         printf("pcx_load(%s): Couldn't open file\n", fn);
         return -1;
     }
@@ -128,7 +128,7 @@ int pcx_load_palette(const char *fn, int *w_out, int *h_out, void *pic_out, void
     /* Open the file */
     fd = fs_open(fn, O_RDONLY);
 
-    if(fd == 0) {
+    if(fd == FILEHND_INVALID) {
         printf("pcx_load(%s): Couldn't open file\n", fn);
         return -1;
     }

--- a/examples/dreamcast/basic/exec/exec.c
+++ b/examples/dreamcast/basic/exec/exec.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
        in memory.
     */
     f = fs_open("/rd/sub.bin", O_RDONLY);
-    assert(f);
+    assert(f != FILEHND_INVALID);
 
     /* Get the size of sub.bin */
     s = fs_total(f);

--- a/examples/dreamcast/filesystem/pty/pty.c
+++ b/examples/dreamcast/filesystem/pty/pty.c
@@ -19,7 +19,7 @@
 
 int main(int argc, char* argv[]) {
     /* Create a PTY pair */
-    file_t master_fd = -1, slave_fd = -1;
+    file_t master_fd = FILEHND_INVALID, slave_fd = FILEHND_INVALID;
     int retval = EXIT_SUCCESS;
 
     if(fs_pty_create(NULL, 0, &master_fd, &slave_fd) < 0) {
@@ -83,8 +83,8 @@ failure:
 
     /* Clean up resources */
 cleanup:
-    if(master_fd) fs_close(master_fd);
-    if(slave_fd) fs_close(slave_fd);
+    if(master_fd != FILEHND_INVALID) fs_close(master_fd);
+    if(slave_fd != FILEHND_INVALID) fs_close(slave_fd);
 
     printf("DONE!\n");
 

--- a/examples/dreamcast/libdream/cdfs/cdfs.c
+++ b/examples/dreamcast/libdream/cdfs/cdfs.c
@@ -16,7 +16,7 @@ void cdfs_test(void) {
     /* Read and print the root directory */
     d = fs_open("/cd", O_RDONLY | O_DIR);
 
-    if(d < 0) {
+    if(d == FILEHND_INVALID) {
         printf("Can't open root!\r\n");
         return;
     }
@@ -37,7 +37,7 @@ void cdfs_test(void) {
     /* Read and print a file called README.TXT (if any) */
     fd = fs_open("/cd/readme.txt", O_RDONLY);
 
-    if(fd < 0) {
+    if(fd == FILEHND_INVALID) {
         printf("Can't open file README.TXT for reading.\r\n");
         return;
     }

--- a/examples/dreamcast/mruby/dreampresent/dckos.c
+++ b/examples/dreamcast/mruby/dreampresent/dckos.c
@@ -66,7 +66,7 @@ static mrb_value read_whole_txt_file(mrb_state *mrb, mrb_value self) {
   path = mrb_str_to_cstr(mrb, m_path);
   f = fs_open(path, O_RDONLY);
 
-  if(f < 0) {
+  if(f == FILEHND_INVALID) {
     printf("Failed to open %s.\n", path);
     return mrb_nil_value();
   }

--- a/examples/dreamcast/network/httpd/httpd.c
+++ b/examples/dreamcast/network/httpd/httpd.c
@@ -244,7 +244,7 @@ void *client_thread(void *p) {
     http_state_t * hs = (http_state_t *)p;
     char * buf, * ext;
     const char * ct;
-    file_t f = -1;
+    file_t f = FILEHND_INVALID;
     int r, o, cnt;
 
     printf("httpd: client thread started, sock %d\n", hs->socket);
@@ -260,13 +260,13 @@ void *client_thread(void *p) {
     // Is it a directory or a file?
     f = fs_open(buf, O_RDONLY | O_DIR);
 
-    if(f >= 0) {
+    if(f != FILEHND_INVALID) {
         do_dirlist(buf, hs, f);
     }
     else {
         f = fs_open(buf, O_RDONLY);
 
-        if(f < 0) {
+        if(f == FILEHND_INVALID) {
             if(send_error(hs, 404, "File not found or unreadable") < 0)
                 printf("Error sending 404\n");
             goto out;
@@ -319,7 +319,7 @@ out:
     close(hs->socket);
     st_destroy(hs);
 
-    if(f >= 0)
+    if(f != FILEHND_INVALID)
         fs_close(f);
 
     return NULL;

--- a/examples/dreamcast/network/speedtest/handle_request.c
+++ b/examples/dreamcast/network/speedtest/handle_request.c
@@ -174,7 +174,7 @@ refresh_buffer:
 done_parsing:
     char response_buf[BUFSIZE];
     if(hr->method == METHOD_GET) {
-        file_t file = -1;
+        file_t file = FILEHND_INVALID;
         uint32_t offset;
         int cnt;
         int wrote;

--- a/examples/dreamcast/sound/ghettoplay-vorbis/songmenu.c
+++ b/examples/dreamcast/sound/ghettoplay-vorbis/songmenu.c
@@ -121,11 +121,11 @@ static void *load_song_list(void * p) {
 
     d = fs_open(curdir, O_RDONLY | O_DIR);
 
-    if(!d) {
+    if(d == FILEHND_INVALID) {
         strcpy(curdir, "/");
         d = fs_open(curdir, O_RDONLY | O_DIR);
 
-        if(!d) {
+        if(d == FILEHND_INVALID) {
             mutex_lock(&mut);
             num_entries = 1;
             strcpy(entries[0].fn, "Error!");

--- a/examples/dreamcast/vmu/vmu_game/vmu_game.c
+++ b/examples/dreamcast/vmu/vmu_game/vmu_game.c
@@ -13,7 +13,7 @@ static void draw_findings(void) {
     file_t d;
 
     d = fs_open("/vmu/a1", O_RDONLY | O_DIR);
-    if(!d) {
+    if(d == FILEHND_INVALID) {
         bfont_draw_str_vram_fmt(10, 88, false, "Can't read VMU");
         return;
     }
@@ -76,7 +76,7 @@ static void write_game_entry(void) {
     maple_device_t *dev;
 
     f = fs_open("/rd/TETRIS.VMS", O_RDONLY);
-    if(!f) {
+    if(f == FILEHND_INVALID) {
         printf("Error reading Tetris game from romdisk\n");
         return;
     }

--- a/examples/dreamcast/vmu/vmu_pkg/vmu.c
+++ b/examples/dreamcast/vmu/vmu_pkg/vmu.c
@@ -137,7 +137,7 @@ void write_entry(void) {
     fs_unlink("/vmu/a1/TESTFILE");
     f = fs_open("/vmu/a1/TESTFILE", O_WRONLY);
 
-    if(!f) {
+    if(f == FILEHND_INVALID) {
         printf("error writing\n");
         return;
     }

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -255,7 +255,7 @@ extern struct fs_hnd *fd_table[FD_SETSIZE];
                             "File Open Modes" list. Multiple values can be ORed
                             together.
     
-    \return                 The new file descriptor on success, -1 on error.
+    \return                 The new file descriptor on success, FILEHND_INVALID on error.
 */
 file_t fs_open(const char *fn, int mode);
 
@@ -623,7 +623,7 @@ int fs_fstat(file_t hnd, struct stat *buf);
 
     \param  oldfd           The old file descriptor to duplicate.
     
-    \return                 The new file descriptor on success, -1 on failure.
+    \return                 The new file descriptor on success, FILEHND_INVALID on failure.
 */
 file_t fs_dup(file_t oldfd);
 
@@ -637,7 +637,7 @@ file_t fs_dup(file_t oldfd);
     \param  oldfd           The old file descriptor to duplicate.
     \param  newfd           The descriptor to copy into.
     
-    \return                 The new file descriptor on success, -1 on failure.
+    \return                 The new file descriptor on success, FILEHND_INVALID on failure.
 */
 file_t fs_dup2(file_t oldfd, file_t newfd);
 
@@ -652,7 +652,7 @@ file_t fs_dup2(file_t oldfd, file_t newfd);
     \param  vfs             The VFS handler structure to use for the file.
     \param  hnd             Internal handle data for the file.
     
-    \return                 The opened descriptor on success, -1 on failure.
+    \return                 The opened descriptor on success, FILEHND_INVALID on failure.
 */
 file_t fs_open_handle(vfs_handler_t *vfs, void *hnd);
 

--- a/kernel/arch/dreamcast/include/dc/fs_vmu.h
+++ b/kernel/arch/dreamcast/include/dc/fs_vmu.h
@@ -98,7 +98,7 @@ static inline int fs_vmu_set_default_header(const vmu_pkg_t *pkg) {
     int ret;
 
     fd = fs_open("/vmu", O_RDONLY | O_DIR);
-    if(!fd)
+    if(fd == FILEHND_INVALID)
         return -1;
 
     ret = fs_vmu_set_header(fd, pkg);

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -396,7 +396,7 @@ sfxhnd_t snd_sfx_load(const char *fn) {
 
     /* Open the sound effect file */
     fd = fs_open(fn, O_RDONLY);
-    if(fd <= FILEHND_INVALID) {
+    if(fd == FILEHND_INVALID) {
         dbglog(DBG_ERROR, "snd_sfx_load: can't open %s\n", fn);
         return SFXHND_INVALID;
     }
@@ -448,7 +448,7 @@ sfxhnd_t snd_sfx_load_ex(const char *fn, uint32_t rate, uint16_t bitsize, uint16
     sfxhnd_t effect;
     file_t fd = fs_open(fn, O_RDONLY);
 
-    if(fd <= FILEHND_INVALID) {
+    if(fd == FILEHND_INVALID) {
         dbglog(DBG_ERROR, "snd_sfx_load_ex: can't open sfx %s\n", fn);
         return SFXHND_INVALID;
     }

--- a/kernel/arch/dreamcast/util/screenshot.c
+++ b/kernel/arch/dreamcast/util/screenshot.c
@@ -131,7 +131,7 @@ int vid_screen_shot(const char *destfn) {
 
     /* Open output file */
     f = fs_open(destfn, O_WRONLY | O_TRUNC);
-    if(!f) {
+    if(f == FILEHND_INVALID) {
         dbglog(DBG_ERROR, "vid_screen_shot: can't open output file '%s'\n", destfn);
         return -1;
     }

--- a/kernel/arch/dreamcast/util/vmu_fb.c
+++ b/kernel/arch/dreamcast/util/vmu_fb.c
@@ -303,7 +303,7 @@ int vmufb_screen_shot(vmufb_t *fb, const char *destfn) {
 
     /* Open output file */
     f = fs_open(destfn, O_WRONLY | O_TRUNC);
-    if(!f) {
+    if(f == FILEHND_INVALID) {
         dbglog(DBG_ERROR, "vmufb_screen_shot: can't open output file '%s'\n", destfn);
         return -1;
     }

--- a/kernel/arch/dreamcast/util/vmu_pkg.c
+++ b/kernel/arch/dreamcast/util/vmu_pkg.c
@@ -274,7 +274,7 @@ int vmu_pkg_load_icon(vmu_pkg_t *pkg, const char *icon_fn) {
     }
 
     fd = fs_open(icon_fn, O_RDONLY);
-    if(fd == -1)
+    if(fd == FILEHND_INVALID)
         return fd;
 
     fs_read(fd, &hdr, sizeof(hdr));

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -814,7 +814,7 @@ int fs_symlink(const char *path1, const char *path2) {
     }
 }
 
-int fs_readlink(const char *path, char *buf, size_t bufsize) {
+ssize_t fs_readlink(const char *path, char *buf, size_t bufsize) {
     vfs_handler_t *vfs;
     char fullpath[PATH_MAX];
 

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -61,12 +61,8 @@ static fs_hnd_t *fs_root_opendir(void) {
 static dirent_t root_readdir_dirent;
 static dirent_t *fs_root_readdir(fs_hnd_t *handle) {
     nmmgr_handler_t *nmhnd;
-    nmmgr_list_t    *nmhead;
-    uintptr_t        cnt;
-
-    cnt = (uintptr_t)handle->hnd;
-
-    nmhead = nmmgr_get_list();
+    nmmgr_list_t    *nmhead = nmmgr_get_list();
+    uintptr_t        cnt = (uintptr_t)handle->hnd;
 
     SLIST_FOREACH(nmhnd, nmhead, list_ent) {
         if((nmhnd->flags & NMMGR_FLAGS_INDEV))
@@ -98,7 +94,7 @@ static dirent_t *fs_root_readdir(fs_hnd_t *handle) {
 /* This version of open deals with raw handles only. This is below the level
    of file descriptors. It is used by the standard fs_open below. The
    returned handle will have no references attached to it. */
-static fs_hnd_t * fs_hnd_open(const char *fn, int mode) {
+static fs_hnd_t *fs_hnd_open(const char *fn, int mode) {
     nmmgr_handler_t *nmhnd;
     vfs_handler_t   *cur;
     const char  *cname;
@@ -215,9 +211,8 @@ static file_t fs_hnd_assign(fs_hnd_t *hnd) {
 }
 
 int fs_fdtbl_destroy(void) {
-    int i;
 
-    for(i = 0; i < FD_SETSIZE; i++) {
+    for(size_t i = 0; i < FD_SETSIZE; i++) {
         if(fd_table[i])
             fs_hnd_unref(fd_table[i]);
 
@@ -230,10 +225,8 @@ int fs_fdtbl_destroy(void) {
 /* Attempt to open a file, given a path name. Follows the process described
    in the above comments. */
 file_t fs_open(const char *fn, int mode) {
-    fs_hnd_t * hnd;
-
     /* First try to open the file handle */
-    hnd = fs_hnd_open(fn, mode);
+    fs_hnd_t *hnd = fs_hnd_open(fn, mode);
 
     if(!hnd)
         return FILEHND_INVALID;
@@ -244,10 +237,8 @@ file_t fs_open(const char *fn, int mode) {
 
 /* See header for comments */
 file_t fs_open_handle(vfs_handler_t *vfs, void *vhnd) {
-    fs_hnd_t * hnd;
-
     /* Wrap it up in a structure */
-    hnd = malloc(sizeof(fs_hnd_t));
+    fs_hnd_t *hnd = malloc(sizeof(fs_hnd_t));
 
     if(hnd == NULL) {
         errno = ENOMEM;
@@ -262,7 +253,7 @@ file_t fs_open_handle(vfs_handler_t *vfs, void *vhnd) {
     return fs_hnd_assign(hnd);
 }
 
-vfs_handler_t * fs_get_handler(file_t fd) {
+vfs_handler_t *fs_get_handler(file_t fd) {
     /* Make sure it exists */
     if(!fd_table[fd]) {
         errno = EBADF;
@@ -272,7 +263,7 @@ vfs_handler_t * fs_get_handler(file_t fd) {
     return fd_table[fd]->handler;
 }
 
-void * fs_get_handle(file_t fd) {
+void *fs_get_handle(file_t fd) {
     /* Make sure it exists */
     if(!fd_table[fd]) {
         errno = EBADF;
@@ -374,9 +365,7 @@ ssize_t fs_read(file_t fd, void *buffer, size_t cnt) {
 }
 
 ssize_t fs_write(file_t fd, const void *buffer, size_t cnt) {
-    fs_hnd_t *h;
-
-    h = fs_map_hnd(fd);
+    fs_hnd_t *h = fs_map_hnd(fd);
 
     if(!h) return -1;
 
@@ -557,7 +546,6 @@ const dirent_t *fs_readdir(file_t fd) {
 
 int fs_vioctl(file_t fd, int cmd, va_list ap) {
     fs_hnd_t *h = fs_map_hnd(fd);
-    int rv;
 
     if(!h) return -1;
 
@@ -566,9 +554,7 @@ int fs_vioctl(file_t fd, int cmd, va_list ap) {
         return -1;
     }
 
-    rv = h->handler->ioctl(h->hnd, cmd, ap);
-
-    return rv;
+    return h->handler->ioctl(h->hnd, cmd, ap);
 }
 
 int fs_ioctl(file_t fd, int cmd, ...) {
@@ -582,9 +568,7 @@ int fs_ioctl(file_t fd, int cmd, ...) {
 }
 
 static vfs_handler_t *fs_verify_handler(const char *fn) {
-    nmmgr_handler_t *nh;
-
-    nh = nmmgr_lookup(fn);
+    nmmgr_handler_t *nh = nmmgr_lookup(fn);
 
     if(nh == NULL || nh->type != NMMGR_TYPE_VFS)
         return NULL;
@@ -730,7 +714,6 @@ int fs_rmdir(const char *fn) {
 
 static int fs_vfcntl(file_t fd, int cmd, va_list ap) {
     fs_hnd_t *h = fs_map_hnd(fd);
-    int rv;
 
     if(!h) return -1;
 
@@ -739,9 +722,7 @@ static int fs_vfcntl(file_t fd, int cmd, va_list ap) {
         return -1;
     }
 
-    rv = h->handler->fcntl(h->hnd, cmd, ap);
-
-    return rv;
+    return h->handler->fcntl(h->hnd, cmd, ap);
 }
 
 int fs_fcntl(file_t fd, int cmd, ...) {

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -189,7 +189,7 @@ static int fs_hnd_unref(fs_hnd_t *ref) {
 
 /* Assigns a file descriptor (index) to a file handle (pointer). Will auto-
    reference the handle, and unrefs on error. */
-static int fs_hnd_assign(fs_hnd_t *hnd) {
+static file_t fs_hnd_assign(fs_hnd_t *hnd) {
     int i;
 
     fs_hnd_ref(hnd);
@@ -208,10 +208,10 @@ static int fs_hnd_assign(fs_hnd_t *hnd) {
 
         fs_hnd_unref(hnd);
         errno = EMFILE;
-        return -1;
+        return FILEHND_INVALID;
     }
 
-    return i;
+    return (file_t)i;
 }
 
 int fs_fdtbl_destroy(void) {
@@ -236,7 +236,7 @@ file_t fs_open(const char *fn, int mode) {
     hnd = fs_hnd_open(fn, mode);
 
     if(!hnd)
-        return -1;
+        return FILEHND_INVALID;
 
     /* Ok, that succeeded -- now look for a file descriptor. */
     return fs_hnd_assign(hnd);
@@ -251,7 +251,7 @@ file_t fs_open_handle(vfs_handler_t *vfs, void *vhnd) {
 
     if(hnd == NULL) {
         errno = ENOMEM;
-        return -1;
+        return FILEHND_INVALID;
     }
 
     hnd->handler = vfs;
@@ -284,13 +284,13 @@ void * fs_get_handle(file_t fd) {
 
 file_t fs_dup(file_t oldfd) {
     /* Make sure it exists */
-    if(oldfd < 0 || oldfd >= FD_SETSIZE) {
+    if(oldfd < 0 || oldfd >= FD_SETSIZE || oldfd == FILEHND_INVALID) {
         errno = EBADF;
-        return -1;
+        return FILEHND_INVALID;
     }
     else if(!fd_table[oldfd]) {
         errno = EBADF;
-        return -1;
+        return FILEHND_INVALID;
     }
 
     return fs_hnd_assign(fd_table[oldfd]);
@@ -300,13 +300,14 @@ file_t fs_dup2(file_t oldfd, file_t newfd) {
     fs_hnd_t *prev;
 
     /* Make sure the descriptors are valid */
-    if(oldfd < 0 || oldfd >= FD_SETSIZE || newfd < 0 || newfd >= FD_SETSIZE) {
+    if(oldfd < 0 || oldfd >= FD_SETSIZE || oldfd == FILEHND_INVALID ||
+       newfd < 0 || newfd >= FD_SETSIZE || newfd == FILEHND_INVALID) {
         errno = EBADF;
-        return -1;
+        return FILEHND_INVALID;
     }
     else if(!fd_table[oldfd]) {
         errno = EBADF;
-        return -1;
+        return FILEHND_INVALID;
     }
 
     if(oldfd == newfd)
@@ -331,7 +332,7 @@ out_get_ref:
 /* Returns a file handle for a given fd, or NULL if the parameters
    are not valid. */
 static fs_hnd_t *fs_map_hnd(file_t fd) {
-    if(fd < 0 || fd >= FD_SETSIZE) {
+    if(fd < 0 || fd >= FD_SETSIZE || fd == FILEHND_INVALID) {
         errno = EBADF;
         return NULL;
     }

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -62,9 +62,9 @@ static dirent_t root_readdir_dirent;
 static dirent_t *fs_root_readdir(fs_hnd_t *handle) {
     nmmgr_handler_t *nmhnd;
     nmmgr_list_t    *nmhead;
-    int         cnt;
+    uintptr_t        cnt;
 
-    cnt = (int)handle->hnd;
+    cnt = (uintptr_t)handle->hnd;
 
     nmhead = nmmgr_get_list();
 
@@ -90,7 +90,7 @@ static dirent_t *fs_root_readdir(fs_hnd_t *handle) {
     else
         strcpy(root_readdir_dirent.name, nmhnd->pathname);
 
-    handle->hnd = (void *)((int)handle->hnd + 1);
+    handle->hnd = (void *)((uintptr_t)handle->hnd + 1);
 
     return &root_readdir_dirent;
 }

--- a/kernel/fs/fs_dev.c
+++ b/kernel/fs/fs_dev.c
@@ -28,9 +28,9 @@ static dirent_t dev_readdir_dirent;
 static dirent_t *dev_root_readdir(dev_hnd_t * handle) {
     nmmgr_handler_t *nmhnd;
     nmmgr_list_t    *nmhead;
-    int         cnt;
+    uintptr_t        cnt;
 
-    cnt = (int)handle->hnd;
+    cnt = (uintptr_t)handle->hnd;
 
     nmhead = nmmgr_get_list();
 
@@ -49,7 +49,7 @@ static dirent_t *dev_root_readdir(dev_hnd_t * handle) {
 
     strcpy(dev_readdir_dirent.name, nmhnd->pathname + strlen("/dev/"));
 
-    handle->hnd = (void *)((int)handle->hnd + 1);
+    handle->hnd = (void *)((uintptr_t)handle->hnd + 1);
 
     return &dev_readdir_dirent;
 }

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -121,8 +121,8 @@ int fs_pty_create(char *buffer, int maxbuflen, file_t *master_out, file_t *slave
         return -1;
 
     /* Initialize outputs to invalid values */
-    *master_out = -1;
-    *slave_out = -1;
+    *master_out = FILEHND_INVALID;
+    *slave_out = FILEHND_INVALID;
 
     /* Are we bootstrapping? */
     boot = LIST_EMPTY(&ptys);
@@ -175,7 +175,7 @@ int fs_pty_create(char *buffer, int maxbuflen, file_t *master_out, file_t *slave
     sprintf(mname, "/pty/ma%02x", master->id);
     sprintf(sname, "/pty/sl%02x", slave->id);
     *slave_out = fs_open(sname, O_RDWR);
-    if(*slave_out < 0)
+    if(*slave_out == FILEHND_INVALID)
         goto cleanup;
 
     if(boot) {
@@ -808,8 +808,8 @@ static int initted = 0;
 
 /* Initialize the file system */
 void fs_pty_init(void) {
-    int cm, cs;
-    int tm, ts;
+    file_t cm, cs;
+    file_t tm, ts;
 
     if(initted)
         return;

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -94,9 +94,9 @@ static rd_dir_t  *rootdir = NULL;
 static struct {
     rd_file_t   *file;      /* ramdisk file struct */
     int         dir;        /* >0 if a directory */
-    uint32_t    ptr;        /* Current read position in bytes */
-    dirent_t    dirent;     /* A static dirent to pass back to clients */
     int         omode;      /* Open mode */
+    uintptr_t   ptr;        /* Current read position in bytes */
+    dirent_t    dirent;     /* A static dirent to pass back to clients */
 } fh[FS_RAMDISK_MAX_FILES];
 
 /* Mutex for file system structs */
@@ -337,7 +337,7 @@ static void * ramdisk_open(vfs_handler_t * vfs, const char *fn, int mode) {
     /* If we opened a dir, then ptr is actually a pointer to the first
        file entry. */
     if(mode & O_DIR) {
-        fh[fd].ptr = (uint32_t)LIST_FIRST((rd_dir_t *)f->data);
+        fh[fd].ptr = (uintptr_t)LIST_FIRST((rd_dir_t *)f->data);
     }
 
     /* Increase the usage count */
@@ -524,7 +524,7 @@ static const dirent_t *ramdisk_readdir(void * h) {
     if(fd < FS_RAMDISK_MAX_FILES && fh[fd].file != NULL && fh[fd].ptr != 0 && fh[fd].dir) {
         /* Find the current file and advance to the next */
         f = (rd_file_t *)fh[fd].ptr;
-        fh[fd].ptr = (uint32_t)LIST_NEXT(f, dirlist);
+        fh[fd].ptr = (uintptr_t)LIST_NEXT(f, dirlist);
 
         /* Copy out the requested data */
         strcpy(fh[fd].dirent.name, f->name);
@@ -670,7 +670,7 @@ static int ramdisk_rewinddir(void * h) {
     }
 
     /* Rewind to the first file. */
-    fh[fd].ptr = (uint32_t)LIST_FIRST((rd_dir_t *)fh[fd].file->data);
+    fh[fd].ptr = (uintptr_t)LIST_FIRST((rd_dir_t *)fh[fd].file->data);
 
     return 0;
 }
@@ -762,7 +762,7 @@ int fs_ramdisk_attach(const char * fn, void * obj, size_t size) {
         return -1;
 
     /* Ditch the data block we had and replace it with the user one. */
-    f = fh[(int)fd].file;
+    f = fh[(uintptr_t)fd].file;
     free(f->data);
     f->data = obj;
     f->datasize = size;
@@ -790,7 +790,7 @@ int fs_ramdisk_detach(const char * fn, void ** obj, size_t * size) {
     assert(obj != NULL);
     assert(size != NULL);
 
-    f = fh[(int)fd].file;
+    f = fh[(uintptr_t)fd].file;
     *obj = f->data;
     *size = f->size;
 

--- a/kernel/fs/fs_socket.c
+++ b/kernel/fs/fs_socket.c
@@ -286,7 +286,7 @@ int socket(int domain, int type, int protocol) {
     /* Attempt to get a handle for this socket */
     sock->fd = fs_open_handle(&vh, sock);
 
-    if(sock->fd < 0) {
+    if(sock->fd == FILEHND_INVALID) {
         free(sock);
         mutex_unlock(&proto_rlock);
         return -1;
@@ -329,7 +329,7 @@ net_socket_t *fs_socket_open_sock(fs_socket_proto_t *proto) {
     /* Attempt to get a handle for this socket */
     sock->fd = fs_open_handle(&vh, sock);
 
-    if(sock->fd < 0) {
+    if(sock->fd == FILEHND_INVALID) {
         free(sock);
         return NULL;
     }

--- a/kernel/libc/koslib/opendir.c
+++ b/kernel/libc/koslib/opendir.c
@@ -18,7 +18,7 @@ DIR * opendir(const char * name) {
     // Try to open the dir itself
     fd = fs_open(name, O_DIR | O_RDONLY);
 
-    if(fd < 0) {
+    if(fd == FILEHND_INVALID) {
         // VFS will set errno
         return NULL;
     }

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -470,7 +470,7 @@ ret_no_remove:
             sock->state == TCP_STATE_CLOSE_WAIT)
         sock->intflags |= TCP_IFLAG_QUEUEDCLOSE;
 
-    sock->sock = -1;
+    sock->sock = FILEHND_INVALID;
 
     /* Don't free anything here, it will be dealt with later on in the
        workqueue job. */
@@ -3153,7 +3153,7 @@ void net_tcp_shutdown(void) {
     while(i) {
         tmp = LIST_NEXT(i, sock_list);
 
-        if(i->sock != -1) {
+        if(i->sock != FILEHND_INVALID) {
             close(i->sock);
         }
         else {


### PR DESCRIPTION
A number of relatively small cleanups related to our vfs system:
- Use `FILEHND_INVALID` where appropriate. Most places in the codebase were checking for a hardcoded `-1` as an error return/invalid `file_t`. There is though a define that is meant just for that. It turns out in searching for this, there were also many places that treated any negative value in `file_t` as an error, and others that seemed to think that a value of `0` was an error (and so would have pretty much never been able to detect an error).
- Adjustments for casts of pointers to appropriate types. In fs, fs_dev, and fs_ramdisk there were usages of plain ints to store cast pointers. In testing out the '[null arch](https://github.com/KallistiOS/KallistiOS/tree/null_arch)' on a 64-bit host, these cropped up as issues.
- In fs_pty use `file_t` types rather than generic ints. Like the use of the error, this presumed the backing value of the type.
- General cleanups in fs.c. Lots of whitespace cleanup and reducing loc via [ignoring ANSI C variable declaration](#1310 ).

The only bits that qualify as 'bug' is some of the checks for invalid `file_t` that were looking for a 0 to indicate invalid. The rest should be  transparent.