### PR TITLE
Drop GCC 4 compatibility workarounds

### DIFF
--- a/examples/dreamcast/basic/threading/compiler_tls/compiler_tls.c
+++ b/examples/dreamcast/basic/threading/compiler_tls/compiler_tls.c
@@ -24,14 +24,8 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#if (__GNUC__ <= 4)
-/* GCC4 only supports using TLS with the __thread identifier,
-   even when passed the -std=c99 flag */
-#define thread_local __thread
-#else
-/* Newer versions of GCC use C11's _Thread_local to specify TLS */
+/* Use C11's _Thread_local to specify TLS */
 #define thread_local _Thread_local
-#endif
 
 typedef struct {
     uint8_t inner[3];

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -35,11 +35,6 @@
 #include "initall_hdrs.h"
 
 /* ctor/dtor stuff from libgcc. */
-#if __GNUC__ == 4
-#define _init init
-#define _fini fini
-#endif
-
 extern void _init(void);
 extern void _fini(void);
 extern void __verify_newlib_patch(void);


### PR DESCRIPTION
KOS no longer supports building with GCC 4, so the __GNUC__ <= 4 / == 4 conditionals are dead code.