### PR TITLE
ci: Update to v7 for checkout so we no longer get Node.js 20 warnings

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -19,7 +19,7 @@ jobs:
       matrix: ${{ steps.setup-matrix.outputs.matrix }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup matrix
       id: setup-matrix

--- a/.github/workflows/no-tab.yml
+++ b/.github/workflows/no-tab.yml
@@ -6,7 +6,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/sourceforge.yml
+++ b/.github/workflows/sourceforge.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -6,7 +6,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Sorry, I thought I updated to the latest checkout version in my last PR. Turns out the latest version is 7.