### PR TITLE
Add nonnull, pure, and const where appropriate

### DIFF
--- a/addons/libkosext2fs/ext2fs.h
+++ b/addons/libkosext2fs/ext2fs.h
@@ -60,11 +60,11 @@ typedef struct kos_blockdev {
     uint32_t l_block_size;
     int (*init)(struct kos_blockdev *d);
     int (*shutdown)(struct kos_blockdev *d);
-    int (*read_blocks)(struct kos_blockdev *d, uint32_t block, size_t count,
+    int (*read_blocks)(const struct kos_blockdev *d, uint32_t block, size_t count,
                        void *buf);
-    int (*write_blocks)(struct kos_blockdev *d, uint32_t block, size_t count,
+    int (*write_blocks)(const struct kos_blockdev *d, uint32_t block, size_t count,
                         const void *buf);
-    uint32_t (*count_blocks)(struct kos_blockdev *d);
+    uint32_t (*count_blocks)(const struct kos_blockdev *d);
 } kos_blockdev_t;
 
 #ifndef SYMLOOP_MAX

--- a/addons/libkosfat/fatfs.h
+++ b/addons/libkosfat/fatfs.h
@@ -58,11 +58,11 @@ typedef struct kos_blockdev {
     uint32_t l_block_size;
     int (*init)(struct kos_blockdev *d);
     int (*shutdown)(struct kos_blockdev *d);
-    int (*read_blocks)(struct kos_blockdev *d, uint64_t block, size_t count,
+    int (*read_blocks)(const struct kos_blockdev *d, uint64_t block, size_t count,
                        void *buf);
-    int (*write_blocks)(struct kos_blockdev *d, uint64_t block, size_t count,
+    int (*write_blocks)(const struct kos_blockdev *d, uint64_t block, size_t count,
                         const void *buf);
-    uint32_t (*count_blocks)(struct kos_blockdev *d);
+    uint32_t (*count_blocks)(const struct kos_blockdev *d);
 } kos_blockdev_t;
 #endif /* FAT_NOT_IN_KOS */
 

--- a/include/kos/blockdev.h
+++ b/include/kos/blockdev.h
@@ -89,7 +89,7 @@ typedef struct kos_blockdev {
         \retval 0           On success.
         \retval -1          On failure. Set errno as appropriate.
     */
-    int (*read_blocks)(struct kos_blockdev *d, uint64_t block, size_t count,
+    int (*read_blocks)(const struct kos_blockdev *d, uint64_t block, size_t count,
                        void *buf);
 
     /** \brief  Write a number of blocks to the device.
@@ -104,7 +104,7 @@ typedef struct kos_blockdev {
         \retval 0           On success.
         \retval -1          On failure. Set errno as appropriate.
     */
-    int (*write_blocks)(struct kos_blockdev *d, uint64_t block, size_t count,
+    int (*write_blocks)(const struct kos_blockdev *d, uint64_t block, size_t count,
                         const void *buf);
 
     /** \brief  Count the number of blocks on the device.
@@ -116,7 +116,7 @@ typedef struct kos_blockdev {
         \param  d           The device to read the block count from.
         \return             The number of blocks that the device has.
     */
-    uint64_t (*count_blocks)(struct kos_blockdev *d);
+    uint64_t (*count_blocks)(const struct kos_blockdev *d);
 
     /** \brief  Flush the write cache (if any) of the device.
 

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -330,7 +330,7 @@ extern kthread_t *thd_current;
 
     \return                 Whatever the unblocker deems necessary to return.
 */
-int thd_block_now(irq_context_t *mycxt);
+int thd_block_now(irq_context_t *mycxt) __nonnull_all;
 
 /** \brief   Find a new thread to swap in.
 
@@ -369,7 +369,7 @@ kthread_t *thd_by_tid(tid_t tid);
 
     \sa thd_remove_from_runnable
 */
-void thd_add_to_runnable(kthread_t *t, bool front_of_line);
+void thd_add_to_runnable(kthread_t *t, bool front_of_line) __nonnull_all;
 
 /** \brief       Removes a thread from the runnable queue, if it's there.
     \relatesalso kthread_t
@@ -384,7 +384,7 @@ void thd_add_to_runnable(kthread_t *t, bool front_of_line);
 
     \sa thd_add_to_runnable
 */
-int thd_remove_from_runnable(kthread_t *thd);
+int thd_remove_from_runnable(kthread_t *thd) __nonnull_all;
 
 /** \brief       Create a new thread.
     \relatesalso kthread_t
@@ -439,7 +439,7 @@ kthread_t *thd_create_ex(const kthread_attr_t *__RESTRICT attr,
 
     \sa thd_create
 */
-int thd_destroy(kthread_t *thd);
+int thd_destroy(kthread_t *thd) __nonnull_all;
 
 /** \brief   Exit the current thread.
 
@@ -480,7 +480,7 @@ void thd_schedule(bool front_of_line);
 
     \param  thd     The thread to schedule next.
 */
-void thd_schedule_next(kthread_t *thd);
+void thd_schedule_next(kthread_t *thd) __nonnull_all;
 
 /** \brief   Throw away the current thread's timeslice.
 
@@ -581,7 +581,8 @@ kthread_t *thd_get_idle(void);
 /** \brief       Retrieve the thread's label.
     \relatesalso kthread_t
 
-    \param  thd             The thread to retrieve from.
+    \param  thd             The thread to retrieve from. If NULL, the current
+                            thread will be used.
 
     \return                 The human-readable label of the thread.
 
@@ -597,7 +598,8 @@ const char *thd_get_label(const kthread_t *thd);
     anything internally, and you can give them any label you want. These are
     mainly seen in the printouts from thd_pslist() or thd_pslist_queue().
 
-    \param  thd             The thread to set the label of.
+    \param  thd             The thread to set the label of. If NULL, the current
+                            thread will be used.
     \param  label           The string to set as the label.
 
     \sa thd_get_label
@@ -612,7 +614,8 @@ void thd_set_label(kthread_t *__RESTRICT thd, const char *__RESTRICT label);
     doing this, but this is here in case you need it when the thread isn't
     active for some reason.
 
-    \param  thd             The thread to retrieve from.
+    \param  thd             The thread to retrieve from. If NULL, the current
+                            thread will be used.
 
     \return                 The thread's working directory.
 
@@ -629,6 +632,7 @@ const char *thd_get_pwd(const kthread_t *thd);
     active for some reason.
 
     \param  thd             The thread to set the working directory of.
+                            If NULL, the current thread will be used.
     \param  pwd             The directory to set as active.
 
     \sa thd_get_pwd
@@ -796,7 +800,7 @@ int thd_each(int (*cb)(kthread_t *thd, void *user_data), void *data);
 
     \sa thd_pslist_queue
 */
-int thd_pslist(int (*pf)(const char *fmt, ...));
+int thd_pslist(int (*pf)(const char *fmt, ...)) __nonnull_all;
 
 /** \brief   Print a list of all queued threads using the given print function.
 
@@ -806,7 +810,7 @@ int thd_pslist(int (*pf)(const char *fmt, ...));
 
     \sa thd_pslist
 */
-int thd_pslist_queue(int (*pf)(const char *fmt, ...));
+int thd_pslist_queue(int (*pf)(const char *fmt, ...)) __nonnull_all;
 
 /** \cond INTERNAL */
 
@@ -819,7 +823,6 @@ int thd_pslist_queue(int (*pf)(const char *fmt, ...));
     \sa thd_shutdown
 */
 int thd_init(void);
-
 
 /** \brief   Shutdown the threading system.
  

--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -135,7 +135,7 @@ static int ucscompare(const uint8_t *isofn, const uint8_t *normalfn, int isosize
         return 0;
 }
 
-static int isjoliet(char *p) {
+static int isjoliet(const char *p) {
     if(p[0] == '%' && p[1] == '/') {
         switch(p[2]) {
             case '@':

--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -1147,7 +1147,7 @@ static int atab_shutdown(kos_blockdev_t *d) {
     return 0;
 }
 
-static int atab_read_blocks(kos_blockdev_t *d, uint64_t block, size_t count,
+static int atab_read_blocks(const kos_blockdev_t *d, uint64_t block, size_t count,
                             void *buf) {
     ata_devdata_t *data = (ata_devdata_t *)d->dev_data;
 
@@ -1159,7 +1159,7 @@ static int atab_read_blocks(kos_blockdev_t *d, uint64_t block, size_t count,
     return g1_ata_read_lba(block + data->start_block, count, (uint16_t *)buf);
 }
 
-static int atab_read_blocks_dma(kos_blockdev_t *d, uint64_t block, size_t count,
+static int atab_read_blocks_dma(const kos_blockdev_t *d, uint64_t block, size_t count,
                                 void *buf) {
     ata_devdata_t *data = (ata_devdata_t *)d->dev_data;
 
@@ -1171,7 +1171,7 @@ static int atab_read_blocks_dma(kos_blockdev_t *d, uint64_t block, size_t count,
     return g1_ata_read_lba_dma(block + data->start_block, count, buf, 1);
 }
 
-static int atab_write_blocks(kos_blockdev_t *d, uint64_t block, size_t count,
+static int atab_write_blocks(const kos_blockdev_t *d, uint64_t block, size_t count,
                              const void *buf) {
     ata_devdata_t *data = (ata_devdata_t *)d->dev_data;
 
@@ -1183,7 +1183,7 @@ static int atab_write_blocks(kos_blockdev_t *d, uint64_t block, size_t count,
     return g1_ata_write_lba(block + data->start_block, count, buf);
 }
 
-static int atab_write_blocks_dma(kos_blockdev_t *d, uint64_t block,
+static int atab_write_blocks_dma(const kos_blockdev_t *d, uint64_t block,
                                  size_t count, const void *buf) {
     ata_devdata_t *data = (ata_devdata_t *)d->dev_data;
 
@@ -1195,7 +1195,7 @@ static int atab_write_blocks_dma(kos_blockdev_t *d, uint64_t block,
     return g1_ata_write_lba_dma(block + data->start_block, count, buf, 1);
 }
 
-static int atab_read_blocks_chs(kos_blockdev_t *d, uint64_t block, size_t count,
+static int atab_read_blocks_chs(const kos_blockdev_t *d, uint64_t block, size_t count,
                                 void *buf) {
     ata_devdata_t *data = (ata_devdata_t *)d->dev_data;
     uint8_t h, s;
@@ -1215,7 +1215,7 @@ static int atab_read_blocks_chs(kos_blockdev_t *d, uint64_t block, size_t count,
     return g1_ata_read_chs(c, h, s, count, buf);
 }
 
-static int atab_write_blocks_chs(kos_blockdev_t *d, uint64_t block,
+static int atab_write_blocks_chs(const kos_blockdev_t *d, uint64_t block,
                                  size_t count, const void *buf) {
     ata_devdata_t *data = (ata_devdata_t *)d->dev_data;
     uint8_t h, s;
@@ -1235,7 +1235,7 @@ static int atab_write_blocks_chs(kos_blockdev_t *d, uint64_t block,
     return g1_ata_write_chs(c, h, s, count, buf);
 }
 
-static uint64_t atab_count_blocks(kos_blockdev_t *d) {
+static uint64_t atab_count_blocks(const kos_blockdev_t *d) {
     ata_devdata_t *data = (ata_devdata_t *)d->dev_data;
 
     return (uint32_t)data->block_count;

--- a/kernel/arch/dreamcast/hardware/sci.c
+++ b/kernel/arch/dreamcast/hardware/sci.c
@@ -574,7 +574,7 @@ sci_result_t sci_read_byte(uint8_t *data) {
     return SCI_OK;
 }
 
-sci_result_t sci_write_data(uint8_t *data, size_t len) {
+sci_result_t sci_write_data(const uint8_t *data, size_t len) {
     uint32_t timeout_cnt;
     sci_result_t result;
 

--- a/kernel/arch/dreamcast/hardware/sd.c
+++ b/kernel/arch/dreamcast/hardware/sd.c
@@ -767,23 +767,23 @@ static int sdb_shutdown(kos_blockdev_t *d) {
     return 0;
 }
 
-static int sdb_read_blocks(kos_blockdev_t *d, uint64_t block, size_t count,
+static int sdb_read_blocks(const kos_blockdev_t *d, uint64_t block, size_t count,
                            void *buf) {
-    sd_devdata_t *data = (sd_devdata_t *)d->dev_data;
+    const sd_devdata_t *data = (const sd_devdata_t *)d->dev_data;
 
     return sd_read_blocks(block + data->start_block, count, (uint8_t *)buf);
 }
 
-static int sdb_write_blocks(kos_blockdev_t *d, uint64_t block, size_t count,
+static int sdb_write_blocks(const kos_blockdev_t *d, uint64_t block, size_t count,
                             const void *buf) {
-    sd_devdata_t *data = (sd_devdata_t *)d->dev_data;
+    const sd_devdata_t *data = (const sd_devdata_t *)d->dev_data;
 
     return sd_write_blocks(block + data->start_block, count,
                            (const uint8_t *)buf);
 }
 
-static uint64_t sdb_count_blocks(kos_blockdev_t *d) {
-    sd_devdata_t *data = (sd_devdata_t *)d->dev_data;
+static uint64_t sdb_count_blocks(const kos_blockdev_t *d) {
+    const sd_devdata_t *data = (sd_devdata_t *)d->dev_data;
 
     return data->block_count;
 }

--- a/kernel/arch/dreamcast/hardware/spu.c
+++ b/kernel/arch/dreamcast/hardware/spu.c
@@ -40,7 +40,7 @@ kernel; so don't use them if you don't need to =).
 /* memcpy and memset designed for sound RAM; for addresses, don't
    bother to include the 0xa0800000 offset that is implied. 'length'
    must be a multiple of 4, but if it is not it will be rounded up. */
-void spu_memload(uintptr_t dst, void *src_void, size_t length) {
+void spu_memload(uintptr_t dst, const void *src_void, size_t length) {
     uint8_t *src = (uint8_t *)src_void;
 
     /* Make sure it's an even number of 32-bit words and convert the
@@ -65,7 +65,7 @@ void spu_memload(uintptr_t dst, void *src_void, size_t length) {
     }
 }
 
-void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
+void spu_memload_sq(uintptr_t dst, const void *src_void, size_t length) {
     uint8_t *src = (uint8_t *)src_void;
     size_t aligned_len;
     g2_ctx_t ctx;
@@ -114,7 +114,7 @@ void spu_memload_sq(uintptr_t dst, void *src_void, size_t length) {
     }
 }
 
-void spu_memload_dma(uintptr_t dst, void *src_void, size_t length) {
+void spu_memload_dma(uintptr_t dst, const void *src_void, size_t length) {
     uint8_t *src = (uint8_t *)src_void;
     size_t aligned_len;
 
@@ -135,7 +135,7 @@ void spu_memload_dma(uintptr_t dst, void *src_void, size_t length) {
     length &= 31;
 
     do {
-        if(spu_dma_transfer(src_void, dst, aligned_len, 1, NULL, NULL) < 0) {
+        if(spu_dma_transfer((void *)src_void, dst, aligned_len, 1, NULL, NULL) < 0) {
             if(errno == EINPROGRESS) {
                 thd_pass();
                 continue;

--- a/kernel/arch/dreamcast/include/arch/dmac.h
+++ b/kernel/arch/dreamcast/include/arch/dmac.h
@@ -160,7 +160,7 @@ typedef uint32_t dma_addr_t;
     \param  hw_addr         The hardware address.
     \return                 The converted DMA address.
 */
-dma_addr_t hw_to_dma_addr(uintptr_t hw_addr);
+dma_addr_t __pure2 hw_to_dma_addr(uintptr_t hw_addr);
 
 /** \brief   Prepare a source memory buffer for a DMA transfer.
     \ingroup dmac

--- a/kernel/arch/dreamcast/include/dc/sci.h
+++ b/kernel/arch/dreamcast/include/dc/sci.h
@@ -168,7 +168,7 @@ sci_result_t sci_write_byte(uint8_t data);
     \param  len             Number of bytes to write.
     \return                 SCI_OK on success, error code otherwise.
 */
-sci_result_t sci_write_data(uint8_t *data, size_t len);
+sci_result_t sci_write_data(const uint8_t *data, size_t len);
 
 /** \brief  Read multiple bytes from the UART.
     \param  data            Buffer to store read data.

--- a/kernel/arch/dreamcast/include/dc/spu.h
+++ b/kernel/arch/dreamcast/include/dc/spu.h
@@ -43,7 +43,7 @@ __BEGIN_DECLS
     \param  length          The number of bytes to copy. Automatically rounded
                             up to be a multiple of 4.
 */
-void spu_memload(uintptr_t to, void *from, size_t length);
+void spu_memload(uintptr_t to, const void *from, size_t length);
 
 
 /** \brief  Copy a block of data to sound RAM by using the Store Queues.
@@ -57,7 +57,7 @@ void spu_memload(uintptr_t to, void *from, size_t length);
     \param  length          The number of bytes to copy. Automatically rounded
                             up to be a multiple of 4.
 */
-void spu_memload_sq(uintptr_t to, void *from, size_t length);
+void spu_memload_sq(uintptr_t to, const void *from, size_t length);
 
 /** \brief  Copy a block of data to sound RAM by using DMA (or SQ on fails).
 
@@ -69,7 +69,7 @@ void spu_memload_sq(uintptr_t to, void *from, size_t length);
     \param  from            A pointer to copy from.
     \param  length          The number of bytes to copy. Must be a multiple of 32.
 */
-void spu_memload_dma(uintptr_t to, void *from, size_t length);
+void spu_memload_dma(uintptr_t to, const void *from, size_t length);
 
 /** \brief  Copy a block of data from sound RAM.
 


### PR DESCRIPTION
I *think* a few of the `__pure` could be `__pure2` (`__const__`). There are also a few other places where a function could be pure if it didn't use `assert`, as we allow custom assert handlers. It *could* be worthwhile to come up with a `__pure_assert` or such that assigns pure when `NDEBUG` is set.