### PR TITLE
treewide: Drop last usages of `arch/types.h` types.

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -58,7 +58,7 @@ static bool percd_done;
 /* Low-level Joliet utils */
 
 /* Joliet UCS is big endian */
-static void utf2ucs(uint8 * ucs, const uint8 * utf) {
+static void utf2ucs(uint8_t *ucs, const uint8_t *utf) {
     int c;
 
     do {
@@ -82,7 +82,7 @@ static void utf2ucs(uint8 * ucs, const uint8 * utf) {
     while(c);
 }
 
-static void ucs2utfn(uint8 * utf, const uint8 * ucs, size_t len) {
+static void ucs2utfn(uint8_t *utf, const uint8_t *ucs, size_t len) {
     int c;
 
     len = len / 2;
@@ -111,7 +111,7 @@ static void ucs2utfn(uint8 * utf, const uint8 * ucs, size_t len) {
     *utf = 0;
 }
 
-static int ucscompare(const uint8 * isofn, const uint8 * normalfn, int isosize) {
+static int ucscompare(const uint8_t *isofn, const uint8_t *normalfn, int isosize) {
     int i, c0, c1 = 0;
 
     /* Compare ISO name */
@@ -135,7 +135,7 @@ static int ucscompare(const uint8 * isofn, const uint8 * normalfn, int isosize) 
         return 0;
 }
 
-static int isjoliet(char * p) {
+static int isjoliet(char *p) {
     if(p[0] == '%' && p[1] == '/') {
         switch(p[2]) {
             case '@':
@@ -157,37 +157,37 @@ static int joliet;
 
 /* ISO Directory entry */
 typedef struct {
-    uint8   length;         /* 711 */
-    uint8   ext_attr_length;    /* 711 */
-    uint8   extent[8];      /* 733 */
-    uint8   size[8];        /* 733 */
-    uint8   date[7];        /* 7x711 */
-    uint8   flags;
-    uint8   file_unit_size;     /* 711 */
-    uint8   interleave;     /* 711 */
-    uint8   vol_sequence[4];    /* 723 */
-    uint8   name_len;       /* 711 */
+    uint8_t length;         /* 711 */
+    uint8_t ext_attr_length;/* 711 */
+    uint8_t extent[8];      /* 733 */
+    uint8_t size[8];        /* 733 */
+    uint8_t date[7];        /* 7x711 */
+    uint8_t flags;
+    uint8_t file_unit_size; /* 711 */
+    uint8_t interleave;     /* 711 */
+    uint8_t vol_sequence[4];/* 723 */
+    uint8_t name_len;       /* 711 */
     char    name[1];
 } iso_dirent_t;
 
-/* Util function to reverse the byte order of a uint32 */
-/* static uint32 ntohl_32(const void *data) {
-    const uint8 *d = (const uint8*)data;
+/* Util function to reverse the byte order of a uint32_t */
+/* static uint32_t ntohl_32(const void *data) {
+    const uint8_t *d = (const uint8_t *)data;
     return (d[0] << 24) | (d[1] << 16) | (d[2] << 8) | (d[3] << 0);
 } */
 
 /* This seems kinda silly, but it's important since it allows us
    to do unaligned accesses on a buffer */
-static uint32 htohl_32(const void *data) {
-    const uint8 *d = (const uint8*)data;
+static uint32_t htohl_32(const void *data) {
+    const uint8_t *d = (const uint8_t *)data;
     return (d[0] << 0) | (d[1] << 8) | (d[2] << 16) | (d[3] << 24);
 }
 
 /* Read red-book section 7.1.1 number (8 bit) */
-/* static uint8 iso_711(const uint8 *from) { return (*from & 0xff); } */
+/* static uint8_t iso_711(const uint8_t *from) { return (*from & 0xff); } */
 
 /* Read red-book section 7.3.3 number (32 bit LE / 32 bit BE) */
-static uint32 iso_733(const uint8 *from) {
+static uint32_t iso_733(const uint8_t *from) {
     return htohl_32(from);
 }
 
@@ -203,8 +203,8 @@ static uint32 iso_733(const uint8 *from) {
    this cache. As the cache fills up, sectors are removed from the end
    of it. */
 typedef struct {
-    uint8   *data;          /* Sector data */
-    uint32  sector;         /* CD sector */
+    uint8_t   *data;          /* Sector data */
+    uint32_t  sector;         /* CD sector */
 } cache_block_t;
 
 /* List of cache blocks (ordered least recently used to most recently) */
@@ -220,19 +220,14 @@ static mutex_t cache_mutex;
 
 /* Clears all cache blocks */
 static void bclear_cache(cache_block_t **cache) {
-    int i;
+    mutex_lock_scoped(&cache_mutex);
 
-    mutex_lock(&cache_mutex);
-
-    for(i = 0; i < NUM_CACHE_BLOCKS; i++)
-        cache[i]->sector = (uint32)-1;
-
-    mutex_unlock(&cache_mutex);
+    for(size_t i = 0; i < NUM_CACHE_BLOCKS; i++)
+        cache[i]->sector = (uint32_t)-1;
 }
 
 /* Graduate a block from its current position to the MRU end of the cache */
 static void bgrad_cache(cache_block_t **cache, int block) {
-    int     i;
     cache_block_t   *tmp;
 
     /* Don't try it with the end block */
@@ -241,7 +236,7 @@ static void bgrad_cache(cache_block_t **cache, int block) {
     /* Make a copy and scoot everything down */
     tmp = cache[block];
 
-    for(i = block; i < (NUM_CACHE_BLOCKS - 1); i++)
+    for(size_t i = block; i < (NUM_CACHE_BLOCKS - 1); i++)
         cache[i] = cache[i + 1];
 
     cache[NUM_CACHE_BLOCKS - 1] = tmp;
@@ -252,7 +247,7 @@ static void bgrad_cache(cache_block_t **cache, int block) {
    cache, in which case it just returns the containing block. */
 static void iso_break_all(void);
 static void iso_abort_stream(bool lock);
-static int bread_cache(cache_block_t **cache, uint32 sector) {
+static int bread_cache(cache_block_t **cache, uint32_t sector) {
     int i, j, rv;
 
     rv = -1;
@@ -269,7 +264,7 @@ static int bread_cache(cache_block_t **cache, uint32 sector) {
 
     /* If not, look for an open cache slot; if we find one, use it */
     for(i = 0; i < NUM_CACHE_BLOCKS; i++) {
-        if(cache[i]->sector == (uint32)-1) break;
+        if(cache[i]->sector == (uint32_t)-1) break;
     }
 
     /* If we didn't find one, kick an LRU block out of cache */
@@ -326,10 +321,10 @@ static inline void bclear(void) {
 /* Higher-level ISO9660 primitives */
 
 /* Root FS session location (in sectors) */
-static uint32 session_base = 0;
+static uint32_t session_base = 0;
 
 /* Root directory extent and size in bytes */
-static uint32 root_extent = 0, root_size = 0;
+static uint32_t root_extent = 0, root_size = 0;
 
 /* Root dirent */
 static iso_dirent_t root_dirent;
@@ -436,14 +431,14 @@ static int fncompare(const char *isofn, int isosize, const char *normalfn) {
    expect this buffer to stay around much longer than the call itself).
  */
 static iso_dirent_t *find_object(const char *fn, int dir,
-                                 uint32 dir_extent, uint32 dir_size) {
+                                 uint32_t dir_extent, uint32_t dir_size) {
     int     i, c;
     iso_dirent_t    *de;
 
     /* RockRidge */
     int     len;
-    uint8       *pnt;
-    char        rrname[NAME_MAX];
+    uint8_t *pnt;
+    char    rrname[NAME_MAX];
     int     rrnamelen;
     int     size_left;
 
@@ -451,11 +446,11 @@ static iso_dirent_t *find_object(const char *fn, int dir,
     size_left = (int)dir_size;
 
     /* Joliet */
-    uint8       * ucsname = (uint8 *)rrname;
+    uint8_t *ucsname = (uint8_t *)rrname;
 
     /* If this is a Joliet CD, then UCSify the name */
     if(joliet)
-        utf2ucs(ucsname, (uint8 *)fn);
+        utf2ucs(ucsname, (uint8_t *)fn);
 
     while(size_left > 0) {
         c = biread(dir_extent);
@@ -470,7 +465,7 @@ static iso_dirent_t *find_object(const char *fn, int dir,
 
             /* Try the Joliet filename if the CD is a Joliet disc */
             if(joliet) {
-                if(!ucscompare((uint8 *)de->name, ucsname, de->name_len)) {
+                if(!ucscompare((uint8_t *)de->name, ucsname, de->name_len)) {
                     if(!((dir << 1) ^ de->flags))
                         return de;
                 }
@@ -482,7 +477,7 @@ static iso_dirent_t *find_object(const char *fn, int dir,
                 /* Check for Rock Ridge NM extension */
                 len = de->length - sizeof(iso_dirent_t)
                       + sizeof(de->name) - de->name_len;
-                pnt = (uint8*)de + sizeof(iso_dirent_t)
+                pnt = (uint8_t *)de + sizeof(iso_dirent_t)
                       - sizeof(de->name) + de->name_len;
 
                 if((de->name_len & 1) == 0) {
@@ -700,10 +695,10 @@ static int iso_stream_done(size_t *remain_size) {
 }
 
 /* Read from a file */
-static ssize_t iso_read(void * h, void *buf, size_t bytes) {
+static ssize_t iso_read(void *h, void *buf, size_t bytes) {
     int rv, c;
     size_t toread, thissect;
-    uint8 * outbuf;
+    uint8_t *outbuf;
     size_t remain_size = 0, req_size;
     uint32_t sector;
     iso_fd_t *fd = (iso_fd_t *)h;
@@ -715,7 +710,7 @@ static ssize_t iso_read(void * h, void *buf, size_t bytes) {
     }
 
     rv = 0;
-    outbuf = (uint8 *)buf;
+    outbuf = (uint8_t *)buf;
     mutex_lock(&fh_mutex);
 
     /* Read zero or more sectors into the buffer from the current pos */
@@ -888,7 +883,7 @@ static off_t iso_seek(void * h, off_t offset, int whence) {
             break;
 
         case SEEK_CUR:
-            if(offset < 0 && ((uint32)-offset) > fd->ptr) {
+            if(offset < 0 && ((uint32_t)-offset) > fd->ptr) {
                 errno = EINVAL;
                 return -1;
             }
@@ -897,7 +892,7 @@ static off_t iso_seek(void * h, off_t offset, int whence) {
             break;
 
         case SEEK_END:
-            if(offset < 0 && ((uint32)-offset) > fd->size) {
+            if(offset < 0 && ((uint32_t)-offset) > fd->size) {
                 errno = EINVAL;
                 return -1;
             }
@@ -970,7 +965,7 @@ static const dirent_t *iso_readdir(void * h) {
 
     /* RockRidge */
     int     len;
-    uint8       *pnt;
+    uint8_t       *pnt;
 
     iso_fd_t *fd = (iso_fd_t *)h;
 
@@ -1011,7 +1006,7 @@ static const dirent_t *iso_readdir(void * h) {
     }
 
     if(joliet) {
-        ucs2utfn((uint8 *)fd->dirent.name, (uint8 *)de->name, de->name_len);
+        ucs2utfn((uint8_t *)fd->dirent.name, (uint8_t *)de->name, de->name_len);
     }
     else {
         /* Fill out the VFS dirent */
@@ -1021,7 +1016,7 @@ static const dirent_t *iso_readdir(void * h) {
 
         /* Check for Rock Ridge NM extension */
         len = de->length - sizeof(iso_dirent_t) + sizeof(de->name) - de->name_len;
-        pnt = (uint8*)de + sizeof(iso_dirent_t) - sizeof(de->name) + de->name_len;
+        pnt = (uint8_t *)de + sizeof(iso_dirent_t) - sizeof(de->name) + de->name_len;
 
         if((de->name_len & 1) == 0) {
             pnt++;
@@ -1099,7 +1094,7 @@ int iso_reset(void) {
    time someone calls in it'll get reset. */
 static int iso_last_status;
 static int iso_vblank_hnd;
-static void iso_vblank(uint32 evt, void *data) {
+static void iso_vblank(uint32_t evt, void *data) {
     int status, disc_type;
 
     (void)evt;

--- a/kernel/arch/dreamcast/fs/fs_vmu.c
+++ b/kernel/arch/dreamcast/fs/fs_vmu.c
@@ -13,7 +13,6 @@
 #include <errno.h>
 #include <time.h>
 
-#include <arch/types.h>
 #include <kos/mutex.h>
 #include <kos/opts.h>
 #include <kos/dbglog.h>
@@ -53,7 +52,7 @@ debug output.
 
 /* File handles */
 typedef struct vmu_fh_str {
-    uint32 strtype;                     /* 0==dir, 1==file */
+    uint32_t strtype;                   /* 0==dir, 1==file */
     TAILQ_ENTRY(vmu_fh_str) listent;    /* list entry */
 
     int mode;                           /* mode the file was opened with */
@@ -62,22 +61,22 @@ typedef struct vmu_fh_str {
     off_t loc;                          /* current position from the start in the file (bytes) */
     off_t start;                        /* start of the data in the file (bytes) */
     maple_device_t *dev;                /* maple address of the vmu to use */
-    uint32 filesize;                    /* file length from dirent (in 512-byte blks) */
-    uint8 *data;                        /* copy of the whole file */
+    uint32_t filesize;                  /* file length from dirent (in 512-byte blks) */
+    uint8_t *data;                      /* copy of the whole file */
     vmu_pkg_t *header;                  /* VMU file header */
     bool raw;                           /* file opened as raw */
 } vmu_fh_t;
 
 /* Directory handles */
 typedef struct vmu_dh_str {
-    uint32 strtype;                     /* 0==dir, 1==file */
+    uint32_t strtype;                   /* 0==dir, 1==file */
     TAILQ_ENTRY(vmu_dh_str) listent;    /* list entry */
 
     int rootdir;                        /* 1 if we're reading /vmu */
     dirent_t dirent;                    /* Dirent to pass back */
     vmu_dir_t *dirblocks;               /* Copy of all directory blocks */
-    uint16 entry;                       /* Current dirent */
-    uint16 dircnt;                      /* Count of dir entries */
+    uint16_t entry;                     /* Current dirent */
+    uint16_t dircnt;                    /* Count of dir entries */
     maple_device_t *dev;                /* VMU address */
 } vmu_dh_t;
 
@@ -285,7 +284,7 @@ static vmu_fh_t *vmu_open_file(maple_device_t * dev, const char *path, int mode)
         fd->start = (unsigned int)vmu_pkg.data - (unsigned int)data;
     }
 
-    fd->data = (uint8 *)data;
+    fd->data = (uint8_t *)data;
     fd->filesize = datasize / 512;
 
     if(fd->filesize == 0) {

--- a/kernel/arch/dreamcast/fs/vmufs.c
+++ b/kernel/arch/dreamcast/fs/vmufs.c
@@ -49,8 +49,8 @@ Function comments located in vmufs.h.
 static mutex_t mutex;
 
 /* Convert a decimal number to BCD; max of two digits */
-static uint8 __pure dec_to_bcd(int dec) {
-    uint8 rv = 0;
+static uint8_t __pure dec_to_bcd(int dec) {
+    uint8_t rv = 0;
 
     rv = dec % 10;
     rv |= ((dec / 10) % 10) << 4;
@@ -59,11 +59,10 @@ static uint8 __pure dec_to_bcd(int dec) {
 }
 
 void vmufs_dir_fill_time(vmu_dir_t *d) {
-    time_t t;
     struct tm tm;
 
     /* Get the time */
-    t = time(NULL);
+    time_t t = time(NULL);
     localtime_r(&t, &tm);
 
     /* Fill in the struct, converting to BCD */
@@ -77,9 +76,9 @@ void vmufs_dir_fill_time(vmu_dir_t *d) {
     d->timestamp.dow = dec_to_bcd((tm.tm_wday - 1) % 7);
 }
 
-int vmufs_root_read(maple_device_t * dev, vmu_root_t * root_buf) {
+int vmufs_root_read(maple_device_t *dev, vmu_root_t *root_buf) {
     /* XXX: Assume root is at 255.. is there some way to figure this out dynamically? */
-    if(vmu_block_read(dev, 255, (uint8 *)root_buf) != 0) {
+    if(vmu_block_read(dev, 255, (uint8_t *)root_buf) != 0) {
         dbglog(DBG_ERROR, "vmufs_root_read: can't read block %d on device %c%c\n",
                255, dev->port + 'A', dev->unit + '0');
         return -1;
@@ -88,9 +87,9 @@ int vmufs_root_read(maple_device_t * dev, vmu_root_t * root_buf) {
     return 0;
 }
 
-int vmufs_root_write(maple_device_t * dev, vmu_root_t * root_buf) {
+int vmufs_root_write(maple_device_t *dev, vmu_root_t *root_buf) {
     /* XXX: Assume root is at 255.. is there some way to figure this out dynamically? */
-    if(vmu_block_write(dev, 255, (uint8 *)root_buf) != 0) {
+    if(vmu_block_write(dev, 255, (uint8_t *)root_buf) != 0) {
         dbglog(DBG_ERROR, "vmufs_root_write: can't write block %d on device %c%c\n",
                255, dev->port + 'A', dev->unit + '0');
         return -1;
@@ -99,44 +98,44 @@ int vmufs_root_write(maple_device_t * dev, vmu_root_t * root_buf) {
         return 0;
 }
 
-int vmufs_dir_blocks(vmu_root_t * root_buf) {
+int vmufs_dir_blocks(vmu_root_t *root_buf) {
     return root_buf->dir_size * 512;
 }
 
-int vmufs_fat_blocks(vmu_root_t * root_buf) {
+int vmufs_fat_blocks(vmu_root_t *root_buf) {
     return root_buf->fat_size * 512;
 }
 
 /* Common code for both dir_read and dir_write */
-static int vmufs_dir_ops(maple_device_t * dev, vmu_root_t * root, vmu_dir_t * dir_buf, int write) {
-    uint16  dir_block, dir_size;
-    unsigned int i;
-    int needsop, rv;
+static int vmufs_dir_ops(maple_device_t *dev, vmu_root_t *root, vmu_dir_t *dir_buf, bool write) {
+    int rv;
 
     /* Find the directory starting block and length */
-    dir_block = root->dir_loc;
-    dir_size = root->dir_size;
+    uint16_t dir_block = root->dir_loc;
+    uint16_t dir_size = root->dir_size;
 
     /* The dir is stored backwards, so we start at the end and go back. */
     while(dir_size > 0) {
+        bool needsop = false;
+
         if(write) {
             /* Scan this block for changes */
-            for(i = 0, needsop = 0; i < 512 / sizeof(vmu_dir_t); i++) {
+            for(size_t i = 0; i < 512 / sizeof(vmu_dir_t); i++) {
                 if(dir_buf[i].dirty) {
-                    needsop = 1;
+                    needsop = true;
                 }
 
                 dir_buf[i].dirty = 0;
             }
         }
         else
-            needsop = 1;
+            needsop = true;
 
         if(needsop) {
             if(!write)
-                rv = vmu_block_read(dev, dir_block, (uint8 *)dir_buf);
+                rv = vmu_block_read(dev, dir_block, (uint8_t *)dir_buf);
             else
-                rv = vmu_block_write(dev, dir_block, (uint8 *)dir_buf);
+                rv = vmu_block_write(dev, dir_block, (uint8_t *)dir_buf);
 
             if(rv != 0) {
                 dbglog(DBG_ERROR, "vmufs_dir_%s: can't %s block %d on device %c%c\n",
@@ -155,22 +154,21 @@ static int vmufs_dir_ops(maple_device_t * dev, vmu_root_t * root, vmu_dir_t * di
     return 0;
 }
 
-int vmufs_dir_read(maple_device_t * dev, vmu_root_t * root, vmu_dir_t * dir_buf) {
-    return vmufs_dir_ops(dev, root, dir_buf, 0);
+int vmufs_dir_read(maple_device_t *dev, vmu_root_t *root, vmu_dir_t *dir_buf) {
+    return vmufs_dir_ops(dev, root, dir_buf, false);
 }
 
-int vmufs_dir_write(maple_device_t * dev, vmu_root_t * root, vmu_dir_t * dir_buf) {
-    return vmufs_dir_ops(dev, root, dir_buf, 1);
+int vmufs_dir_write(maple_device_t *dev, vmu_root_t *root, vmu_dir_t *dir_buf) {
+    return vmufs_dir_ops(dev, root, dir_buf, true);
 }
 
 /* Common code for both fat_read and fat_write */
-static int vmufs_fat_ops(maple_device_t * dev, vmu_root_t * root, uint16 * fat_buf, int write) {
-    uint16  fat_block, fat_size;
+static int vmufs_fat_ops(maple_device_t *dev, vmu_root_t *root, uint16_t *fat_buf, bool write) {
     int rv;
 
     /* Find the FAT starting block and length */
-    fat_block = root->fat_loc;
-    fat_size = root->fat_size;
+    uint16_t fat_block = root->fat_loc;
+    uint16_t fat_size = root->fat_size;
 
     /* We can't reliably handle VMUs with a larger FAT... */
     if(fat_size > 1) {
@@ -181,9 +179,9 @@ static int vmufs_fat_ops(maple_device_t * dev, vmu_root_t * root, uint16 * fat_b
     }
 
     if(!write)
-        rv = vmu_block_read(dev, fat_block, (uint8 *)fat_buf);
+        rv = vmu_block_read(dev, fat_block, (uint8_t *)fat_buf);
     else
-        rv = vmu_block_write(dev, fat_block, (uint8 *)fat_buf);
+        rv = vmu_block_write(dev, fat_block, (uint8_t *)fat_buf);
 
     if(rv != 0) {
         dbglog(DBG_ERROR, "vmufs_fat_%s: can't %s block %d on device %c%c (error %d)\n",
@@ -196,21 +194,18 @@ static int vmufs_fat_ops(maple_device_t * dev, vmu_root_t * root, uint16 * fat_b
     return 0;
 }
 
-int vmufs_fat_read(maple_device_t * dev, vmu_root_t * root, uint16 * fat_buf) {
-    return vmufs_fat_ops(dev, root, fat_buf, 0);
+int vmufs_fat_read(maple_device_t *dev, vmu_root_t *root, uint16_t *fat_buf) {
+    return vmufs_fat_ops(dev, root, fat_buf, false);
 }
 
-int vmufs_fat_write(maple_device_t * dev, vmu_root_t * root, uint16 * fat_buf) {
-    return vmufs_fat_ops(dev, root, fat_buf, 1);
+int vmufs_fat_write(maple_device_t *dev, vmu_root_t *root, uint16_t *fat_buf) {
+    return vmufs_fat_ops(dev, root, fat_buf, true);
 }
 
-int vmufs_dir_find(vmu_root_t * root, vmu_dir_t * dir, const char * fn) {
-    int i;
-    int dcnt;
+int vmufs_dir_find(vmu_root_t *root, vmu_dir_t *dir, const char *fn) {
+    int dcnt = root->dir_size * 512 / sizeof(vmu_dir_t);
 
-    dcnt = root->dir_size * 512 / sizeof(vmu_dir_t);
-
-    for(i = 0; i < dcnt; i++) {
+    for(int i = 0; i < dcnt; i++) {
         /* Not a file -> skip it */
         if(dir[i].filetype == 0)
             continue;
@@ -224,13 +219,10 @@ int vmufs_dir_find(vmu_root_t * root, vmu_dir_t * dir, const char * fn) {
     return -1;
 }
 
-int vmufs_dir_add(vmu_root_t * root, vmu_dir_t * dir, vmu_dir_t * newdirent) {
-    int i;
-    int dcnt;
+int vmufs_dir_add(vmu_root_t *root, vmu_dir_t *dir, vmu_dir_t *newdirent) {
+    size_t dcnt = root->dir_size * 512 / sizeof(vmu_dir_t);
 
-    dcnt = root->dir_size * 512 / sizeof(vmu_dir_t);
-
-    for(i = 0; i < dcnt; i++) {
+    for(size_t i = 0; i < dcnt; i++) {
         /* A file -> skip it */
         if(dir[i].filetype != 0)
             continue;
@@ -248,17 +240,14 @@ int vmufs_dir_add(vmu_root_t * root, vmu_dir_t * dir, vmu_dir_t * newdirent) {
     return -1;
 }
 
-int vmufs_file_read(maple_device_t * dev, uint16 * fat, vmu_dir_t * dirent, void * outbuf) {
-    int curblk, blkleft, rv;
-    uint8   * out;
-
-    out = (uint8 *)outbuf;
+int vmufs_file_read(maple_device_t *dev, uint16_t *fat, vmu_dir_t *dirent, void *outbuf) {
+    uint8_t *out = (uint8_t *)outbuf;
 
     /* Find the first block */
-    curblk = dirent->firstblk;
+    int curblk = dirent->firstblk;
 
     /* And the blocks remaining */
-    blkleft = dirent->filesize;
+    int blkleft = dirent->filesize;
 
     /* While we've got stuff remaining... */
     while(blkleft > 0) {
@@ -272,7 +261,7 @@ int vmufs_file_read(maple_device_t * dev, uint16 * fat, vmu_dir_t * dirent, void
         }
 
         /* Read the block */
-        rv = vmu_block_read(dev, curblk, (uint8 *)out);
+        int rv = vmu_block_read(dev, curblk, out);
 
         if(rv != 0) {
             dbglog(DBG_ERROR, "vmufs_file_read: can't read block %d on device %c%c (error %d)\n",
@@ -299,19 +288,17 @@ int vmufs_file_read(maple_device_t * dev, uint16 * fat, vmu_dir_t * dirent, void
 }
 
 /* Find an open block for writing in the FAT */
-static int vmufs_find_block(vmu_root_t * root, uint16 * fat, vmu_dir_t * dirent) {
-    int i;
-
+static int vmufs_find_block(vmu_root_t *root, uint16_t *fat, vmu_dir_t *dirent) {
     if(dirent->filetype == 0x33) {
         /* Data files -- count down from top */
-        for(i = root->blk_cnt - 1; i >= 0; i--) {
+        for(int i = root->blk_cnt - 1; i >= 0; i--) {
             if(fat[i] == 0xfffc)
                 return i;
         }
     }
     else if(dirent->filetype == 0xcc) {
         /* VMU games -- count up from bottom */
-        for(i = 0; i < root->blk_cnt; i++) {
+        for(int i = 0; i < root->blk_cnt; i++) {
             if(fat[i] == 0xfffc)
                 return i;
         }
@@ -333,11 +320,11 @@ static int vmufs_find_block(vmu_root_t * root, uint16 * fat, vmu_dir_t * dirent)
     return -2;
 }
 
-int vmufs_file_write(maple_device_t * dev, vmu_root_t * root, uint16 * fat,
-                     vmu_dir_t * dir, vmu_dir_t * newdirent, void * filebuf, int size) {
+int vmufs_file_write(maple_device_t *dev, vmu_root_t *root, uint16_t *fat,
+                     vmu_dir_t *dir, vmu_dir_t *newdirent, void *filebuf, int size) {
     int curblk, blkleft, rv;
     int vmuspaceleft;
-    uint8   * out;
+    uint8_t *out = (uint8_t *)filebuf;
 
     /* Files must be at least one block long */
     if(size <= 0) {
@@ -355,8 +342,6 @@ int vmufs_file_write(maple_device_t * dev, vmu_root_t * root, uint16 * fat,
                fn, dev->port + 'A', dev->unit + '0');
         return -4;
     }
-
-    out = (uint8 *)filebuf;
 
     /* Don't even start if there isn't enough room to write the whole file */
     vmuspaceleft = vmufs_fat_free(root, fat);
@@ -378,7 +363,7 @@ int vmufs_file_write(maple_device_t * dev, vmu_root_t * root, uint16 * fat,
     /* While we've got stuff remaining... */
     while(blkleft > 0) {
         /* Write the block */
-        rv = vmu_block_write(dev, curblk, (uint8 *)out);
+        rv = vmu_block_write(dev, curblk, out);
 
         if(rv != 0) {
             dbglog(DBG_ERROR, "vmufs_file_write: can't write block %d on device %c%c (error %d)\n",
@@ -422,12 +407,11 @@ int vmufs_file_write(maple_device_t * dev, vmu_root_t * root, uint16 * fat,
     return 0;
 }
 
-int vmufs_file_delete(vmu_root_t * root, uint16 * fat, vmu_dir_t * dir, const char * fn) {
-    int idx;
+int vmufs_file_delete(vmu_root_t *root, uint16_t *fat, vmu_dir_t *dir, const char *fn) {
     int blk, nextblk;
 
     /* Find the file */
-    idx = vmufs_dir_find(root, dir, fn);
+    int idx = vmufs_dir_find(root, dir, fn);
 
     if(idx < 0) {
         dbglog(DBG_ERROR, "vmufs_file_delete: can't find file '%s'\n", fn);
@@ -461,12 +445,11 @@ int vmufs_file_delete(vmu_root_t * root, uint16 * fat, vmu_dir_t * dir, const ch
 }
 
 /* hee hee :) */
-int vmufs_fat_free(vmu_root_t * root, uint16 * fat) {
-    int i, freeblocks;
+int vmufs_fat_free(vmu_root_t *root, uint16_t *fat) {
+    int freeblocks = 0;
 
-    freeblocks = 0;
-
-    for(i = 0; i < root->blk_cnt; i++) { /* only count user blocks */
+    for(size_t i = 0; i < root->blk_cnt; i++) {
+        /* only count user blocks */
         if(fat[i] == 0xfffc)
             freeblocks++;
     }
@@ -474,13 +457,10 @@ int vmufs_fat_free(vmu_root_t * root, uint16 * fat) {
     return freeblocks;
 }
 
-int vmufs_dir_free(vmu_root_t * root, vmu_dir_t * dir) {
-    unsigned int i;
-    int freeblocks;
+int vmufs_dir_free(vmu_root_t *root, vmu_dir_t *dir) {
+    int freeblocks = 0;
 
-    freeblocks = 0;
-
-    for(i = 0; i < root->dir_size * 512 / sizeof(vmu_dir_t); i++) {
+    for(size_t i = 0; i < root->dir_size * 512 / sizeof(vmu_dir_t); i++) {
         if(dir[i].filetype == 0)
             freeblocks++;
     }
@@ -499,8 +479,8 @@ int vmufs_mutex_unlock(void) {
 /* ****************** Higher level functions ******************** */
 
 /* Internal function gets everything setup for you */
-static int vmufs_setup(maple_device_t * dev, vmu_root_t * root, vmu_dir_t ** dir, int * dirsize,
-                       uint16 ** fat, int * fatsize) {
+static int vmufs_setup(maple_device_t *dev, vmu_root_t *root, vmu_dir_t **dir, int *dirsize,
+                       uint16_t **fat, int *fatsize) {
     /* Check to make sure this is a valid device right now */
     if(!dev || !(dev->info.functions & MAPLE_FUNC_MEMCARD)) {
         if(!dev)
@@ -543,7 +523,7 @@ static int vmufs_setup(maple_device_t * dev, vmu_root_t * root, vmu_dir_t ** dir
     if(fat) {
         /* Alloc enough space for the fat */
         *fatsize = vmufs_fat_blocks(root);
-        *fat = (uint16 *)malloc(*fatsize);
+        *fat = (uint16_t *)malloc(*fatsize);
 
         if(!*fat) {
             dbglog(DBG_ERROR, "vmufs_setup: can't alloc %d bytes for FAT on device %c%c\n",
@@ -571,7 +551,7 @@ dead:
 }
 
 /* Internal function to tear everything down for you */
-static void vmufs_teardown(vmu_dir_t * dir, uint16 * fat) {
+static void vmufs_teardown(vmu_dir_t *dir, uint16_t *fat) {
     if(dir)
         free(dir);
 
@@ -581,11 +561,10 @@ static void vmufs_teardown(vmu_dir_t * dir, uint16 * fat) {
     vmufs_mutex_unlock();
 }
 
-int vmufs_readdir(maple_device_t * dev, vmu_dir_t ** outbuf, int * outcnt) {
+int vmufs_readdir(maple_device_t *dev, vmu_dir_t **outbuf, int *outcnt) {
     vmu_root_t root;
     vmu_dir_t *dir;
-    int dircnt, dirsize, rv = 0;
-    unsigned int i, j;
+    int dircnt = 0, dirsize, rv = 0;
 
     *outbuf = NULL;
     *outcnt = 0;
@@ -595,16 +574,14 @@ int vmufs_readdir(maple_device_t * dev, vmu_dir_t ** outbuf, int * outcnt) {
         return -1;
 
     /* Go through and move all entries to the lowest-numbered spots. */
-    dircnt = 0;
-
-    for(i = 0; i < dirsize / sizeof(vmu_dir_t); i++) {
+    for(size_t i = 0; i < dirsize / sizeof(vmu_dir_t); i++) {
         /* Skip blanks */
         if(dir[i].filetype == 0)
             continue;
 
         /* Not a blank -- look for an earlier slot that's empty. If
            we don't find one, just leave it alone. */
-        for(j = 0; j < i; j++) {
+        for(size_t j = 0; j < i; j++) {
             if(dir[j].filetype == 0) {
                 memcpy(dir + j, dir + i, sizeof(vmu_dir_t));
                 dir[i].filetype = 0;
@@ -634,7 +611,7 @@ ex:
 }
 
 /* Shared code between read/read_dirent */
-static int vmufs_read_common(maple_device_t * dev, vmu_dir_t * dirent, uint16 * fat, void ** outbuf, int * outsize) {
+static int vmufs_read_common(maple_device_t *dev, vmu_dir_t *dirent, uint16_t *fat, void **outbuf, int *outsize) {
     /* Allocate the output space */
     *outsize = dirent->filesize * 512;
     *outbuf = malloc(*outsize);
@@ -656,10 +633,10 @@ static int vmufs_read_common(maple_device_t * dev, vmu_dir_t * dirent, uint16 * 
     return 0;
 }
 
-int vmufs_read(maple_device_t * dev, const char * fn, void ** outbuf, int * outsize) {
+int vmufs_read(maple_device_t *dev, const char *fn, void **outbuf, int *outsize) {
     vmu_root_t  root;
-    vmu_dir_t   * dir = NULL;
-    uint16      * fat = NULL;
+    vmu_dir_t   *dir = NULL;
+    uint16_t    *fat = NULL;
     int     fatsize, dirsize, idx, rv = 0;
 
     *outbuf = NULL;
@@ -689,9 +666,9 @@ ex:
     return rv;
 }
 
-int vmufs_read_dirent(maple_device_t * dev, vmu_dir_t * dirent, void ** outbuf, int * outsize) {
+int vmufs_read_dirent(maple_device_t *dev, vmu_dir_t *dirent, void **outbuf, int *outsize) {
     vmu_root_t  root;
-    uint16      * fat = NULL;
+    uint16_t      *fat = NULL;
     int     fatsize, rv = 0;
 
     *outbuf = NULL;
@@ -709,10 +686,10 @@ int vmufs_read_dirent(maple_device_t * dev, vmu_dir_t * dirent, void ** outbuf, 
 }
 
 /* Returns 0 for success, -7 for 'not enough space', and other values for other errors. :-)  */
-int vmufs_write(maple_device_t * dev, const char * fn, void * inbuf, int insize, int flags) {
+int vmufs_write(maple_device_t *dev, const char *fn, void *inbuf, int insize, int flags) {
     vmu_root_t  root;
-    vmu_dir_t   * dir = NULL, nd;
-    uint16      * fat = NULL;
+    vmu_dir_t   *dir = NULL, nd;
+    uint16_t    *fat = NULL;
     int     oldinsize, fatsize, dirsize, idx, rv = 0, st, fnlength;
 
     /* Round up the size if necessary */
@@ -801,10 +778,10 @@ ex:
     return rv;
 }
 
-int vmufs_delete(maple_device_t * dev, const char * fn) {
+int vmufs_delete(maple_device_t *dev, const char *fn) {
     vmu_root_t  root;
-    vmu_dir_t   * dir = NULL;
-    uint16      * fat = NULL;
+    vmu_dir_t   *dir = NULL;
+    uint16_t    *fat = NULL;
     int     fatsize, dirsize, rv = 0;
 
     /* Init everything */
@@ -838,10 +815,10 @@ ex:
     return rv;
 }
 
-int vmufs_free_blocks(maple_device_t * dev) {
+int vmufs_free_blocks(maple_device_t *dev) {
     vmu_root_t  root;
-    uint16      * fat = NULL;
-    int     fatsize, rv = 0;
+    uint16_t      *fat = NULL;
+    int     fatsize, rv;
 
     /* Init everything */
     if(vmufs_setup(dev, &root, NULL, NULL, &fat, &fatsize) < 0)
@@ -852,9 +829,6 @@ int vmufs_free_blocks(maple_device_t * dev) {
     vmufs_teardown(NULL, fat);
     return rv;
 }
-
-
-
 
 int vmufs_init(void) {
     mutex_init(&mutex, MUTEX_TYPE_NORMAL);

--- a/kernel/arch/dreamcast/include/dc/vmufs.h
+++ b/kernel/arch/dreamcast/include/dc/vmufs.h
@@ -25,6 +25,7 @@
 #ifndef __DC_VMUFS_H
 #define __DC_VMUFS_H
 
+#include <stdint.h>
 #include <kos/cdefs.h>
 __BEGIN_DECLS
 
@@ -38,49 +39,49 @@ __BEGIN_DECLS
     \headerfile dc/vmufs.h
 */
 typedef struct {
-    uint8   cent;   /**< \brief Century */
-    uint8   year;   /**< \brief Year, within century */
-    uint8   month;  /**< \brief Month of the year */
-    uint8   day;    /**< \brief Day of the month */
-    uint8   hour;   /**< \brief Hour of the day */
-    uint8   min;    /**< \brief Minutes */
-    uint8   sec;    /**< \brief Seconds */
-    uint8   dow;    /**< \brief Day of week (0 = monday, etc) */
+    uint8_t cent;   /**< \brief Century */
+    uint8_t year;   /**< \brief Year, within century */
+    uint8_t month;  /**< \brief Month of the year */
+    uint8_t day;    /**< \brief Day of the month */
+    uint8_t hour;   /**< \brief Hour of the day */
+    uint8_t min;    /**< \brief Minutes */
+    uint8_t sec;    /**< \brief Seconds */
+    uint8_t dow;    /**< \brief Day of week (0 = monday, etc) */
 } vmu_timestamp_t;
 
 /** \brief  VMU FS Root block layout.
     \headerfile dc/vmufs.h
 */
 typedef struct {
-    uint8           magic[16];      /**< \brief All should contain 0x55 */
-    uint8           use_custom;     /**< \brief 0 = standard, 1 = custom */
-    uint8           custom_color[4];/**< \brief blue, green, red, alpha */
-    uint8           pad1[27];       /**< \brief All zeros */
+    uint8_t         magic[16];      /**< \brief All should contain 0x55 */
+    uint8_t         use_custom;     /**< \brief 0 = standard, 1 = custom */
+    uint8_t         custom_color[4];/**< \brief blue, green, red, alpha */
+    uint8_t         pad1[27];       /**< \brief All zeros */
     vmu_timestamp_t timestamp;      /**< \brief BCD timestamp */
-    uint8           pad2[8];        /**< \brief All zeros */
-    uint8           unk1[6];        /**< \brief ??? */
-    uint16          fat_loc;        /**< \brief FAT location */
-    uint16          fat_size;       /**< \brief FAT size in blocks */
-    uint16          dir_loc;        /**< \brief Directory location */
-    uint16          dir_size;       /**< \brief Directory size in blocks */
-    uint16          icon_shape;     /**< \brief Icon shape for this VMS */
-    uint16          blk_cnt;        /**< \brief Number of user blocks */
-    uint8           unk2[430];      /**< \brief ??? */
+    uint8_t         pad2[8];        /**< \brief All zeros */
+    uint8_t         unk1[6];        /**< \brief ??? */
+    uint16_t        fat_loc;        /**< \brief FAT location */
+    uint16_t        fat_size;       /**< \brief FAT size in blocks */
+    uint16_t        dir_loc;        /**< \brief Directory location */
+    uint16_t        dir_size;       /**< \brief Directory size in blocks */
+    uint16_t        icon_shape;     /**< \brief Icon shape for this VMS */
+    uint16_t        blk_cnt;        /**< \brief Number of user blocks */
+    uint8_t         unk2[430];      /**< \brief ??? */
 } vmu_root_t;
 
 /** \brief  VMU FS Directory entries, 32 bytes each.
     \headerfile dc/vmufs.h
 */
 typedef struct {
-    uint8           filetype;       /**< \brief 0x00 = no file; 0x33 = data; 0xcc = a game */
-    uint8           copyprotect;    /**< \brief 0x00 = copyable; 0xff = copy protected */
-    uint16          firstblk;       /**< \brief Location of the first block in the file */
+    uint8_t         filetype;       /**< \brief 0x00 = no file; 0x33 = data; 0xcc = a game */
+    uint8_t         copyprotect;    /**< \brief 0x00 = copyable; 0xff = copy protected */
+    uint16_t        firstblk;       /**< \brief Location of the first block in the file */
     char            filename[12];   /**< \brief Note: there is no null terminator */
     vmu_timestamp_t timestamp;      /**< \brief File time */
-    uint16          filesize;       /**< \brief Size of the file in blocks */
-    uint16          hdroff;         /**< \brief Offset of header, in blocks from start of file */
-    uint8           dirty;          /**< \brief See header notes */
-    uint8           pad1[3];        /**< \brief All zeros */
+    uint16_t        filesize;       /**< \brief Size of the file in blocks */
+    uint16_t        hdroff;         /**< \brief Offset of header, in blocks from start of file */
+    uint8_t         dirty;          /**< \brief See header notes */
+    uint8_t         pad1[3];        /**< \brief All zeros */
 } vmu_dir_t;
 
 /* Notes about the "dirty" field on vmu_dir_t :)
@@ -115,7 +116,7 @@ void vmufs_dir_fill_time(vmu_dir_t *d);
     \retval -1              On failure.
     \retval 0               On success.
 */
-int vmufs_root_read(maple_device_t * dev, vmu_root_t * root_buf);
+int vmufs_root_read(maple_device_t *dev, vmu_root_t *root_buf);
 
 /** \brief  Writes a selected VMU's root block.
 
@@ -126,7 +127,7 @@ int vmufs_root_read(maple_device_t * dev, vmu_root_t * root_buf);
     \retval -1              On failure.
     \retval 0               On success.
 */
-int vmufs_root_write(maple_device_t * dev, vmu_root_t * root_buf);
+int vmufs_root_write(maple_device_t *dev, vmu_root_t *root_buf);
 
 /** \brief  Given a VMU's root block, return the amount of space in bytes
             required to hold its directory.
@@ -134,7 +135,7 @@ int vmufs_root_write(maple_device_t * dev, vmu_root_t * root_buf);
     \param  root_buf        The root block to check.
     \return                 The amount of space, in bytes, needed.
 */
-int vmufs_dir_blocks(vmu_root_t * root_buf);
+int vmufs_dir_blocks(vmu_root_t *root_buf);
 
 /** \brief  Given a VMU's root block, return the amount of space in bytes
             required to hold its FAT.
@@ -142,7 +143,7 @@ int vmufs_dir_blocks(vmu_root_t * root_buf);
     \param  root_buf        The root block to check.
     \return                 The amount of space, in bytes, needed.
 */
-int vmufs_fat_blocks(vmu_root_t * root_buf);
+int vmufs_fat_blocks(vmu_root_t *root_buf);
 
 /** \brief  Given a selected VMU's root block, read its directory.
 
@@ -156,8 +157,8 @@ int vmufs_fat_blocks(vmu_root_t * root_buf);
                             allocated this yourself.
     \return                 0 on success, <0 on failure.
 */
-int vmufs_dir_read(maple_device_t * dev, vmu_root_t * root_buf,
-                   vmu_dir_t * dir_buf);
+int vmufs_dir_read(maple_device_t *dev, vmu_root_t *root_buf,
+                   vmu_dir_t *dir_buf);
 
 /** \brief  Given a selected VMU's root block and dir blocks, write the dirty
             dir blocks back to the VMU. Assumes the mutex is held.
@@ -167,8 +168,8 @@ int vmufs_dir_read(maple_device_t * dev, vmu_root_t * root_buf,
     \param  dir_buf         The VMU's directory structure.
     \return                 0 on success, <0 on failure.
 */
-int vmufs_dir_write(maple_device_t * dev, vmu_root_t * root,
-                    vmu_dir_t * dir_buf);
+int vmufs_dir_write(maple_device_t *dev, vmu_root_t *root,
+                    vmu_dir_t *dir_buf);
 
 /** \brief Given a selected VMU's root block, read its FAT.
 
@@ -182,7 +183,7 @@ int vmufs_dir_write(maple_device_t * dev, vmu_root_t * root,
                             pre-allocate this.
     \return                 0 on success, <0 on failure.
 */
-int vmufs_fat_read(maple_device_t * dev, vmu_root_t * root, uint16 * fat_buf);
+int vmufs_fat_read(maple_device_t *dev, vmu_root_t *root, uint16_t *fat_buf);
 
 /** \brief  Given a selected VMU's root block and its FAT, write the FAT blocks
             back to the VMU.
@@ -194,7 +195,7 @@ int vmufs_fat_read(maple_device_t * dev, vmu_root_t * root, uint16 * fat_buf);
     \param  fat_buf         The buffer to write to the FAT.
     \return                 0 on success, <0 on failure.
 */
-int vmufs_fat_write(maple_device_t * dev, vmu_root_t * root, uint16 * fat_buf);
+int vmufs_fat_write(maple_device_t *dev, vmu_root_t *root, uint16_t *fat_buf);
 
 /** \brief  Given a previously-read directory, locate a file by filename.
 
@@ -204,7 +205,7 @@ int vmufs_fat_write(maple_device_t * dev, vmu_root_t * root, uint16 * fat_buf);
     \return                 The index into the directory array on success, or
                             <0 on failure.
 */
-int vmufs_dir_find(vmu_root_t * root, vmu_dir_t * dir, const char * fn);
+int vmufs_dir_find(vmu_root_t *root, vmu_dir_t *dir, const char *fn);
 
 /** \brief  Given a previously-read directory, add a new dirent to the dir.
 
@@ -215,7 +216,7 @@ int vmufs_dir_find(vmu_root_t * root, vmu_dir_t * dir, const char * fn);
     \param  dir             The VMU directory.
     \param  newdirent       The new entry to add.
     \return                 0 on success, or <0 on failure. */
-int vmufs_dir_add(vmu_root_t * root, vmu_dir_t * dir, vmu_dir_t * newdirent);
+int vmufs_dir_add(vmu_root_t *root, vmu_dir_t *dir, vmu_dir_t *newdirent);
 
 /** \brief  Given a pointer to a directory struct and a previously loaded FAT,
             load the indicated file from the VMU.
@@ -230,7 +231,7 @@ int vmufs_dir_add(vmu_root_t * root, vmu_dir_t * dir, vmu_dir_t * newdirent);
                             this yourself with the appropriate amount of space.
     \return                 0 on success, <0 on failure.
 */
-int vmufs_file_read(maple_device_t * dev, uint16 * fat, vmu_dir_t * dirent, void * outbuf);
+int vmufs_file_read(maple_device_t *dev, uint16_t *fat, vmu_dir_t *dirent, void *outbuf);
 
 /** \brief  Given a pointer to a mostly-filled directory struct and a previously
             loaded directory and FAT, write the indicated file to the VMU.
@@ -248,8 +249,8 @@ int vmufs_file_read(maple_device_t * dev, uint16 * fat, vmu_dir_t * dirent, void
     \param  size            The size of the file in blocks (512-bytes each).
     \return                 0 on success, <0 on failure.
 */
-int vmufs_file_write(maple_device_t * dev, vmu_root_t * root, uint16 * fat,
-                     vmu_dir_t * dir, vmu_dir_t * newdirent, void * filebuf, int size);
+int vmufs_file_write(maple_device_t *dev, vmu_root_t *root, uint16_t *fat,
+                     vmu_dir_t *dir, vmu_dir_t *newdirent, void *filebuf, int size);
 
 /** \brief  Given a previously-read FAT and directory, delete the named file.
 
@@ -262,7 +263,7 @@ int vmufs_file_write(maple_device_t * dev, vmu_root_t * root, uint16 * fat,
     \retval 0               On success.
     \retval -1              If fn is not found.
 */
-int vmufs_file_delete(vmu_root_t * root, uint16 * fat, vmu_dir_t * dir, const char *fn);
+int vmufs_file_delete(vmu_root_t *root, uint16_t *fat, vmu_dir_t *dir, const char *fn);
 
 /** \brief  Given a previously-read FAT, return the number of blocks available
             to write out new file data.
@@ -271,7 +272,7 @@ int vmufs_file_delete(vmu_root_t * root, uint16 * fat, vmu_dir_t * dir, const ch
     \param  fat             The FAT to be examined.
     \return                 The number of blocks available.
 */
-int vmufs_fat_free(vmu_root_t * root, uint16 * fat);
+int vmufs_fat_free(vmu_root_t *root, uint16_t *fat);
 
 /** \brief  Given a previously-read directory, return the number of dirents
             available for new files.
@@ -280,7 +281,7 @@ int vmufs_fat_free(vmu_root_t * root, uint16 * fat);
     \param  dir             The directory in question.
     \return                 The number of entries available.
 */
-int vmufs_dir_free(vmu_root_t * root, vmu_dir_t * dir);
+int vmufs_dir_free(vmu_root_t *root, vmu_dir_t *dir);
 
 /** \brief  Lock the vmufs mutex.
 
@@ -312,7 +313,7 @@ int vmufs_mutex_unlock(void);
                             data will be placed.
     \param  outcnt          The number of entries in outbuf.
     \return                 0 on success, or <0 on failure. */
-int vmufs_readdir(maple_device_t * dev, vmu_dir_t ** outbuf, int * outcnt);
+int vmufs_readdir(maple_device_t *dev, vmu_dir_t **outbuf, int *outcnt);
 
 /** \brief  Read a file from the VMU.
 
@@ -327,7 +328,7 @@ int vmufs_readdir(maple_device_t * dev, vmu_dir_t ** outbuf, int * outcnt);
     \param  outsize         Storage for the size of the file, in bytes.
     \return                 0 on success, or <0 on failure.
 */
-int vmufs_read(maple_device_t * dev, const char * fn, void ** outbuf, int * outsize);
+int vmufs_read(maple_device_t *dev, const char *fn, void **outbuf, int *outsize);
 
 /** \brief  Read a file from the VMU, using a pre-read dirent.
 
@@ -341,7 +342,7 @@ int vmufs_read(maple_device_t * dev, const char * fn, void ** outbuf, int * outs
     \param  outsize         Storage for the size of the file, in bytes.
     \return                 0 on success, <0 on failure.
 */
-int vmufs_read_dirent(maple_device_t * dev, vmu_dir_t * dirent, void ** outbuf, int * outsize);
+int vmufs_read_dirent(maple_device_t *dev, vmu_dir_t *dirent, void **outbuf, int *outsize);
 
 /* Flags for vmufs_write */
 #define VMUFS_OVERWRITE 1   /**< \brief Overwrite existing files */
@@ -363,7 +364,7 @@ int vmufs_read_dirent(maple_device_t * dev, vmu_dir_t * dirent, void ** outbuf, 
                             VMUFS_VMUGAME, VMUFS_NOCOPY).
     \return                 0 on success, or <0 for failure.
 */
-int vmufs_write(maple_device_t * dev, const char * fn, void * inbuf, int insize, int flags);
+int vmufs_write(maple_device_t *dev, const char *fn, void *inbuf, int insize, int flags);
 
 /** \brief  Delete a file from the VMU.
 
@@ -371,7 +372,7 @@ int vmufs_write(maple_device_t * dev, const char * fn, void * inbuf, int insize,
     \retval -1              If the file is not found.
     \retval -2              On other failure.
 */
-int vmufs_delete(maple_device_t * dev, const char * fn);
+int vmufs_delete(maple_device_t *dev, const char *fn);
 
 /** \brief  Return the number of user blocks free for file writing.
 
@@ -379,7 +380,7 @@ int vmufs_delete(maple_device_t * dev, const char * fn);
 
     \return                 The number of blocks free for writing.
 */
-int vmufs_free_blocks(maple_device_t * dev);
+int vmufs_free_blocks(maple_device_t *dev);
 
 
 /** \brief  Initialize vmufs.

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -51,12 +51,12 @@ void arch_real_exit(int ret_code) __noreturn;
 void (*__kos_init_early_fn)(void) __attribute__((weak,section(".data"))) = NULL;
 
 int main(int argc, char **argv);
-uint32 _fs_dclsocket_get_ip(void);
+uint32_t _fs_dclsocket_get_ip(void);
 
 void arch_init_net_dcload_ip(void) {
     union {
-        uint32 ipl;
-        uint8 ipb[4];
+        uint32_t ipl;
+        uint8_t ipb[4];
     } ip = { 0 };
 
     if(dcload_type == DCLOAD_TYPE_IP) {

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -13,7 +13,6 @@
 #include <assert.h>
 #include <stdio.h>
 #include <arch/arch.h>
-#include <arch/types.h>
 #include <arch/stack.h>
 #include <kos/dbgio.h>
 #include <kos/dbglog.h>

--- a/kernel/net/net_dhcp.c
+++ b/kernel/net/net_dhcp.c
@@ -281,7 +281,7 @@ static int do_net_dhcp_request(uint32_t required_address, bool in_wq) {
     return rv;
 }
 
-int net_dhcp_request(uint32 required_address) {
+int net_dhcp_request(uint32_t required_address) {
     return do_net_dhcp_request(required_address, false);
 }
 


### PR DESCRIPTION
Along the way also did some whitespace and minor code cleanup (replaced one mutex lock/unlock with a lock_scoped, and collapsed a few variable declarations with their assignments).

With this the only usages of `arch/types.h` types are in some kos-ports which still need cleaning up, then a final PR can be put in to stop including the header anywhere and drop it entirely. Tagging #840 for reference.