### PR TITLE
Examples cleanups

### DIFF
--- a/examples/dreamcast/basic/dma/speedtest/speedtest.c
+++ b/examples/dreamcast/basic/dma/speedtest/speedtest.c
@@ -27,7 +27,7 @@ static void dma_done(void *d)
 }
 
 static dma_config_t dma_cfg = {
-    .channel = 1,
+    .channel = DMA_CHANNEL_1,
     .request = DMA_REQUEST_AUTO_MEM_TO_MEM,
     .unit_size = DMA_UNITSIZE_32BYTE,
     .src_mode = DMA_ADDRMODE_INCREMENT,

--- a/examples/dreamcast/cpp/modplug_test/example.cpp
+++ b/examples/dreamcast/cpp/modplug_test/example.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
 
     printf("Memory allocated\n");
 
-    if((size_t)fs_read(hnd, mod_buffer, fs_total(hnd)) != fs_total(hnd)) {
+    if(fs_read(hnd, mod_buffer, fs_total(hnd)) != fs_total(hnd)) {
         printf("Read error\n");
         free(mod_buffer);
         return 0;
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
 
         snd_stream_poll(shnd);
 
-        timer_spin_sleep(10);
+        thd_sleep(10);
     }
 
     delete soundfile;

--- a/examples/dreamcast/filesystem/browse/browse.c
+++ b/examples/dreamcast/filesystem/browse/browse.c
@@ -218,7 +218,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-static bool mount_sd_fat() {
+static bool mount_sd_fat(void) {
     if(sd_init()) {
         fprintf(stderr, "Could not initialize the SD card. Please make sure that you "
                "have an SD card adapter plugged in and an SD card inserted.\n");
@@ -244,7 +244,7 @@ static bool mount_sd_fat() {
     return true;
 }
 
-static void unmount_sd_fat() {
+static void unmount_sd_fat(void) {
     fs_fat_unmount("/sd");
     fs_fat_shutdown();
     sd_shutdown();
@@ -387,7 +387,7 @@ static bool draw_stat(const char *path) {
     return true;
 }
 
-static cont_state_t *get_cont_state() {
+static cont_state_t *get_cont_state(void) {
     maple_device_t *cont;
     cont_state_t *state;
 

--- a/examples/dreamcast/libdream/cdfs/cdfs.c
+++ b/examples/dreamcast/libdream/cdfs/cdfs.c
@@ -8,7 +8,7 @@ char buffer[2048];
 void cdfs_test(void) {
     file_t fd;
     file_t d;
-    dirent_t *de;
+    const dirent_t *de;
     int amt;
 
     printf("Reading directory from CD-Rom:\r\n");

--- a/examples/dreamcast/libdream/keyboard/keyboard.c
+++ b/examples/dreamcast/libdream/keyboard/keyboard.c
@@ -90,7 +90,7 @@ static void on_key_event(maple_device_t *dev, kbd_key_t key,
     /* Print keyboard address + key ID and state change type. */
     printf("[%c%u] %c: %s\n",
            'A' + dev->port, dev->unit,
-           kbd_key_to_ascii(key, 1, mods, leds),
+           kbd_key_to_ascii(key, ((kbd_state_t *)dev->status)->region, mods, leds),
            state.value == KEY_STATE_CHANGED_DOWN? "PRESSED" : "RELEASED");
 
     /* Check whether the RETURN key was pressed (but not held): */

--- a/examples/dreamcast/library/loadable-dependence/library-dependence.c
+++ b/examples/dreamcast/library/loadable-dependence/library-dependence.c
@@ -26,11 +26,11 @@ static symtab_handler_t library_hnd = {
 };
 
 /* Library functions */
-const char *lib_get_name() {
+const char *lib_get_name(void) {
     return library_hnd.nmmgr.pathname + 12;
 }
 
-uint32_t lib_get_version() {
+uint32_t lib_get_version(void) {
     return KOS_VERSION_MAKE(1, 0, 0);
 }
 

--- a/examples/dreamcast/library/loadable-dependent/library-dependent.c
+++ b/examples/dreamcast/library/loadable-dependent/library-dependent.c
@@ -16,11 +16,11 @@
 
 #include "library-dependence.h"
 
-const char *lib_get_name() {
+const char *lib_get_name(void) {
     return "dependent";
 }
 
-uint32_t lib_get_version() {
+uint32_t lib_get_version(void) {
     return KOS_VERSION_MAKE(1, 0, 0);
 }
 

--- a/examples/dreamcast/network/httpd/simhost.c
+++ b/examples/dreamcast/network/httpd/simhost.c
@@ -7,7 +7,7 @@
 
 KOS_INIT_FLAGS(INIT_DEFAULT | INIT_NET);
 
-void httpd();
+void httpd(void);
 void *do_httpd(void * foo) {
     httpd();
     return NULL;

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -111,7 +111,7 @@ static void sphere(sphere_t *s) { /* {{{ */
     }
 }
 
-static void draw_sphere(sphere_t *s, int list) {
+static void draw_sphere(sphere_t *s, pvr_list_t list) {
     void * sqd;
     pvr_vertex_t *v, *vd;
 

--- a/examples/dreamcast/parallax/serpent_dma/serpent.c
+++ b/examples/dreamcast/parallax/serpent_dma/serpent.c
@@ -23,8 +23,8 @@ vertex DMA usage as well as showing off interleaved polygon type usage, etc.
 */
 
 // These are in perfmeter.c
-void pm_init();
-void pm_draw();
+void pm_init(void);
+void pm_draw(void);
 
 /* Draws a sphere out of GL_QUADS according to the syntax of glutSolidSphere
 

--- a/examples/dreamcast/pvr/palette/4bpp/4bpp.c
+++ b/examples/dreamcast/pvr/palette/4bpp/4bpp.c
@@ -22,6 +22,7 @@
 
 #include <stdlib.h>
 #include <math.h>
+#include <assert.h>
 
 #include <dc/pvr.h>
 #include <dc/maple.h>
@@ -81,7 +82,7 @@ static float distance(float x0, float y0, float x1, float y1) {
 }
 
 static pvr_ptr_t generate_texture(uint32_t width, uint32_t height) {
-    int i, j, mid_x, mid_y;
+    size_t i, j, mid_x, mid_y;
     float max_dist;
 
     uint8_t *texbuf;
@@ -96,6 +97,7 @@ static pvr_ptr_t generate_texture(uint32_t width, uint32_t height) {
 
     /* Allocate temp storage in RAM to generate texture in */
     texbuf = calloc(width * height / 2, sizeof(uint8_t));
+    if(!texbuf) return NULL;
 
     /* Generate the texture */
     for(i = 0; i < height; i++)
@@ -152,6 +154,7 @@ int main(int argc, char** argv) {
 
     /* Initialize the texture */
     texptr = generate_texture(TEXTURE_WIDTH, TEXTURE_HEIGHT);
+    assert_msg(texptr, "Texture initialization failed\n");
 
     /* Setup PVR context */
     pvr_poly_cxt_txr(&cxt, PVR_LIST_OP_POLY, PVR_TXRFMT_PAL4BPP | 

--- a/examples/dreamcast/pvr/palette/8bpp/8bpp.c
+++ b/examples/dreamcast/pvr/palette/8bpp/8bpp.c
@@ -21,6 +21,7 @@
 
 #include <stdlib.h>
 #include <math.h>
+#include <assert.h>
 
 #include <dc/pvr.h>
 #include <dc/maple.h>
@@ -80,7 +81,7 @@ static float distance(float x0, float y0, float x1, float y1) {
 }
 
 static pvr_ptr_t generate_texture(uint32_t width, uint32_t height) {
-    int i, j, mid_x, mid_y;
+    size_t i, j, mid_x, mid_y;
     float max_dist;
 
     uint8_t *texbuf;
@@ -95,6 +96,7 @@ static pvr_ptr_t generate_texture(uint32_t width, uint32_t height) {
 
     /* Allocate temp storage in RAM to generate texture in */
     texbuf = calloc(width * height, sizeof(uint8_t));
+    if(!texbuf) return NULL;
 
     /* Generate the texture */
     for(i = 0; i < height; i++)
@@ -143,6 +145,7 @@ int main(int argc, char** argv) {
 
     /* Initialize the texture */
     texptr = generate_texture(TEXTURE_WIDTH, TEXTURE_HEIGHT);
+    assert_msg(texptr, "Texture initialization failed\n");
 
     /* Setup PVR context */
     pvr_poly_cxt_txr(&cxt, PVR_LIST_OP_POLY, PVR_TXRFMT_PAL8BPP | 

--- a/examples/dreamcast/pvr/palette/wormhole/wormhole.c
+++ b/examples/dreamcast/pvr/palette/wormhole/wormhole.c
@@ -23,6 +23,7 @@
 
 #include <stdlib.h>
 #include <math.h>
+#include <assert.h>
 
 #include <dc/pvr.h>
 #include <dc/maple.h>
@@ -99,12 +100,13 @@ static void draw_screen() {
 }
 
 static pvr_ptr_t generate_texture(uint32_t width, uint32_t height) {
-    int x, y, index;
+    size_t x, y, index;
     float dx, dy, dist, angle;
     uint8_t *texbuf;
     pvr_ptr_t texptr;
 
     texbuf = calloc(width * height, sizeof(uint8_t));
+    if(!texbuf) return NULL;
 
     for(y = 0; y < height; y++)
         for(x = 0; x < width; x++) {
@@ -119,7 +121,7 @@ static pvr_ptr_t generate_texture(uint32_t width, uint32_t height) {
                 angle = (atan2f(dy, dx) + F_PI) * (31.0 / (2 * F_PI));
 
                 /* Calculate palette index based on distance and angle, skipping index 0 */
-                index = 1 + (int)(dist / 8 + angle) % 31;
+                index = 1 + (size_t)(dist / 8 + angle) % 31;
 
                 /* Use wormhole colors (1-31) */
                 texbuf[y * width + x] = index;
@@ -166,6 +168,7 @@ int main(int argc, char** argv) {
 
     /* Initialize the texture */
     texptr = generate_texture(WORMHOLE_WIDTH, WORMHOLE_HEIGHT);
+    assert_msg(texptr, "Texture initialization failed\n");
 
     /* Set the background color */
     pvr_set_pal_entry(0, wormhole_palette[0]);

--- a/examples/dreamcast/pvr/palette/wormhole/wormhole.c
+++ b/examples/dreamcast/pvr/palette/wormhole/wormhole.c
@@ -60,7 +60,7 @@ static const uint32_t wormhole_palette[32] = {
 
 static pvr_poly_hdr_t hdr;
 
-static void draw_screen() {
+static void draw_screen(void) {
     pvr_vertex_t vert;
 
     pvr_prim(&hdr, sizeof(hdr));

--- a/examples/dreamcast/pvr/pvrline/pvrline.c
+++ b/examples/dreamcast/pvr/pvrline/pvrline.c
@@ -37,7 +37,7 @@ uint8_t __attribute__((aligned(32))) tr_buf[VERTBUF_SIZE];
  * representing a quad
 */
 void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, float width, int color,
-    int which_list, pvr_poly_hdr_t *which_hdr);
+    pvr_list_t which_list, pvr_poly_hdr_t *which_hdr);
 
 int main(int argc, char **argv)
 {
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
 }
 
 void draw_pvr_line(vec3f_t *v1, vec3f_t *v2, float width, int color,
-    int which_list, pvr_poly_hdr_t *which_hdr)
+    pvr_list_t which_list, pvr_poly_hdr_t *which_hdr)
 {
     pvr_vertex_t __attribute__((aligned(32))) line_verts[4];
     pvr_vertex_t *vert = line_verts;

--- a/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
+++ b/examples/dreamcast/pvr/yuv_converter/YUV420/yuv420.c
@@ -177,7 +177,7 @@ static int setup_pvr(void) {
 }
 
 static void convert_YUV420_to_YUV422_texture(void) {
-    int i, j, index, x_blk, y_blk;
+    size_t i, j, index, x_blk, y_blk;
     size_t dummies = (BYTE_SIZE_FOR_16x16_BLOCK *
         ((PVR_TEXTURE_WIDTH >> 4) - (FRAME_TEXTURE_WIDTH >> 4))) >> 5;
     uint32_t *db = (uint32_t *)SQ_MASK_DEST_ADDR(PVR_TA_YUV_CONV);

--- a/examples/dreamcast/raylib/texture2d/main.c
+++ b/examples/dreamcast/raylib/texture2d/main.c
@@ -96,7 +96,7 @@ uint32_t power_of_two(int dim) {
 	return (uint32_t)dim;
 }
 
-int main() {
+int main(int argc, char* argv[]) {
 	InitWindow(640, 480, "Raylib Image Test");
 	if (!IsWindowReady())
 		return 1;

--- a/examples/dreamcast/sh4zam/bruces_balls/bruces_balls.c
+++ b/examples/dreamcast/sh4zam/bruces_balls/bruces_balls.c
@@ -425,7 +425,17 @@ int main(int argc, const char *argv[]) {
         // The only tile bins we need are those for opaque geometry. This is 32 bins per TA tile.
         { PVR_BINSIZE_32, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_0 },
         // We need 3MB of vertex array storage in VRAM to fit all of Bruce's balls.
-        1024 * 1024 * 3, 0, 0, 0, 6
+        1024 * 1024 * 3,
+        // No vertex DMA
+        0,
+        // No FSAA
+        0,
+        // Enable translucent polygon autosort
+        0,
+        // Preallocate 6 extra OPBs
+        6,
+        // Default vertex buffer double-buffering
+        0
     });
 
     // Precompute our projection view matrix.

--- a/examples/dreamcast/sound/hello-adx/libADXplay.c
+++ b/examples/dreamcast/sound/hello-adx/libADXplay.c
@@ -28,7 +28,7 @@
 #define CONT_VOLUP   0x05
 #define CONT_VOLDN   0x06
 
-int check_cont()
+int check_cont(void)
 {
     int ret=0;
     maple_device_t *cont;

--- a/examples/dreamcast/sound/multi-stream/main.c
+++ b/examples/dreamcast/sound/multi-stream/main.c
@@ -14,7 +14,7 @@
 
 static void draw_instructions(int faucet_vol, int brushing_vol);
 
-static cont_state_t *get_cont_state();
+static cont_state_t *get_cont_state(void);
 static int button_pressed(uint32_t current_buttons, uint32_t changed_buttons, uint32_t button);
 
 int main(int argc, char **argv) {
@@ -124,7 +124,7 @@ static void draw_instructions(int faucet_vol, int brushing_vol) {
     bfont_draw_str(vram_s + y*640+x, 640, color, "Press Start to exit program");
 }
 
-static cont_state_t *get_cont_state() {
+static cont_state_t *get_cont_state(void) {
     maple_device_t *cont;
     cont_state_t *state;
 

--- a/examples/dreamcast/sound/sfx/main.c
+++ b/examples/dreamcast/sound/sfx/main.c
@@ -23,7 +23,7 @@
 
 static void draw_instructions(uint8_t volume);
 
-static cont_state_t *get_cont_state();
+static cont_state_t *get_cont_state(void);
 static int button_pressed(uint32_t current_buttons, uint32_t changed_buttons, uint32_t button);
 
 int main(int argc, char **argv) {
@@ -140,7 +140,7 @@ static void draw_instructions(uint8_t volume) {
     bfont_draw_str(vram_s + y*640+x, 640, color, "Press Start to exit program");
 }
 
-static cont_state_t *get_cont_state() {
+static cont_state_t *get_cont_state(void) {
     maple_device_t *cont;
     cont_state_t *state;
 

--- a/examples/dreamcast/sound/sfxbuf/main.c
+++ b/examples/dreamcast/sound/sfxbuf/main.c
@@ -24,7 +24,7 @@
 
 static void draw_instructions(uint8_t volume);
 
-static cont_state_t *get_cont_state();
+static cont_state_t *get_cont_state(void);
 static int button_pressed(uint32_t current_buttons, uint32_t changed_buttons, uint32_t button);
 
 int main(int argc, char **argv) {
@@ -160,7 +160,7 @@ static void draw_instructions(uint8_t volume) {
     bfont_draw_str(vram_s + y*640+x, 640, color, "Press Start to exit program");
 }
 
-static cont_state_t *get_cont_state() {
+static cont_state_t *get_cont_state(void) {
     maple_device_t *cont;
     cont_state_t *state;
 


### PR DESCRIPTION
A pile of small cleanups for our examples. Some are just kind of trivial `-Wextra` stuff, but most either clear away actual warnings or prevent issues with different gcc or language revisions.

The only behavior change is in the keyboard example where it will no longer treat all keyboards as JP region, but read the region from the dev state for key translation. This should allow it to work properly on euro keyboards (though I don't have any to test with).