### PR TITLE
init_flags: Ensure that the static const has a value.

### DIFF
--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -108,7 +108,7 @@ __BEGIN_DECLS
 
 #define INIT_CDROM          0x00100000  /**< \brief Enable CD-ROM support */
 
-static const uint32_t INIT_OCRAM __depr("INIT_OCRAM has been removed. Use dcache_toggle_ocram().");
+static const uint32_t INIT_OCRAM __depr("INIT_OCRAM has been removed. Use dcache_toggle_ocram().") = 0;
 #define INIT_NO_DCLOAD      0x20000000  /**< \brief Disable dcload */
 
 /** @} */


### PR DESCRIPTION
Otherwise if it's used it'd cause errors rather than the intended warning in C++

Sample error:
```
kos-c++   -c fnt_test.cc -o fnt_test.o
In file included from /home/quzar/dcdev/KallistiOS/include/kos/init.h:35,
                 from /home/quzar/dcdev/KallistiOS/include/kos.h:62,
                 from fnt_test.cc:5:
/home/quzar/dcdev/KallistiOS/kernel/arch/dreamcast/include/arch/init_flags.h:111:23: error: uninitialized ‘const INIT_OCRAM’ [-fpermissive]
  111 | static const uint32_t INIT_OCRAM __depr("INIT_OCRAM has been removed. Use dcache_toggle_ocram().");
      |                       ^~~~~~~~~~