### PR TITLE
examples: Add `INIT_DEFAULT` to restore basic functions.

### DIFF
--- a/examples/dreamcast/cpp/out_of_memory/out_of_memory.cc
+++ b/examples/dreamcast/cpp/out_of_memory/out_of_memory.cc
@@ -18,7 +18,7 @@
 
 #include <kos/init.h>
 
-KOS_INIT_FLAGS(INIT_MALLOCSTATS);
+KOS_INIT_FLAGS(INIT_DEFAULT | INIT_MALLOCSTATS);
 
 static unsigned new_handler_counter = 0;
 


### PR DESCRIPTION
This example predated the various modularization updates. At the time it was written `INIT_DEFAULT` wasn't needed for basic functionality of the kernel like filesystems and output.

Adding it in so that the example behaves as intended.