### PR TITLE
dc: Add scif_spi_write_data() and speed up SPI transfers

### DIFF
--- a/kernel/arch/dreamcast/exports.txt
+++ b/kernel/arch/dreamcast/exports.txt
@@ -49,6 +49,7 @@ scif_spi_set_cs
 scif_spi_rw_byte
 scif_spi_slow_rw_byte
 scif_spi_write_byte
+scif_spi_write_data
 scif_spi_read_byte
 scif_spi_read_data
 

--- a/kernel/arch/dreamcast/hardware/network/w5500_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/w5500_adapter.c
@@ -105,9 +105,7 @@ static int scif_read_data_wrapper(uint8_t *data, size_t len) {
 }
 
 static int scif_write_data_wrapper(const uint8_t *data, size_t len) {
-    while(len--) {
-        scif_spi_write_byte(*data++);
-    }
+    scif_spi_write_data(data, len);
     return 0;
 }
 
@@ -489,7 +487,7 @@ static int w5500_tx(const uint8_t *pkt, int len, int blocking) {
     fsr = w5500_read_reg16_safe(W5500_S0_REG_BLOCK, Sn_TX_FSR);
     if(fsr < len) {
         dbglog(DBG_ERROR, "w5500: TX buffer full\n");
-        return -1; 
+        return -1;
     }
 
     /* Write Data */
@@ -630,7 +628,7 @@ static int w5500_if_init(netif_t *self) {
 static int w5500_if_start(netif_t *self) {
     if(!(self->flags & NETIF_INITIALIZED))
         return -1;
-        
+
     if(self->flags & NETIF_RUNNING)
         return 0;
 

--- a/kernel/arch/dreamcast/hardware/scif-spi.c
+++ b/kernel/arch/dreamcast/hardware/scif-spi.c
@@ -324,14 +324,18 @@ void scif_spi_read_data(uint8_t *buffer, size_t len) {
     uint32_t data;
     uint32_t *ptr;
 
-    /* Less optimized version for unaligned buffers or lengths not divisible by
-       four. */
-    if((((uint32_t)buffer) & 0x03) || (len & 0x03)) {
+    /* Not worth the alignment/setup overhead for short reads. */
+    if(len < 16) {
         while(len--) {
             *buffer++ = scif_spi_read_byte();
         }
-
         return;
+    }
+
+    /* Read single bytes until the buffer is 4-byte aligned. */
+    while(((uint32_t)buffer) & 0x03) {
+        *buffer++ = scif_spi_read_byte();
+        --len;
     }
 
     b = 0xff;
@@ -339,7 +343,7 @@ void scif_spi_read_data(uint8_t *buffer, size_t len) {
     ptr = (uint32_t *)buffer;
     SCSPTR2 = tmp;
 
-    for(; len > 0; len -= 4) {
+    for(; len >= 4; len -= 4) {
         SCSPTR2 = tmp | PTR2_CTSDT;
         b = (b << 1) | (SCSPTR2 & PTR2_SPB2DT);   /* 7 */
         SCSPTR2 = tmp;
@@ -443,6 +447,13 @@ void scif_spi_read_data(uint8_t *buffer, size_t len) {
         b = (b << 1) | (SCSPTR2 & PTR2_SPB2DT);   /* 0 */
         SCSPTR2 = tmp;
         data |= b << 24;
+
         *ptr++ = data;
+    }
+
+    /* Read any leftover bytes. */
+    buffer = (uint8_t *)ptr;
+    while(len--) {
+        *buffer++ = scif_spi_read_byte();
     }
 }

--- a/kernel/arch/dreamcast/hardware/scif-spi.c
+++ b/kernel/arch/dreamcast/hardware/scif-spi.c
@@ -169,7 +169,7 @@ void scif_spi_write_byte(uint8_t b) {
 
 void scif_spi_write_data(const uint8_t *buffer, size_t len) {
     uint16_t tmp;
-    uint8_t bit;
+    uint32_t bit;
     uint32_t data;
     const uint32_t *ptr;
 
@@ -192,75 +192,15 @@ void scif_spi_write_data(const uint8_t *buffer, size_t len) {
     SCSPTR2 = tmp;
 
     for(; len >= 4; len -= 4) {
-        data = *ptr++;
+        /* Swap so the MSB-first loop sends the lowest-address byte first. */
+        data = __builtin_bswap32(*ptr++);
 
-        SCSPTR2 = tmp | (bit = (data >> 7) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 6) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 5) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 4) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 3) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 2) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 1) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 0) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-
-        SCSPTR2 = tmp | (bit = (data >> 15) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 14) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 13) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 12) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 11) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 10) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 9) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 8) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-
-        SCSPTR2 = tmp | (bit = (data >> 23) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 22) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 21) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 20) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 19) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 18) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 17) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 16) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-
-        SCSPTR2 = tmp | (bit = (data >> 31) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 30) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 29) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 28) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 27) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 26) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 25) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
-        SCSPTR2 = tmp | (bit = (data >> 24) & 0x01);
-        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        for(uint32_t i = 0; i < 32; i++) {
+            bit = data >> 31;
+            SCSPTR2 = tmp | bit;
+            SCSPTR2 = tmp | bit | PTR2_CTSDT;
+            data <<= 1;
+        }
 
         SCSPTR2 = tmp;
     }

--- a/kernel/arch/dreamcast/hardware/scif-spi.c
+++ b/kernel/arch/dreamcast/hardware/scif-spi.c
@@ -162,28 +162,20 @@ void scif_spi_write_byte(uint8_t b) {
        CTS, otherwise it doesn't work -- that's why this looks so ugly... */
     SCSPTR2 = tmp | (bit = (b >> 7) & 0x01);
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
-    SD_WAIT();
     SCSPTR2 = tmp | (bit = (b >> 6) & 0x01);
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
-    SD_WAIT();
     SCSPTR2 = tmp | (bit = (b >> 5) & 0x01);
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
-    SD_WAIT();
     SCSPTR2 = tmp | (bit = (b >> 4) & 0x01);
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
-    SD_WAIT();
     SCSPTR2 = tmp | (bit = (b >> 3) & 0x01);
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
-    SD_WAIT();
     SCSPTR2 = tmp | (bit = (b >> 2) & 0x01);
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
-    SD_WAIT();
     SCSPTR2 = tmp | (bit = (b >> 1) & 0x01);
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
-    SD_WAIT();
     SCSPTR2 = tmp | (bit = (b >> 0) & 0x01);
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
-    SD_WAIT();
     SCSPTR2 = tmp;
 }
 

--- a/kernel/arch/dreamcast/hardware/scif-spi.c
+++ b/kernel/arch/dreamcast/hardware/scif-spi.c
@@ -34,10 +34,6 @@
 #define PTR2_SPB2IO BIT(1)
 #define PTR2_SPB2DT BIT(0)
 
-/* This doesn't seem to actually be necessary on any of the SD cards I've tried,
-   but I'm keeping it around, just in case... */
-#define SD_WAIT() __asm__("nop\n\tnop\n\tnop\n\tnop\n\tnop")
-
 static uint16_t scsptr2 = 0;
 static int initialized = 0;
 
@@ -96,35 +92,27 @@ uint8_t scif_spi_rw_byte(uint8_t b) {
        For some reason, we have to have the bit set on the Tx line before we set
        CTS, otherwise it doesn't work -- that's why this looks so ugly... */
     SCSPTR2 = tmp | (bit = (b >> 7) & 0x01);    /* write 7 */
-    SD_WAIT();
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
     rv = SCSPTR2 & PTR2_SPB2DT;                 /* read 7 */
     SCSPTR2 = tmp | (bit = (b >> 6) & 0x01);    /* write 6 */
-    SD_WAIT();
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
     rv = (rv << 1) | (SCSPTR2 & PTR2_SPB2DT);   /* read 6 */
     SCSPTR2 = tmp | (bit = (b >> 5) & 0x01);    /* write 5 */
-    SD_WAIT();
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
     rv = (rv << 1) | (SCSPTR2 & PTR2_SPB2DT);   /* read 5 */
     SCSPTR2 = tmp | (bit = (b >> 4) & 0x01);    /* write 4 */
-    SD_WAIT();
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
     rv = (rv << 1) | (SCSPTR2 & PTR2_SPB2DT);   /* read 4 */
     SCSPTR2 = tmp | (bit = (b >> 3) & 0x01);    /* write 3 */
-    SD_WAIT();
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
     rv = (rv << 1) | (SCSPTR2 & PTR2_SPB2DT);   /* read 3 */
     SCSPTR2 = tmp | (bit = (b >> 2) & 0x01);    /* write 2 */
-    SD_WAIT();
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
     rv = (rv << 1) | (SCSPTR2 & PTR2_SPB2DT);   /* read 2 */
     SCSPTR2 = tmp | (bit = (b >> 1) & 0x01);    /* write 1 */
-    SD_WAIT();
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
     rv = (rv << 1) | (SCSPTR2 & PTR2_SPB2DT);   /* read 1 */
     SCSPTR2 = tmp | (bit = (b >> 0) & 0x01);    /* write 0 */
-    SD_WAIT();
     SCSPTR2 = tmp | bit | PTR2_CTSDT;
     rv = (rv << 1) | (SCSPTR2 & PTR2_SPB2DT);   /* read 0 */
 

--- a/kernel/arch/dreamcast/hardware/scif-spi.c
+++ b/kernel/arch/dreamcast/hardware/scif-spi.c
@@ -187,6 +187,111 @@ void scif_spi_write_byte(uint8_t b) {
     SCSPTR2 = tmp;
 }
 
+void scif_spi_write_data(const uint8_t *buffer, size_t len) {
+    uint16_t tmp;
+    uint8_t bit;
+    uint32_t data;
+    const uint32_t *ptr;
+
+    /* Not worth the alignment/setup overhead for short writes. */
+    if(len < 16) {
+        while(len--) {
+            scif_spi_write_byte(*buffer++);
+        }
+        return;
+    }
+
+    /* Write single bytes until the buffer is 4-byte aligned. */
+    while(((uint32_t)buffer) & 0x03) {
+        scif_spi_write_byte(*buffer++);
+        --len;
+    }
+
+    tmp = scsptr2 & ~PTR2_CTSDT & ~PTR2_SPB2DT;
+    ptr = (const uint32_t *)buffer;
+    SCSPTR2 = tmp;
+
+    for(; len >= 4; len -= 4) {
+        data = *ptr++;
+
+        SCSPTR2 = tmp | (bit = (data >> 7) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 6) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 5) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 4) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 3) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 2) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 1) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 0) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+
+        SCSPTR2 = tmp | (bit = (data >> 15) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 14) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 13) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 12) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 11) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 10) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 9) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 8) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+
+        SCSPTR2 = tmp | (bit = (data >> 23) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 22) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 21) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 20) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 19) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 18) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 17) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 16) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+
+        SCSPTR2 = tmp | (bit = (data >> 31) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 30) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 29) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 28) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 27) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 26) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 25) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+        SCSPTR2 = tmp | (bit = (data >> 24) & 0x01);
+        SCSPTR2 = tmp | bit | PTR2_CTSDT;
+
+        SCSPTR2 = tmp;
+    }
+
+    /* Write any leftover bytes. */
+    buffer = (const uint8_t *)ptr;
+    while(len--) {
+        scif_spi_write_byte(*buffer++);
+    }
+}
+
 uint8_t scif_spi_read_byte(void) {
     uint8_t b = 0xff;
     uint16_t tmp = (scsptr2 & ~PTR2_CTSDT) | PTR2_SPB2DT;

--- a/kernel/arch/dreamcast/hardware/sd.c
+++ b/kernel/arch/dreamcast/hardware/sd.c
@@ -131,9 +131,7 @@ static int scif_read_data_wrapper(uint8_t *data, size_t len) {
 }
 
 static int scif_write_data_wrapper(const uint8_t *data, size_t len) {
-    while(len--) {
-        scif_spi_write_byte(*data++);
-    }
+    scif_spi_write_data(data, len);
     return 0;
 }
 

--- a/kernel/arch/dreamcast/hardware/sd.c
+++ b/kernel/arch/dreamcast/hardware/sd.c
@@ -116,10 +116,10 @@ static uint8_t sci_rw_byte(uint8_t data) {
     return rx;
 }
 
-static bool current_speed = false; /* false = slow, true = fast */
+static bool fast_mode = false; /* false = slow, true = fast */
 
 static uint8_t scif_rw_byte_wrapper(uint8_t data) {
-    if(current_speed)
+    if(fast_mode)
         return scif_spi_rw_byte(data);
     else
         return scif_spi_slow_rw_byte(data);
@@ -168,7 +168,7 @@ static void sci_shutdown_wrapper(void) {
 }
 
 static int scif_init_wrapper(bool fast) {
-    current_speed = fast;
+    fast_mode = fast;
     return scif_spi_init();
 }
 

--- a/kernel/arch/dreamcast/include/dc/scif.h
+++ b/kernel/arch/dreamcast/include/dc/scif.h
@@ -193,6 +193,17 @@ uint8_t scif_spi_slow_rw_byte(uint8_t b);
 */
 void scif_spi_write_byte(uint8_t b);
 
+/** \brief  Write data to the SPI device.
+
+    This function writes data to the SPI device. The bulk of the buffer is
+    written four bytes at a time; any unaligned leading bytes and leftover
+    trailing bytes are written one byte at a time.
+
+    \param  buffer          Buffer to write data from.
+    \param  len             Number of bytes to write to the device.
+*/
+void scif_spi_write_data(const uint8_t *buffer, size_t len);
+
 /** \brief  Read a byte from the SPI device.
 
     This function reads a byte from the SPI device, one bit at a time. Timing
@@ -202,7 +213,7 @@ void scif_spi_write_byte(uint8_t b);
 */
 uint8_t scif_spi_read_byte(void);
 
-/** \brief  Read a data from the SPI device.
+/** \brief  Read data from the SPI device.
 
     This function reads data from the SPI device. If the buffer is aligned and
     len is divisible by 4, optimizations are applied.


### PR DESCRIPTION
While working on the SD driver I noticed scif_spi_read_data() had a fast path but there was no scif_spi_write_data() counterpart. This PR adds the missing function and then takes both bulk paths a step further.

- New scif_spi_write_data() — clocks the buffer out 4 bytes at a time instead of per byte. Rather than a straight mirror of the read function, it handles any alignment and length: unaligned leading bytes and leftover trailing bytes go one at a time, the aligned middle uses the fast loop, and short transfers skip the setup entirely.

- Reworked scif_spi_read_data() the same way, so it no longer drops to a byte read just because the buffer is unaligned or the length isn't a multiple of 4.

- Dropped SD_WAIT() from scif_spi_write_byte() — the inter-bit nop delay didn't appear to do anything on the hardware I tested, and removing it picked up speed(+ 1 %).

- Wired the SD and W5500 drivers to use the new bulk write.

Net result: ~10% faster SD writes over SCIF-SPI on real hardware.  This speedup broke writing many blocks at a time on my KINGSTON 8gb SD card but this PR #1422 fixes that and should be merged first.

This is a draft because I want @DC-SWAT input on if we can remove SD_WAIT entirely (its still in scif_spi_rw_byte()). If so, then I can also include those in this PR.

EDIT: Was given his approval on Discord