### PR TITLE
ldscripts: Shave off common ldscript bits to common.xc

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -30,7 +30,7 @@ export KOS_INC_PATHS="${KOS_INC_PATHS} -isystem ${KOS_BASE}/include \
 -isystem ${KOS_PORTS}/include"
 
 # "System" libraries.
-export KOS_LIB_PATHS="-L${KOS_BASE}/lib/${KOS_ARCH} -L${KOS_BASE}/addons/lib/${KOS_ARCH} -L${KOS_PORTS}/lib"
+export KOS_LIB_PATHS="-L${KOS_BASE}/lib/${KOS_ARCH} -L${KOS_BASE}/addons/lib/${KOS_ARCH} -L${KOS_BASE}/utils/ldscripts -L${KOS_PORTS}/lib"
 export KOS_LIBS="-Wl,--start-group -lkallisti -lm -lc -lgcc -Wl,--end-group"
 
 # Main arch compiler paths.

--- a/utils/ldscripts/common.xc
+++ b/utils/ldscripts/common.xc
@@ -1,0 +1,239 @@
+.text           :
+{
+  *(.text .stub .text.* .gnu.linkonce.t.*)
+  /* .gnu.warning sections are handled specially by elf32.em.  */
+  *(.gnu.warning)
+} =0
+
+.init           :
+{
+  KEEP (*(.init))
+} =0
+.fini           :
+{
+  KEEP (*(.fini))
+} =0
+.interp         : { *(.interp) }
+.note.gnu.build-id : { *(.note.gnu.build-id) }
+.hash           : { *(.hash) }
+.gnu.hash       : { *(.gnu.hash) }
+.dynsym         : { *(.dynsym) }
+.dynstr         : { *(.dynstr) }
+.gnu.version    : { *(.gnu.version) }
+.gnu.version_d  : { *(.gnu.version_d) }
+.gnu.version_r  : { *(.gnu.version_r) }
+.rel.dyn        :
+  {
+    *(.rel.init)
+    *(.rel.text .rel.text.* .rel.gnu.linkonce.t.*)
+    *(.rel.fini)
+    *(.rel.rodata .rel.rodata.* .rel.gnu.linkonce.r.*)
+    *(.rel.data.rel.ro* .rel.gnu.linkonce.d.rel.ro.*)
+    *(.rel.data .rel.data.* .rel.gnu.linkonce.d.*)
+    *(.rel.tdata .rel.tdata.* .rel.gnu.linkonce.td.*)
+    *(.rel.tbss .rel.tbss.* .rel.gnu.linkonce.tb.*)
+    *(.rel.ctors)
+    *(.rel.dtors)
+    *(.rel.got)
+    *(.rel.sdata .rel.sdata.* .rel.gnu.linkonce.s.*)
+    *(.rel.sbss .rel.sbss.* .rel.gnu.linkonce.sb.*)
+    *(.rel.sdata2 .rel.sdata2.* .rel.gnu.linkonce.s2.*)
+    *(.rel.sbss2 .rel.sbss2.* .rel.gnu.linkonce.sb2.*)
+    *(.rel.bss .rel.bss.* .rel.gnu.linkonce.b.*)
+  }
+.rela.dyn       :
+  {
+    *(.rela.init)
+    *(.rela.text .rela.text.* .rela.gnu.linkonce.t.*)
+    *(.rela.fini)
+    *(.rela.rodata .rela.rodata.* .rela.gnu.linkonce.r.*)
+    *(.rela.data .rela.data.* .rela.gnu.linkonce.d.*)
+    *(.rela.tdata .rela.tdata.* .rela.gnu.linkonce.td.*)
+    *(.rela.tbss .rela.tbss.* .rela.gnu.linkonce.tb.*)
+    *(.rela.ctors)
+    *(.rela.dtors)
+    *(.rela.got)
+    *(.rela.sdata .rela.sdata.* .rela.gnu.linkonce.s.*)
+    *(.rela.sbss .rela.sbss.* .rela.gnu.linkonce.sb.*)
+    *(.rela.sdata2 .rela.sdata2.* .rela.gnu.linkonce.s2.*)
+    *(.rela.sbss2 .rela.sbss2.* .rela.gnu.linkonce.sb2.*)
+    *(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*)
+  }
+.rel.plt        : { *(.rel.plt) }
+.rela.plt       : { *(.rela.plt) }
+.plt            : { *(.plt) }
+PROVIDE (__etext = .);
+PROVIDE (_etext = .);
+PROVIDE (etext = .);
+.rodata         :
+{
+  *(.rodata .rodata.* .gnu.linkonce.r.*)
+  . = ALIGN(4);
+  __tdata_align = .;
+  LONG (ALIGNOF(.tdata));
+  . = ALIGN(4);
+  __tbss_align = .;
+  LONG (ALIGNOF(.tbss));
+  . = ALIGN(4);
+}
+.rodata1        : { *(.rodata1) }
+.sdata2         :
+{
+  *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
+}
+.sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) }
+.eh_frame_hdr : { *(.eh_frame_hdr) }
+.eh_frame       : ONLY_IF_RO { KEEP (*(.eh_frame)) }
+.gcc_except_table   : ONLY_IF_RO { *(.gcc_except_table .gcc_except_table.*) }
+/* Adjust the address for the data segment.  We want to adjust up to
+   the same address within the page on the next page up.  */
+. = ALIGN(128) + (. & (128 - 1));
+/* Exception handling  */
+.eh_frame       : ONLY_IF_RW { KEEP (*(.eh_frame)) }
+.gcc_except_table   : ONLY_IF_RW { *(.gcc_except_table .gcc_except_table.*) }
+/* Thread Local Storage sections  */
+.tdata  :
+{
+  __tdata_start = .;
+  *(.tdata .tdata.* .gnu.linkonce.td.*)
+}
+__tdata_size = SIZEOF(.tdata);
+.tbss (NOLOAD)  :
+{
+  *(.tbss .tbss.* .gnu.linkonce.tb.*)
+  *(.tcommon)
+}
+__tbss_size = SIZEOF(.tbss);
+.preinit_array     :
+{
+  PROVIDE_HIDDEN (__preinit_array_start = .);
+  KEEP (*(.preinit_array))
+  PROVIDE_HIDDEN (__preinit_array_end = .);
+}
+.init_array     :
+{
+   PROVIDE_HIDDEN (__init_array_start = .);
+   KEEP (*(SORT(.init_array.*)))
+   KEEP (*(.init_array))
+   PROVIDE_HIDDEN (__init_array_end = .);
+}
+.fini_array     :
+{
+  PROVIDE_HIDDEN (__fini_array_start = .);
+  KEEP (*(.fini_array))
+  KEEP (*(SORT(.fini_array.*)))
+  PROVIDE_HIDDEN (__fini_array_end = .);
+}
+.ctors          :
+{
+  ___ctors = .;
+  /* gcc uses crtbegin.o to find the start of
+     the constructors, so we make sure it is
+     first.  Because this is a wildcard, it
+     doesn't matter if the user does not
+     actually link against crtbegin.o; the
+     linker won't look for a file to match a
+     wildcard.  The wildcard also means that it
+     doesn't matter which directory crtbegin.o
+     is in.  */
+  KEEP (*crtbegin.o(.ctors))
+  KEEP (*crtbegin?.o(.ctors))
+  /* We don't want to include the .ctor section from
+     the crtend.o file until after the sorted ctors.
+     The .ctor section from the crtend file contains the
+     end of ctors marker and it must be last */
+  KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+  KEEP (*(SORT(.ctors.*)))
+  KEEP (*(.ctors))
+  ___ctors_end = .;
+}
+.dtors          :
+{
+  ___dtors = .;
+  KEEP (*crtbegin.o(.dtors))
+  KEEP (*crtbegin?.o(.dtors))
+  KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+  KEEP (*(SORT(.dtors.*)))
+  KEEP (*(.dtors))
+  ___dtors_end = .;
+}
+.jcr            : { KEEP (*(.jcr)) }
+.data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro* .gnu.linkonce.d.rel.ro.*) }
+.dynamic        : { *(.dynamic) }
+.data           :
+{
+  *(.data .data.* .gnu.linkonce.d.*)
+  SORT(CONSTRUCTORS)
+}
+.data1          : { *(.data1) }
+.got            : { *(.got.plt) *(.got) }
+/* We want the small data sections together, so single-instruction offsets
+   can access them all, and initialized data all before uninitialized, so
+   we can shorten the on-disk segment size.  */
+.sdata          :
+{
+  *(.sdata .sdata.* .gnu.linkonce.s.*)
+}
+_edata = .; PROVIDE (edata = .);
+. = ALIGN(8);
+__bss_start = .;
+.sbss           :
+{
+  *(.dynsbss)
+  *(.sbss .sbss.* .gnu.linkonce.sb.*)
+  *(.scommon)
+}
+.bss            :
+{
+ *(.dynbss)
+ *(.bss .bss.* .gnu.linkonce.b.*)
+ *(COMMON)
+ /* Align here to ensure that the .bss section occupies space up to
+    _end.  Align after .bss to ensure correct alignment even if the
+    .bss section disappears because there are no input sections.
+    FIXME: Why do we need it? When there is no .bss section, we don't
+    pad the .data section.  */
+ . = ALIGN(. != 0 ? 32 / 8 : 1);
+}
+. = ALIGN(32 / 8);
+. = ALIGN(32 / 8);
+_end = .; PROVIDE (end = .);
+
+/* Stabs debugging sections.  */
+.stab          0 : { *(.stab) }
+.stabstr       0 : { *(.stabstr) }
+.stab.excl     0 : { *(.stab.excl) }
+.stab.exclstr  0 : { *(.stab.exclstr) }
+.stab.index    0 : { *(.stab.index) }
+.stab.indexstr 0 : { *(.stab.indexstr) }
+.comment       0 : { *(.comment) }
+/* DWARF debug sections.
+Symbols in the DWARF debugging sections are relative to the beginning
+of the section so we begin them at 0.  */
+/* DWARF 1 */
+.debug          0 : { *(.debug) }
+.line           0 : { *(.line) }
+/* GNU DWARF 1 extensions */
+.debug_srcinfo  0 : { *(.debug_srcinfo) }
+.debug_sfnames  0 : { *(.debug_sfnames) }
+/* DWARF 1.1 and DWARF 2 */
+.debug_aranges  0 : { *(.debug_aranges) }
+.debug_pubnames 0 : { *(.debug_pubnames) }
+/* DWARF 2 */
+.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+.debug_abbrev   0 : { *(.debug_abbrev) }
+.debug_line     0 : { *(.debug_line) }
+.debug_frame    0 : { *(.debug_frame) }
+.debug_str      0 : { *(.debug_str) }
+.debug_loc      0 : { *(.debug_loc) }
+.debug_macinfo  0 : { *(.debug_macinfo) }
+/* SGI/MIPS DWARF 2 extensions */
+.debug_weaknames 0 : { *(.debug_weaknames) }
+.debug_funcnames 0 : { *(.debug_funcnames) }
+.debug_typenames 0 : { *(.debug_typenames) }
+.debug_varnames  0 : { *(.debug_varnames) }
+/* DWARF 3 */
+.debug_pubtypes 0 : { *(.debug_pubtypes) }
+.debug_ranges   0 : { *(.debug_ranges) }
+.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+/DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) }

--- a/utils/ldscripts/shlelf.xc
+++ b/utils/ldscripts/shlelf.xc
@@ -14,12 +14,8 @@ SECTIONS
 {
   /* Read-only sections, merged into text segment: */
   PROVIDE (__executable_start = LOAD_OFFSET); . = LOAD_OFFSET;
-  .text           :
-  {
-    *(.text .stub .text.* .gnu.linkonce.t.*)
-    /* .gnu.warning sections are handled specially by elf32.em.  */
-    *(.gnu.warning)
-  } =0
+
+  INCLUDE common.xc
 
   /* Custom sections, aligned to the icache size */
   .sub0 : ALIGN(ICACHE_SIZE) {
@@ -83,206 +79,6 @@ SECTIONS
   }
   ASSERT(__sub9_end - __sub9_start <= ICACHE_SIZE, "Error: Sub-section .sub9 is bigger than icache size")
 
-  .init           :
-  {
-    KEEP (*(.init))
-  } =0
-  .fini           :
-  {
-    KEEP (*(.fini))
-  } =0
-  .interp         : { *(.interp) }
-  .note.gnu.build-id : { *(.note.gnu.build-id) }
-  .hash           : { *(.hash) }
-  .gnu.hash       : { *(.gnu.hash) }
-  .dynsym         : { *(.dynsym) }
-  .dynstr         : { *(.dynstr) }
-  .gnu.version    : { *(.gnu.version) }
-  .gnu.version_d  : { *(.gnu.version_d) }
-  .gnu.version_r  : { *(.gnu.version_r) }
-  .rel.dyn        :
-    {
-      *(.rel.init)
-      *(.rel.text .rel.text.* .rel.gnu.linkonce.t.*)
-      *(.rel.fini)
-      *(.rel.rodata .rel.rodata.* .rel.gnu.linkonce.r.*)
-      *(.rel.data.rel.ro* .rel.gnu.linkonce.d.rel.ro.*)
-      *(.rel.data .rel.data.* .rel.gnu.linkonce.d.*)
-      *(.rel.tdata .rel.tdata.* .rel.gnu.linkonce.td.*)
-      *(.rel.tbss .rel.tbss.* .rel.gnu.linkonce.tb.*)
-      *(.rel.ctors)
-      *(.rel.dtors)
-      *(.rel.got)
-      *(.rel.sdata .rel.sdata.* .rel.gnu.linkonce.s.*)
-      *(.rel.sbss .rel.sbss.* .rel.gnu.linkonce.sb.*)
-      *(.rel.sdata2 .rel.sdata2.* .rel.gnu.linkonce.s2.*)
-      *(.rel.sbss2 .rel.sbss2.* .rel.gnu.linkonce.sb2.*)
-      *(.rel.bss .rel.bss.* .rel.gnu.linkonce.b.*)
-    }
-  .rela.dyn       :
-    {
-      *(.rela.init)
-      *(.rela.text .rela.text.* .rela.gnu.linkonce.t.*)
-      *(.rela.fini)
-      *(.rela.rodata .rela.rodata.* .rela.gnu.linkonce.r.*)
-      *(.rela.data .rela.data.* .rela.gnu.linkonce.d.*)
-      *(.rela.tdata .rela.tdata.* .rela.gnu.linkonce.td.*)
-      *(.rela.tbss .rela.tbss.* .rela.gnu.linkonce.tb.*)
-      *(.rela.ctors)
-      *(.rela.dtors)
-      *(.rela.got)
-      *(.rela.sdata .rela.sdata.* .rela.gnu.linkonce.s.*)
-      *(.rela.sbss .rela.sbss.* .rela.gnu.linkonce.sb.*)
-      *(.rela.sdata2 .rela.sdata2.* .rela.gnu.linkonce.s2.*)
-      *(.rela.sbss2 .rela.sbss2.* .rela.gnu.linkonce.sb2.*)
-      *(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*)
-    }
-  .rel.plt        : { *(.rel.plt) }
-  .rela.plt       : { *(.rela.plt) }
-  .plt            : { *(.plt) }
-  PROVIDE (__etext = .);
-  PROVIDE (_etext = .);
-  PROVIDE (etext = .);
-  .rodata         : 
-  { 
-    *(.rodata .rodata.* .gnu.linkonce.r.*) 
-    . = ALIGN(4);
-    __tdata_align = .;
-    LONG (ALIGNOF(.tdata));
-    . = ALIGN(4);
-    __tbss_align = .;
-    LONG (ALIGNOF(.tbss));
-    . = ALIGN(4);
-  }
-  .rodata1        : { *(.rodata1) }
-  .sdata2         :
-  {
-    *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
-  }
-  .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) }
-  .eh_frame_hdr : { *(.eh_frame_hdr) }
-  .eh_frame       : ONLY_IF_RO { KEEP (*(.eh_frame)) }
-  .gcc_except_table   : ONLY_IF_RO { *(.gcc_except_table .gcc_except_table.*) }
-  /* Adjust the address for the data segment.  We want to adjust up to
-     the same address within the page on the next page up.  */
-  . = ALIGN(128) + (. & (128 - 1));
-  /* Exception handling  */
-  .eh_frame       : ONLY_IF_RW { KEEP (*(.eh_frame)) }
-  .gcc_except_table   : ONLY_IF_RW { *(.gcc_except_table .gcc_except_table.*) }
-  /* Thread Local Storage sections  */
-  .tdata	  : 
-  { 
-    __tdata_start = .;
-    *(.tdata .tdata.* .gnu.linkonce.td.*) 
-  }
-  __tdata_size = SIZEOF(.tdata);
-  .tbss	(NOLOAD)	  : 
-  { 
-    *(.tbss .tbss.* .gnu.linkonce.tb.*) 
-    *(.tcommon)
-  }
-  __tbss_size = SIZEOF(.tbss);
-  .preinit_array     :
-  {
-    PROVIDE_HIDDEN (__preinit_array_start = .);
-    KEEP (*(.preinit_array))
-    PROVIDE_HIDDEN (__preinit_array_end = .);
-  }
-  .init_array     :
-  {
-     PROVIDE_HIDDEN (__init_array_start = .);
-     KEEP (*(SORT(.init_array.*)))
-     KEEP (*(.init_array))
-     PROVIDE_HIDDEN (__init_array_end = .);
-  }
-  .fini_array     :
-  {
-    PROVIDE_HIDDEN (__fini_array_start = .);
-    KEEP (*(.fini_array))
-    KEEP (*(SORT(.fini_array.*)))
-    PROVIDE_HIDDEN (__fini_array_end = .);
-  }
-  .ctors          :
-  {
-    ___ctors = .;
-    /* gcc uses crtbegin.o to find the start of
-       the constructors, so we make sure it is
-       first.  Because this is a wildcard, it
-       doesn't matter if the user does not
-       actually link against crtbegin.o; the
-       linker won't look for a file to match a
-       wildcard.  The wildcard also means that it
-       doesn't matter which directory crtbegin.o
-       is in.  */
-    KEEP (*crtbegin.o(.ctors))
-    KEEP (*crtbegin?.o(.ctors))
-    /* We don't want to include the .ctor section from
-       the crtend.o file until after the sorted ctors.
-       The .ctor section from the crtend file contains the
-       end of ctors marker and it must be last */
-    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
-    KEEP (*(SORT(.ctors.*)))
-    KEEP (*(.ctors))
-    ___ctors_end = .;
-  }
-  .dtors          :
-  {
-    ___dtors = .;
-    KEEP (*crtbegin.o(.dtors))
-    KEEP (*crtbegin?.o(.dtors))
-    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
-    KEEP (*(SORT(.dtors.*)))
-    KEEP (*(.dtors))
-    ___dtors_end = .;
-  }
-  .jcr            : { KEEP (*(.jcr)) }
-  .data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro* .gnu.linkonce.d.rel.ro.*) }
-  .dynamic        : { *(.dynamic) }
-  .data           :
-  {
-    *(.data .data.* .gnu.linkonce.d.*)
-    SORT(CONSTRUCTORS)
-  }
-  .data1          : { *(.data1) }
-  .got            : { *(.got.plt) *(.got) }
-  /* We want the small data sections together, so single-instruction offsets
-     can access them all, and initialized data all before uninitialized, so
-     we can shorten the on-disk segment size.  */
-  .sdata          :
-  {
-    *(.sdata .sdata.* .gnu.linkonce.s.*)
-  }
-  _edata = .; PROVIDE (edata = .);
-  . = ALIGN(8);
-  __monitors_start = .;
-  .monitors       :
-  {
-    *(.monitors)
-  }
-  __monitors_end = .;
-  . = ALIGN(8);
-  __bss_start = .;
-  .sbss           :
-  {
-    *(.dynsbss)
-    *(.sbss .sbss.* .gnu.linkonce.sb.*)
-    *(.scommon)
-  }
-  .bss            :
-  {
-   *(.dynbss)
-   *(.bss .bss.* .gnu.linkonce.b.*)
-   *(COMMON)
-   /* Align here to ensure that the .bss section occupies space up to
-      _end.  Align after .bss to ensure correct alignment even if the
-      .bss section disappears because there are no input sections.
-      FIXME: Why do we need it? When there is no .bss section, we don't
-      pad the .data section.  */
-   . = ALIGN(. != 0 ? 32 / 8 : 1);
-  }
-  . = ALIGN(32 / 8);
-  . = ALIGN(32 / 8);
-  _end = .; PROVIDE (end = .);
   .ocram 0x7c001000 (NOLOAD) :
   {
     *(.ocram)
@@ -290,42 +86,11 @@ SECTIONS
        an error if we exceed that size.  */
     . = . > 0x2000 ? 0x2000 : .;
   }
-  /* Stabs debugging sections.  */
-  .stab          0 : { *(.stab) }
-  .stabstr       0 : { *(.stabstr) }
-  .stab.excl     0 : { *(.stab.excl) }
-  .stab.exclstr  0 : { *(.stab.exclstr) }
-  .stab.index    0 : { *(.stab.index) }
-  .stab.indexstr 0 : { *(.stab.indexstr) }
-  .comment       0 : { *(.comment) }
-  /* DWARF debug sections.
-     Symbols in the DWARF debugging sections are relative to the beginning
-     of the section so we begin them at 0.  */
-  /* DWARF 1 */
-  .debug          0 : { *(.debug) }
-  .line           0 : { *(.line) }
-  /* GNU DWARF 1 extensions */
-  .debug_srcinfo  0 : { *(.debug_srcinfo) }
-  .debug_sfnames  0 : { *(.debug_sfnames) }
-  /* DWARF 1.1 and DWARF 2 */
-  .debug_aranges  0 : { *(.debug_aranges) }
-  .debug_pubnames 0 : { *(.debug_pubnames) }
-  /* DWARF 2 */
-  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
-  .debug_abbrev   0 : { *(.debug_abbrev) }
-  .debug_line     0 : { *(.debug_line) }
-  .debug_frame    0 : { *(.debug_frame) }
-  .debug_str      0 : { *(.debug_str) }
-  .debug_loc      0 : { *(.debug_loc) }
-  .debug_macinfo  0 : { *(.debug_macinfo) }
-  /* SGI/MIPS DWARF 2 extensions */
-  .debug_weaknames 0 : { *(.debug_weaknames) }
-  .debug_funcnames 0 : { *(.debug_funcnames) }
-  .debug_typenames 0 : { *(.debug_typenames) }
-  .debug_varnames  0 : { *(.debug_varnames) }
-  /* DWARF 3 */
-  .debug_pubtypes 0 : { *(.debug_pubtypes) }
-  .debug_ranges   0 : { *(.debug_ranges) }
-  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
-  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) }
+
+  .data : {
+    . = ALIGN(8);
+    __monitors_start = .;
+    *(.monitors)
+    __monitors_end = .;
+  }
 }


### PR DESCRIPTION
A good part of the linker script is composed of arch-independent stuff. Move it to a common.xc script that can then be shared across the supported archs.