### PR TITLE
Modernize CI

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -19,7 +19,7 @@ jobs:
       matrix: ${{ steps.setup-matrix.outputs.matrix }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup matrix
       id: setup-matrix
@@ -41,9 +41,9 @@ jobs:
       profile: ${{ fromJSON(matrix.toolchain).profile }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@v4
       id: filter
       with:
         filters: |

--- a/.github/workflows/no-tab.yml
+++ b/.github/workflows/no-tab.yml
@@ -6,7 +6,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/no-tab.yml
+++ b/.github/workflows/no-tab.yml
@@ -13,4 +13,10 @@ jobs:
     - name: No-tabulation check
       run: |
         git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-        test -z "$(git diff ${{ github.base_ref }} -- . ':(exclude)*Makefile' ':(exclude)*.mk' |grep ^+.*$'\t')"
+        git diff ${{ github.base_ref }} -- . ':(exclude)*Makefile' ':(exclude)*.mk' | awk '
+          /^\+\+\+ / { f=$2; sub(/^b\//,"",f); next }
+          /^@@ /     { match($0,/\+[0-9]+/); ln=substr($0,RSTART+1,RLENGTH-1)+0; next }
+          /^\+/      { if(index($0,"\t")){ printf "::error file=%s,line=%d::Tab character not allowed\n", f, ln; rc=1 } ln++; next }
+          /^[ ]/     { ln++ }
+          END        { exit rc }
+        '

--- a/.github/workflows/sourceforge.yml
+++ b/.github/workflows/sourceforge.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -6,7 +6,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -13,4 +13,10 @@ jobs:
     - name: Whitespace check
       run: |
         git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-        ! git diff ${{ github.base_ref }} |grep '^\+.* $' >/dev/null
+        git diff ${{ github.base_ref }} | awk '
+          /^\+\+\+ / { f=$2; sub(/^b\//,"",f); next }
+          /^@@ /     { match($0,/\+[0-9]+/); ln=substr($0,RSTART+1,RLENGTH-1)+0; next }
+          /^\+/      { if($0 ~ / $/){ printf "::error file=%s,line=%d::Trailing whitespace\n", f, ln; rc=1 } ln++; next }
+          /^[ ]/     { ln++ }
+          END        { exit rc }
+        '


### PR DESCRIPTION
This PR updates the Github actions to the current versions so we don't get "Node.js 20 actions are deprecated" anymore. Also extend the no-tab and whitespace checks to display file and line number on failure.