### PR TITLE
Fix stale file paths in banners and header guards

### DIFF
--- a/include/kos/dbgio.h
+++ b/include/kos/dbgio.h
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   kos/include/dbgio.h
+   include/kos/dbgio.h
    Copyright (C) 2000, 2004 Megan Potter
    Copyright (C) 2026 Eric Fradella
 

--- a/include/kos/init_base.h
+++ b/include/kos/init_base.h
@@ -65,4 +65,4 @@ __BEGIN_DECLS
 
 __END_DECLS
 
-#endif /* !__ARCH_INIT_BASE_H */
+#endif /* !__KOS_INIT_BASE_H */

--- a/include/kos/regfield.h
+++ b/include/kos/regfield.h
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   kos/compiler.h
+   kos/regfield.h
    Copyright (C) 2024 Paul Cercueil
 
    Macros to extract / insert bit fields

--- a/include/poll.h
+++ b/include/poll.h
@@ -99,4 +99,4 @@ int poll(struct pollfd fds[], nfds_t nfds, int timeout);
 
 __END_DECLS
 
-#endif /* !POLL_H */
+#endif /* !__POLL_H */

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   lock_common.h
+   sys/lock.h
    Copyright (C) 2004 Megan Potter
 
    This file is patched into the kos-chain newlib's <sys/lock.h>, by newlib.mk

--- a/kernel/arch/dreamcast/gdb/gdb.c
+++ b/kernel/arch/dreamcast/gdb/gdb.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb.c
+   arch/dreamcast/gdb/gdb.c
 
    Copyright (C) Megan Potter
    Copyright (C) Richard Moats

--- a/kernel/arch/dreamcast/gdb/gdb_break.c
+++ b/kernel/arch/dreamcast/gdb/gdb_break.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_break.c
+   arch/dreamcast/gdb/gdb_break.c
 
    Copyright (C) Megan Potter
    Copyright (C) Richard Moats

--- a/kernel/arch/dreamcast/gdb/gdb_ctrl.c
+++ b/kernel/arch/dreamcast/gdb/gdb_ctrl.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_ctrl.c
+   arch/dreamcast/gdb/gdb_ctrl.c
 
    Copyright (C) Megan Potter
    Copyright (C) Richard Moats

--- a/kernel/arch/dreamcast/gdb/gdb_internal.h
+++ b/kernel/arch/dreamcast/gdb/gdb_internal.h
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_internal.h
+   arch/dreamcast/gdb/gdb_internal.h
 
    Copyright (C) 2026 Andy Barajas
 

--- a/kernel/arch/dreamcast/gdb/gdb_mem.c
+++ b/kernel/arch/dreamcast/gdb/gdb_mem.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_mem.c
+   arch/dreamcast/gdb/gdb_mem.c
 
    Copyright (C) Megan Potter
    Copyright (C) Richard Moats

--- a/kernel/arch/dreamcast/gdb/gdb_packet.c
+++ b/kernel/arch/dreamcast/gdb/gdb_packet.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_packet.c
+   arch/dreamcast/gdb/gdb_packet.c
 
    Copyright (C) Megan Potter
    Copyright (C) Richard Moats

--- a/kernel/arch/dreamcast/gdb/gdb_query.c
+++ b/kernel/arch/dreamcast/gdb/gdb_query.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_query.c
+   arch/dreamcast/gdb/gdb_query.c
 
    Copyright (C) 2026 Andy Barajas
 

--- a/kernel/arch/dreamcast/gdb/gdb_regs.c
+++ b/kernel/arch/dreamcast/gdb/gdb_regs.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_regs.c
+   arch/dreamcast/gdb/gdb_regs.c
 
    Copyright (C) Megan Potter
    Copyright (C) Richard Moats

--- a/kernel/arch/dreamcast/gdb/gdb_remote.c
+++ b/kernel/arch/dreamcast/gdb/gdb_remote.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_remote.c
+   arch/dreamcast/gdb/gdb_remote.c
 
    Copyright (C) 2026 Andy Barajas
 

--- a/kernel/arch/dreamcast/gdb/gdb_utils.c
+++ b/kernel/arch/dreamcast/gdb/gdb_utils.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_utils.c
+   arch/dreamcast/gdb/gdb_utils.c
 
    Copyright (C) Megan Potter
    Copyright (C) Richard Moats

--- a/kernel/arch/dreamcast/gdb/gdb_vpacket.c
+++ b/kernel/arch/dreamcast/gdb/gdb_vpacket.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   arch/dreamcast/kernel/gdb/gdb_vpacket.c
+   arch/dreamcast/gdb/gdb_vpacket.c
 
    Copyright (C) 2026 Andy Barajas
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem_core.h
@@ -1392,6 +1392,6 @@ void     public_pvr_mSTATs();
 
 __END_DECLS
 
-#endif  /* __MALLOC_H */
+#endif  /* __PVR_MEM_CORE_H */
 
 

--- a/kernel/arch/dreamcast/include/arch/stack.h
+++ b/kernel/arch/dreamcast/include/arch/stack.h
@@ -153,4 +153,4 @@ void arch_stk_trace_at(uintptr_t sp, size_t n);
 
 __END_DECLS
 
-#endif  /* __ARCH_EXEC_H */
+#endif  /* __ARCH_STACK_H */

--- a/kernel/arch/dreamcast/include/dc/fs_iso9660.h
+++ b/kernel/arch/dreamcast/include/dc/fs_iso9660.h
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   dc/fs/iso9660.h
+   dc/fs_iso9660.h
    (c)2000-2001 Megan Potter
 
 */


### PR DESCRIPTION
After moving the gdb folder one directory higher I forgot to update the header paths. Also did a check across the whole code base for the same header path issue. Also came across an incorrect comment on header guards so I did a check across the whole code base and fixed those too.