### PR TITLE
fs_iso9660: Check for CD init in stat() callback

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -39,6 +39,7 @@ ISO9660 systems, as these were used as references as well.
 #include <kos/opts.h>
 #include <kos/dbglog.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdalign.h>
@@ -50,7 +51,7 @@ ISO9660 systems, as these were used as references as well.
 #include <sys/ioctl.h>
 
 static int init_percd(void);
-static int percd_done;
+static bool percd_done;
 
 /********************************************************************************/
 /* Low-level Joliet utils */
@@ -643,7 +644,7 @@ static void * iso_open(vfs_handler_t * vfs, const char *fn, int mode) {
         return 0;
     }
 
-    percd_done = 1;
+    percd_done = true;
 
     /* Find the file we want */
     de = find_object_path(fn, (mode & O_DIR) ? 1 : 0, &root_dirent);
@@ -1087,7 +1088,7 @@ int iso_reset(void) {
     iso_break_all();
     bclear();
     iso_abort_stream(false);
-    percd_done = 0;
+    percd_done = false;
     return 0;
 }
 
@@ -1110,7 +1111,7 @@ static void iso_vblank(uint32 evt, void *data) {
 
     if(iso_last_status != status) {
         if(status == CD_STATUS_OPEN || status == CD_STATUS_NO_DISC)
-            percd_done = 0;
+            percd_done = false;
 
         iso_last_status = status;
     }
@@ -1281,7 +1282,7 @@ void fs_iso9660_init(void) {
         dcache[i]->sector = -1;
     }
 
-    percd_done = 0;
+    percd_done = false;
     iso_last_status = -1;
 
     /* Register with the vblank */

--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -1138,6 +1138,14 @@ static int iso_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
         return 0;
     }
 
+    /* Do this only when we need to (this is still imperfect) */
+    if(!percd_done && init_percd() < 0) {
+        errno = ENODEV;
+        return -1;
+    }
+
+    percd_done = true;
+
     /* First try opening as a file */
     de = find_object_path(path, 0, &root_dirent);
     md = S_IFREG;


### PR DESCRIPTION
The stat() callback does not take an opened file descriptor as its argument, but a filename. Therefore, if fs_stat() is called before fs_open(), the code would return an error as the CD-Rom hardware was not initialized.

Address this issue by also conditionally initializing the CD-Rom hardware from the stat() callback.