### PR TITLE
Maple cleanups

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -69,7 +69,6 @@ int maple_driver_attach(maple_frame_t *det) {
     maple_response_t    *resp;
     maple_devinfo_t     *devinfo;
     maple_device_t      *dev = maple_state.ports[det->dst_port].units[det->dst_unit];
-    bool                attached = false;
     bool                dev_allocated = false;
 
     /* Resolve some pointers first */
@@ -100,6 +99,7 @@ int maple_driver_attach(maple_frame_t *det) {
             if(i->status_size && !dev->status) {
                 dev->status = calloc(1, i->status_size);
                 if(!dev->status) {
+                    /* If dev was freshly allocated, don't keep it */
                     if(dev_allocated)
                         free(dev);
                     return 1;
@@ -109,35 +109,25 @@ int maple_driver_attach(maple_frame_t *det) {
             if(dev_allocated)
                 maple_state.ports[det->dst_port].units[det->dst_unit] = dev;
 
-            if(!i->status_size || dev->status) {
-                /* Try to attach if we need to then break out. */
-                if(!(i->attach) || (i->attach(i, dev) >= 0)) {
-                    attached = true;
-                    break;
-                }
+            /* Try to attach if we need to then finish up. */
+            if(!i->attach || (i->attach(i, dev) >= 0)) {
+                dev->drv = i;
+                dev->valid = true;
+
+                if(i->user_attach)
+                    i->user_attach(dev);
+
+                return 0;
+            }
+            else {
+                /* We allocated a status, but couldn't attach */
+                free(dev->status);
+                dev->status = NULL;
             }
         }
     }
 
-    if(!dev)
-        return -1;
-
-    /* Did we get any hits? */
-    if(!attached) {
-        free(dev->status);
-        dev->status = NULL;
-
-        return -1;
-    }
-
-    /* Finish setting stuff up */
-    dev->drv = i;
-    dev->valid = true;
-
-    if(i->user_attach)
-        i->user_attach(dev);
-
-    return 0;
+    return -1;
 }
 
 /* Detach an attached maple device */

--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -159,12 +159,10 @@ int maple_driver_detach(int p, int u) {
 
 /* For each device which the given driver controls, call the callback */
 int maple_driver_foreach(maple_driver_t *drv, int (*callback)(maple_device_t *)) {
-    int     p, u;
-    maple_device_t  *dev;
 
-    for(p = 0; p < MAPLE_PORT_COUNT; p++) {
-        for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-            dev = maple_enum_dev(p, u);
+    for(size_t p = 0; p < MAPLE_PORT_COUNT; p++) {
+        for(size_t u = 0; u < MAPLE_UNIT_COUNT; u++) {
+            maple_device_t *dev = maple_enum_dev(p, u);
 
             if(dev && dev->drv == drv && !dev->frame.queued)
                 if(callback(dev) < 0)

--- a/kernel/arch/dreamcast/hardware/maple/maple_enum.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_enum.c
@@ -12,10 +12,10 @@
 
 /* Return the number of connected devices */
 int maple_enum_count(void) {
-    int p, u, cnt;
+    size_t cnt = 0;
 
-    for(cnt = 0, p = 0; p < MAPLE_PORT_COUNT; p++)
-        for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
+    for(size_t p = 0; p < MAPLE_PORT_COUNT; p++)
+        for(size_t u = 0; u < MAPLE_UNIT_COUNT; u++) {
             if(maple_dev_valid(p,u))
                 cnt++;
         }
@@ -33,12 +33,10 @@ maple_device_t *maple_enum_dev(int p, int u) {
 
 /* Return the Nth device of the requested type (where N is zero-indexed) */
 maple_device_t *maple_enum_type(int n, uint32_t func) {
-    int p, u;
-    maple_device_t *dev;
 
-    for(p = 0; p < MAPLE_PORT_COUNT; p++) {
-        for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-            dev = maple_enum_dev(p, u);
+    for(size_t p = 0; p < MAPLE_PORT_COUNT; p++) {
+        for(size_t u = 0; u < MAPLE_UNIT_COUNT; u++) {
+            maple_device_t *dev = maple_enum_dev(p, u);
 
             if(dev != NULL && (dev->info.functions & func)) {
                 if(!n) return dev;
@@ -54,8 +52,6 @@ maple_device_t *maple_enum_type(int n, uint32_t func) {
 /* Return the Nth device that is of the requested type and supports the list of
    capabilities given. */
 maple_device_t *maple_enum_type_ex(int n, uint32_t func, uint32_t cap) {
-    int p, u, d;
-    maple_device_t *dev;
     uint32_t funcmask;
 
     /* If func is 0, there can be no match (and it's UB for clz below) */
@@ -64,9 +60,9 @@ maple_device_t *maple_enum_type_ex(int n, uint32_t func, uint32_t cap) {
     /* Create a mask that leaves only the bits above func. */
     funcmask = ~GENMASK(31 - __builtin_clz(func), 0);
 
-    for(p = 0; p < MAPLE_PORT_COUNT; ++p) {
-        for(u = 0; u < MAPLE_UNIT_COUNT; ++u) {
-            dev = maple_enum_dev(p, u);
+    for(size_t p = 0; p < MAPLE_PORT_COUNT; ++p) {
+        for(size_t u = 0; u < MAPLE_UNIT_COUNT; ++u) {
+            maple_device_t *dev = maple_enum_dev(p, u);
 
             /* If the device supports the function code we passed in, check
                if it supports the capabilities that the user requested. */
@@ -75,7 +71,7 @@ maple_device_t *maple_enum_type_ex(int n, uint32_t func, uint32_t cap) {
                 /* Figure out which function data we want to look at. Function
                    data entries are arranged by the function code, most
                    significant bit first. So we count the bits above func. */
-                d = __builtin_popcount(dev->info.functions & funcmask);
+                int d = __builtin_popcount(dev->info.functions & funcmask);
 
                 /* Ensure that the result is in-bounds */
                 assert((d >= 0) && (d < 3));

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -125,7 +125,7 @@ static void maple_hw_init(void) {
     }
 
     maple_state.dma_in_progress = 0;
-    dbglog(DBG_INFO, "  DMA Buffer at %08lx\n", (uint32_t)maple_state.dma_buffer);
+    dbglog(DBG_SOURCE(MAPLE_DMA_DEBUG), "  DMA Buffer at %08lx\n", (uint32_t)maple_state.dma_buffer);
 
     /* Initialize other misc stuff */
     maple_state.vbl_cntr = maple_state.dma_cntr = 0;

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -4,6 +4,7 @@
    Copyright (C) 2002 Megan Potter
  */
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -88,15 +89,14 @@ static void maple_dev_reset_all(void) {
 /* Initialize Hardware (call after driver inits) */
 static void maple_hw_init(void) {
     maple_driver_t *drv;
-    int p, u;
 
     dbglog(DBG_INFO, "maple: active drivers:\n");
 
     /* Reset structures */
-    for(p = 0; p < MAPLE_PORT_COUNT; p++) {
+    for(size_t p = 0; p < MAPLE_PORT_COUNT; p++) {
         maple_state.ports[p].port = p;
 
-        for(u = 0; u < MAPLE_UNIT_COUNT; u++)
+        for(size_t u = 0; u < MAPLE_UNIT_COUNT; u++)
             maple_state.ports[p].units[u] = NULL;
     }
 
@@ -114,7 +114,7 @@ static void maple_hw_init(void) {
         maple_state.dma_buffer = aligned_alloc(32, MAPLE_DMA_SIZE);
 
     assert_msg(maple_state.dma_buffer != NULL, "Couldn't allocate maple DMA buffer");
-    assert_msg((((uint32_t)maple_state.dma_buffer) & 0x1f) == 0, "DMA buffer was unaligned; bug in dlmalloc; please report!");
+    assert_msg(__is_aligned((uint32_t)maple_state.dma_buffer, 32), "DMA buffer was unaligned; bug in dlmalloc; please report!");
 
     /* Force it into the P2 area */
     maple_state.dma_buffer = (uint8_t *)((((uint32_t)maple_state.dma_buffer) & MEM_AREA_CACHE_MASK) | MEM_AREA_P2_BASE);
@@ -149,8 +149,7 @@ static void maple_hw_init(void) {
 /* Turn off the maple bus, free mem */
 /* AGGG!! Someone save me from this idiotic voodoo bug fixing crap.. */
 void maple_hw_shutdown(void) {
-    int p, u, cnt;
-    uint32_t  ptr;
+    size_t cnt = 0;
 
     /* Reset all devices to leave them as we found them */
     maple_dev_reset_all();
@@ -170,7 +169,7 @@ void maple_hw_shutdown(void) {
 
     /* We must cast this back to P1 or cache issues will arise */
     if(maple_state.dma_buffer != NULL) {
-        ptr = (uint32_t)maple_state.dma_buffer;
+        uint32_t ptr = (uint32_t)maple_state.dma_buffer;
 
         if(__is_defined(MAPLE_DMA_DEBUG))
             ptr -= 512;
@@ -181,8 +180,8 @@ void maple_hw_shutdown(void) {
     }
 
     /* Free any attached devices */
-    for(cnt = 0, p = 0; p < MAPLE_PORT_COUNT; p++) {
-        for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
+    for(size_t p = 0; p < MAPLE_PORT_COUNT; p++) {
+        for(size_t u = 0; u < MAPLE_UNIT_COUNT; u++) {
             cnt += !maple_driver_detach(p, u);
 
             free(maple_state.ports[p].units[u]);
@@ -199,8 +198,6 @@ static int maple_scan_done(maple_state_t *state) {
 
 /* Wait for the initial bus scan to complete */
 void maple_wait_scan(void) {
-    int     p, u;
-    maple_device_t  *dev;
 
     /* Wait for it to finish */
     thd_poll((thd_cb_t)maple_scan_done, &maple_state, 0);
@@ -208,9 +205,9 @@ void maple_wait_scan(void) {
     /* Enumerate everything */
     dbglog(DBG_INFO, "maple: attached devices:\n");
 
-    for(p = 0; p < MAPLE_PORT_COUNT; p++) {
-        for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
-            dev = maple_enum_dev(p, u);
+    for(size_t p = 0; p < MAPLE_PORT_COUNT; p++) {
+        for(size_t u = 0; u < MAPLE_UNIT_COUNT; u++) {
+            maple_device_t *dev = maple_enum_dev(p, u);
 
             if(dev) {
                 dbglog(DBG_INFO, "  %c%c: %.30s (%08lx: %s)\n",

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -274,7 +274,7 @@ void maple_dma_irq_hnd(uint32_t code, void *data) {
            For instance, when setting motor selection to '0' rather than '1'. */
         else if(resp == MAPLE_RESPONSE_BADFUNC) {
             dbglog(DBG_ERROR, "maple_irq: error EBADFUNC on %c%i when sending command: %i\n",
-            ('A' - i->dst_port), i->dst_unit, i->cmd);
+            ('A' + i->dst_port), i->dst_unit, i->cmd);
         }
 
         if(__is_defined(MAPLE_DMA_DEBUG))

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -63,10 +63,9 @@ static void vbl_chk_disconnect(maple_state_t *state, int p, int u) {
 
 static void vbl_chk_next_subdev(maple_state_t *state, maple_frame_t *frm, int p) {
     maple_device_t *dev = maple_enum_dev(p, 0);
-    int u;
 
     if(dev && dev->probe_mask) {
-        u = __builtin_ffs(dev->probe_mask);
+        int u = __builtin_ffs(dev->probe_mask);
         dev->probe_mask &= ~(1 << (u - 1));
 
         vbl_send_devinfo(frm, p, u);
@@ -86,12 +85,11 @@ static void vbl_dev_probed(int p, int u) {
 /* Check the sub-devices for a top-level port */
 static void vbl_chk_subdevs(maple_state_t *state, int p, uint8_t newmask) {
     maple_device_t *dev = maple_enum_dev(p, 0);
-    unsigned int u;
 
     newmask &= (1 << (MAPLE_UNIT_COUNT - 1)) - 1;
 
     /* Disconnect any device that disappeared */
-    for(u = 1; u < MAPLE_UNIT_COUNT; u++) {
+    for(size_t u = 1; u < MAPLE_UNIT_COUNT; u++) {
         if(dev->dev_mask & ~newmask & (1 << (u - 1))) {
             vbl_chk_disconnect(state, p, u);
         }
@@ -147,10 +145,8 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     else if(resp->response == MAPLE_RESPONSE_DEVINFO) {
         /* Device is present, check for connections */
         if(!dev) {
-            if(__is_defined(MAPLE_IRQ_DEBUG)) {
-                dbglog(DBG_KDEBUG, "maple: attach on device %c%c\n",
-                       'A' + p, '0' + u);
-            }
+            dbglog(DBG_SOURCE(MAPLE_IRQ_DEBUG), "maple: attach on device %c%c\n",
+                   'A' + p, '0' + u);
 
             if(maple_driver_attach(frm) == 0) {
                 assert(maple_dev_valid(p, u));
@@ -186,12 +182,11 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
 }
 
 static void vbl_autodetect(maple_state_t *state) {
-    bool queued;
     maple_device_t  *dev = maple_state.ports[state->detect_port_next].units[0];
     maple_frame_t   *frm = (dev != NULL) ? &dev->frame : &detect_frame;
 
     /* Queue a detection on the next device */
-    queued = vbl_send_devinfo(frm,
+    bool queued = vbl_send_devinfo(frm,
                               state->detect_port_next, 0);
 
     /* Move to the next device */
@@ -210,8 +205,6 @@ void maple_vbl_irq_hnd(uint32_t code, void *data) {
 
     (void)code;
 
-    /* dbgio_write_str("inside vbl_irq_hnd\n"); */
-
     /* Count, for fun and profit */
     state->vbl_cntr++;
 
@@ -227,8 +220,6 @@ void maple_vbl_irq_hnd(uint32_t code, void *data) {
     /* Send any queued data */
     if(!state->dma_in_progress)
         maple_queue_flush();
-
-    /* dbgio_write_str("finish vbl_irq_hnd\n"); */
 }
 
 /*********************************************************************/
@@ -238,12 +229,8 @@ void maple_vbl_irq_hnd(uint32_t code, void *data) {
 void maple_dma_irq_hnd(uint32_t code, void *data) {
     maple_state_t *state = data;
     maple_frame_t   *i, *tmp;
-    int8_t        resp;
-    uint32_t gun;
 
     (void)code;
-
-    /* dbgio_write_str("start dma_irq_hnd\n"); */
 
     /* Count, for fun and profit */
     state->dma_cntr++;
@@ -264,7 +251,7 @@ void maple_dma_irq_hnd(uint32_t code, void *data) {
 
         /* Check to see if it got a proper response; we might
            have to resubmit the request */
-        resp = ((int8_t *)i->recv_buf)[0];
+        int8_t resp = ((int8_t *)i->recv_buf)[0];
 
         if(resp == MAPLE_RESPONSE_AGAIN) {
             i->state = MAPLE_FRAME_UNSENT;
@@ -287,7 +274,7 @@ void maple_dma_irq_hnd(uint32_t code, void *data) {
 
         /* If it's got a callback, call it; otherwise unlock
            it manually (or it'll never get used again) */
-        if(i->callback != NULL)
+        if(i->callback)
             i->callback(state, i);
         else
             maple_frame_unlock(i);
@@ -295,11 +282,9 @@ void maple_dma_irq_hnd(uint32_t code, void *data) {
 
     /* If gun mode is enabled, read the latched H/V counter values. */
     if(state->gun_port > -1) {
-        gun = PVR_GET(PVR_GUN_POS);
+        uint32_t gun = PVR_GET(PVR_GUN_POS);
         state->gun_x = gun & 0x3ff;
         state->gun_y = (gun >> 16) & 0x3ff;
         state->gun_port = -1;
     }
-
-    /* dbgio_write_str("finish dma_irq_hnd\n"); */
 }

--- a/kernel/arch/dreamcast/hardware/maple/maple_queue.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_queue.c
@@ -91,7 +91,7 @@ void maple_queue_flush(void) {
 
 /* Submit a frame for queueing; see header for notes */
 int maple_queue_frame(maple_frame_t *frame) {
-    uint32_t save = 0;
+    irq_mask_t save = 0;
 
     /* Don't add it twice */
     if(frame->queued)
@@ -118,7 +118,7 @@ int maple_queue_frame(maple_frame_t *frame) {
 
 /* Remove a used frame from the queue */
 int maple_queue_remove(maple_frame_t *frame) {
-    uint32_t save = 0;
+    irq_mask_t save = 0;
 
     /* Don't remove twice */
     if(!frame->queued)
@@ -148,16 +148,12 @@ int maple_queue_remove(maple_frame_t *frame) {
    the old system I put it inside a big chunk of memory so it couldn't do
    that, and that seems to be the only working fix here too. *shrug* */
 void maple_frame_init(maple_frame_t *frame) {
-    uint32_t buf_ptr;
 
     assert(frame->state == MAPLE_FRAME_UNSENT);
     assert(!frame->queued);
 
-    /* Setup the buffer pointer (64-byte align and force -> P2) */
-    buf_ptr = (uint32_t)frame->recv_buf_arr;
-
-    if(buf_ptr & 0x1f)
-        buf_ptr = (buf_ptr & ~0x1f) + 0x20;
+    /* Setup the buffer pointer (32-byte align and force -> P2) */
+    uint32_t buf_ptr = __align_up((uint32_t)frame->recv_buf_arr, 32);
 
     if(__is_defined(MAPLE_DMA_DEBUG))
         buf_ptr += 512;

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -292,7 +292,7 @@ typedef struct maple_device {
 
 /** \brief   Internal representation of a Maple port.
     \ingroup maple
-    
+
     Each maple port can contain up to 6 devices, the first one of which is
     always the port itself.
 
@@ -441,7 +441,7 @@ typedef struct maple_state_str {
  */
 #define maple_read(A) ( *((volatile uint32_t*)(A)) )
 
-/** \brief   Maple memory write macro. 
+/** \brief   Maple memory write macro.
     \ingroup maple
  */
 #define maple_write(A, V) ( *((volatile uint32_t*)(A)) = (V) )
@@ -529,7 +529,7 @@ uint8_t maple_addr(int port, int unit);
 
 /** \brief   Decompose a "maple address" into a port, unit pair.
     \ingroup maple
-    
+
     \warning
     This function will not work with multi-cast addresses!
 
@@ -537,7 +537,7 @@ uint8_t maple_addr(int port, int unit);
     \param  port            Output space for the port of the address.
     \param  unit            Output space for the unit of the address.
 */
-void maple_raddr(uint8_t addr, int * port, int * unit);
+void maple_raddr(uint8_t addr, int *port, int *unit);
 
 /** \brief   Return a string with the capabilities of a given function code.
     \ingroup maple
@@ -547,7 +547,7 @@ void maple_raddr(uint8_t addr, int * port, int * unit);
     \param  functions       The list of function codes.
     \return                 A string containing the capabilities.
 */
-const char * maple_pcaps(uint32_t functions);
+const char *maple_pcaps(uint32_t functions);
 
 /** \brief   Return a string representing the maple response code.
     \ingroup maple
@@ -556,7 +556,7 @@ const char * maple_pcaps(uint32_t functions);
     \return                 A string containing a textual representation of the
                             response code.
 */
-const char * maple_perror(int response);
+const char *maple_perror(int response);
 
 /** \brief   Determine if a given device is valid.
     \ingroup maple
@@ -617,7 +617,7 @@ void maple_gun_read_pos(int *x, int *y);
     \param  buffer          The buffer to add the sentinel to.
     \param  bufsize         The size of the data in the buffer.
 */
-void maple_sentinel_setup(void * buffer, int bufsize);
+void maple_sentinel_setup(void *buffer, int bufsize);
 
 /** \brief   Verify the presence of the sentine.
     \ingroup maple
@@ -626,12 +626,12 @@ void maple_sentinel_setup(void * buffer, int bufsize);
     \param  buffer          The buffer to check.
     \param  bufsize         The size of the buffer.
 */
-void maple_sentinel_verify(const char * bufname, void * buffer, int bufsize);
+void maple_sentinel_verify(const char *bufname, void *buffer, int bufsize);
 
 /**************************************************************************/
 /* maple_queue.c */
 
-/** \brief   Send all queued frames. 
+/** \brief   Send all queued frames.
     \ingroup maple
  */
 void maple_queue_flush(void);
@@ -688,7 +688,7 @@ int maple_frame_trylock(maple_frame_t *frame);
 */
 int maple_frame_lock(maple_frame_t *frame);
 
-/** \brief   Unlock a frame. 
+/** \brief   Unlock a frame.
     \ingroup maple
  */
 void maple_frame_unlock(maple_frame_t *frame);
@@ -791,15 +791,15 @@ void maple_detach_callback(uint32_t functions, maple_detach_callback_t cb);
 
 /** \brief   Called on every VBL (~60fps).
     \ingroup maple
-    
+
     \param  code            The ASIC event code.
     \param  data            The user pointer associated with this callback.
 */
 void maple_vbl_irq_hnd(uint32_t code, void *data);
 
 /** \brief   Called after a Maple DMA send / receive pair completes.
-    \ingroup maple 
-    
+    \ingroup maple
+
     \param  code            The ASIC event code.
     \param  data            The user pointer associated with this callback.
 */
@@ -864,17 +864,17 @@ void *maple_dev_status(maple_device_t *dev);
 /**************************************************************************/
 /* maple_init.c */
 
-/** \brief   Initialize Maple. 
-    \ingroup maple 
+/** \brief   Initialize Maple.
+    \ingroup maple
  */
 void maple_init(void);
 
-/** \brief   Shutdown Maple. 
+/** \brief   Shutdown Maple.
     \ingroup maple
  */
 void maple_shutdown(void);
 
-/** \brief   Wait for the initial bus scan to complete. 
+/** \brief   Wait for the initial bus scan to complete.
     \ingroup maple
  */
 void maple_wait_scan(void);
@@ -911,11 +911,10 @@ void maple_wait_scan(void);
 */
 #define MAPLE_FOREACH_BEGIN(TYPE, VARTYPE, VAR) \
     do { \
-        maple_device_t  * __dev; \
+        maple_device_t  *__dev; \
         VARTYPE * VAR; \
-        int __i; \
+        int __i = 0; \
         \
-        __i = 0; \
         while( (__dev = maple_enum_type(__i, TYPE)) ) { \
             VAR = (VARTYPE *)maple_dev_status(__dev); \
             do {


### PR DESCRIPTION
Mostly just whitespace, types, macro usage, and variable scoping cleanups. Also though some minor changes:
- Correct a faulty debug message that had the wrong port number unless it was port A.
- Remove the default info output of the location of the maple dma buffer, now only print when debugging dma.
- Small refactor in `maple_driver_attach` . This is probably the most sensitive thing in the PR, but I believe it simplifies the function by removing a flag that was being used to signal a successful attach and nesting the logic the flag was triggering directly into the inner loop path.