### PR TITLE
Cleanups around stricter type usage

### DIFF
--- a/kernel/arch/dreamcast/hardware/biosfont.c
+++ b/kernel/arch/dreamcast/hardware/biosfont.c
@@ -56,7 +56,7 @@ static uint8_t *get_font_address(void) {
     return font_address;
 }
 
-static inline uint8_t bits_per_pixel() {
+static inline uint8_t bits_per_pixel(void) {
     return ((vid_mode->pm == PM_RGB0888) ? sizeof(uint32_t) : sizeof(uint16_t)) << 3;
 }
 

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -43,7 +43,7 @@ also for the CDDA playback routines.
 */
 
 struct cmd_req_data {
-    int cmd;
+    cd_cmd_code_t cmd;
     void *data;
 };
 
@@ -80,7 +80,7 @@ static int cur_sector_size = 2048;
 
 /* Shortcut to cdrom_reinit_ex. Typically this is the only thing changed. */
 int cdrom_set_sector_size(int size) {
-    return cdrom_reinit_ex(-1, -1, size);
+    return cdrom_reinit_ex(CDROM_READ_DEFAULT, -1, size);
 }
 
 static int cdrom_poll(void *d, uint32_t timeout, int (*cb)(void *)) {

--- a/kernel/arch/dreamcast/hardware/dmac.c
+++ b/kernel/arch/dreamcast/hardware/dmac.c
@@ -59,8 +59,8 @@ static const irq_t channel_to_irq[] = {
     [3] = EXC_DMAC_DMTE3,
 };
 
-static inline unsigned char irq_to_channel(irq_t irq) {
-    return (irq - EXC_DMAC_DMTE0) >> 5;
+static inline dma_channel_t irq_to_channel(irq_t irq) {
+    return (dma_channel_t)((irq - EXC_DMAC_DMTE0) >> 5);
 }
 
 static uint32_t dmac_read(dma_channel_t channel, dma_register_t reg) {
@@ -111,7 +111,7 @@ static const unsigned char dma_unit_size[] = {
 };
 
 static void dma_irq_handler(irq_t code, irq_context_t *context, void *d) {
-    unsigned char channel = irq_to_channel(code);
+    dma_channel_t channel = irq_to_channel(code);
 
     (void)context;
 
@@ -199,16 +199,16 @@ void dma_init(void) {
     if(KOS_PLATFORM_IS_NAOMI) {
         uint32_t chcr, dmaor;
 
-        dmac_write(2, DMA_REG_SAR, 0);
+        dmac_write(DMA_CHANNEL_2, DMA_REG_SAR, 0);
 
         chcr = FIELD_PREP(REG_CHCR_SRC_ADDRMODE, DMA_ADDRMODE_INCREMENT)
             | FIELD_PREP(REG_CHCR_REQUEST, DMA_REQUEST_EXTERNAL_MEM_TO_DEV)
             | FIELD_PREP(REG_CHCR_DMAC_EN, 1);
-        dmac_write(2, DMA_REG_CHCR, chcr);
+        dmac_write(DMA_CHANNEL_2, DMA_REG_CHCR, chcr);
 
         dmaor = REG_DMAOR_DDT
             | FIELD_PREP(REG_DMAOR_PR, DMAOR_PR_CH2013)
             | REG_DMAOR_DME;
-        dmac_write(0, DMA_REG_DMAOR, dmaor);
+        dmac_write(DMA_CHANNEL_0, DMA_REG_DMAOR, dmaor);
     }
 }

--- a/kernel/arch/dreamcast/hardware/network/lan_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/lan_adapter.c
@@ -556,8 +556,6 @@ static void la_irq_hnd(uint32_t code, void *data) {
 /****************************************************************************/
 /* Netcore interface */
 
-netif_t la_if;
-
 static void set_ipv6_lladdr(void) {
     /* Set up the IPv6 link-local address. This is done in accordance with
        Section 4/5 of RFC 2464 based on the MAC Address of the adapter. */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -109,7 +109,7 @@ int pvr_init(const pvr_init_params_t *params) {
     pvr_state.ta_target = 0;
     pvr_state.view_target = 0;
 
-    pvr_state.list_reg_open = -1;
+    pvr_state.list_reg_open = PVR_LIST_NONE;
 
     // Sync all the hardware registers with our pipeline state.
     pvr_sync_view();

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -157,7 +157,7 @@ typedef struct {
     int     view_target;                // Frame buffer we're viewing
                                         // (^1 == frame buffer we're rendering to)
 
-    int       list_reg_open;            // Which list is open for registration, if any? (non-DMA only)
+    pvr_list_t  list_reg_open;          // Which list is open for registration, if any? (non-DMA only)
     uint32_t  lists_closed;             // (1 << idx) for each list which the SH4 has lost interest in
     uint32_t  lists_transferred;        // (1 << idx) for each list which has completely transferred to the TA
     uint32_t  lists_dmaed;              // (1 << idx) for each list which has been DMA'd (DMA mode only)

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.c
@@ -63,7 +63,7 @@ static Void_t** iCOMALLOc(size_t, size_t*, Void_t**);
 static void     cFREe(Void_t*);
 static int      mTRIm(size_t);
 static size_t   mUSABLe(Void_t*);
-static void     mSTATs();
+static void     mSTATs(void);
 static int      mALLOPt(int, int);
 static struct mallinfo mALLINFo(void);
 #else

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.h
@@ -1178,7 +1178,7 @@ size_t   public_pvr_mUSABLe();
 
 */
 #if __STD_C
-void     public_pvr_mSTATs();
+void     public_pvr_mSTATs(void);
 #else
 void     public_pvr_mSTATs();
 #endif

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_scene.c
@@ -122,7 +122,7 @@ void pvr_scene_begin(void) {
     pvr_state.lists_closed = 0;
 
     // Get general stuff ready.
-    pvr_state.list_reg_open = -1;
+    pvr_state.list_reg_open = PVR_LIST_NONE;
 
     // Clear these out in case we're using DMA.
     if(pvr_state.dma_mode) {
@@ -183,7 +183,7 @@ int pvr_list_begin(pvr_list_t list) {
     }
 
     /* If we already had a list open, close it first */
-    if(pvr_state.list_reg_open != -1 && pvr_state.list_reg_open != (int)list)
+    if(pvr_state.list_reg_open != PVR_LIST_NONE && pvr_state.list_reg_open != list)
         pvr_list_finish();
 
     pvr_list_dma = pvr_list_uses_dma(list);
@@ -207,7 +207,7 @@ int pvr_list_begin(pvr_list_t list) {
    simplicity we just always submit a blank primitive. */
 int pvr_list_finish(void) {
     /* Check to make sure we can do this */
-    if(PVR_DEBUG && !pvr_state.dma_mode && pvr_state.list_reg_open == -1) {
+    if(PVR_DEBUG && !pvr_state.dma_mode && pvr_state.list_reg_open == PVR_LIST_NONE) {
         dbglog(DBG_WARNING, "pvr_list_finish: attempt to close unopened list\n");
         return -1;
     }
@@ -231,14 +231,14 @@ int pvr_list_finish(void) {
         pvr_sq_set32((void *)0, 0, 32, PVR_DMA_TA);
     }
 
-    pvr_state.list_reg_open = -1;
+    pvr_state.list_reg_open = PVR_LIST_NONE;
 
     return 0;
 }
 
 int pvr_prim(const void *data, size_t size) {
     /* Check to make sure we can do this */
-    if(PVR_DEBUG && pvr_state.list_reg_open == -1) {
+    if(PVR_DEBUG && pvr_state.list_reg_open == PVR_LIST_NONE) {
         dbglog(DBG_WARNING, "pvr_prim: attempt to submit to unopened list\n");
         return -1;
     }
@@ -348,7 +348,7 @@ int pvr_scene_finish(void) {
     }
     else {
         /* If a list was open, close it */
-        if(pvr_state.list_reg_open != -1)
+        if(pvr_state.list_reg_open != PVR_LIST_NONE)
             pvr_list_finish();
 
         /* If any lists weren't submitted, then submit blank ones now */

--- a/kernel/arch/dreamcast/hardware/sci.c
+++ b/kernel/arch/dreamcast/hardware/sci.c
@@ -151,11 +151,11 @@ static dma_config_t sci_dma_rx_config = {
     .callback = NULL
 };
 
-static __always_inline void clear_sci_errors() {
+static __always_inline void clear_sci_errors(void) {
     SCSSR1 &= ~(ORER | FER | PER);
 }
 
-static __always_inline sci_result_t check_sci_errors() {
+static __always_inline sci_result_t check_sci_errors(void) {
     uint8_t status = SCSSR1;
 
     if(status & ORER) {
@@ -416,7 +416,7 @@ void sci_configure_uart(sci_uart_config_t config, uint8_t *scsmr1) {
     }
 }
 
-static void sci_shutdown_spi_cs() {
+static void sci_shutdown_spi_cs(void) {
     uint16_t sptr;
     uint16_t fcr;
 

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_header.h
@@ -61,8 +61,9 @@ typedef enum pvr_list_type {
     PVR_LIST_OP_POLY,           /**< Opaque polygon list */
     PVR_LIST_OP_MOD,            /**< Opaque modifier list */
     PVR_LIST_TR_POLY,           /**< Translucent polygon list */
-    PVR_LIST_TR_MOD,            /**< Translucent modifier list*/
+    PVR_LIST_TR_MOD,            /**< Translucent modifier list */
     PVR_LIST_PT_POLY,           /**< Punch-thru polygon list */
+    PVR_LIST_NONE = -1          /**< Used internally to signal unset values */
 } pvr_list_t;
 
 #define pvr_list_type_t pvr_list_t

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -42,7 +42,7 @@
 
 extern void _init(void);
 extern void _fini(void);
-extern void __verify_newlib_patch();
+extern void __verify_newlib_patch(void);
 extern void dma_init(void);
 
 /* Jump back to the bootloader. From startup.S */
@@ -433,7 +433,7 @@ void arch_abort(void) {
 /* Called to reboot the system; assume the system is in peril and don't
    try to call the dtors */
 void arch_reboot(void) {
-    typedef void (*reboot_func)() __noreturn;
+    typedef void (*reboot_func)(void) __noreturn;
     reboot_func rb;
 
     dbglog(DBG_CRITICAL, "arch: rebooting the system\n");

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -25,8 +25,8 @@
 
 /* Macros for accessing related registers. */
 #define TRA    ( *((volatile uint32_t *)(0xff000020)) ) /* TRAPA Exception Register */
-#define EXPEVT ( *((volatile uint32_t *)(0xff000024)) ) /* Exception Event Register */
-#define INTEVT ( *((volatile uint32_t *)(0xff000028)) ) /* Interrupt Event Register */
+#define EXPEVT ((irq_t) *((volatile uint32_t *)(0xff000024)) ) /* Exception Event Register */
+#define INTEVT ((irq_t) *((volatile uint32_t *)(0xff000028)) ) /* Interrupt Event Register */
 
 /* Interrupt priority registers */
 #define REG_IPR(x) ( *((volatile uint16_t *)(0xffd00004 + (x) * 4)) )
@@ -179,7 +179,7 @@ void irq_dump_regs(int code, irq_t evt) {
 volatile uint32_t jiffies = 0;
 void irq_handle_exception(int code) {
     const struct irq_cb *hnd;
-    uint32_t evt = 0;
+    irq_t evt;
     int handled = 0;
 
     if(__is_defined(__SH_ATOMIC_MODEL_SOFT_GUSA__)
@@ -257,19 +257,17 @@ void irq_handle_exception(int code) {
 }
 
 static void irq_handle_trapa(irq_t code, irq_context_t *context, void *data) {
-    const struct irq_cb *hnd, *handlers = data;
-    uint32_t vec;
-
     (void)code;
+    const struct irq_cb *hnd, *handlers = data;
 
     /* Get the trapa vector */
-    vec = TRA >> 2;
+    uint32_t vec = TRA >> 2;
 
     /* Check for handler and call if present */
     hnd = &handlers[vec];
 
     if(hnd->hdl)
-        hnd->hdl(vec, context, hnd->data);
+        hnd->hdl(IRQ_TRAP_CODE(vec), context, hnd->data);
 }
 
 extern void irq_vma_table(void);

--- a/kernel/exports/library.c
+++ b/kernel/exports/library.c
@@ -267,8 +267,8 @@ klibrary_t *library_open(const char *name, const char *fn) {
     }
 
     // Pull out the image pointers
-    lib->lib_get_name = (const char * (*)())lib->image.lib_get_name;
-    lib->lib_get_version = (uint32_t(*)())lib->image.lib_get_version;
+    lib->lib_get_name = (const char * (*)(void))lib->image.lib_get_name;
+    lib->lib_get_version = (uint32_t(*)(void))lib->image.lib_get_version;
     lib->lib_open = (int (*)(klibrary_t *))lib->image.lib_open;
     lib->lib_close = (int (*)(klibrary_t *))lib->image.lib_close;
 

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -654,7 +654,7 @@ static int pty_stat(vfs_handler_t *vfs, const char *path, struct stat *st,
     }
 
     /* Handle paths that start directly with '/maXX' or '/slXX' */
-    if(sscanf(path, "/%2c%02x", (char[3]){}, &id) != 2) {
+    if(sscanf(path, "/%*2c%02x", &id) != 2) {
         errno = ENOENT;
         return -1;
     }

--- a/kernel/libc/koslib/malloc.c
+++ b/kernel/libc/koslib/malloc.c
@@ -1343,7 +1343,7 @@ extern "C" {
 
     */
 #if __STD_C
-    void     public_mSTATs();
+    void     public_mSTATs(void);
 #else
     void     public_mSTATs();
 #endif
@@ -1589,7 +1589,7 @@ static Void_t*  cALLOc(size_t, size_t);
 static int      mTRIm(size_t);
 #endif
 static size_t   mUSABLe(Void_t*);
-static void     mSTATs();
+static void     mSTATs(void);
 static int      mALLOPt(int, int);
 static struct mallinfo mALLINFo(void);
 #else


### PR DESCRIPTION
Various places where we've done retyping and refactoring of different internal and public types had small instances where we were still using the older/generic types. These changes help move those to use the proper types.

Additionally included a similar set of fixes around function prototypes. These were all found using `-Wc++-compat` as it is much stricter about implicit type conversion it was able to point them out.