### PR TITLE
Examples makefile rules updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ romdisk.img
 html/
 /doc/reference/
 /ports/
+/examples/errors.txt
+/examples/error_count.txt

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -95,10 +95,10 @@ $(patsubst %, _clean_dir_%, $(SUBDIRS)):
 
 # Define KOS_ROMDISK_DIR in your Makefile if you want these two handy rules.
 ifdef KOS_ROMDISK_DIR
-romdisk.img:
+romdisk.img: $(wildcard $(KOS_ROMDISK_DIR)/*)
 	$(KOS_GENROMFS) -f romdisk.img -d $(KOS_ROMDISK_DIR) -v -x .gitignore -x .DS_Store -x Thumbs.db
 
-romdisk.o: romdisk.img
+romdisk.o: romdisk.img $(KOS_BASE)/utils/bin2c/bin2c
 	$(KOS_BASE)/utils/bin2c/bin2c romdisk.img romdisk_tmp.c romdisk
 	kos-cc -o romdisk_tmp.o -c romdisk_tmp.c
 	$(KOS_CC) -o romdisk.o -r romdisk_tmp.o $(KOS_LIB_PATHS) -Wl,--whole-archive -lromdiskbase -nostdlib

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -50,11 +50,29 @@ else
 
 endif
 
-.PHONY: all_naomi all_pristine
+define KOS_GCCVER_MIN_CHECK
+$(shell \
+	awk 'BEGIN { \
+		split("$(1)", min, "."); \
+		split("$(KOS_GCCVER)", cur, "."); \
+		if (cur[1] > min[1] || \
+			(cur[1] == min[1] && cur[2] > min[2]) || \
+			(cur[1] == min[1] && cur[2] == min[2] && cur[3] >= min[3])) { \
+			print 1; \
+		} \
+	}')
+endef
 
-all_naomi: $(if $(filter $(KOS_BUILD_SUBARCHS),naomi),all)
+.PHONY: all_naomi all_pristine check err_kos_gccver_min_warning
 
-all_pristine: $(if $(filter $(KOS_BUILD_SUBARCHS),pristine),all)
+all_naomi: $(if $(filter $(KOS_BUILD_SUBARCHS),naomi),check)
+
+all_pristine: $(if $(filter $(KOS_BUILD_SUBARCHS),pristine),check)
+
+check: $(if $(KOS_GCCVER_MIN),$(if $(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),all,err_kos_gccver_min_warning),all)
+
+err_kos_gccver_min_warning:
+	@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
 
 %.o: %.s
 	kos-as $< -o $@
@@ -86,25 +104,6 @@ romdisk.o: romdisk.img
 	$(KOS_CC) -o romdisk.o -r romdisk_tmp.o $(KOS_LIB_PATHS) -Wl,--whole-archive -lromdiskbase -nostdlib
 	rm romdisk_tmp.c romdisk_tmp.o
 endif
-
-define KOS_GCCVER_MIN_CHECK
-$(shell \
-	awk 'BEGIN { \
-		split("$(1)", min, "."); \
-		split("$(KOS_GCCVER)", cur, "."); \
-		if (cur[1] > min[1] || \
-			(cur[1] == min[1] && cur[2] > min[2]) || \
-			(cur[1] == min[1] && cur[2] == min[2] && cur[3] >= min[3])) { \
-			print 1; \
-		} else { \
-			print 0; \
-		} \
-	}')
-endef
-
-define KOS_GCCVER_MIN_WARNING
-@echo "Skipping $(TARGET) build as current GCC version ($(KOS_GCCVER)) is less than $(KOS_GCCVER_MIN)."
-endef
 
 ifdef EXPORTS_FILE
 

--- a/addons/Makefile.prefab
+++ b/addons/Makefile.prefab
@@ -16,7 +16,11 @@
 # Include the KOS-specific config for the build arch, if any
 -include kos/$(KOS_ARCH).cnf
 
+include $(KOS_BASE)/Makefile.rules
+
 defaultall: $(OBJS) subdirs linklib
+
+all: defaultall
 
 linklib: $(OBJS) $(LIB_OBJS)
 	rm -f $(KOS_BASE)/addons/lib/$(KOS_ARCH)/$(TARGET)
@@ -27,4 +31,3 @@ clean: defaultclean
 defaultclean: clean_subdirs
 	-rm -f $(OBJS) $(KOS_BASE)/addons/lib/$(KOS_ARCH)/$(TARGET) $(LOCAL_CLEAN)
 
-include $(KOS_BASE)/Makefile.rules

--- a/addons/libkosgcov/Makefile
+++ b/addons/libkosgcov/Makefile
@@ -8,19 +8,4 @@ TARGET = libkosgcov.a
 OBJS = kos_gcov.o
 KOS_GCCVER_MIN = 12.0.0
 
-.PHONY: libkosgcov
-
-all: libkosgcov
-
 include $(KOS_BASE)/addons/Makefile.prefab
-
-ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
-
-libkosgcov: defaultall
-
-else
-
-libkosgcov:
-	$(KOS_GCCVER_MIN_WARNING)
-
-endif

--- a/examples/dreamcast/basic/breaking/Makefile
+++ b/examples/dreamcast/basic/breaking/Makefile
@@ -9,11 +9,7 @@ OBJS = breaking.o
 KOS_CFLAGS += -std=gnu2x -Wno-strict-aliasing
 KOS_GCCVER_MIN = 13.0.0
 
-
-
 include $(KOS_BASE)/Makefile.rules
-
-ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
 
 all: rm-elf $(TARGET)
 
@@ -32,9 +28,3 @@ run: $(TARGET)
 dist: $(TARGET)
 	-rm -f $(OBJS)
 	$(KOS_STRIP) $(TARGET)
-
-else
-  all $(TARGET) clean rm-elf run dist:
-	$(KOS_GCCVER_MIN_WARNING)
-endif
-

--- a/examples/dreamcast/basic/fpu/exc/Makefile
+++ b/examples/dreamcast/basic/fpu/exc/Makefile
@@ -6,13 +6,8 @@
 
 TARGET = fpu_exc.elf
 OBJS = fpu_exc.o
-KOS_GCCVER_MIN = 5.0.0
-
-
 
 include $(KOS_BASE)/Makefile.rules
-
-ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
 
 all: rm-elf $(TARGET)
 
@@ -31,8 +26,3 @@ run: $(TARGET)
 dist: $(TARGET)
 	-rm -f $(OBJS)
 	$(KOS_STRIP) $(TARGET)
-
-else
-  all $(TARGET) clean rm-elf run dist:
-	$(KOS_GCCVER_MIN_WARNING)
-endif

--- a/examples/dreamcast/basic/stackprotector/Makefile
+++ b/examples/dreamcast/basic/stackprotector/Makefile
@@ -10,11 +10,8 @@ OBJS = stackprotector.o
 KOS_CFLAGS += -O0 -Wno-stringop-overflow -Wno-analyzer-out-of-bounds
 # Force stack protector on
 KOS_CFLAGS += -fstack-protector-all
-KOS_GCCVER_MIN = 4.0.0
 
 include $(KOS_BASE)/Makefile.rules
-
-ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
 
 all: rm-elf $(TARGET)
 
@@ -34,10 +31,4 @@ dist: $(TARGET)
 	-rm -f $(OBJS)
 	$(KOS_STRIP) $(TARGET)
 
-else
-  all $(TARGET) clean rm-elf run dist:
-	$(KOS_GCCVER_MIN_WARNING)
-endif
-
 .PHONY: run dist clean rm-elf
-

--- a/examples/dreamcast/cpp/concurrency/Makefile
+++ b/examples/dreamcast/cpp/concurrency/Makefile
@@ -10,8 +10,6 @@ KOS_GCCVER_MIN = 12.0.0
 
 include $(KOS_BASE)/Makefile.rules
 
-ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
-
 all: rm-elf $(TARGET)
 
 clean:
@@ -29,8 +27,3 @@ run: $(TARGET)
 dist:
 	rm -f $(OBJS)
 	$(KOS_STRIP) $(TARGET)
-
-else
-  all $(TARGET) clean rm-elf run dist:
-	$(KOS_GCCVER_MIN_WARNING)
-endif

--- a/examples/dreamcast/cpp/filesystem/Makefile
+++ b/examples/dreamcast/cpp/filesystem/Makefile
@@ -12,8 +12,6 @@ all: rm-elf $(TARGET)
 
 include $(KOS_BASE)/Makefile.rules
 
-ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
-
 clean: rm-elf
 	-rm -f $(OBJS) 
 
@@ -29,8 +27,3 @@ run: $(TARGET)
 dist: $(TARGET)
 	-rm -f $(OBJS) romdisk.img
 	$(KOS_STRIP) $(TARGET)
-
-else
-  all $(TARGET) clean rm-elf run dist:
-	$(KOS_GCCVER_MIN_WARNING)
-endif

--- a/examples/dreamcast/profiling/gcov/Makefile
+++ b/examples/dreamcast/profiling/gcov/Makefile
@@ -14,8 +14,6 @@ CFLAGS = --coverage
 
 include $(KOS_BASE)/Makefile.rules
 
-ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
-
 all: rm-elf $(TARGET)
 
 clean: rm-elf
@@ -44,8 +42,3 @@ report:
 	lcov --capture --directory . --gcov-tool $(KOS_GCOV) --rc geninfo_unexecuted_blocks=1 --ignore-errors inconsistent,unused,source,empty --output-file coverage.info
 	genhtml coverage.info --output-directory html --ignore-errors inconsistent,source
 	@echo "open html/index.html"
-
-else
-  all $(TARGET) clean rm-elf run dist:
-	$(KOS_GCCVER_MIN_WARNING)
-endif

--- a/examples/dreamcast/sh4zam/bruces_balls/Makefile
+++ b/examples/dreamcast/sh4zam/bruces_balls/Makefile
@@ -15,8 +15,6 @@ KOS_GCCVER_MIN = 13.0.0
 
 include $(KOS_BASE)/Makefile.rules
 
-ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
-
 all: rm-elf $(TARGET)
 
 clean: rm-elf
@@ -34,8 +32,3 @@ run: $(TARGET)
 dist: $(TARGET)
 	-rm -f $(OBJS)  
 	$(KOS_STRIP) $(TARGET)
-
-else
-  all $(TARGET) clean rm-elf run dist:
-	$(KOS_GCCVER_MIN_WARNING)
-endif


### PR DESCRIPTION
Some changes drawn out from #1038 . They still don't correct #1025 and allow foolproof multithreaded building of examples, but should help some. I left behind the changes that change the rules into a provider of all the make targets as that's a much heavier change.

- Remove gcc version checks for unsupported versions.
- Ensure git ignores example build error files.
- Integrate the gcc version check logic just like we do for romdisk and exports, just define the version number.
- Add dependencies to romdisk objects to prevent failures.

The gcc version checker probably needs a bit further tweaking. As far as I can tell it works fine for our examples but I'm not too fluent with makefiles.