### PR TITLE
maple: Don't reset controllers on shutdown.

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -80,7 +80,9 @@ static void maple_dev_reset(maple_device_t *dev) {
 }
 
 static void maple_dev_reset_all(void) {
-    MAPLE_FOREACH_BEGIN(MAPLE_FUNC_ANY, void, st)
+    /* Skip controllers: a RESET re-zeroes their analog axes at the current
+       position, so triggers/stick held at exit stay miscalibrated. */
+    MAPLE_FOREACH_BEGIN(MAPLE_FUNC_ANY & ~MAPLE_FUNC_CONTROLLER, void, st)
         maple_dev_reset(__dev);
         (void)st;
     MAPLE_FOREACH_END()


### PR DESCRIPTION
This addresses #1384.

First, I tested on real hardware with the retail Marvel vs. Capcom 2 to see what the production behavior was. With the triggers held down and the stick offset I plugged the controller into the game and it also shows miscalibrated stick and trigger input. That confirms the controller calibrates its analog inputs whenever power is provided to it (or maple RESET command). If the controls aren't in their default positions at that moment, tough luck, the software can't prevent it and does not try to fix it.

So we should avoid the RESET command on controller init/shutdown because the controller was already calibrated "correctly" when the console powered on or when the controller was inserted into the port while the console is on. If a program uses those buttons to exit back to dcload, the controller is left miscalibrated and stays that way on the next run.