### PR TITLE
Add callback data to maple user callbacks

### DIFF
--- a/examples/dreamcast/maple/Makefile
+++ b/examples/dreamcast/maple/Makefile
@@ -1,0 +1,28 @@
+#
+# Maple Device Detection Example
+# Copyright (C) 2024 Falco Girgis
+#   
+
+TARGET = maple.elf
+
+OBJS = maple.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist: $(TARGET)
+	-rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/maple/maple.c
+++ b/examples/dreamcast/maple/maple.c
@@ -1,0 +1,89 @@
+/*  KallistiOS ##version##
+
+    maple.c
+    Copyright (C) 2024 Falco Girgis
+*/
+
+/*
+    This example demonstrates how to detect devices getting attached to and
+    removed from the maple bus (controller ports) along with querying for and
+    displaying the device details upon detection.
+
+    Simply connect or disconnect maple devices or press START on a controller
+    to exit.
+
+    NOTE: All program output is in the terminal; you will not see anything
+          drawn to the screen!
+*/
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <kos.h>
+
+/* Called every time a new maple device is detected. */
+static void on_maple_attach(maple_device_t *dev, void *user_data) {
+    unsigned *attach_counter = (unsigned *)user_data;
+
+    printf("Maple device attached [%c%d]: %.30s\n",
+           'A' + dev->port, dev->unit, dev->info.product_name);
+
+    printf("\t%-15s: %55s\n", "Functions", maple_pcaps(dev->info.functions));
+    printf("\t%-15s: %55s\n", "Driver", dev->drv->name);
+    printf("\t%-15s: %55d\n", "Region Code", dev->info.area_code);
+    printf("\t%-15s: %55d\n", "Orientation", dev->info.connector_direction);
+    printf("\t%-15s: %55d\n", "Standby Power", dev->info.standby_power);
+    printf("\t%-15s: %55d\n", "Max Power", dev->info.max_power);
+    printf("\t%-15s: %55.60s\n", "License", dev->info.product_license);
+
+    ++(*attach_counter);
+}
+
+/* Called every time an existing maple device is removed. */
+static void on_maple_detach(maple_device_t *dev, void *user_data) {
+    unsigned *detach_counter = (unsigned *)user_data;
+
+    printf("Maple device detached [%c%d]: %.30s\n",
+           'A' + dev->port, dev->unit, dev->info.product_name);
+
+    ++(*detach_counter);
+}
+
+/* Flag for whether to exit the example. */
+static volatile bool quit = false;
+
+/* Called whenever start is pressed on any controller. */
+static void on_press_start(uint8_t address, uint32_t buttons) {
+    (void)address;
+    (void)buttons;
+
+    quit = true;
+}
+
+/* Program entry point */
+int main(int argc, char* argv[]) {
+    /* Event counters. */
+    unsigned attach_counter = 0, detach_counter = 0;
+
+    /* Subscribe a callback to maple attach events. */
+    maple_attach_callback(MAPLE_FUNC_ANY, on_maple_attach, &attach_counter);
+    /* Subscribe a callback to maple detach events. */
+    maple_detach_callback(MAPLE_FUNC_ANY, on_maple_detach, &detach_counter);
+
+    /* Subscribe a callback to be notified whenever the start button is pressed
+       on any connected controller. */
+    cont_btn_callback(0, CONT_START, on_press_start);
+
+    printf("Listening for device hotplug events...\n");
+
+    /* Do nothing while we wait for maple events */
+    while(!quit)
+        thd_pass();
+
+    printf("Attached Events: %u, Detached Events: %u\n",
+           attach_counter, detach_counter);
+
+    return EXIT_SUCCESS;
+}

--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <dc/maple.h>
 
-void maple_attach_callback(uint32_t functions, maple_user_callback_t cb) {
+void maple_attach_callback(uint32_t functions, maple_user_callback_t cb, void *user_data) {
     maple_driver_t *i;
 
     if(!functions)
@@ -17,6 +17,7 @@ void maple_attach_callback(uint32_t functions, maple_user_callback_t cb) {
     LIST_FOREACH(i, &maple_state.driver_list, drv_list) {
         if(i->functions & functions) {
             i->user_attach = cb;
+            i->user_attach_data = user_data;
             functions &= ~i->functions;
 
             if(!functions)
@@ -25,7 +26,7 @@ void maple_attach_callback(uint32_t functions, maple_user_callback_t cb) {
     }
 }
 
-void maple_detach_callback(uint32_t functions, maple_user_callback_t cb) {
+void maple_detach_callback(uint32_t functions, maple_user_callback_t cb, void *user_data) {
     maple_driver_t *i;
 
     if(!functions)
@@ -34,6 +35,7 @@ void maple_detach_callback(uint32_t functions, maple_user_callback_t cb) {
     LIST_FOREACH(i, &maple_state.driver_list, drv_list) {
         if(i->functions & functions) {
             i->user_detach = cb;
+            i->user_detach_data = user_data;
             functions &= ~i->functions;
 
             if(!functions)
@@ -115,7 +117,7 @@ int maple_driver_attach(maple_frame_t *det) {
                 dev->valid = true;
 
                 if(i->user_attach)
-                    i->user_attach(dev);
+                    i->user_attach(dev, i->user_attach_data);
 
                 return 0;
             }
@@ -141,7 +143,7 @@ int maple_driver_detach(int p, int u) {
 
     if(dev->drv) {
         if(dev->drv->user_detach)
-            dev->drv->user_detach(dev);
+            dev->drv->user_detach(dev, dev->drv->user_detach_data);
         if(dev->drv->detach)
             dev->drv->detach(dev->drv, dev);
     }

--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <dc/maple.h>
 
-void maple_attach_callback(uint32_t functions, maple_attach_callback_t cb) {
+void maple_attach_callback(uint32_t functions, maple_user_callback_t cb) {
     maple_driver_t *i;
 
     if(!functions)
@@ -25,7 +25,7 @@ void maple_attach_callback(uint32_t functions, maple_attach_callback_t cb) {
     }
 }
 
-void maple_detach_callback(uint32_t functions, maple_detach_callback_t cb) {
+void maple_detach_callback(uint32_t functions, maple_user_callback_t cb) {
     maple_driver_t *i;
 
     if(!functions)

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -303,6 +303,22 @@ typedef struct maple_port {
     maple_device_t *units[MAPLE_UNIT_COUNT];    /**< \brief Pointers to active units */
 } maple_port_t;
 
+/** \brief   Maple user callback type.
+    \ingroup maple
+
+    Functions of this type can be set with maple_{attach,detach}_callback()
+    to respond automatically to those events.
+
+    \param  dev         The device that triggered the callback.
+*/
+typedef void (*maple_user_callback_t)(maple_device_t *dev);
+
+/* \cond */
+/* Compat */
+#define maple_attach_callback_t __depr("Use the type maple_user_callback_t rather than maple_attach_callback_t.") maple_user_callback_t
+#define maple_detach_callback_t __depr("Use the type maple_user_callback_t rather than maple_detach_callback_t.") maple_user_callback_t
+/* \endcond */
+
 /** \brief   A maple device driver.
     \ingroup maple
 
@@ -360,22 +376,16 @@ typedef struct maple_driver {
         This callback will be called when a new device of this driver is
         connected to the system. It should be set by applications using
         maple_attach_callback().
-
-        \param  dev         The device that was connected.
-        \return             0 on success, <0 on error.
     */
-    void (*user_attach)(maple_device_t *dev);
+    maple_user_callback_t user_attach;
 
     /** \brief  User-specified device detached callback.
 
-        This callback will be called when a new device of this driver is
-        connected to the system. It should be set by applications using
+        This callback will be called when a device using this driver is
+        disconnected from the system. It should be set by applications using
         maple_detach_callback().
-
-        \param  dev         The device that was connected.
-        \return             0 on success, <0 on error.
     */
-    void (*user_detach)(maple_device_t *dev);
+    maple_user_callback_t user_detach;
 } maple_driver_t;
 
 /** \brief   Maple state structure.
@@ -744,35 +754,25 @@ int maple_driver_detach(int p, int u);
 */
 int maple_driver_foreach(maple_driver_t *drv, int (*callback)(maple_device_t *));
 
-/** \brief   Maple attach callback type.
-    \ingroup maple
-
-    Functions of this type can be set with maple_attach_callback() to respond
-    automatically to the attachment of a maple device that supports specified
-    functions.
-*/
-typedef void (*maple_attach_callback_t)(maple_device_t *dev);
-
 /** \brief   Set an automatic maple attach callback.
     \ingroup maple
 
     This function sets a callback function to be called when the specified
     maple device that supports functions has been attached.
 
+    \note
+    Your function will not be called for devices which have already been
+    detected on the maple bus. This is only for newly detected devices.
+
+    \warning
+    \p cb will be invoked from within an IRQ context! Do not perform any logic
+    which requires additional interrupt processing!
+
     \param  functions       The functions maple device must support. Set to
                             0 or MAPLE_FUNC_ANY to support all maple devices.
     \param  cb              The callback to call when the maple is attached.
 */
-void maple_attach_callback(uint32_t functions, maple_attach_callback_t cb);
-
-/** \brief   Maple detach callback type.
-    \ingroup maple
-
-    Functions of this type can be set with maple_detach_callback() to respond
-    automatically to the detachment of a maple device that supports specified
-    functions.
-*/
-typedef void (*maple_detach_callback_t)(maple_device_t *dev);
+void maple_attach_callback(uint32_t functions, maple_user_callback_t cb);
 
 /** \brief   Set an automatic maple detach callback.
     \ingroup maple
@@ -784,7 +784,7 @@ typedef void (*maple_detach_callback_t)(maple_device_t *dev);
                             0 or MAPLE_FUNC_ANY to support all maple devices.
     \param  cb              The callback to call when the maple is detached.
 */
-void maple_detach_callback(uint32_t functions, maple_detach_callback_t cb);
+void maple_detach_callback(uint32_t functions, maple_user_callback_t cb);
 
 /**************************************************************************/
 /* maple_irq.c */

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -311,7 +311,7 @@ typedef struct maple_port {
 
     \param  dev         The device that triggered the callback.
 */
-typedef void (*maple_user_callback_t)(maple_device_t *dev);
+typedef void (*maple_user_callback_t)(maple_device_t *dev, void *user_data);
 
 /* \cond */
 /* Compat */
@@ -379,6 +379,12 @@ typedef struct maple_driver {
     */
     maple_user_callback_t user_attach;
 
+    /** \brief  User-specified device attached callback data.
+
+        This data will be passed to user_attach when called.
+    */
+    void *user_attach_data;
+
     /** \brief  User-specified device detached callback.
 
         This callback will be called when a device using this driver is
@@ -386,6 +392,12 @@ typedef struct maple_driver {
         maple_detach_callback().
     */
     maple_user_callback_t user_detach;
+
+    /** \brief  User-specified device detached callback data.
+
+        This data will be passed to user_detach when called.
+    */
+    void *user_detach_data;
 } maple_driver_t;
 
 /** \brief   Maple state structure.
@@ -771,8 +783,9 @@ int maple_driver_foreach(maple_driver_t *drv, int (*callback)(maple_device_t *))
     \param  functions       The functions maple device must support. Set to
                             0 or MAPLE_FUNC_ANY to support all maple devices.
     \param  cb              The callback to call when the maple is attached.
+    \param  user_data       User data to be passed to cb when called.
 */
-void maple_attach_callback(uint32_t functions, maple_user_callback_t cb);
+void maple_attach_callback(uint32_t functions, maple_user_callback_t cb, void *user_data);
 
 /** \brief   Set an automatic maple detach callback.
     \ingroup maple
@@ -783,8 +796,9 @@ void maple_attach_callback(uint32_t functions, maple_user_callback_t cb);
     \param  functions       The functions maple device must support. Set to
                             0 or MAPLE_FUNC_ANY to support all maple devices.
     \param  cb              The callback to call when the maple is detached.
+    \param  user_data       User data to be passed to cb when called.
 */
-void maple_detach_callback(uint32_t functions, maple_user_callback_t cb);
+void maple_detach_callback(uint32_t functions, maple_user_callback_t cb, void *user_data);
 
 /**************************************************************************/
 /* maple_irq.c */


### PR DESCRIPTION
Rebuild of #498 . Key differences are the starting cleanup and adjustments made for all the various changes over the past 2 years.

An example of this functionality was actually requested by one of our developers looking to hook it into the raylib DC implementation.

- Added userdata pointer to maple attach/detach callback event registration.
- Added an example called "maple" which shows users how to subscribe to the attach/detach events and displays detailed device information.
- Added a few more details to the Doxygen description for the API.

Example output just playing around attaching/removing devices:

```
KallistiOS v2.3.0 [dreamcast/pristine]
  Git revision: 245c3e3d-dirty
  Tue Jun 16 06:54:04 PM EDT 2026
  quzar@Centurion-IV.localdomain:/home/quzar/dcdev/KallistiOS
  sh-elf-gcc (GCC) 17.0.0 20260611 (experimental)
maple: active drivers:
    Dreameye (Camera): Camera
    Sound Input Peripheral: Microphone
    PuruPuru (Vibration) Pack: JumpPack
    VMU Driver: Clock, LCD, MemoryCard
    Mouse Driver: Mouse
    Keyboard Driver: Keyboard
    Controller Driver: Controller
    Lightgun: LightGun
vid_set_mode: 640x480 VGA with 1 framebuffers.
dc-load console support enabled
maple: attached devices:
  A0: Dreamcast Controller           (01000000: Controller)
  A1: Visual Memory                  (0e000000: Clock, LCD, MemoryCard)
  A2: Puru Puru Pack                 (00010000: JumpPack)
  B0: Dreamcast Camera Flash  Device (01000000: Controller)
  B1: Dreamcast Camera Flash LDevice (00080000: Camera)
  B2: Dreamcast Camera Flash LDevice (00080000: Camera)
  B3: Dreamcast Camera Flash LDevice (00080000: Camera)
  B4: Dreamcast Camera Flash LDevice (00080000: Camera)
  B5: Dreamcast Camera Flash LDevice (00080000: Camera)
  C0: Keyboard                       (40000000: Keyboard)

Listening for device hotplug events...
Maple device detached [A1]: Visual Memory                 Produced By or Under License From SEGA ENTERPRISES,LTD.     |
Maple device attached [A1]: Visual Memory
        Functions      :                                  Clock, LCD, MemoryCard
        Driver         :                                              VMU Driver
        Region Code    :                                                     255
        Orientation    :                                                       0
        Standby Power  :                                                     124
        Max Power      :                                                     130
        License        : Produced By or Under License From SEGA ENTERPRISES,LTD.
Maple device detached [A2]: Puru Puru Pack                Produced By or Under License From SEGA ENTERPRISES,LTD.     �
Maple device attached [A2]: Puru Puru Pack
        Functions      :                                                JumpPack
        Driver         :                               PuruPuru (Vibration) Pack
        Region Code    :                                                     255
        Orientation    :                                                       0
        Standby Power  :                                                     200
        Max Power      :                                                    1600
        License        : Produced By or Under License From SEGA ENTERPRISES,LTD.
Attached Events: 2, Detached Events: 2