### PR TITLE
filesystem_browse: Handle browsing via `.` and `..`

### DIFF
--- a/examples/dreamcast/filesystem/browse/browse.c
+++ b/examples/dreamcast/filesystem/browse/browse.c
@@ -126,9 +126,11 @@ int main(int argc, char **argv) {
                     fs_path_append(directory_temp, current_directory, BUFFER_LENGTH);
                     fs_path_append(directory_temp, directory_contents[selector_index].filename, BUFFER_LENGTH);
 
-                    content_count = browse_directory(directory_temp, directory_contents);
+                    memset(directory_temp2, 0, BUFFER_LENGTH);
+                    fs_normalize_path(directory_temp, directory_temp2);
+                    content_count = browse_directory(directory_temp2, directory_contents);
                     if(content_count > 0) {
-                        realpath(directory_temp, current_directory);
+                        realpath(directory_temp2, current_directory);
                         changed_directory = true;
                         selector_index = 0;
                     } 


### PR DESCRIPTION
Without this, if navigating solely using the `A` button and going 'up' using `..` current_directory only removes the `..` and tries to navigate from the previous subfolder into another root folder. So going into `/vmu` then `..` and `/rd` will attempt to browse to `/vmu/rd`.

Open to more efficient or comprehensive ways to solve the issue, but it seems quite a bit that normalizing the path is what's required (though perhaps it could/should happen elsewhere).