### PR TITLE
ldscripts: Fix c++ exceptions

### DIFF
--- a/utils/ldscripts/shlelf.xc
+++ b/utils/ldscripts/shlelf.xc
@@ -143,9 +143,9 @@ SECTIONS
   PROVIDE (__etext = .);
   PROVIDE (_etext = .);
   PROVIDE (etext = .);
-  .rodata         : 
-  { 
-    *(.rodata .rodata.* .gnu.linkonce.r.*) 
+  .rodata         :
+  {
+    *(.rodata .rodata.* .gnu.linkonce.r.*)
     . = ALIGN(4);
     __tdata_align = .;
     LONG (ALIGNOF(.tdata));
@@ -170,15 +170,15 @@ SECTIONS
   .eh_frame       : ONLY_IF_RW { KEEP (*(.eh_frame)) }
   .gcc_except_table   : ONLY_IF_RW { *(.gcc_except_table .gcc_except_table.*) }
   /* Thread Local Storage sections  */
-  .tdata	  : 
-  { 
+  .tdata	  :
+  {
     __tdata_start = .;
-    *(.tdata .tdata.* .gnu.linkonce.td.*) 
+    *(.tdata .tdata.* .gnu.linkonce.td.*)
   }
   __tdata_size = SIZEOF(.tdata);
-  .tbss	(NOLOAD)	  : 
-  { 
-    *(.tbss .tbss.* .gnu.linkonce.tb.*) 
+  .tbss	(NOLOAD)	  :
+  {
+    *(.tbss .tbss.* .gnu.linkonce.tb.*)
     *(.tcommon)
   }
   __tbss_size = SIZEOF(.tbss);

--- a/utils/ldscripts/shlelf.xc
+++ b/utils/ldscripts/shlelf.xc
@@ -161,13 +161,21 @@ SECTIONS
   }
   .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) }
   .eh_frame_hdr : { *(.eh_frame_hdr) }
-  .eh_frame       : ONLY_IF_RO { KEEP (*(.eh_frame)) }
+  .eh_frame       : ONLY_IF_RO {
+    KEEP (*crtbegin.o(.eh_frame))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .eh_frame))
+    KEEP (*crtend.o(.eh_frame))
+  }
   .gcc_except_table   : ONLY_IF_RO { *(.gcc_except_table .gcc_except_table.*) }
   /* Adjust the address for the data segment.  We want to adjust up to
      the same address within the page on the next page up.  */
   . = ALIGN(128) + (. & (128 - 1));
   /* Exception handling  */
-  .eh_frame       : ONLY_IF_RW { KEEP (*(.eh_frame)) }
+  .eh_frame       : ONLY_IF_RW {
+    KEEP (*crtbegin.o(.eh_frame))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .eh_frame))
+    KEEP (*crtend.o(.eh_frame))
+  }
   .gcc_except_table   : ONLY_IF_RW { *(.gcc_except_table .gcc_except_table.*) }
   /* Thread Local Storage sections  */
   .tdata	  :


### PR DESCRIPTION
Implemented fix shown in this discord post:

https://discord.com/channels/488332893324836864/614912396460556298/1515986867051561083

Verified against cpp/out_of_memory example that was failing before