### PR TITLE
Introduce MIE-JVS bridge driver for NAOMI systems

### DIFF
--- a/environ_base.sh
+++ b/environ_base.sh
@@ -50,7 +50,7 @@ export KOS_SIZE="${KOS_CC_BASE}/bin/${KOS_CC_PREFIX}-size"
 # Pull in the arch environ file.
 . ${KOS_BASE}/environ_${KOS_ARCH}.sh
 
-export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_INC_PATHS} -D_arch_${KOS_ARCH} -D_arch_sub_${KOS_SUBARCH} -Wall -g"
+export KOS_CFLAGS="${KOS_CFLAGS} ${KOS_INC_PATHS} -D_arch_${KOS_ARCH}=1 -D_arch_sub_${KOS_SUBARCH}=1 -Wall -g"
 export KOS_CPPFLAGS="${KOS_CPPFLAGS} ${KOS_INC_PATHS_CPP}"
 
 # Which standards modes we want to compile for.

--- a/examples/dreamcast/mie/basic/Makefile
+++ b/examples/dreamcast/mie/basic/Makefile
@@ -1,0 +1,29 @@
+# KallistiOS ##version##
+#
+# mie/basic/Makefile
+# Copyright (C) 2026 Ruslan Rostovtsev
+#
+
+TARGET = mie_basic.elf
+OBJS = mie_basic.o
+
+all: rm-elf $(TARGET)
+
+include $(KOS_BASE)/Makefile.rules
+
+clean: rm-elf
+	-rm -f $(OBJS)
+
+rm-elf:
+	-rm -f $(TARGET)
+
+$(TARGET): $(OBJS)
+	kos-cc -o $(TARGET) $(OBJS)
+
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
+
+dist: $(TARGET)
+	-rm -f $(OBJS)
+	$(KOS_STRIP) $(TARGET)
+	$(KOS_OBJCOPY) -R .stack -O binary $(TARGET) $(TARGET).bin

--- a/examples/dreamcast/mie/basic/mie_basic.c
+++ b/examples/dreamcast/mie/basic/mie_basic.c
@@ -1,0 +1,431 @@
+/* KallistiOS ##version##
+
+   mie_basic.c
+   Copyright (C) 2026 Ruslan Rostovtsev
+
+   Poll MIE/JVS inputs, run wheel/pedal calibration, blink JVS outputs,
+   and print mapped controller state plus native JVS fields.
+*/
+
+#include <stdio.h>
+#include <string.h>
+
+#include <kos.h>
+#include <kos/init.h>
+
+#if defined(_arch_sub_naomi)
+#include <dc/minifont.h>
+#define bfont_draw(a,b,c,d) minifont_draw((a),(b),(d))
+#else
+#include <dc/biosfont.h>
+#endif
+#include <dc/maple.h>
+#include <dc/maple/controller.h>
+#include <dc/maple/keyboard.h>
+#include <dc/maple/mie.h>
+#include <dc/maple/mouse.h>
+#include <dc/pvr.h>
+
+KOS_INIT_FLAGS(INIT_DEFAULT | INIT_MIE);
+
+#define UI_FONT_W   12
+#define UI_FONT_H   24
+#define UI_LINE_MAX 80
+#define UI_ROW_MAX  19
+
+static pvr_ptr_t ui_font_tex;
+
+static const char *port_mode_name(mie_port0_mode_t mode) {
+    switch(mode) {
+    case MIE_PORT0_JVS:
+        return "JVS";
+    case MIE_PORT0_MAPLE:
+        return "Maple";
+    default:
+        return "unknown";
+    }
+}
+
+static void ui_font_init(void) {
+    uint16_t *vram;
+    int x, y;
+
+    ui_font_tex = pvr_mem_malloc(256 * 256 * 2);
+    vram = (uint16_t *)ui_font_tex;
+
+    for(y = 0; y < 8; y++) {
+        for(x = 0; x < 16; x++) {
+            bfont_draw(vram, 256, 0, y * 16 + x);
+            vram += 16;
+        }
+        vram += 23 * 256;
+    }
+}
+
+static void ui_draw_char(float x1, float y1, int c) {
+    pvr_vertex_t vert;
+    int ix, iy;
+    float u1, v1, u2, v2;
+
+    if(c == ' ') {
+        return;
+    }
+
+    if(!(c > ' ' && c < 127)) {
+        return;
+    }
+
+    ix = (c % 16) * 16;
+    iy = (c / 16) * 24;
+    u1 = ix * 1.0f / 256.0f;
+    v1 = iy * 1.0f / 256.0f;
+    u2 = (ix + 12) * 1.0f / 256.0f;
+    v2 = (iy + 24) * 1.0f / 256.0f;
+
+    vert.flags = PVR_CMD_VERTEX;
+    vert.x = x1;
+    vert.y = y1 + UI_FONT_H;
+    vert.z = 1.0f;
+    vert.u = u1;
+    vert.v = v2;
+    vert.argb = PVR_PACK_COLOR(1.0f, 1.0f, 1.0f, 1.0f);
+    vert.oargb = 0;
+    pvr_prim(&vert, sizeof(vert));
+
+    vert.x = x1;
+    vert.y = y1;
+    vert.u = u1;
+    vert.v = v1;
+    pvr_prim(&vert, sizeof(vert));
+
+    vert.x = x1 + UI_FONT_W;
+    vert.y = y1 + UI_FONT_H;
+    vert.u = u2;
+    vert.v = v2;
+    pvr_prim(&vert, sizeof(vert));
+
+    vert.flags = PVR_CMD_VERTEX_EOL;
+    vert.x = x1 + UI_FONT_W;
+    vert.y = y1;
+    vert.u = u2;
+    vert.v = v1;
+    pvr_prim(&vert, sizeof(vert));
+}
+
+static void ui_draw_str(float x, float y, const char *str) {
+    pvr_poly_cxt_t cxt;
+    pvr_poly_hdr_t poly;
+    int i, len;
+
+    if(!str || !str[0]) {
+        return;
+    }
+
+    len = (int)strlen(str);
+
+    pvr_poly_cxt_txr(&cxt, PVR_LIST_TR_POLY,
+                     PVR_TXRFMT_ARGB1555 | PVR_TXRFMT_NONTWIDDLED,
+                     256, 256, ui_font_tex, PVR_FILTER_NONE);
+    pvr_poly_compile(&poly, &cxt);
+    pvr_prim(&poly, sizeof(poly));
+
+    for(i = 0; i < len; i++) {
+        ui_draw_char(x, y, str[i]);
+        x += UI_FONT_W;
+    }
+}
+
+static void ui_draw(const char lines[][UI_LINE_MAX], int count) {
+    float x = 8.0f;
+    float y = 8.0f;
+    int i;
+
+    pvr_wait_ready();
+    pvr_scene_begin();
+    pvr_list_begin(PVR_LIST_TR_POLY);
+
+    for(i = 0; i < count; i++) {
+        ui_draw_str(x, y, lines[i]);
+        y += UI_FONT_H;
+    }
+
+    pvr_list_finish();
+    pvr_scene_finish();
+}
+
+static volatile uint32_t coin_cb_count = 0;
+
+static void mie_coin_cb(mie_jvs_input_t input, uint32_t mask) {
+    (void)input;
+    (void)mask;
+    coin_cb_count++;
+}
+
+static void mie_service_cb(mie_jvs_input_t input, uint32_t mask) {
+    (void)input;
+    (void)mask;
+    mie_coin_add(0, 1, true);
+}
+
+static void outputs_blink(void) {
+    static uint64_t last_ms;
+    static uint8_t step;
+    uint64_t now;
+
+    if(mie_port0_mode() != MIE_PORT0_JVS) {
+        return;
+    }
+
+    now = timer_ms_gettime64();
+    if(now - last_ms < 500) {
+        return;
+    }
+
+    last_ms = now;
+    mie_jvs_set_outputs(MIE_JVS_OUTPUT_MASK(step), false);
+    step = (uint8_t)((step + 1) % MIE_JVS_OUTPUT_COUNT);
+}
+
+static const char *calib_step_name(mie_analog_calib_step_t step) {
+    switch(step) {
+    case MIE_ANALOG_CALIB_WHEEL:
+        return "turn wheel fully both ways, press A";
+    case MIE_ANALOG_CALIB_WHEEL_CENTER:
+        return "hold wheel centered, press A";
+    case MIE_ANALOG_CALIB_ACCEL:
+        return "press accel fully, press A";
+    case MIE_ANALOG_CALIB_BRAKE:
+        return "press brake fully, press A";
+    default:
+        return "idle";
+    }
+}
+
+static uint32_t ui_poll_aux_buttons(void) {
+    uint32_t btns = 0;
+
+    MAPLE_FOREACH_BEGIN(MAPLE_FUNC_CONTROLLER, cont_state_t, c)
+        if(c) {
+            btns |= c->buttons;
+        }
+    MAPLE_FOREACH_END()
+
+    MAPLE_FOREACH_BEGIN(MAPLE_FUNC_KEYBOARD, kbd_state_t, kbd)
+        if(kbd) {
+            if(kbd->key_states[KBD_KEY_A].is_down) {
+                btns |= CONT_A;
+            }
+            if(kbd->key_states[KBD_KEY_B].is_down) {
+                btns |= CONT_B;
+            }
+            if(kbd->key_states[KBD_KEY_ESCAPE].is_down) {
+                btns |= CONT_START;
+            }
+        }
+    MAPLE_FOREACH_END()
+
+    MAPLE_FOREACH_BEGIN(MAPLE_FUNC_MOUSE, mouse_state_t, m)
+        if(m) {
+            if(m->buttons & MOUSE_LEFTBUTTON) {
+                btns |= CONT_A;
+            }
+            if(m->buttons & MOUSE_RIGHTBUTTON) {
+                btns |= CONT_B;
+            }
+            if(m->buttons & MOUSE_SIDEBUTTON) {
+                btns |= CONT_START;
+            }
+        }
+    MAPLE_FOREACH_END()
+
+    return btns;
+}
+
+static void ui_buttons_text(char *linebuf, size_t len, uint32_t btns) {
+    size_t n = 0;
+
+    linebuf[0] = '\0';
+
+    if(btns & CONT_START)
+        n += snprintf(linebuf + n, len - n, "START ");
+    if(btns & CONT_A)
+        n += snprintf(linebuf + n, len - n, "A ");
+    if(btns & CONT_B)
+        n += snprintf(linebuf + n, len - n, "B ");
+    if(btns & CONT_X)
+        n += snprintf(linebuf + n, len - n, "X ");
+    if(btns & CONT_Y)
+        n += snprintf(linebuf + n, len - n, "Y ");
+    if(btns & CONT_Z)
+        n += snprintf(linebuf + n, len - n, "Z ");
+    if(btns & CONT_C)
+        n += snprintf(linebuf + n, len - n, "C ");
+    if(btns & CONT_D)
+        n += snprintf(linebuf + n, len - n, "D ");
+    if(btns & CONT_DPAD_UP)
+        n += snprintf(linebuf + n, len - n, "UP ");
+    if(btns & CONT_DPAD_DOWN)
+        n += snprintf(linebuf + n, len - n, "DOWN ");
+    if(btns & CONT_DPAD_LEFT)
+        n += snprintf(linebuf + n, len - n, "LEFT ");
+    if(btns & CONT_DPAD_RIGHT)
+        n += snprintf(linebuf + n, len - n, "RIGHT ");
+
+    if(n == 0) {
+        snprintf(linebuf, len, "(none)");
+    }
+}
+
+static void ui_sys_line(char *linebuf, size_t len,
+                        const mie_jvs_system_t *sys) {
+    size_t n;
+
+    n = snprintf(linebuf, len, "sys=0x%02x", sys->raw);
+    if(sys->test) {
+        n += snprintf(linebuf + n, len - n, " test");
+    }
+    if(sys->raw == 0) {
+        snprintf(linebuf + n, len - n, " (idle)");
+    }
+}
+
+static void ui_panel_line(char *linebuf, size_t len,
+                            const mie_jvs_panel_t *panel) {
+    snprintf(linebuf, len,
+             "panel dip=0x%02x psw=0x%02x test=%d service=%d",
+             panel->dip.raw, panel->psw.raw,
+             panel->psw.test, panel->psw.service);
+}
+
+static int ui_build(mie_state_t *st, char lines[][UI_LINE_MAX]) {
+    int n = 0;
+
+    snprintf(lines[n++], UI_LINE_MAX, "MIE basic example");
+    snprintf(lines[n++], UI_LINE_MAX, "port A mode: %s",
+             port_mode_name(mie_port0_mode()));
+
+    if(!st) {
+        snprintf(lines[n++], UI_LINE_MAX, "No MIE device (waiting...)");
+        snprintf(lines[n++], UI_LINE_MAX,
+                 "outputs=0x%08lx (running light 0..%d)",
+                 (unsigned long)mie_jvs_get_outputs(),
+                 MIE_JVS_OUTPUT_COUNT - 1);
+        snprintf(lines[n++], UI_LINE_MAX,
+                 "Press START on pad or Esc to exit");
+        return n;
+    }
+
+    snprintf(lines[n++], UI_LINE_MAX, "Mapped controller (st->cont):");
+    ui_buttons_text(lines[n++], UI_LINE_MAX, st->cont.buttons);
+    snprintf(lines[n++], UI_LINE_MAX,
+             "joyx=%d ltrig=%d rtrig=%d",
+             st->cont.joyx, st->cont.ltrig, st->cont.rtrig);
+    snprintf(lines[n++], UI_LINE_MAX, "Native JVS (st->jvs):");
+    ui_sys_line(lines[n++], UI_LINE_MAX, &st->jvs.system);
+    snprintf(lines[n++], UI_LINE_MAX, "p1=0x%04x p2=0x%04x",
+             st->jvs.p1.raw, st->jvs.p2.raw);
+    ui_panel_line(lines[n++], UI_LINE_MAX, &st->jvs.panel);
+    snprintf(lines[n++], UI_LINE_MAX,
+             "meter0=%u meter1=%u coin callbacks: %lu",
+             mie_get_coin_meter(0), mie_get_coin_meter(1),
+             (unsigned long)coin_cb_count);
+    snprintf(lines[n++], UI_LINE_MAX,
+             "coin0 raw=0x%04x count=%u busy=0x%04x",
+             st->jvs.coin[0].raw, (unsigned)st->jvs.coin[0].count,
+             (unsigned)(st->jvs.coin[0].raw & MIE_JVS_COIN_BUSY));
+    snprintf(lines[n++], UI_LINE_MAX,
+             "coin1 raw=0x%04x count=%u busy=0x%04x",
+             st->jvs.coin[1].raw, (unsigned)st->jvs.coin[1].count,
+             (unsigned)(st->jvs.coin[1].raw & MIE_JVS_COIN_BUSY));
+    snprintf(lines[n++], UI_LINE_MAX,
+             "wheel=%u accel=%u brake=%u",
+             st->jvs.wheel, st->jvs.accel, st->jvs.brake);
+    snprintf(lines[n++], UI_LINE_MAX,
+             "outputs=0x%08lx (running light 0..%d)",
+             (unsigned long)mie_jvs_get_outputs(),
+             MIE_JVS_OUTPUT_COUNT - 1);
+
+    if(mie_analog_calib_active()) {
+        snprintf(lines[n++], UI_LINE_MAX, "CALIB: %s",
+                 calib_step_name(mie_analog_calib_current()));
+    }
+    else if(mie_analog_calib_valid()) {
+        snprintf(lines[n++], UI_LINE_MAX,
+                 "calibrated (B/pad/kbd/mouse: recalibrate)");
+    }
+    else {
+        snprintf(lines[n++], UI_LINE_MAX,
+                 "not calibrated (B/pad/kbd/mouse: calibrate)");
+    }
+
+    snprintf(lines[n++], UI_LINE_MAX,
+             "B=calib A=capture (MIE/pad/key/mouse)");
+    snprintf(lines[n++], UI_LINE_MAX,
+             "START/Esc/mouse side=exit");
+    return n;
+}
+
+int main(int argc, char *argv[]) {
+    mie_state_t *st;
+    char lines[UI_ROW_MAX][UI_LINE_MAX];
+    int count;
+    uint32_t old_btns = 0;
+
+    (void)argc;
+    (void)argv;
+
+    pvr_init_defaults();
+    pvr_set_bg_color(0.0f, 0.0f, 0.0f);
+    ui_font_init();
+
+    mie_jvs_callback(MIE_JVS_IN_COIN1, MIE_JVS_COIN_INSERT_BIT, mie_coin_cb);
+    mie_jvs_callback(MIE_JVS_IN_COIN2, MIE_JVS_COIN_INSERT_BIT, mie_coin_cb);
+    mie_jvs_callback(MIE_JVS_IN_PANEL_PSW, MIE_JVS_PANEL_SERVICE_BIT, mie_service_cb);
+    mie_jvs_callback(MIE_JVS_IN_P1, MIE_JVS_SERVICE_BIT, mie_service_cb);
+
+    for(;;) {
+        int quit = 0;
+        uint32_t btns = ui_poll_aux_buttons();
+
+        outputs_blink();
+
+        st = NULL;
+
+        MAPLE_FOREACH_BEGIN(MAPLE_FUNC_MIE, mie_state_t, ms)
+            if(ms) {
+                st = ms;
+                btns |= ms->cont.buttons;
+
+                if((btns & CONT_B) && !(old_btns & CONT_B) &&
+                        !mie_analog_calib_active()) {
+                    mie_analog_calib_start();
+                }
+
+                if((btns & CONT_A) && !(old_btns & CONT_A) &&
+                        mie_analog_calib_active()) {
+                    mie_analog_calib_capture();
+                }
+
+                if((btns & CONT_START) && !(old_btns & CONT_START)) {
+                    quit = 1;
+                }
+            }
+        MAPLE_FOREACH_END()
+
+        if(!st && (btns & CONT_START) && !(old_btns & CONT_START)) {
+            quit = 1;
+        }
+
+        old_btns = btns;
+
+        if(quit) {
+            break;
+        }
+
+        count = ui_build(st, lines);
+        ui_draw(lines, count);
+    }
+
+    pvr_mem_free(ui_font_tex);
+    return 0;
+}

--- a/kernel/arch/dreamcast/exports.txt
+++ b/kernel/arch/dreamcast/exports.txt
@@ -1,5 +1,6 @@
 include kos.h
 include dc/sound/sound.h
+include dc/maple/mie.h
 
 # Cache management
 arch_icache_inval_range
@@ -235,6 +236,38 @@ vmu_draw_lcd
 vmu_block_read
 vmu_block_write
 vmu_set_icon
+
+# MIE
+mie_port0_mode
+mie_get_coin_meter
+mie_read_coin_input
+mie_coin_decrease
+mie_coin_add
+mie_jvs_set_outputs
+mie_jvs_set_output
+mie_jvs_get_outputs
+mie_jvs_driver_outputs
+mie_btn_callback
+mie_jvs_callback
+mie_set_cont_map
+mie_analog_calib_get
+mie_analog_calib_set
+mie_analog_calib_reset
+mie_analog_calib_valid
+mie_analog_calib_start
+mie_analog_calib_cancel
+mie_analog_calib_active
+mie_analog_calib_current
+mie_analog_calib_capture
+mie_analog_norm_wheel
+mie_analog_norm_accel
+mie_analog_norm_brake
+mie_get_id
+mie_get_eeprom
+mie_set_eeprom
+mie_eeprom_crc16
+mie_eeprom_fix_crc
+mie_init_fw
 
 # VMUFS
 vmufs_dir_fill_time

--- a/kernel/arch/dreamcast/hardware/maple/Makefile
+++ b/kernel/arch/dreamcast/hardware/maple/Makefile
@@ -16,6 +16,7 @@ OBJS := $(OBJS) purupuru.o sip.o dreameye.o lightgun.o
 # Output devices
 OBJS := $(OBJS) vmu.o
 
-SUBDIRS =
+# MIE-JVS bridge
+SUBDIRS := mie
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -2,6 +2,7 @@
 
    maple_init_shutdown.c
    Copyright (C) 2002 Megan Potter
+   Copyright (C) 2026 Ruslan Rostovtsev
  */
 
 #include <inttypes.h>
@@ -9,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <arch/arch.h>
 #include <dc/memory.h>
 #include <dc/maple.h>
 #include <dc/asic.h>
@@ -88,6 +90,18 @@ static void maple_dev_reset_all(void) {
     MAPLE_FOREACH_END()
 }
 
+static uint8_t maple_dma_addr_prot_byte(uint32_t addr) {
+    return ((((addr) & MEM_AREA_CACHE_MASK) >> 20) - 0x80) & 0xff;
+}
+
+static uint32_t maple_dma_mem_protection(void) {
+    uint32_t ram_lo, ram_hi;
+
+    ram_lo = maple_dma_addr_prot_byte(0x0c000000);
+    ram_hi = maple_dma_addr_prot_byte(_arch_mem_top - 1);
+    return MAPLE_DMA_PROT_MAGIC | (ram_lo << 8) | ram_hi;
+}
+
 /* Initialize Hardware (call after driver inits) */
 static void maple_hw_init(void) {
     maple_driver_t *drv;
@@ -137,8 +151,8 @@ static void maple_hw_init(void) {
     maple_state.gun_x = maple_state.gun_y = -1;
 
     /* Reset hardware */
-    maple_write(MAPLE_RESET1, MAPLE_RESET1_MAGIC);
-    maple_write(MAPLE_RESET2, MAPLE_RESET2_MAGIC);
+    maple_write(MAPLE_DMA_PROT, maple_dma_mem_protection());
+    maple_write(MAPLE_DMA_TSEL, MAPLE_DMA_TSEL_SOFTWARE);
     maple_write(MAPLE_SPEED, MAPLE_SPEED_2MBPS | MAPLE_SPEED_TIMEOUT(50000));
     maple_bus_enable();
 

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -28,6 +28,7 @@
 #include <dc/maple/sip.h>
 #include <dc/maple/dreameye.h>
 #include <dc/maple/lightgun.h>
+#include <dc/maple/mie.h>
 
 /*
   This system handles low-level communication/initialization of the maple
@@ -147,6 +148,7 @@ static void maple_hw_init(void) {
     maple_state.vbl_cntr = maple_state.dma_cntr = 0;
     maple_state.detect_port_next = 0;
     maple_state.scan_ready_mask = 0;
+    maple_state.port0_mie = 0;
     maple_state.gun_port = -1;
     maple_state.gun_x = maple_state.gun_y = -1;
 
@@ -213,11 +215,15 @@ static int maple_scan_done(maple_state_t *state) {
     return state->scan_ready_mask == 0xf;
 }
 
+KOS_INIT_FLAG_WEAK(mie_init_scan, __is_defined(_arch_sub_naomi));
+
 /* Wait for the initial bus scan to complete */
 void maple_wait_scan(void) {
 
     /* Wait for it to finish */
     thd_poll((thd_cb_t)maple_scan_done, &maple_state, 0);
+
+    KOS_INIT_FLAG_CALL(mie_init_scan);
 
     /* Enumerate everything */
     dbglog(DBG_INFO, "maple: attached devices:\n");
@@ -227,7 +233,7 @@ void maple_wait_scan(void) {
             maple_device_t *dev = maple_enum_dev(p, u);
 
             if(dev) {
-                dbglog(DBG_INFO, "  %c%c: %.30s (%08lx: %s)\n",
+                dbglog(DBG_INFO, "  %c%c: %-30.30s (%08lx: %s)\n",
                        'A' + p, '0' + u,
                        dev->info.product_name,
                        dev->info.functions, maple_pcaps(dev->info.functions));
@@ -244,6 +250,7 @@ KOS_INIT_FLAG_WEAK(vmu_init, true);
 KOS_INIT_FLAG_WEAK(purupuru_init, true);
 KOS_INIT_FLAG_WEAK(sip_init, true);
 KOS_INIT_FLAG_WEAK(dreameye_init, true);
+KOS_INIT_FLAG_WEAK(mie_init, __is_defined(_arch_sub_naomi));
 
 /* Full init: initialize known drivers and start maple operations */
 void maple_init(void) {
@@ -255,6 +262,7 @@ void maple_init(void) {
     KOS_INIT_FLAG_CALL(purupuru_init);
     KOS_INIT_FLAG_CALL(sip_init);
     KOS_INIT_FLAG_CALL(dreameye_init);
+    KOS_INIT_FLAG_CALL(mie_init);
 
     maple_hw_init();
 }
@@ -267,9 +275,11 @@ KOS_INIT_FLAG_WEAK(vmu_shutdown, true);
 KOS_INIT_FLAG_WEAK(purupuru_shutdown, true);
 KOS_INIT_FLAG_WEAK(sip_shutdown, true);
 KOS_INIT_FLAG_WEAK(dreameye_shutdown, true);
+KOS_INIT_FLAG_WEAK(mie_shutdown, __is_defined(_arch_sub_naomi));
 
 /* Full shutdown: shutdown each driver, then all hardware operations. */
 void maple_shutdown(void) {
+    KOS_INIT_FLAG_CALL(mie_shutdown);
     KOS_INIT_FLAG_CALL(dreameye_shutdown);
     KOS_INIT_FLAG_CALL(sip_shutdown);
     KOS_INIT_FLAG_CALL(purupuru_shutdown);

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -183,8 +183,14 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
 }
 
 static void vbl_autodetect(maple_state_t *state) {
-    maple_device_t  *dev = maple_state.ports[state->detect_port_next].units[0];
-    maple_frame_t   *frm = (dev != NULL) ? &dev->frame : &detect_frame;
+
+    if(state->detect_port_next == 0 && state->port0_mie) {
+        state->detect_port_next = 1;
+        return;
+    }
+
+    maple_device_t *dev = maple_state.ports[state->detect_port_next].units[0];
+    maple_frame_t *frm = (dev != NULL) ? &dev->frame : &detect_frame;
 
     /* Queue a detection on the next device */
     bool queued = vbl_send_devinfo(frm,

--- a/kernel/arch/dreamcast/hardware/maple/maple_utils.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_utils.c
@@ -93,7 +93,10 @@ static const char *maple_cap_names[] = {
     "Camera",
     NULL,
     "Mouse",
-    "JumpPack"
+    "JumpPack",
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    "JVS I/O"
 };
 
 /* Print the capabilities of a given driver to dbglog; NOT THREAD SAFE */

--- a/kernel/arch/dreamcast/hardware/maple/maple_utils.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_utils.c
@@ -35,7 +35,7 @@ int maple_dma_in_progress(void) {
 
 /* Set the DMA Address */
 void maple_dma_addr(void *ptr) {
-    maple_write(MAPLE_DMAADDR, ((uint32_t) ptr) & MEM_AREA_CACHE_MASK);
+    maple_write(MAPLE_DMA_ADDR, ((uint32_t) ptr) & MEM_AREA_CACHE_MASK);
 }
 
 /* Return a "maple address" for a port,unit pair */

--- a/kernel/arch/dreamcast/hardware/maple/mie/Makefile
+++ b/kernel/arch/dreamcast/hardware/maple/mie/Makefile
@@ -1,0 +1,9 @@
+# KallistiOS ##version##
+#
+# arch/dreamcast/hardware/maple/mie/Makefile
+# Copyright (C) 2026 Ruslan Rostovtsev
+#
+
+OBJS := mie.o mie_proto.o mie_input.o mie_calib.o mie_fw.o
+
+include $(KOS_BASE)/Makefile.prefab

--- a/kernel/arch/dreamcast/hardware/maple/mie/mie.c
+++ b/kernel/arch/dreamcast/hardware/maple/mie/mie.c
@@ -1,0 +1,1005 @@
+/* KallistiOS ##version##
+
+   mie.c
+   Copyright (C) 2026 Ruslan Rostovtsev
+
+   MIE (Maple I/O Emulator) driver for the JVS bridge on port A.
+
+   Two Maple frames share the bus:
+     - dev->frame  — periodic input poll and deferred coin/output commands
+     - mie_cmd_frame — blocking init/eeprom/fw commands (mie_cmd_resp)
+
+   Input poll is a two-step IO transaction handled in mie_poll/mie_reply:
+     1) send bundled JVS read (SWINP + COININP + ANLINP)
+     2) fetch IOR buffer and parse via mie_apply_buttons
+*/
+
+#include <string.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdalign.h>
+#include <assert.h>
+#include <arch/arch.h>
+
+#include <dc/maple.h>
+#include <dc/maple/mie.h>
+#include <dc/maple/controller.h>
+
+#include "mie_internal.h"
+
+#include <kos/dbglog.h>
+#include <kos/genwait.h>
+#include <kos/mutex.h>
+#include <kos/regfield.h>
+#include <kos/thread.h>
+#include <kos/timer.h>
+
+#define MIE_MAPLE_PORT 0
+#define MIE_MAPLE_UNIT 0
+
+#define MIE_CMD_GET_ID   0x82
+#define MIE_RESP_GET_ID  0x83
+#define MIE_CMD_IO       0x86
+#define MIE_RESP_IO      0x87
+
+#define MIE_MAPLE_IDLE_PROBE MAPLE_COMMAND_DEVINFO
+
+#define MIE_IOR_JVS_EMPTY 0x32
+#define MIE_JVS_FETCH_MIN_WORDS 8
+
+#define MIE_COIN_CMD_TX_WORDS 3
+
+#define MIE_IO_TIMEOUT_MAX        60
+#define MIE_IO_ERR_BACKOFF        30
+#define MIE_POLL_IDLE_TIMEOUT_MS  2000
+
+/* Two-phase JVS poll on Maple port A: send bundled request, then fetch result. */
+enum {
+    MIE_IO_IDLE = 0,
+    MIE_IO_WAIT_ACK,
+    MIE_IO_NEED_FETCH,
+    MIE_IO_WAIT_FETCH
+};
+
+typedef enum {
+    MIE_DEF_CMD_PENDING = 0,
+    MIE_DEF_CMD_OK = 1,
+    MIE_DEF_CMD_ERR = -1
+} mie_def_cmd_state_t;
+
+static int mie_attach(maple_driver_t *drv, maple_device_t *dev);
+static void mie_detach(maple_driver_t *drv, maple_device_t *dev);
+static void mie_periodic(maple_driver_t *drv);
+
+static maple_driver_t mie_drv = {
+    .functions = MAPLE_FUNC_MIE,
+    .name = "MIE Driver",
+    .periodic = mie_periodic,
+    .status_size = sizeof(mie_drv_state_t),
+    .attach = mie_attach,
+    .detach = mie_detach,
+};
+static maple_frame_t mie_cmd_frame;
+static mie_drv_state_t mie_static_state;
+/* Synthetic device when nothing else occupies port A unit 0. */
+static maple_device_t mie_static_dev = {
+    .port = MIE_MAPLE_PORT,
+    .unit = MIE_MAPLE_UNIT,
+    .frame = { .state = MAPLE_FRAME_VACANT },
+    .status = &mie_static_state,
+    .info = {
+        .functions = MAPLE_FUNC_MIE,
+        .product_name = "MIE JVS Bridge",
+        .product_license = "SEGA ENTERPRISES,LTD.",
+        .area_code = 0xff,
+    },
+};
+alignas(32) static uint8_t mie_io_tx_arr[32];
+/* Port A role: unknown until GET_ID, then JVS bridge or plain Maple. */
+static mie_port0_mode_t port0_mode = MIE_PORT0_UNKNOWN;
+static bool mie_jvs_ready;       /* periodic poll enabled after Z80 init */
+static bool mie_z80_init_done;
+static bool mie_drv_registered;
+static uint32_t mie_jvs_output_cache;
+static mutex_t mie_bus_mtx = MUTEX_INITIALIZER;
+static volatile bool mie_bus_suspend; /* blocks new polls during sync IO */
+
+typedef struct mie_cmd_req {
+    uint8_t tx[16];
+    uint8_t words;
+    volatile mie_def_cmd_state_t state;
+} mie_cmd_req_t;
+
+/* Deferred coin/output commands queued by API, sent on next idle poll cycle. */
+static mutex_t mie_def_mtx = MUTEX_INITIALIZER;
+static mie_cmd_req_t mie_def_req;
+static mie_cmd_req_t *volatile mie_active_cmd;
+static volatile bool mie_def_pending;
+static int mie_def_wq;
+
+_Static_assert(offsetof(mie_drv_state_t, cont) == offsetof(mie_state_t, cont),
+               "mie_drv_state_t layout must match mie_state_t");
+_Static_assert(offsetof(mie_drv_state_t, jvs) == offsetof(mie_state_t, jvs),
+               "mie_drv_state_t layout must match mie_state_t");
+
+static void mie_reply(maple_state_t *st, maple_frame_t *frm);
+static void mie_port0_detach(maple_device_t *dev);
+static int mie_bind_device(maple_device_t *dev);
+static int mie_poll(maple_device_t *dev);
+static void mie_bind_port0(void);
+static void mie_port0_set_mode(mie_port0_mode_t mode);
+static void mie_init_common(const char *fw_path);
+static void mie_frame_reset(maple_frame_t *frm);
+static maple_response_t *mie_cmd(int cmd, void *send_buf, int length,
+                               int expect_resp);
+
+static void mie_frame_reset(maple_frame_t *frm) {
+    if(frm->queued) {
+        maple_queue_remove(frm);
+    }
+
+    frm->state = MAPLE_FRAME_VACANT;
+    frm->queued = 0;
+}
+
+static int mie_bus_drained(void *data) {
+    (void)data;
+
+    return mie_static_state.io_state == MIE_IO_IDLE &&
+           !mie_static_dev.frame.queued;
+}
+
+bool mie_bus_acquire(void) {
+    /* Exclusive bus access for synchronous IO (eeprom, init, etc.).
+       The periodic poll uses dev->frame on the same port and must finish first. */
+    if(mutex_lock_timed(&mie_bus_mtx, 2000) < 0) {
+        return false;
+    }
+
+    /* Tell periodic to stop starting new polls and only drain in-flight IO. */
+    mie_bus_suspend = true;
+
+    if(thd_poll(mie_bus_drained, NULL, 2000) > 0) {
+        return true;
+    }
+
+    mie_bus_suspend = false;
+    mutex_unlock(&mie_bus_mtx);
+    return false;
+}
+
+void mie_bus_release(void) {
+    mie_bus_suspend = false;
+    mutex_unlock(&mie_bus_mtx);
+}
+
+static bool mie_cmd_submit(const uint8_t *tx, uint8_t words, bool block) {
+    bool ok;
+
+    if(words == 0 || words * 4 > (int)sizeof(mie_def_req.tx)) {
+        return false;
+    }
+
+    /* One deferred command at a time; poll picks it up on the next idle frame. */
+    mutex_lock_scoped(&mie_def_mtx);
+
+    if(mie_def_pending || mie_active_cmd) {
+        return false;
+    }
+
+    memcpy(mie_def_req.tx, tx, (size_t)words * 4);
+    mie_def_req.words = words;
+    mie_def_req.state = MIE_DEF_CMD_PENDING;
+    mie_def_pending = true;
+
+    /* Async path: poll will send the command; caller does not wait. */
+    if(!block) {
+        return true;
+    }
+
+    /* Sleep until mie_cmd_finish() completes the poll-cycle transaction. */
+    if(mie_def_req.state == MIE_DEF_CMD_PENDING) {
+        genwait_wait(&mie_def_wq, "mie_cmd", 2000);
+    }
+
+    ok = mie_def_req.state == MIE_DEF_CMD_OK;
+    /* Drop the request so periodic resumes normal input polling. */
+    mie_def_pending = false;
+    /* On timeout poll may still hold a stale pointer to this request. */
+    if(mie_active_cmd == &mie_def_req) {
+        mie_active_cmd = NULL;
+    }
+    return ok;
+}
+
+static int mie_queue_io(maple_device_t *dev, void (*build)(uint8_t *),
+                        int length, uint8_t next_state) {
+    mie_drv_state_t *ms;
+
+    assert(dev);
+    assert(dev->status);
+    assert(build);
+
+    ms = dev->status;
+
+    if(dev->frame.queued && dev->frame.state == MAPLE_FRAME_VACANT) {
+        mie_frame_reset(&dev->frame);
+    }
+
+    if(maple_frame_trylock(&dev->frame) < 0) {
+        return -1;
+    }
+
+    maple_frame_init(&dev->frame);
+    build((uint8_t *)dev->frame.send_buf);
+    dev->frame.cmd = MIE_CMD_IO;
+    dev->frame.dst_port = dev->port;
+    dev->frame.dst_unit = dev->unit;
+    dev->frame.length = length;
+    dev->frame.callback = mie_reply;
+    dev->frame.dev = dev;
+    ms->io_state = next_state;
+    return maple_queue_frame(&dev->frame);
+}
+
+/* Periodic bundled JVS input read; skipped while io_backoff counts down. */
+static int mie_queue_buttons_request(maple_device_t *dev) {
+    mie_drv_state_t *ms = dev->status;
+
+
+    if(ms->io_state != MIE_IO_IDLE || ms->io_backoff > 0) {
+        return -1;
+    }
+
+    return mie_queue_io(dev, mie_build_buttons_tx, mie_jvs_poll_tx_words(),
+                        MIE_IO_WAIT_ACK);
+}
+
+static int mie_queue_jvs_fetch(maple_device_t *dev) {
+    return mie_queue_io(dev, mie_build_jvs_fetch, 1, MIE_IO_WAIT_FETCH);
+}
+
+static void mie_build_active_cmd(uint8_t *buf) {
+    mie_cmd_req_t *req = mie_active_cmd;
+
+    memcpy(buf, req->tx, (size_t)req->words * 4);
+}
+
+static int mie_queue_cmd(maple_device_t *dev) {
+    return mie_queue_io(dev, mie_build_active_cmd, mie_active_cmd->words,
+                        MIE_IO_WAIT_ACK);
+}
+
+/* Complete a blocking deferred command and wake mie_cmd_submit waiter. */
+static void mie_cmd_finish(mie_def_cmd_state_t result) {
+    if(!mie_active_cmd) {
+        return;
+    }
+
+    mie_active_cmd->state = result;
+    mie_active_cmd = NULL;
+    genwait_wake_all(&mie_def_wq);
+}
+
+
+/* Maple callback for periodic IO. Advances io_state and applies input on fetch. */
+static void mie_reply(maple_state_t *st, maple_frame_t *frm) {
+    maple_response_t *resp;
+    maple_device_t *dev;
+    mie_drv_state_t *ms;
+    uint8_t *payload;
+    uint8_t *tx;
+    int payload_len;
+
+    (void)st;
+
+    assert(frm);
+    dev = frm->dev;
+    assert(dev);
+    assert(dev->status);
+
+    ms = dev->status;
+    resp = (maple_response_t *)frm->recv_buf;
+
+    /* Bus busy — retry fetch or drop back to idle. */
+    if(resp->response == MAPLE_RESPONSE_AGAIN) {
+        maple_frame_unlock(frm);
+        if(ms->io_state == MIE_IO_WAIT_FETCH) {
+            ms->io_state = MIE_IO_NEED_FETCH;
+        }
+        else {
+            ms->io_state = MIE_IO_IDLE;
+        }
+        return;
+    }
+
+    maple_frame_unlock(frm);
+
+    /* Unexpected response code — may still be a partial IOR echo of send_buf[0]. */
+    if((uint8_t)resp->response != MIE_RESP_IO) {
+        tx = (uint8_t *)frm->send_buf;
+
+        if(ms->io_state == MIE_IO_WAIT_FETCH &&
+                tx && (uint8_t)resp->response == tx[0]) {
+            ms->io_state = MIE_IO_NEED_FETCH;
+            return;
+        }
+
+        /* One-shot deferred cmd (coin/output) acked without fetch phase. */
+        if(ms->io_state == MIE_IO_WAIT_ACK &&
+                tx && (uint8_t)resp->response == tx[0]) {
+            mie_cmd_finish(MIE_DEF_CMD_OK);
+            ms->io_state = MIE_IO_IDLE;
+            return;
+        }
+
+        if(resp->response != MAPLE_RESPONSE_NONE) {
+            ms->io_backoff = MIE_IO_ERR_BACKOFF;
+        }
+        mie_cmd_finish(MIE_DEF_CMD_ERR);
+        ms->io_state = MIE_IO_IDLE;
+        return;
+    }
+
+    payload = (uint8_t *)resp->data;
+    payload_len = (int)resp->data_len * 4;
+
+    /* Fetch phase: Z80 may return empty until JVS data is ready. */
+    if(ms->io_state == MIE_IO_WAIT_FETCH) {
+        if(payload_len >= 1 && payload[0] == MIE_IOR_JVS_EMPTY) {
+            ms->io_state = MIE_IO_NEED_FETCH;
+            return;
+        }
+
+        if(resp->data_len < MIE_JVS_FETCH_MIN_WORDS) {
+            ms->io_state = MIE_IO_NEED_FETCH;
+            return;
+        }
+
+        if(mie_active_cmd) {
+            mie_cmd_finish(MIE_DEF_CMD_OK);
+        }
+        else {
+            mie_apply_buttons(resp, dev);
+        }
+
+        ms->io_state = MIE_IO_IDLE;
+        return;
+    }
+
+    /* Request accepted — schedule fetch on next periodic tick. */
+    if(ms->io_state == MIE_IO_WAIT_ACK) {
+        ms->io_state = MIE_IO_NEED_FETCH;
+        return;
+    }
+
+    ms->io_state = MIE_IO_IDLE;
+}
+
+static int mie_poll(maple_device_t *dev) {
+    mie_drv_state_t *ms;
+
+    assert(dev);
+    assert(dev->status);
+
+    ms = dev->status;
+
+    /* Continue a poll cycle waiting for JVS fetch data. */
+    if(ms->io_state == MIE_IO_NEED_FETCH) {
+        return mie_queue_jvs_fetch(dev);
+    }
+
+    /* Mid-transaction or error backoff — wait for mie_reply / mie_io_tick. */
+    if(ms->io_state != MIE_IO_IDLE || ms->io_backoff > 0) {
+        return -1;
+    }
+
+    /* Retry a deferred command after AGAIN or partial fetch. */
+    if(mie_active_cmd) {
+        return mie_queue_cmd(dev);
+    }
+
+    /* Pick up a new deferred command (coin add, output, etc.). */
+    if(mie_def_pending) {
+        mie_active_cmd = &mie_def_req;
+        mie_def_pending = false;
+        return mie_queue_cmd(dev);
+    }
+
+    /* Normal input poll: SWINP + coin + analog bundled request. */
+    return mie_queue_buttons_request(dev);
+}
+
+static int mie_attach(maple_driver_t *drv, maple_device_t *dev) {
+    mie_drv_state_t *ms;
+
+    (void)drv;
+
+    ms = dev->status;
+    memset(ms, 0, sizeof(*ms));
+    ms->io_state = MIE_IO_IDLE;
+    return 0;
+}
+
+static void mie_detach(maple_driver_t *drv, maple_device_t *dev) {
+    (void)drv;
+    (void)dev;
+}
+
+static int mie_bind_device(maple_device_t *dev) {
+    mie_drv_state_t *ms;
+
+    if(dev->drv == &mie_drv) {
+        return 1;
+    }
+
+    if(!dev->status) {
+        if(dev != &mie_static_dev) {
+            return -1;
+        }
+        dev->status = &mie_static_state;
+    }
+
+    if(mie_attach(&mie_drv, dev) < 0) {
+        return -1;
+    }
+
+    dev->drv = &mie_drv;
+    dev->valid = true;
+
+    if(dev->status) {
+        ms = dev->status;
+
+        memset(&ms->jvs.coin, 0, sizeof(ms->jvs.coin));
+    }
+
+    if(mie_drv.user_attach) {
+        mie_drv.user_attach(dev, mie_drv.user_attach_data);
+    }
+
+    dbglog(DBG_DEBUG, "mie: attached on port %c%d\n", 'A' + dev->port,
+           dev->unit);
+    return 0;
+}
+
+static void mie_port0_detach(maple_device_t *dev) {
+    if(!dev || dev->drv != &mie_drv) {
+        return;
+    }
+
+    dev->valid = false;
+
+    if(mie_drv.user_detach) {
+        mie_drv.user_detach(dev, mie_drv.user_detach_data);
+    }
+    if(mie_drv.detach) {
+        mie_drv.detach(&mie_drv, dev);
+    }
+
+    dev->drv = NULL;
+    dev->probe_mask = 0;
+    dev->dev_mask = 0;
+}
+
+mie_port0_mode_t mie_port0_mode(void) {
+    if(hardware_sys_mode(NULL) == HW_TYPE_RETAIL) {
+        return MIE_PORT0_MAPLE;
+    }
+
+    return (mie_port0_mode_t)port0_mode;
+}
+
+/* Periodic IO state housekeeping: decay post-error backoff while idle,
+   or abort a transaction that never completed. */
+static void mie_io_tick(maple_device_t *dev) {
+    mie_drv_state_t *ms;
+
+    assert(dev);
+    assert(dev->status);
+
+    ms = dev->status;
+
+    if(ms->io_state == MIE_IO_IDLE) {
+        /* No in-flight transaction; stale timeout must not carry over. */
+        ms->io_timeout = 0;
+        /* After a protocol error mie_reply sets io_backoff; tick it down
+           each period so mie_poll resumes input polling gradually. */
+        if(ms->io_backoff > 0) {
+            ms->io_backoff--;
+        }
+        return;
+    }
+
+    /* Transaction pending — mie_reply should advance io_state; if it does
+       not within MIE_IO_TIMEOUT_MAX periodic ticks, force recovery. */
+    if(++ms->io_timeout < MIE_IO_TIMEOUT_MAX) {
+        return;
+    }
+
+    ms->io_timeout = 0;
+    ms->io_state = MIE_IO_IDLE;
+    mie_cmd_finish(MIE_DEF_CMD_ERR);
+    mie_frame_reset(&dev->frame);
+}
+
+static void mie_bind_port0(void) {
+    maple_device_t *dev;
+
+    dev = maple_enum_dev(MIE_MAPLE_PORT, MIE_MAPLE_UNIT);
+    if(!dev) {
+        /* No Maple scan hit — install our static placeholder on port A. */
+        maple_state.ports[MIE_MAPLE_PORT].units[MIE_MAPLE_UNIT] = &mie_static_dev;
+        dev = &mie_static_dev;
+    }
+
+    mie_bind_device(dev);
+}
+
+/* Called every maple tick for each attached MIE device. */
+static int mie_periodic_dev(maple_device_t *dev) {
+    mie_drv_state_t *ms;
+
+    assert(dev);
+    assert(dev->status);
+
+    ms = dev->status;
+
+    /* Sync IO holds the bus: only drain in-flight fetch, no new polls. */
+    if(mie_bus_suspend) {
+        mie_io_tick(dev);
+
+        if(ms->io_state == MIE_IO_NEED_FETCH) {
+            return mie_queue_jvs_fetch(dev);
+        }
+
+        return -1;
+    }
+
+    mie_io_tick(dev);
+    return mie_poll(dev);
+}
+
+static void mie_periodic(maple_driver_t *drv) {
+    (void)drv;
+
+    if(port0_mode != MIE_PORT0_JVS || !mie_jvs_ready) {
+        return;
+    }
+
+    maple_driver_foreach(drv, mie_periodic_dev);
+}
+
+static int mie_bus_idle_check(void *data) {
+    (void)data;
+
+    return mie_static_state.io_state == MIE_IO_IDLE &&
+           !mie_static_dev.frame.queued &&
+           mie_cmd_frame.state == MAPLE_FRAME_VACANT &&
+           !mie_cmd_frame.queued;
+}
+
+static bool mie_maple_idle_probe(void) {
+    maple_response_t *resp;
+
+    /* Idle probe succeeds only when the bridge is not mid-transaction. */
+    resp = mie_cmd_resp(MIE_MAPLE_IDLE_PROBE, NULL, 0);
+    return resp &&
+           resp->response != MAPLE_RESPONSE_AGAIN &&
+           resp->response != MAPLE_RESPONSE_NONE;
+}
+
+/* Wait until both frames are idle and bridge accepts a DEVINFO probe. */
+bool mie_poll_idle(void) {
+    uint64_t deadline = timer_ms_gettime64() + MIE_POLL_IDLE_TIMEOUT_MS;
+    uint64_t now;
+    unsigned long remain;
+
+    for(;;) {
+        now = timer_ms_gettime64();
+        if(now >= deadline) {
+            return false;
+        }
+
+        remain = (unsigned long)(deadline - now);
+
+        if(thd_poll(mie_bus_idle_check, NULL, remain) <= 0) {
+            return false;
+        }
+
+        if(mie_maple_idle_probe()) {
+            return true;
+        }
+    }
+}
+
+maple_response_t *mie_jvs_fetch_retry(bool (*ready)(maple_response_t *)) {
+    uint8_t fetch[4];
+    maple_response_t *resp;
+    int i;
+
+    mie_build_jvs_fetch(fetch);
+
+    /* Z80 fills the IOR buffer asynchronously; retry until data is ready. */
+    for(i = 0; i < 80; i++) {
+        if(i > 0) {
+            thd_sleep(20);
+        }
+
+        resp = mie_cmd_resp(MIE_CMD_IO, fetch, 1);
+
+        if(!resp || resp->data_len < 1
+            || resp->response == MAPLE_RESPONSE_AGAIN
+            || (uint8_t)resp->response != MIE_RESP_IO) {
+            continue;
+        }
+
+        if(((uint8_t *)resp->data)[0] == MIE_IOR_JVS_EMPTY) {
+            continue;
+        }
+
+        if(!ready || ready(resp)) {
+            return resp;
+        }
+    }
+
+    return NULL;
+}
+
+/* Synchronous JVS IO for init/reset; caller must hold mie_bus_acquire. */
+bool mie_jvs_io_cmd(const uint8_t *req, int length) {
+    maple_response_t *resp;
+    uint8_t code;
+
+    assert(req);
+    assert(length > 0);
+
+    mie_bus_acquire_scoped(bus);
+    if(!bus) {
+        return false;
+    }
+
+    if(!mie_poll_idle()) {
+        return false;
+    }
+
+    resp = mie_cmd_resp(MIE_CMD_IO, (void *)req, length);
+    if(!resp) {
+        return false;
+    }
+
+    code = (uint8_t)resp->response;
+    return code == MIE_RESP_IO;
+}
+
+static void mie_cmd_cb(maple_state_t *st, maple_frame_t *frm) {
+    (void)st;
+    maple_frame_unlock(frm);
+    genwait_wake_all(frm);
+}
+
+/* Blocking Maple command on dedicated frame (init, eeprom, fw upload). */
+maple_response_t *mie_cmd_resp(int cmd, void *send_buf, int length) {
+    maple_frame_t *frm = &mie_cmd_frame;
+    maple_response_t *resp;
+
+    if(frm->queued && frm->state == MAPLE_FRAME_VACANT) {
+        mie_frame_reset(frm);
+    }
+
+    if(maple_frame_lock(frm) < 0) {
+        return NULL;
+    }
+
+    maple_frame_init(frm);
+    ((uint32_t *)frm->recv_buf)[0] = 0xffffffff;
+    frm->cmd = cmd;
+    frm->dst_port = MIE_MAPLE_PORT;
+    frm->dst_unit = MIE_MAPLE_UNIT;
+    frm->length = length;
+    if(length > 0 && send_buf) {
+        memcpy(mie_io_tx_arr, send_buf, length * 4);
+    }
+    frm->send_buf = (uint32_t *)mie_io_tx_arr;
+    frm->callback = mie_cmd_cb;
+    maple_queue_frame(frm);
+
+    if(!maple_state.dma_in_progress) {
+        maple_queue_flush();
+    }
+
+    if(genwait_wait(frm, "mie_cmd", 1000) < 0) {
+        mie_frame_reset(frm);
+        return NULL;
+    }
+
+    resp = (maple_response_t *)frm->recv_buf;
+    return resp;
+}
+
+static maple_response_t *mie_cmd(int cmd, void *send_buf, int length,
+                                      int expect_resp) {
+    maple_response_t *resp;
+
+    resp = mie_cmd_resp(cmd, send_buf, length);
+    if(!resp) {
+        return NULL;
+    }
+
+    if((uint8_t)resp->response != (uint8_t)expect_resp) {
+        return NULL;
+    }
+
+    return resp;
+}
+
+uint16_t mie_get_coin_meter(uint8_t slot) {
+    if(slot >= MIE_JVS_COIN_SLOTS) {
+        return 0;
+    }
+
+    return mie_static_state.jvs.coin[slot].count;
+}
+
+bool mie_read_coin_input(mie_jvs_coin_slot_t *out, int max_slots) {
+    int slots;
+    int i;
+
+    if(!out || max_slots < 1 || !mie_z80_init_done) {
+        return false;
+    }
+
+    slots = max_slots;
+    if(slots > MIE_JVS_COIN_SLOTS) {
+        slots = MIE_JVS_COIN_SLOTS;
+    }
+
+    for(i = 0; i < slots; i++) {
+        out[i] = mie_static_state.jvs.coin[i];
+    }
+
+    return true;
+}
+
+bool mie_coin_decrease(uint8_t slot, uint16_t amount, bool block) {
+    uint8_t req[12];
+
+    if(!mie_z80_init_done || amount == 0) {
+        return false;
+    }
+
+    mie_build_jvs_coin_dec(req, slot, amount);
+    return mie_cmd_submit(req, MIE_COIN_CMD_TX_WORDS, block);
+}
+
+bool mie_coin_add(uint8_t slot, uint16_t amount, bool block) {
+    uint8_t req[12];
+
+    if(!mie_z80_init_done || amount == 0) {
+        return false;
+    }
+
+    mie_build_jvs_coin_add(req, slot, amount);
+    return mie_cmd_submit(req, MIE_COIN_CMD_TX_WORDS, block);
+}
+
+static void mie_jvs_output_mask_to_wire(uint32_t mask, uint8_t *wire,
+                                        uint8_t wire_bytes) {
+    uint8_t i;
+
+    for(i = 0; i < wire_bytes; i++) {
+        wire[i] = (uint8_t)((mask >> (24 - i * 8)) & GENMASK(7, 0));
+    }
+}
+
+bool mie_jvs_set_outputs(uint32_t outputs, bool block) {
+    uint8_t req[16];
+    uint8_t wire[(MIE_JVS_OUTPUT_COUNT + 7) / 8];
+    uint8_t wire_bytes;
+    uint8_t tx_words;
+
+    if(!mie_z80_init_done) {
+        return false;
+    }
+
+    wire_bytes = mie_jvs_output_wire_bytes();
+    mie_jvs_output_mask_to_wire(outputs, wire, wire_bytes);
+    tx_words = mie_jvs_output_tx_words(wire_bytes);
+
+    mie_build_jvs_output(req, wire, wire_bytes);
+    if(!mie_cmd_submit(req, tx_words, block)) {
+        return false;
+    }
+
+    mie_jvs_output_cache = outputs;
+    return true;
+}
+
+bool mie_jvs_set_output(uint8_t index, bool on, bool block) {
+    uint32_t bit;
+
+    if(index >= MIE_JVS_OUTPUT_COUNT) {
+        return false;
+    }
+
+    bit = MIE_JVS_OUTPUT_MASK(index);
+    if(on) {
+        return mie_jvs_set_outputs(mie_jvs_output_cache | bit, block);
+    }
+
+    return mie_jvs_set_outputs(mie_jvs_output_cache & ~bit, block);
+}
+
+uint32_t mie_jvs_get_outputs(void) {
+    return mie_jvs_output_cache;
+}
+
+char *mie_get_id(char *dst) {
+    maple_response_t *resp;
+
+    assert(dst);
+
+    mie_bus_acquire_scoped(bus);
+    if(!bus) {
+        dst[0] = '\0';
+        return NULL;
+    }
+
+    resp = mie_cmd(MIE_CMD_GET_ID, NULL, 0, MIE_RESP_GET_ID);
+    if(!resp) {
+        dst[0] = '\0';
+        return NULL;
+    }
+
+    if(mie_copy_id(resp, dst, MIE_ID_SIZE) < 1) {
+        dst[0] = '\0';
+        return NULL;
+    }
+
+    return dst;
+}
+
+static void mie_port0_set_mode(mie_port0_mode_t mode) {
+    port0_mode = mode;
+    maple_state.port0_mie = (mode == MIE_PORT0_JVS);
+}
+
+/* Called from maple scan: skip probe if a normal controller already on port A. */
+void mie_init_scan(void) {
+    if(!mie_drv_registered) {
+        return;
+    }
+
+    if(port0_mode == MIE_PORT0_UNKNOWN) {
+        if(maple_dev_valid(MIE_MAPLE_PORT, MIE_MAPLE_UNIT)) {
+            mie_port0_set_mode(MIE_PORT0_MAPLE);
+            return;
+        }
+    }
+
+    if(port0_mode != MIE_PORT0_MAPLE) {
+        mie_init_common(NULL);
+    }
+}
+
+/* Detect JVS bridge on port A, bind driver, upload/activate Z80 firmware. */
+static void mie_init_common(const char *fw_path) {
+    maple_response_t *resp;
+    char id[MIE_ID_SIZE];
+
+    if(port0_mode == MIE_PORT0_MAPLE) {
+        return;
+    }
+
+    /* Probe GET_ID: MIE present -> JVS mode, absent -> normal Maple on port A. */
+    if(port0_mode == MIE_PORT0_UNKNOWN) {
+        resp = mie_cmd(MIE_CMD_GET_ID, NULL, 0, MIE_RESP_GET_ID);
+
+        if(!resp) {
+            dbglog(DBG_INFO, "mie: no JVS bridge, port A in Maple mode\n");
+            mie_port0_set_mode(MIE_PORT0_MAPLE);
+            return;
+        }
+
+        if(mie_copy_id(resp, id, sizeof(id)) >= 1) {
+            dbglog(DBG_INFO, "mie: JVS I/O %s\n", id);
+        }
+        mie_port0_set_mode(MIE_PORT0_JVS);
+    }
+
+    if(port0_mode != MIE_PORT0_JVS) {
+        return;
+    }
+
+    mie_bind_port0();
+
+    if(!mie_z80_init_done) {
+        mie_poll_idle();
+
+        /* Prefer existing Z80 code; upload fw_path only when probe fails. */
+        if(fw_path && fw_path[0]) {
+            if(mie_z80_init(fw_path, &mie_static_dev)) {
+                mie_z80_init_done = true;
+            }
+        }
+        else if(mie_z80_try_active(&mie_static_dev)) {
+            mie_z80_init_done = true;
+        }
+    }
+
+    if(mie_z80_init_done) {
+        mie_scan_complete();
+    }
+}
+/* Unblocks periodic input polling after Z80 firmware is verified. */
+void mie_scan_complete(void) {
+    mie_jvs_ready = port0_mode == MIE_PORT0_JVS;
+}
+
+bool mie_init_fw(const char *fw_path) {
+    if(hardware_sys_mode(NULL) == HW_TYPE_RETAIL) {
+        return false;
+    }
+
+    if(!fw_path || !fw_path[0]) {
+        return false;
+    }
+
+    if(mie_z80_init_done) {
+        return true;
+    }
+
+    if(!mie_drv_registered) {
+        mie_init();
+    }
+
+    if(!mie_drv_registered) {
+        return false;
+    }
+
+    mie_init_common(fw_path);
+
+    return mie_z80_init_done;
+}
+
+void mie_init(void) {
+    if(hardware_sys_mode(NULL) == HW_TYPE_RETAIL) {
+        return;
+    }
+
+    if(mie_drv_registered) {
+        return;
+    }
+
+    mie_set_cont_map(NULL);
+    mie_analog_calib_reset();
+    mie_callbacks_init();
+
+    mie_jvs_ready = false;
+    mie_z80_init_done = false;
+
+    memset(&mie_cmd_frame, 0, sizeof(mie_cmd_frame));
+    mie_cmd_frame.state = MAPLE_FRAME_VACANT;
+
+    maple_driver_reg(&mie_drv);
+    mie_drv_registered = true;
+}
+
+void mie_shutdown(void) {
+    maple_device_t **mie_unit;
+
+    if(!mie_drv_registered) {
+        return;
+    }
+
+    mie_callbacks_shutdown();
+    mie_port0_detach(&mie_static_dev);
+    mie_unit = &maple_state.ports[MIE_MAPLE_PORT].units[MIE_MAPLE_UNIT];
+    if(*mie_unit == &mie_static_dev) {
+        *mie_unit = NULL;
+    }
+    mie_port0_set_mode(MIE_PORT0_UNKNOWN);
+    mie_jvs_ready = false;
+    mie_z80_init_done = false;
+    mie_drv_registered = false;
+    maple_driver_unreg(&mie_drv);
+}

--- a/kernel/arch/dreamcast/hardware/maple/mie/mie_calib.c
+++ b/kernel/arch/dreamcast/hardware/maple/mie/mie_calib.c
@@ -1,0 +1,260 @@
+/* KallistiOS ##version##
+
+   mie_calib.c
+   Copyright (C) 2026 Ruslan Rostovtsev
+
+   Wheel/pedal calibration: track raw min/max during a wizard, then map
+   JVS 16-bit values to cont_state ranges (-128..127 wheel, 0..255 pedals).
+   Without valid calib data, legacy fixed-scale conversion is used.
+*/
+
+#include <string.h>
+
+#include <dc/maple/mie.h>
+
+#include "mie_internal.h"
+
+static mie_analog_calib_t active_calib;
+static mie_analog_calib_t work_calib;
+static mie_analog_calib_step_t step_calib;
+static bool active_calib_valid;
+static uint16_t last_wheel;
+static uint16_t last_accel;
+static uint16_t last_brake;
+
+static uint16_t mie_analog_raw_clean(uint16_t v) {
+    return v & MIE_JVS_ANALOG_RAW_MASK;
+}
+
+/* Fixed center at 0x8000, scale to -128..127 (used when no calib stored). */
+static int mie_analog_legacy_wheel(uint16_t v) {
+    int32_t centered;
+
+    v = mie_analog_raw_clean(v);
+    centered = (int32_t)v - 0x8000;
+    centered = centered * 127 / 0x8000;
+    if(centered < -128) {
+        return -128;
+    }
+    if(centered > 127) {
+        return 127;
+    }
+    return (int)centered;
+}
+
+static int mie_analog_legacy_pedal(uint16_t v) {
+    v = mie_analog_raw_clean(v);
+    return (int)(v >> 8);
+}
+
+static int mie_analog_apply_wheel_calib(uint16_t raw) {
+    const mie_analog_axis_calib_t *a = &active_calib.wheel;
+    int32_t v;
+
+    raw = mie_analog_raw_clean(raw);
+
+    if(raw <= a->center) {
+        if(a->center == a->min) {
+            return -128;
+        }
+        v = (int32_t)(raw - a->center) * 128 / (int32_t)(a->center - a->min);
+        if(v < -128) {
+            return -128;
+        }
+        return (int)v;
+    }
+
+    if(a->max == a->center) {
+        return 127;
+    }
+    v = (int32_t)(raw - a->center) * 127 / (int32_t)(a->max - a->center);
+    if(v > 127) {
+        return 127;
+    }
+    return (int)v;
+}
+
+static int mie_analog_apply_pedal_calib(uint16_t raw,
+                                        const mie_analog_axis_calib_t *a) {
+    int32_t v;
+
+    raw = mie_analog_raw_clean(raw);
+
+    if(a->max <= a->min) {
+        return mie_analog_legacy_pedal(raw);
+    }
+    if(raw <= a->min) {
+        return 0;
+    }
+    if(raw >= a->max) {
+        return 255;
+    }
+
+    v = (int32_t)(raw - a->min) * 255 / (int32_t)(a->max - a->min);
+    return (int)v;
+}
+
+static bool mie_analog_calib_ranges_valid(const mie_analog_calib_t *c) {
+    return c->wheel.min < c->wheel.center
+        && c->wheel.center < c->wheel.max
+        && c->accel.min < c->accel.max
+        && c->brake.min < c->brake.max;
+}
+
+static void mie_analog_set_active(const mie_analog_calib_t *calib) {
+    active_calib = *calib;
+    active_calib_valid = mie_analog_calib_ranges_valid(&active_calib);
+}
+
+bool mie_analog_calib_valid(void) {
+    return active_calib_valid;
+}
+
+int mie_analog_norm_wheel(uint16_t raw) {
+    if(active_calib_valid) {
+        return mie_analog_apply_wheel_calib(raw);
+    }
+    return mie_analog_legacy_wheel(raw);
+}
+
+int mie_analog_norm_accel(uint16_t raw) {
+    if(active_calib_valid) {
+        return mie_analog_apply_pedal_calib(raw, &active_calib.accel);
+    }
+    return mie_analog_legacy_pedal(raw);
+}
+
+int mie_analog_norm_brake(uint16_t raw) {
+    if(active_calib_valid) {
+        return mie_analog_apply_pedal_calib(raw, &active_calib.brake);
+    }
+    return mie_analog_legacy_pedal(raw);
+}
+
+int mie_analog_map_wheel(uint16_t raw) {
+    /* During calib wizard return raw values so the UI can display them. */
+    if(step_calib != MIE_ANALOG_CALIB_IDLE) {
+        return (int)mie_analog_raw_clean(raw);
+    }
+    return mie_analog_norm_wheel(raw);
+}
+
+int mie_analog_map_accel(uint16_t raw) {
+    if(step_calib != MIE_ANALOG_CALIB_IDLE) {
+        return (int)mie_analog_raw_clean(raw);
+    }
+    return mie_analog_norm_accel(raw);
+}
+
+int mie_analog_map_brake(uint16_t raw) {
+    if(step_calib != MIE_ANALOG_CALIB_IDLE) {
+        return (int)mie_analog_raw_clean(raw);
+    }
+    return mie_analog_norm_brake(raw);
+}
+
+static void mie_analog_track_axis(mie_analog_axis_calib_t *axis, uint16_t raw) {
+    raw = mie_analog_raw_clean(raw);
+
+    if(axis->min == 0xFFFF && axis->max == 0) {
+        axis->min = raw;
+        axis->max = raw;
+        return;
+    }
+    if(raw < axis->min) {
+        axis->min = raw;
+    }
+    if(raw > axis->max) {
+        axis->max = raw;
+    }
+}
+
+/* Record min/max (or center) while the user moves one axis per calib step. */
+void mie_analog_track(const mie_jvs_inputs_t *jvs) {
+    if(step_calib == MIE_ANALOG_CALIB_IDLE) {
+        return;
+    }
+
+    last_wheel = mie_analog_raw_clean(jvs->wheel);
+    last_accel = mie_analog_raw_clean(jvs->accel);
+    last_brake = mie_analog_raw_clean(jvs->brake);
+
+    switch(step_calib) {
+        case MIE_ANALOG_CALIB_WHEEL:
+            mie_analog_track_axis(&work_calib.wheel, jvs->wheel);
+            break;
+        case MIE_ANALOG_CALIB_ACCEL:
+            mie_analog_track_axis(&work_calib.accel, jvs->accel);
+            break;
+        case MIE_ANALOG_CALIB_BRAKE:
+            mie_analog_track_axis(&work_calib.brake, jvs->brake);
+            break;
+        default:
+            break;
+    }
+}
+
+const mie_analog_calib_t *mie_analog_calib_get(void) {
+    return &active_calib;
+}
+
+void mie_analog_calib_set(const mie_analog_calib_t *calib) {
+    if(!calib) {
+        return;
+    }
+    mie_analog_set_active(calib);
+}
+
+void mie_analog_calib_reset(void) {
+    memset(&active_calib, 0, sizeof(active_calib));
+    active_calib_valid = false;
+    step_calib = MIE_ANALOG_CALIB_IDLE;
+}
+
+void mie_analog_calib_start(void) {
+    memset(&work_calib, 0, sizeof(work_calib));
+    work_calib.wheel.min = 0xFFFF;
+    work_calib.accel.min = 0xFFFF;
+    work_calib.brake.min = 0xFFFF;
+    last_wheel = 0;
+    last_accel = 0;
+    last_brake = 0;
+    /* User moves wheel full range first, then captures center on next step. */
+    step_calib = MIE_ANALOG_CALIB_WHEEL;
+}
+
+void mie_analog_calib_cancel(void) {
+    step_calib = MIE_ANALOG_CALIB_IDLE;
+}
+
+bool mie_analog_calib_active(void) {
+    return step_calib != MIE_ANALOG_CALIB_IDLE;
+}
+
+mie_analog_calib_step_t mie_analog_calib_current(void) {
+    return step_calib;
+}
+
+/* Wizard: wheel extremes -> wheel center -> accel -> brake -> commit. */
+bool mie_analog_calib_capture(void) {
+    switch(step_calib) {
+        case MIE_ANALOG_CALIB_WHEEL:
+            step_calib = MIE_ANALOG_CALIB_WHEEL_CENTER;
+            return false;
+        case MIE_ANALOG_CALIB_WHEEL_CENTER:
+            work_calib.wheel.center = last_wheel;
+            step_calib = MIE_ANALOG_CALIB_ACCEL;
+            return false;
+        case MIE_ANALOG_CALIB_ACCEL:
+            step_calib = MIE_ANALOG_CALIB_BRAKE;
+            return false;
+        case MIE_ANALOG_CALIB_BRAKE:
+            if(mie_analog_calib_ranges_valid(&work_calib)) {
+                mie_analog_set_active(&work_calib);
+            }
+            step_calib = MIE_ANALOG_CALIB_IDLE;
+            return true;
+        default:
+            return false;
+    }
+}

--- a/kernel/arch/dreamcast/hardware/maple/mie/mie_fw.c
+++ b/kernel/arch/dreamcast/hardware/maple/mie/mie_fw.c
@@ -1,0 +1,567 @@
+/* KallistiOS ##version##
+
+   mie_fw.c
+   Copyright (C) 2026 Ruslan Rostovtsev
+
+   Z80 firmware lifecycle: self-test, code upload to bridge RAM, JVS bus
+   reset/setaddr, and verification poll. EEPROM access uses a separate
+   IOR command sequence (REQUEST/FETCH/WRITE).
+*/
+
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include <dc/maple.h>
+#include <dc/maple/mie.h>
+
+#include "mie_internal.h"
+
+#include <kos/dbglog.h>
+#include <kos/fs.h>
+#include <kos/thread.h>
+
+#define MIE_CMD_IO       0x86
+#define MIE_RESP_IO      0x87
+
+#define MIE_CMD_UPLOAD_FW  0x80
+#define MIE_RESP_UPLOAD_FW 0x81
+#define MIE_CMD_SELF_TEST  0x84
+#define MIE_RESP_SELF_TEST 0x85
+
+#define MIE_IOR_EEPROM_REQUEST 0x01
+#define MIE_IOR_EEPROM_ACK     0x02
+#define MIE_IOR_EEPROM_FETCH   0x03
+#define MIE_IOR_EEPROM_WRITE   0x0B
+
+#define MIE_IOR_JVS_EMPTY       0x32
+
+#define MIE_JVS_FETCH_MIN_WORDS 8
+
+#define MIE_EEPROM_CHUNK 16
+
+#define MIE_Z80_RAM_BASE            0x8010
+#define MIE_CODE_CHUNK              24
+#define MIE_CODE_MAX                65536
+#define MIE_RESP_UPLOAD_BOOTROM     0x80
+#define MIE_UPLOAD_CHUNK_RETRIES    8
+#define MIE_UPLOAD_RETRY_DELAY_MS   5
+#define MIE_IO_RETRY_ATTEMPTS       8
+#define MIE_IO_RETRY_DELAY_MS       50
+
+static maple_response_t *mie_io_retry(const void *req, int len);
+
+/* Bridge must respond before code upload or EEPROM access. */
+static bool mie_self_test(void) {
+    maple_response_t *resp;
+    int i;
+
+    for(i = 0; i < 5; i++) {
+        resp = mie_cmd_resp(MIE_CMD_SELF_TEST, NULL, 0);
+        if(resp && (uint8_t)resp->response == MIE_RESP_SELF_TEST) {
+            break;
+        }
+        thd_sleep(5);
+    }
+
+    if(!resp || (uint8_t)resp->response != MIE_RESP_SELF_TEST) {
+        dbglog(DBG_ERROR, "mie: self test no resp\n");
+        return false;
+    }
+
+    if(resp->data_len < 1) {
+        dbglog(DBG_ERROR, "mie: self test no payload\n");
+        return false;
+    }
+
+    return true;
+}
+
+/* Maple-level reset before uploading new Z80 image into bridge RAM. */
+static bool mie_maple_dev_reset(void) {
+    maple_response_t *resp;
+    int i;
+
+    for(i = 0; i < 40; i++) {
+        mie_poll_idle();
+        resp = mie_cmd_resp(MAPLE_COMMAND_RESET, NULL, 0);
+        if(resp && resp->response == MAPLE_RESPONSE_OK) {
+            thd_sleep(30);
+            return mie_poll_idle();
+        }
+        thd_sleep(20);
+    }
+
+    dbglog(DBG_ERROR, "mie: maple dev reset failed\n");
+    return false;
+}
+
+static maple_response_t *mie_io_retry(const void *req, int len) {
+    maple_response_t *resp = NULL;
+    int attempt;
+
+    for(attempt = 0; attempt < MIE_IO_RETRY_ATTEMPTS; attempt++) {
+        if(attempt > 0) {
+            mie_poll_idle();
+            thd_sleep(MIE_IO_RETRY_DELAY_MS);
+        }
+
+        resp = mie_cmd_resp(MIE_CMD_IO, (void *)req, len);
+        if(!resp || resp->response == MAPLE_RESPONSE_AGAIN) {
+            continue;
+        }
+
+        if((uint8_t)resp->response == MIE_RESP_IO) {
+            return resp;
+        }
+    }
+
+    return NULL;
+}
+
+uint16_t mie_eeprom_crc16(const uint8_t *buf, size_t size) {
+    uint32_t n = 0xdebdeb00;
+    size_t i;
+    int bit;
+
+    assert(buf);
+
+    for(i = 0; i < size; i++) {
+        n &= 0xffffff00;
+        n += buf[i];
+
+        for(bit = 0; bit < 8; bit++) {
+            if(n & 0x80000000) {
+                n = (n << 1) + 0x10210000;
+            }
+            else {
+                n <<= 1;
+            }
+        }
+    }
+
+    for(bit = 0; bit < 8; bit++) {
+        if(n & 0x80000000) {
+            n = (n << 1) + 0x10210000;
+        }
+        else {
+            n <<= 1;
+        }
+    }
+
+    return (uint16_t)(n >> 16);
+}
+
+/* EEPROM stores two CRC copies per section (header at 0/18 and 36/40). */
+void mie_eeprom_fix_crc(uint8_t *eeprom) {
+    uint16_t crc;
+    uint8_t size;
+
+    assert(eeprom);
+
+    crc = mie_eeprom_crc16(eeprom + 2, 16);
+    eeprom[0] = (uint8_t)(crc & 0xff);
+    eeprom[1] = (uint8_t)(crc >> 8);
+    eeprom[18] = eeprom[0];
+    eeprom[19] = eeprom[1];
+
+    size = eeprom[39];
+    if(size == 0 || (uint32_t)44 + size > MIE_EEPROM_SIZE) {
+        return;
+    }
+
+    crc = mie_eeprom_crc16(eeprom + 44, size);
+    eeprom[36] = (uint8_t)(crc & 0xff);
+    eeprom[37] = (uint8_t)(crc >> 8);
+    eeprom[40] = eeprom[36];
+    eeprom[41] = eeprom[37];
+}
+
+/* EEPROM read: REQUEST -> idle -> FETCH (128 bytes). */
+bool mie_get_eeprom(void *dst) {
+    uint8_t ioreq[4];
+    maple_response_t *resp;
+
+    assert(dst);
+
+    mie_bus_acquire_scoped(bus);
+    if(!bus) {
+        return false;
+    }
+
+    if(!mie_poll_idle()) {
+        dbglog(DBG_ERROR, "mie: eeprom pre poll timeout\n");
+        return false;
+    }
+
+    memset(ioreq, 0, sizeof(ioreq));
+    ioreq[0] = MIE_IOR_EEPROM_REQUEST;
+
+    resp = mie_io_retry(ioreq, 1);
+    if(!resp) {
+        dbglog(DBG_ERROR, "mie: eeprom req failed\n");
+        return false;
+    }
+
+    if(resp->data_len >= 1 && resp->data[0] != MIE_IOR_EEPROM_ACK) {
+        dbglog(DBG_ERROR, "mie: eeprom req ack %02x\n", resp->data[0]);
+        return false;
+    }
+
+    if(!mie_poll_idle()) {
+        dbglog(DBG_ERROR, "mie: eeprom read poll timeout\n");
+        return false;
+    }
+
+    ioreq[0] = MIE_IOR_EEPROM_FETCH;
+
+    resp = mie_io_retry(ioreq, 1);
+    if(!resp) {
+        dbglog(DBG_ERROR, "mie: eeprom fetch failed\n");
+        return false;
+    }
+
+    if(resp->data_len != 0x20) {
+        dbglog(DBG_ERROR, "mie: eeprom fetch len %02x\n", resp->data_len);
+        return false;
+    }
+
+    memcpy(dst, resp->data, MIE_EEPROM_SIZE);
+    return true;
+}
+
+/* Write 128-byte EEPROM in 16-byte chunks with settle delay between. */
+bool mie_set_eeprom(uint8_t *eeprom) {
+    uint8_t ioreq[20];
+    maple_response_t *resp;
+    unsigned int offset;
+
+    assert(eeprom);
+
+    mie_bus_acquire_scoped(bus);
+    if(!bus) {
+        return false;
+    }
+
+    if(!mie_poll_idle()) {
+        return false;
+    }
+
+    for(offset = 0; offset < MIE_EEPROM_SIZE; offset += MIE_EEPROM_CHUNK) {
+        memset(ioreq, 0, sizeof(ioreq));
+        ioreq[0] = MIE_IOR_EEPROM_WRITE;
+        ioreq[1] = (uint8_t)offset;
+        ioreq[2] = MIE_EEPROM_CHUNK;
+        memcpy(ioreq + 4, eeprom + offset, MIE_EEPROM_CHUNK);
+
+        resp = mie_io_retry(ioreq, 5);
+        if(!resp) {
+            dbglog(DBG_ERROR, "mie: eeprom write failed at %02x\n", offset);
+            return false;
+        }
+
+        if(!mie_poll_idle()) {
+            dbglog(DBG_ERROR, "mie: eeprom write poll timeout at %02x\n", offset);
+            return false;
+        }
+
+        thd_sleep(50);
+    }
+
+    return true;
+}
+
+static bool mie_upload_code_chunk_ack(maple_response_t *resp, uint16_t addr,
+                                      uint8_t checksum) {
+    uint32_t ack;
+    uint16_t resp_addr;
+
+    if(!resp || ((uint8_t)resp->response != MIE_RESP_UPLOAD_FW &&
+            (uint8_t)resp->response != MIE_RESP_UPLOAD_BOOTROM)) {
+        return false;
+    }
+
+    if(resp->data_len != 1) {
+        return false;
+    }
+
+    ack = *(uint32_t *)resp->data;
+    resp_addr = (uint16_t)(((ack & 0xff0000) >> 8) | ((ack & 0xff000000) >> 24));
+    if(resp_addr != addr) {
+        return false;
+    }
+
+    return (ack & 0xff) == checksum;
+}
+
+static bool mie_upload_code_chunk(uint16_t addr, const uint8_t *data,
+                                       int chunk_len) {
+    uint8_t upload[28];
+    maple_response_t *resp;
+    uint8_t checksum;
+    int attempt;
+    int i;
+
+    memset(upload, 0, sizeof(upload));
+    upload[2] = (uint8_t)(addr >> 8);
+    upload[3] = (uint8_t)(addr & 0xff);
+    memcpy(upload + 4, data, chunk_len);
+
+    checksum = 0;
+    for(i = 0; i < 28; i++)
+        checksum = (checksum + upload[i]) & 0xff;
+
+    resp = NULL;
+    for(attempt = 0; attempt < MIE_UPLOAD_CHUNK_RETRIES; attempt++) {
+        if(attempt > 0) {
+            thd_sleep(MIE_UPLOAD_RETRY_DELAY_MS);
+        }
+
+        resp = mie_cmd_resp(MIE_CMD_UPLOAD_FW, upload, 28 / 4);
+        if(!resp) {
+            continue;
+        }
+
+        if(resp->response == MAPLE_RESPONSE_AGAIN ||
+                resp->response == MAPLE_RESPONSE_NONE) {
+            continue;
+        }
+
+        if(mie_upload_code_chunk_ack(resp, addr, checksum)) {
+            return true;
+        }
+
+        resp = NULL;
+    }
+
+    if(!resp) {
+        dbglog(DBG_ERROR, "mie: code upload timeout %04x\n", addr);
+    }
+    else {
+        dbglog(DBG_ERROR, "mie: code upload bad ack %04x\n", addr);
+    }
+
+    return false;
+}
+
+static bool mie_upload_code_range(uint16_t memloc, const uint8_t *bin,
+                                       size_t len, bool poll_first) {
+    size_t remain = len;
+    size_t chunk;
+    const uint8_t *binloc = bin;
+
+    if(poll_first && !mie_poll_idle()) {
+        return false;
+    }
+
+    while(remain > 0) {
+        chunk = remain > MIE_CODE_CHUNK ? MIE_CODE_CHUNK : remain;
+
+        if(!mie_upload_code_chunk(memloc, binloc, (int)chunk)) {
+            return false;
+        }
+
+        binloc += chunk;
+        memloc = (uint16_t)(memloc + chunk);
+        remain -= chunk;
+    }
+
+    return true;
+}
+
+/* 0xFFFFFFFF payload tells the bridge to jump to uploaded code in RAM. */
+static bool mie_upload_code_exec(void) {
+    uint8_t execdata[4] = { 0xff, 0xff, 0xff, 0xff };
+    maple_response_t *resp;
+    int attempt;
+
+    for(attempt = 0; attempt < MIE_UPLOAD_CHUNK_RETRIES; attempt++) {
+        if(attempt > 0) {
+            thd_sleep(MIE_UPLOAD_RETRY_DELAY_MS);
+        }
+
+        resp = mie_cmd_resp(MIE_CMD_UPLOAD_FW, execdata, 1);
+        if(!resp) {
+            continue;
+        }
+
+        if(resp->response == MAPLE_RESPONSE_AGAIN ||
+                resp->response == MAPLE_RESPONSE_NONE) {
+            continue;
+        }
+
+        if((uint8_t)resp->response == MAPLE_RESPONSE_OK) {
+            return true;
+        }
+    }
+
+    dbglog(DBG_ERROR, "mie: code exec failed\n");
+    return false;
+}
+
+/* Reset bridge, upload Z80 image to RAM in 24-byte chunks, then jump. */
+static bool mie_upload_code(const uint8_t *bin, size_t len) {
+    mie_maple_dev_reset();
+    mie_self_test();
+
+    if(!mie_upload_code_range(MIE_Z80_RAM_BASE, bin, len, true)) {
+        return false;
+    }
+
+    return mie_upload_code_exec();
+}
+
+static bool mie_upload_code_file(const char *path) {
+    file_t fd;
+    ssize_t size;
+    ssize_t rd;
+    uint8_t *buf;
+    bool ok = false;
+
+    fd = fs_open(path, O_RDONLY);
+    if(fd == FILEHND_INVALID) {
+        return false;
+    }
+
+    size = fs_total(fd);
+    if(size <= 0 || size > MIE_CODE_MAX) {
+        goto out;
+    }
+
+    buf = aligned_alloc(32, size);
+    if(!buf) {
+        goto out;
+    }
+
+    rd = fs_read(fd, buf, size);
+    if(rd != size) {
+        goto out_free;
+    }
+
+    ok = mie_upload_code(buf, size);
+
+out_free:
+    free(buf);
+out:
+    fs_close(fd);
+    return ok;
+}
+
+/* Broadcast JVS reset, then setaddr (retried until Maple ACK). */
+static bool mie_z80_jvs_reset(void) {
+    uint8_t reset_buf[12];
+    uint8_t setaddr_buf[12];
+    int i;
+
+    mie_build_jvs_reset(reset_buf);
+    if(!mie_jvs_io_cmd(reset_buf, 3)) {
+        return false;
+    }
+
+    mie_build_jvs_setaddr(setaddr_buf);
+    for(i = 0; i < 50; i++) {
+        thd_sleep(20);
+
+        if(mie_jvs_io_cmd(setaddr_buf, 3)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool mie_fetch_has_func_check(maple_response_t *resp) {
+    const uint8_t *data;
+    int len;
+
+    assert(resp);
+
+    if(resp->data_len < MIE_JVS_FETCH_MIN_WORDS) {
+        return false;
+    }
+
+    if(((uint8_t *)resp->data)[0] == MIE_IOR_JVS_EMPTY) {
+        return false;
+    }
+
+    data = resp->data;
+    len = (int)resp->data_len * 4;
+    return mie_ior_jvs_report_ready(data, len);
+}
+
+bool mie_jvs_function_check(void) {
+    uint8_t req[12];
+    maple_response_t *resp;
+    mie_jvs_poll_cfg_t cfg;
+    const uint8_t *data;
+    int len;
+
+    mie_build_jvs_func_check(req);
+    if(!mie_jvs_io_cmd(req, 3)) {
+        return false;
+    }
+
+    if(!mie_poll_idle()) {
+        return false;
+    }
+
+    resp = mie_jvs_fetch_retry(mie_fetch_has_func_check);
+    if(!resp) {
+        return false;
+    }
+
+    data = resp->data;
+    len = (int)resp->data_len * 4;
+    if(!mie_parse_jvs_func_check(data, len, &cfg)) {
+        return false;
+    }
+
+    mie_jvs_poll_cfg_apply(&cfg);
+    return true;
+}
+
+/* Probe live firmware; on failure JVS-reset and probe again. */
+bool mie_z80_try_active(maple_device_t *dev) {
+    (void)dev;
+
+    if(mie_jvs_function_check()) {
+        return true;
+    }
+
+    if(!mie_z80_jvs_reset()) {
+        return false;
+    }
+
+    return mie_jvs_function_check();
+}
+
+/* Try running firmware first; upload from file and JVS-reset only if needed. */
+bool mie_z80_init(const char *fw_path, maple_device_t *dev) {
+    assert(dev);
+
+    mie_poll_idle();
+
+    if(mie_z80_try_active(dev)) {
+        return true;
+    }
+
+    if(!mie_upload_code_file(fw_path)) {
+        dbglog(DBG_ERROR, "mie: fw upload failed\n");
+        return false;
+    }
+
+    mie_poll_idle();
+    thd_sleep(30);
+
+    if(!mie_z80_jvs_reset()) {
+        dbglog(DBG_ERROR, "mie: jvs reset failed after upload firmware\n");
+        return false;
+    }
+
+    if(!mie_jvs_function_check()) {
+        dbglog(DBG_ERROR, "mie: JVS I/O board is not responding\n");
+        return false;
+    }
+
+    return true;
+}

--- a/kernel/arch/dreamcast/hardware/maple/mie/mie_input.c
+++ b/kernel/arch/dreamcast/hardware/maple/mie/mie_input.c
@@ -1,0 +1,548 @@
+/* KallistiOS ##version##
+
+   mie_input.c
+   Copyright (C) 2026 Ruslan Rostovtsev
+
+   Input path: IOR fetch payload -> JVS state -> optional cont_state mapping.
+   Callbacks run in a shared worker thread on rising-edge button/JVS input matches.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/queue.h>
+
+#include <dc/maple/mie.h>
+
+#include "mie_internal.h"
+
+#include <kos/mutex.h>
+#include <kos/worker_thread.h>
+
+#ifndef MIE_CALLBACK_THD_STACK_SIZE
+#define MIE_CALLBACK_THD_STACK_SIZE (8 * 1024)
+#endif
+
+typedef enum mie_cb_type {
+    MIE_CB_CONT,
+    MIE_CB_JVS
+} mie_cb_type_t;
+
+typedef struct mie_callback_params {
+    mie_cb_type_t type;
+    bool cb_pending;
+    union {
+        struct {
+            mie_btn_callback_t cb;
+            uint32_t match;
+            uint32_t cur;
+        } cont;
+        struct {
+            mie_jvs_callback_t cb;
+            mie_jvs_input_t input;
+            uint32_t mask;
+            mie_jvs_input_t cur_input;
+            uint32_t cur_mask;
+        } jvs;
+    } u;
+    TAILQ_ENTRY(mie_callback_params) listent;
+    STAILQ_ENTRY(mie_callback_params) pending;
+} mie_callback_params_t;
+
+TAILQ_HEAD(mie_callback_list, mie_callback_params);
+struct mie_callback_list cbs = TAILQ_HEAD_INITIALIZER(cbs);
+
+STAILQ_HEAD(mie_cb_pending_list, mie_callback_params);
+static struct mie_cb_pending_list mie_cb_pending =
+    STAILQ_HEAD_INITIALIZER(mie_cb_pending);
+
+static kthread_worker_t *mie_cb_worker;
+
+static void mie_default_cont_map(const mie_jvs_inputs_t *jvs,
+                                  cont_state_t *cont);
+
+static mutex_t cbs_mtx = MUTEX_INITIALIZER;
+static mie_cont_map_fn_t cont_map_fn = mie_default_cont_map;
+
+static bool mie_callback_same_key(const mie_callback_params_t *a,
+                                     const mie_callback_params_t *b) {
+    if(a->type != b->type) {
+        return false;
+    }
+
+    if(a->type == MIE_CB_CONT) {
+        return a->u.cont.match == b->u.cont.match;
+    }
+
+    return a->u.jvs.input == b->u.jvs.input &&
+           a->u.jvs.mask == b->u.jvs.mask;
+}
+
+static bool mie_callback_same_cb(const mie_callback_params_t *a,
+                                    const mie_callback_params_t *b) {
+    if(a->type == MIE_CB_CONT) {
+        return a->u.cont.cb == b->u.cont.cb;
+    }
+
+    return a->u.jvs.cb == b->u.jvs.cb;
+}
+
+static void mie_callbacks_invoke(int baseline, uint32_t prev_btns,
+                                  uint32_t cur_btns,
+                                  const mie_jvs_inputs_t *prev_jvs,
+                                  const mie_jvs_inputs_t *cur_jvs);
+
+static void mie_coin_meter_apply(mie_drv_state_t *state,
+                                  const mie_jvs_inputs_t *prev_jvs,
+                                  const uint16_t *raws, int raw_count);
+
+static void mie_cb_worker_fn(void *d) {
+    STAILQ_HEAD(, mie_callback_params) batch;
+    mie_callback_params_t *c, *n;
+
+    (void)d;
+
+    STAILQ_INIT(&batch);
+
+    mutex_lock(&cbs_mtx);
+    STAILQ_CONCAT(&batch, &mie_cb_pending);
+    mutex_unlock(&cbs_mtx);
+
+    STAILQ_FOREACH_SAFE(c, &batch, pending, n) {
+        c->cb_pending = false;
+
+        if(c->type == MIE_CB_CONT) {
+            c->u.cont.cb(c->u.cont.cur);
+        }
+        else {
+            c->u.jvs.cb(c->u.jvs.cur_input, c->u.jvs.cur_mask);
+        }
+    }
+}
+
+void mie_callbacks_init(void) {
+    const kthread_attr_t thd_attr = {
+        .stack_size = MIE_CALLBACK_THD_STACK_SIZE,
+        .prio = PRIO_DEFAULT,
+        .label = "mie_callback"
+    };
+
+    TAILQ_INIT(&cbs);
+    STAILQ_INIT(&mie_cb_pending);
+    mie_cb_worker = thd_worker_create_ex(&thd_attr, mie_cb_worker_fn, NULL);
+}
+
+static void mie_callback_del(mie_callback_params_t *params) {
+    mie_callback_params_t *c, *n;
+
+    mutex_lock_scoped(&cbs_mtx);
+
+    TAILQ_FOREACH_SAFE(c, &cbs, listent, n) {
+        if((params == NULL) || mie_callback_same_key(params, c)) {
+            if((params == NULL) ||
+                    ((params->type == MIE_CB_CONT && params->u.cont.cb == NULL) ||
+                     (params->type == MIE_CB_JVS && params->u.jvs.cb == NULL) ||
+                     mie_callback_same_cb(params, c))) {
+                if(c->cb_pending) {
+                    STAILQ_REMOVE(&mie_cb_pending, c, mie_callback_params,
+                                  pending);
+                    c->cb_pending = false;
+                }
+                TAILQ_REMOVE(&cbs, c, listent);
+                free(c);
+            }
+        }
+    }
+}
+
+void mie_callbacks_shutdown(void) {
+    mie_callback_del(NULL);
+
+    if(mie_cb_worker) {
+        thd_worker_destroy(mie_cb_worker);
+        mie_cb_worker = NULL;
+    }
+}
+
+/* Parse IOR fetch payload, update JVS/cont state, fire edge-triggered callbacks. */
+bool mie_apply_buttons(maple_response_t *resp, maple_device_t *dev) {
+    mie_drv_state_t *state;
+    mie_jvs_inputs_t prev_jvs;
+    uint32_t prev_buttons;
+    int prev_ltrig;
+    int prev_rtrig;
+    uint16_t p1, p2;
+    uint8_t sys;
+    uint16_t analog[MIE_JVS_ANALOG_CHANNELS];
+    mie_jvs_panel_t panel;
+    uint16_t coin_raw[MIE_JVS_COIN_SLOTS];
+    bool has_analog;
+    bool has_coin;
+    bool has_panel;
+    int baseline;
+    const uint8_t *data;
+    int len;
+
+    assert(resp);
+    assert(dev);
+    assert(dev->status);
+
+    state = dev->status;
+
+    data = mie_ior_resp_map(resp, &len);
+    if(!data) {
+        return false;
+    }
+
+    if(!mie_extract_sw(data, len, &sys, &p1, &p2)) {
+        return false;
+    }
+
+    /* Snapshot previous state for edge detection and analog hold-over. */
+    prev_buttons = state->cont.buttons;
+    prev_ltrig = state->cont.ltrig;
+    prev_rtrig = state->cont.rtrig;
+    prev_jvs = state->jvs;
+    baseline = state->input_baseline;
+
+    has_analog = mie_extract_analog(data, len, analog);
+    has_coin = mie_extract_coin(data, len, coin_raw, MIE_JVS_COIN_SLOTS);
+    has_panel = mie_extract_panel(data, len, &panel);
+
+    state->jvs.system.raw = sys;
+    state->jvs.p1.raw = p1;
+    state->jvs.p2.raw = p2;
+    state->jvs.coin_pulse = 0;
+    state->jvs.coin_fault = 0;
+
+    if(has_panel) {
+        state->jvs.panel = panel;
+    }
+
+    if(has_coin) {
+        mie_coin_meter_apply(state, &prev_jvs, coin_raw, MIE_JVS_COIN_SLOTS);
+    }
+
+    if(has_analog) {
+        memcpy(state->jvs.analog, analog,
+               sizeof(uint16_t) * MIE_JVS_ANALOG_CHANNELS);
+        mie_analog_track(&state->jvs);
+    }
+
+    /* Map JVS inputs to cont_state (default or user-provided mapper). */
+    cont_map_fn(&state->jvs, &state->cont);
+
+    /* Bundled poll may omit analog; keep last trigger values in that case. */
+    if(!has_analog) {
+        state->cont.joyx = 0;
+        state->cont.ltrig = prev_ltrig;
+        state->cont.rtrig = prev_rtrig;
+    }
+
+    mie_callbacks_invoke(baseline, prev_buttons, state->cont.buttons,
+                         &prev_jvs, &state->jvs);
+
+    state->jvs.coin_pulse = 0;
+
+    /* Skip callbacks on the very first frame to avoid spurious edges. */
+    if(!state->input_baseline) {
+        state->input_baseline = 1;
+    }
+
+    dev->valid = true;
+    return true;
+}
+
+/* Track coin meter deltas; first sample seeds baseline without pulse events. */
+static void mie_coin_meter_apply(mie_drv_state_t *state,
+                                  const mie_jvs_inputs_t *prev_jvs,
+                                  const uint16_t *raws, int raw_count) {
+    uint8_t slot;
+    mie_jvs_coin_slot_t cur;
+    uint16_t read_count;
+    uint16_t prev;
+    uint8_t bit;
+
+    if(raw_count > MIE_JVS_COIN_SLOTS) {
+        raw_count = MIE_JVS_COIN_SLOTS;
+    }
+
+    for(slot = 0; slot < (uint8_t)raw_count; slot++) {
+
+        prev = prev_jvs->coin[slot].count;
+        bit = (uint8_t)BIT(slot);
+
+        cur.raw = raws[slot];
+
+        if(!mie_jvs_coin_usable(&cur)) {
+            state->jvs.coin[slot].raw = cur.raw;
+            state->jvs.coin_fault |= bit;
+            if(!(state->coin_seeded & bit)) {
+                state->jvs.coin[slot].count = prev;
+                state->coin_seeded |= bit;
+            }
+            continue;
+        }
+
+        read_count = mie_jvs_coin_meter(&cur);
+
+        if(!(state->coin_seeded & bit)) {
+            mie_jvs_coin_slot_set(&state->jvs.coin[slot], raws[slot], prev);
+            state->coin_seeded |= bit;
+            if(!state->input_baseline) {
+                continue;
+            }
+            state->jvs.coin[slot].count = prev;
+        }
+
+        if(read_count > MIE_JVS_COIN_DEC_LIMIT) {
+            if((state->coin_dec_pending & bit) == 0) {
+                mie_coin_decrease(slot, read_count, false);
+                state->coin_dec_pending |= bit;
+            }
+        }
+        else {
+            state->coin_dec_pending &= (uint8_t)~bit;
+        }
+
+        if(read_count == prev) {
+            state->jvs.coin[slot].raw = cur.raw;
+            state->jvs.coin[slot].count = read_count;
+            continue;
+        }
+
+        mie_jvs_coin_slot_set(&state->jvs.coin[slot], raws[slot], prev);
+
+        if(state->input_baseline && read_count > prev) {
+            state->jvs.coin_pulse |= bit;
+        }
+    }
+}
+
+static int mie_callback_register(mie_callback_params_t *params) {
+    if(!mie_cb_worker) {
+        return -1;
+    }
+
+    params->cb_pending = false;
+
+    mutex_lock_scoped(&cbs_mtx);
+    TAILQ_INSERT_TAIL(&cbs, params, listent);
+
+    return 0;
+}
+
+int mie_btn_callback(uint32_t btns, mie_btn_callback_t cb) {
+    mie_callback_params_t *params;
+
+    params = (mie_callback_params_t *)malloc(sizeof(mie_callback_params_t));
+
+    if(!params) {
+        return -1;
+    }
+
+    params->type = MIE_CB_CONT;
+    params->u.cont.match = btns;
+    params->u.cont.cb = cb;
+
+    if(cb == NULL) {
+        mie_callback_del(params);
+        free(params);
+        return 0;
+    }
+
+    if(mie_callback_register(params) < 0) {
+        free(params);
+        return -1;
+    }
+
+    return 0;
+}
+
+int mie_jvs_callback(mie_jvs_input_t input, uint32_t mask,
+                     mie_jvs_callback_t cb) {
+    mie_callback_params_t *params;
+
+    params = (mie_callback_params_t *)malloc(sizeof(mie_callback_params_t));
+
+    if(!params) {
+        return -1;
+    }
+
+    params->type = MIE_CB_JVS;
+    params->u.jvs.input = input;
+    params->u.jvs.mask = mask;
+    params->u.jvs.cb = cb;
+
+    if(cb == NULL) {
+        mie_callback_del(params);
+        free(params);
+        return 0;
+    }
+
+    if(mie_callback_register(params) < 0) {
+        free(params);
+        return -1;
+    }
+
+    return 0;
+}
+
+static uint32_t mie_jvs_input_val(mie_jvs_input_t input,
+                                   const mie_jvs_inputs_t *jvs) {
+    switch(input) {
+        case MIE_JVS_IN_SYSTEM:
+            return jvs->system.raw;
+        case MIE_JVS_IN_P1:
+            return jvs->p1.raw;
+        case MIE_JVS_IN_P2:
+            return jvs->p2.raw;
+        case MIE_JVS_IN_PANEL_DIP:
+            return jvs->panel.dip.raw;
+        case MIE_JVS_IN_PANEL_PSW:
+            return jvs->panel.psw.raw;
+        case MIE_JVS_IN_COIN1:
+            return (jvs->coin_pulse & BIT(0)) ? MIE_JVS_COIN_INSERT_BIT : 0;
+        case MIE_JVS_IN_COIN2:
+            return (jvs->coin_pulse & BIT(1)) ? MIE_JVS_COIN_INSERT_BIT : 0;
+        default:
+            return 0;
+    }
+}
+
+/* Queue callbacks for the shared worker on rising-edge matches. */
+static void mie_callbacks_invoke(int baseline, uint32_t prev_btns,
+                                  uint32_t cur_btns,
+                                  const mie_jvs_inputs_t *prev_jvs,
+                                  const mie_jvs_inputs_t *cur_jvs) {
+    mie_callback_params_t *c;
+    uint32_t prev_val;
+    uint32_t cur_val;
+    bool wake_worker = false;
+
+    if(!baseline || !mie_cb_worker) {
+        return;
+    }
+
+    if(mutex_lock_irqsafe(&cbs_mtx)) {
+        return;
+    }
+
+    TAILQ_FOREACH(c, &cbs, listent) {
+        if(c->type == MIE_CB_CONT) {
+            if((cur_btns & c->u.cont.match) == c->u.cont.match &&
+                    (prev_btns & c->u.cont.match) != c->u.cont.match) {
+                c->u.cont.cur = cur_btns;
+                if(!c->cb_pending) {
+                    c->cb_pending = true;
+                    STAILQ_INSERT_TAIL(&mie_cb_pending, c, pending);
+                    wake_worker = true;
+                }
+            }
+        }
+        else {
+            prev_val = mie_jvs_input_val(c->u.jvs.input, prev_jvs);
+            cur_val = mie_jvs_input_val(c->u.jvs.input, cur_jvs);
+            if((cur_val & c->u.jvs.mask) == c->u.jvs.mask &&
+                    (prev_val & c->u.jvs.mask) != c->u.jvs.mask) {
+                c->u.jvs.cur_mask = cur_val & c->u.jvs.mask;
+                c->u.jvs.cur_input = c->u.jvs.input;
+                if(!c->cb_pending) {
+                    c->cb_pending = true;
+                    STAILQ_INSERT_TAIL(&mie_cb_pending, c, pending);
+                    wake_worker = true;
+                }
+            }
+        }
+    }
+
+    mutex_unlock(&cbs_mtx);
+
+    if(wake_worker) {
+        thd_worker_wakeup(mie_cb_worker);
+    }
+}
+
+static bool mie_default_analog_unused(const mie_jvs_inputs_t *jvs) {
+    uint16_t w;
+    uint16_t p;
+    uint16_t diff;
+
+    /* Wheel and accel near each other means no real steering hardware. */
+    w = (uint16_t)(jvs->wheel & MIE_JVS_ANALOG_RAW_MASK);
+    p = (uint16_t)(jvs->accel & MIE_JVS_ANALOG_RAW_MASK);
+    if(w > p) {
+        diff = w - p;
+    }
+    else {
+        diff = p - w;
+    }
+
+    return diff <= 0x500;
+}
+
+/* Default JVS arcade inputs -> Dreamcast controller mapping. */
+static void mie_default_cont_map(const mie_jvs_inputs_t *jvs,
+                                  cont_state_t *cont) {
+    uint32_t buttons = 0;
+
+    assert(jvs);
+    assert(cont);
+
+    if(jvs->p1.start || jvs->p2.start) {
+        buttons |= CONT_START;
+    }
+    if(jvs->p1.left || jvs->p2.left) {
+        buttons |= CONT_DPAD_LEFT;
+    }
+    if(jvs->p1.right || jvs->p2.right) {
+        buttons |= CONT_DPAD_RIGHT;
+    }
+    if(jvs->p1.up || jvs->p2.up) {
+        buttons |= CONT_DPAD_UP;
+    }
+    if(jvs->p1.down || jvs->p2.down) {
+        buttons |= CONT_DPAD_DOWN;
+    }
+    if(jvs->p1.sw16 || jvs->p2.sw16) {
+        buttons |= CONT_A;
+    }
+    if(jvs->p1.sw2 || jvs->p2.sw2) {
+        buttons |= CONT_B;
+    }
+    if(jvs->p1.sw1 || jvs->p2.sw1) {
+        buttons |= CONT_X;
+    }
+    if(jvs->p1.sw14 || jvs->p2.sw14) {
+        buttons |= CONT_Y;
+    }
+    if(jvs->p1.service || jvs->p2.service) {
+        buttons |= CONT_Z;
+    }
+    if(jvs->panel.psw.test) {
+        buttons |= CONT_C;
+    }
+    if(jvs->panel.psw.service) {
+        buttons |= CONT_D;
+    }
+
+    cont->buttons = buttons;
+    cont->joyy = 0;
+    cont->joy2x = 0;
+    cont->joy2y = 0;
+    if(mie_default_analog_unused(jvs)) {
+        cont->joyx = 0;
+        cont->ltrig = 0;
+        cont->rtrig = 0;
+    }
+    else {
+        /* Wheel/accel/brake when JVS reports distinct analog channels. */
+        cont->joyx = mie_analog_map_wheel(jvs->wheel);
+        cont->rtrig = mie_analog_map_accel(jvs->accel);
+        cont->ltrig = mie_analog_map_brake(jvs->brake);
+    }
+}
+
+void mie_set_cont_map(mie_cont_map_fn_t fn) {
+    cont_map_fn = fn ? fn : mie_default_cont_map;
+}

--- a/kernel/arch/dreamcast/hardware/maple/mie/mie_internal.h
+++ b/kernel/arch/dreamcast/hardware/maple/mie/mie_internal.h
@@ -1,0 +1,99 @@
+/* KallistiOS ##version##
+
+   mie_internal.h
+   Copyright (C) 2026 Ruslan Rostovtsev
+*/
+
+#ifndef MIE_INTERNAL_H
+#define MIE_INTERNAL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <dc/maple.h>
+#include <dc/maple/mie.h>
+
+/* Driver state for the single MIE bridge on port A. io_state drives the
+   two-step Maple IO cycle: poll request (WAIT_ACK) -> JVS fetch
+   (WAIT_FETCH) -> parse (IDLE). */
+typedef struct mie_jvs_poll_cfg {
+    uint8_t players;
+    uint8_t sw_bytes;
+    uint8_t coin_slots;
+    uint8_t analog_channels;
+    uint8_t driver_outputs;
+} mie_jvs_poll_cfg_t;
+
+typedef struct mie_drv_state {
+    cont_state_t cont;       /* mapped Dreamcast controller state */
+    mie_jvs_inputs_t jvs;    /* raw JVS inputs from last fetch */
+    uint8_t io_state;        /* poll transaction phase (see mie.c enum) */
+    uint8_t io_timeout;      /* periodic ticks before forced recovery */
+    uint8_t io_backoff;      /* post-error delay before next poll */
+    uint8_t input_baseline;  /* 0 until first valid frame (skip callbacks) */
+    uint8_t coin_seeded;     /* bitmask: slot baseline initialized */
+    uint8_t coin_dec_pending; /* bitmask: COINDEC queued for overflow slot */
+} mie_drv_state_t;
+
+void mie_build_jvs_coin_dec(uint8_t *buf, uint8_t slot, uint16_t amount);
+void mie_build_jvs_coin_add(uint8_t *buf, uint8_t slot, uint16_t amount);
+void mie_build_buttons_tx(uint8_t *buf);
+void mie_build_jvs_reset(uint8_t *buf);
+void mie_build_jvs_setaddr(uint8_t *buf);
+void mie_build_jvs_func_check(uint8_t *buf);
+void mie_build_jvs_fetch(uint8_t *buf);
+uint8_t mie_jvs_poll_tx_words(void);
+bool mie_jvs_poll_cfg_apply(const mie_jvs_poll_cfg_t *cfg);
+uint8_t mie_jvs_driver_outputs(void);
+uint8_t mie_jvs_output_wire_bytes(void);
+uint8_t mie_jvs_output_tx_words(uint8_t data_bytes);
+bool mie_parse_jvs_func_check(const uint8_t *data, int len,
+                              mie_jvs_poll_cfg_t *cfg);
+bool mie_ior_jvs_report_ready(const uint8_t *data, int len);
+void mie_build_jvs_output(uint8_t *buf, const uint8_t *data, uint8_t bytes);
+
+uint16_t mie_jvs_coin_meter(const mie_jvs_coin_slot_t *slot);
+bool mie_jvs_coin_usable(const mie_jvs_coin_slot_t *slot);
+uint16_t mie_jvs_coin_count(const mie_jvs_coin_slot_t *slot);
+void mie_jvs_coin_slot_set(mie_jvs_coin_slot_t *slot, uint16_t raw,
+                           uint16_t prev_count);
+const uint8_t *mie_ior_resp_map(maple_response_t *resp, int *len_out);
+bool mie_extract_coin(const uint8_t *data, int len, uint16_t *raw, int max_slots);
+bool mie_extract_analog(const uint8_t *data, int len, uint16_t *analog);
+bool mie_extract_panel(const uint8_t *data, int len, mie_jvs_panel_t *panel);
+bool mie_extract_sw(const uint8_t *data, int len, uint8_t *sys, uint16_t *p1,
+                    uint16_t *p2);
+int mie_copy_id(maple_response_t *resp, char *buf, int buf_len);
+
+void mie_callbacks_init(void);
+void mie_callbacks_shutdown(void);
+bool mie_apply_buttons(maple_response_t *resp, maple_device_t *dev);
+
+void mie_analog_track(const mie_jvs_inputs_t *jvs);
+int mie_analog_map_wheel(uint16_t raw);
+int mie_analog_map_accel(uint16_t raw);
+int mie_analog_map_brake(uint16_t raw);
+
+bool mie_poll_idle(void);
+bool mie_bus_acquire(void);  /* pause periodic poll, wait for bus drain */
+void mie_bus_release(void);
+
+static inline void mie_bus_scope_cleanup(bool *held) {
+    if(*held) {
+        mie_bus_release();
+    }
+}
+
+#define mie_bus_acquire_scoped(name) \
+    bool name __attribute__((cleanup(mie_bus_scope_cleanup))) = mie_bus_acquire()
+
+maple_response_t *mie_cmd_resp(int cmd, void *send_buf, int length);
+maple_response_t *mie_jvs_fetch_retry(bool (*ready)(maple_response_t *));
+bool mie_jvs_io_cmd(const uint8_t *req, int length);
+bool mie_read_coin_input(mie_jvs_coin_slot_t *out, int max_slots);
+
+bool mie_z80_init(const char *fw_path, maple_device_t *dev);
+bool mie_z80_try_active(maple_device_t *dev);
+bool mie_jvs_function_check(void);
+
+#endif

--- a/kernel/arch/dreamcast/hardware/maple/mie/mie_proto.c
+++ b/kernel/arch/dreamcast/hardware/maple/mie/mie_proto.c
@@ -1,0 +1,519 @@
+/* KallistiOS ##version##
+
+   mie_proto.c
+   Copyright (C) 2026 Ruslan Rostovtsev
+
+   Protocol helpers: build Maple IO payloads and parse the Z80 IOR response
+   buffer. JVS commands are nested inside IOR envelopes (REQUEST/FETCH/RESPONSE).
+*/
+
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#include <dc/maple.h>
+#include <dc/maple/mie.h>
+
+#include "mie_internal.h"
+
+#define MIE_IOR_JVS_FETCH       0x15
+#define MIE_IOR_JVS_RESPONSE    0x16
+#define MIE_IOR_JVS_REQUEST     0x17
+#define MIE_JVS_REQ_MAGIC       0x77
+
+#define JVS_REPORT_OK 0x01
+
+#define MIE_JVS_CMD_RESET   0xF0
+#define MIE_JVS_CMD_SETADDR 0xF1
+#define MIE_JVS_RESET_ARG   0xD9
+
+#define JVS_CMD_SWINP       0x20
+#define JVS_CMD_COININP     0x21
+#define JVS_CMD_ANLINP      0x22
+#define JVS_CMD_COINDEC     0x30
+#define JVS_CMD_COINADD     0x35
+#define JVS_CMD_OUTPUT      0x32
+#define JVS_CMD_FUNC_CHECK  0x14
+
+#define MIE_JVS_SW_BYTES_DEFAULT 2
+
+/* Fixed offsets within the IOR JVS response buffer (see mie_ior_resp_ready). */
+#define MIE_IOR_RESP_STATUS_OFF        18
+#define MIE_IOR_RESP_STATUS_READY      0x80
+#define MIE_IOR_RESP_JVS_REPORT_OFF    26
+#define MIE_IOR_RESP_PANEL_OFF         6
+#define MIE_IOR_RESP_PANEL_TEST_BIT    0x10
+#define MIE_IOR_RESP_PANEL_SERVICE_BIT 0x20
+#define MIE_IOR_RESP_SYS_OFF           27
+#define MIE_IOR_RESP_P1_SW_OFF         28
+#define MIE_IOR_RESP_P2_SW_OFF         30
+#define MIE_IOR_RESP_COIN_OFF          32
+#define MIE_IOR_RESP_ANALOG_OFF        38
+#define MIE_IOR_RESP_MIN_LEN           54
+#define MIE_IOR_RESP_SW_MIN_LEN        32
+
+static mie_jvs_poll_cfg_t mie_jvs_poll_cfg = {
+    MIE_JVS_PLAYER_SLOTS,
+    MIE_JVS_SW_BYTES_DEFAULT,
+    MIE_JVS_COIN_SLOTS,
+    MIE_JVS_ANALOG_CHANNELS,
+    0
+};
+
+static uint8_t mie_jvs_poll_bundle_len(void) {
+    uint8_t len = 0;
+
+    if(mie_jvs_poll_cfg.players > 0) {
+        len = (uint8_t)(len + 3);
+    }
+    if(mie_jvs_poll_cfg.coin_slots > 0) {
+        len = (uint8_t)(len + 2);
+    }
+    if(mie_jvs_poll_cfg.analog_channels > 0) {
+        len = (uint8_t)(len + 2);
+    }
+    return len;
+}
+
+uint8_t mie_jvs_poll_tx_words(void) {
+    return (uint8_t)((8 + mie_jvs_poll_bundle_len() + 3) / 4);
+}
+
+bool mie_jvs_poll_cfg_apply(const mie_jvs_poll_cfg_t *cfg) {
+    mie_jvs_poll_cfg_t next;
+
+    assert(cfg);
+
+    next = *cfg;
+    if(next.players == 0) {
+        next.players = MIE_JVS_PLAYER_SLOTS;
+    }
+    if(next.players > MIE_JVS_PLAYER_SLOTS) {
+        next.players = MIE_JVS_PLAYER_SLOTS;
+    }
+    if(next.sw_bytes == 0) {
+        next.sw_bytes = MIE_JVS_SW_BYTES_DEFAULT;
+    }
+    if(next.coin_slots == 0) {
+        next.coin_slots = MIE_JVS_COIN_SLOTS;
+    }
+    if(next.coin_slots > MIE_JVS_COIN_SLOTS) {
+        next.coin_slots = MIE_JVS_COIN_SLOTS;
+    }
+    if(next.analog_channels == 0) {
+        next.analog_channels = MIE_JVS_ANALOG_CHANNELS;
+    }
+    if(next.analog_channels > MIE_JVS_ANALOG_CHANNELS) {
+        next.analog_channels = MIE_JVS_ANALOG_CHANNELS;
+    }
+    if(next.driver_outputs == 0) {
+        next.driver_outputs = MIE_JVS_OUTPUT_COUNT;
+    }
+    if(next.driver_outputs > MIE_JVS_OUTPUT_COUNT) {
+        next.driver_outputs = MIE_JVS_OUTPUT_COUNT;
+    }
+
+    mie_jvs_poll_cfg = next;
+    return true;
+}
+
+uint8_t mie_jvs_driver_outputs(void) {
+    if(mie_jvs_poll_cfg.driver_outputs == 0) {
+        return MIE_JVS_OUTPUT_COUNT;
+    }
+    return mie_jvs_poll_cfg.driver_outputs;
+}
+
+uint8_t mie_jvs_output_wire_bytes(void) {
+    uint8_t bytes;
+
+    bytes = (uint8_t)((mie_jvs_driver_outputs() + 7) / 8);
+    if(bytes > (MIE_JVS_OUTPUT_COUNT + 7) / 8) {
+        bytes = (uint8_t)((MIE_JVS_OUTPUT_COUNT + 7) / 8);
+    }
+    if(bytes == 0) {
+        bytes = 1;
+    }
+    return bytes;
+}
+
+uint8_t mie_jvs_output_tx_words(uint8_t data_bytes) {
+    uint8_t jvs_len;
+
+    jvs_len = (uint8_t)(2 + data_bytes);
+    return (uint8_t)((8 + jvs_len + 3) / 4);
+}
+
+#define MIE_JVS_NODE      1
+#define MIE_JVS_BROADCAST 0xFF
+
+/* Wrap a raw JVS command in the MIE IOR request envelope (Maple IO payload). */
+static uint8_t *mie_jvs_req_hdr(uint8_t *buf, uint8_t node, uint8_t jvs_len) {
+    buf[0] = MIE_IOR_JVS_REQUEST;
+    buf[1] = MIE_JVS_REQ_MAGIC;
+    buf[6] = node;
+    buf[7] = jvs_len;
+    return buf + 8;
+}
+
+void mie_build_jvs_coin_cmd(uint8_t *buf, uint8_t jvs_cmd,
+                                    uint8_t slot, uint16_t amount) {
+    uint8_t *cmd;
+
+    memset(buf, 0, 12);
+    cmd = mie_jvs_req_hdr(buf, MIE_JVS_NODE, 4);
+    cmd[0] = jvs_cmd;
+    cmd[1] = slot + 1;
+    cmd[2] = (uint8_t)(amount >> 8);
+    cmd[3] = (uint8_t)(amount & 0xFF);
+}
+
+void mie_build_jvs_coin_dec(uint8_t *buf, uint8_t slot, uint16_t amount) {
+    mie_build_jvs_coin_cmd(buf, JVS_CMD_COINDEC, slot, amount);
+}
+
+void mie_build_jvs_coin_add(uint8_t *buf, uint8_t slot, uint16_t amount) {
+    mie_build_jvs_coin_cmd(buf, JVS_CMD_COINADD, slot, amount);
+}
+
+/* Single poll bundles switch, coin and analog reads for the periodic input loop. */
+void mie_build_buttons_tx(uint8_t *buf) {
+    uint8_t *cmd;
+    uint8_t len = 0;
+
+    memset(buf, 0, 16);
+    cmd = mie_jvs_req_hdr(buf, MIE_JVS_NODE, 0);
+    if(mie_jvs_poll_cfg.players > 0) {
+        cmd[len++] = JVS_CMD_SWINP;
+        cmd[len++] = mie_jvs_poll_cfg.players;
+        cmd[len++] = mie_jvs_poll_cfg.sw_bytes;
+    }
+    if(mie_jvs_poll_cfg.coin_slots > 0) {
+        cmd[len++] = JVS_CMD_COININP;
+        cmd[len++] = mie_jvs_poll_cfg.coin_slots;
+    }
+    if(mie_jvs_poll_cfg.analog_channels > 0) {
+        cmd[len++] = JVS_CMD_ANLINP;
+        cmd[len++] = mie_jvs_poll_cfg.analog_channels;
+    }
+    buf[7] = len;
+}
+
+void mie_build_jvs_output(uint8_t *buf, const uint8_t *data, uint8_t bytes) {
+    uint8_t *cmd;
+    uint8_t i;
+
+    memset(buf, 0, 12);
+    cmd = mie_jvs_req_hdr(buf, MIE_JVS_NODE, (uint8_t)(2 + bytes));
+    cmd[0] = JVS_CMD_OUTPUT;
+    cmd[1] = bytes;
+    for(i = 0; i < bytes; i++) {
+        cmd[2 + i] = data[i];
+    }
+}
+
+void mie_build_jvs_reset(uint8_t *buf) {
+    uint8_t *cmd;
+
+    memset(buf, 0, 12);
+    /* Broadcast reset — all JVS nodes must see this before setaddr. */
+    cmd = mie_jvs_req_hdr(buf, MIE_JVS_BROADCAST, 2);
+    cmd[0] = MIE_JVS_CMD_RESET;
+    cmd[1] = MIE_JVS_RESET_ARG;
+}
+
+void mie_build_jvs_setaddr(uint8_t *buf) {
+    uint8_t *cmd;
+
+    memset(buf, 0, 12);
+    /* Assign node 1 after broadcast reset (retried until ack in mie_fw.c). */
+    cmd = mie_jvs_req_hdr(buf, MIE_JVS_BROADCAST, 2);
+    cmd[0] = MIE_JVS_CMD_SETADDR;
+    cmd[1] = MIE_JVS_NODE;
+}
+
+void mie_build_jvs_func_check(uint8_t *buf) {
+    uint8_t *cmd;
+
+    memset(buf, 0, 12);
+    cmd = mie_jvs_req_hdr(buf, MIE_JVS_NODE, 1);
+    cmd[0] = JVS_CMD_FUNC_CHECK;
+}
+
+void mie_build_jvs_fetch(uint8_t *buf) {
+    /* Second step of the poll cycle — read Z80-assembled JVS result. */
+    buf[0] = MIE_IOR_JVS_FETCH;
+    buf[1] = 0;
+    buf[2] = 0;
+    buf[3] = 0;
+}
+
+static inline uint16_t mie_read_jvs_u16(const uint8_t *p) {
+    return ((uint16_t)p[0] << 8) | p[1];
+}
+
+/* IOR fetch buffer: status byte + JVS report must be OK before parsing fields. */
+static bool mie_ior_resp_ready(const uint8_t *data, int len) {
+    if(len < MIE_IOR_RESP_MIN_LEN || data[0] != MIE_IOR_JVS_RESPONSE) {
+        return false;
+    }
+
+    if((data[MIE_IOR_RESP_STATUS_OFF] & MIE_IOR_RESP_STATUS_READY) == 0) {
+        return false;
+    }
+
+    if(data[MIE_IOR_RESP_JVS_REPORT_OFF] != JVS_REPORT_OK) {
+        return false;
+    }
+
+    return true;
+}
+
+bool mie_ior_jvs_report_ready(const uint8_t *data, int len) {
+    if(len < MIE_IOR_RESP_JVS_REPORT_OFF + 2 ||
+            data[0] != MIE_IOR_JVS_RESPONSE) {
+        return false;
+    }
+
+    return data[MIE_IOR_RESP_JVS_REPORT_OFF] == JVS_REPORT_OK;
+}
+
+bool mie_parse_jvs_func_check(const uint8_t *data, int len,
+                              mie_jvs_poll_cfg_t *cfg) {
+    const uint8_t *p;
+    const uint8_t *end;
+    uint8_t type;
+    uint8_t p1;
+    uint8_t p2;
+    bool found = false;
+
+    assert(data);
+    assert(cfg);
+
+    if(!mie_ior_jvs_report_ready(data, len)) {
+        return false;
+    }
+
+    memset(cfg, 0, sizeof(*cfg));
+    p = data + MIE_IOR_RESP_JVS_REPORT_OFF + 1;
+    end = data + len;
+
+    while(p + 4 <= end && p[0] != 0) {
+        type = p[0];
+        p1 = p[1];
+        p2 = p[2];
+        p += 4;
+
+        switch(type) {
+        case 0x01:
+            cfg->players = p1;
+            if(p2 == 0) {
+                cfg->sw_bytes = 0;
+            }
+            else {
+                cfg->sw_bytes = (uint8_t)(((p2 - 1) / 8) + 1);
+            }
+            found = true;
+            break;
+        case 0x02:
+            cfg->coin_slots = p1;
+            found = true;
+            break;
+        case 0x03:
+            cfg->analog_channels = p1;
+            found = true;
+            break;
+        case 0x12:
+            cfg->driver_outputs = p1;
+            found = true;
+            break;
+        default:
+            break;
+        }
+    }
+
+    return found;
+}
+
+const uint8_t *mie_ior_resp_map(maple_response_t *resp, int *len_out) {
+    const uint8_t *data;
+    int len;
+
+    if(!resp || resp->data_len < 2) {
+        return NULL;
+    }
+
+    data = resp->data;
+    len = (int)resp->data_len * 4;
+
+    if(!mie_ior_resp_ready(data, len)) {
+        return NULL;
+    }
+
+    if(len_out) {
+        *len_out = len;
+    }
+
+    return data;
+}
+
+uint16_t mie_jvs_coin_meter(const mie_jvs_coin_slot_t *slot) {
+    assert(slot);
+
+    return slot->raw & (uint16_t)~MIE_JVS_COIN_BUSY;
+}
+
+bool mie_jvs_coin_usable(const mie_jvs_coin_slot_t *slot) {
+    assert(slot);
+
+    return (slot->raw & MIE_JVS_COIN_BUSY) == 0;
+}
+
+uint16_t mie_jvs_coin_count(const mie_jvs_coin_slot_t *slot) {
+    assert(slot);
+
+    if(!mie_jvs_coin_usable(slot)) {
+        return slot->count;
+    }
+
+    return mie_jvs_coin_meter(slot);
+}
+
+void mie_jvs_coin_slot_set(mie_jvs_coin_slot_t *slot, uint16_t raw,
+                           uint16_t prev_count) {
+    assert(slot);
+
+    slot->raw = raw;
+
+    if(mie_jvs_coin_usable(slot)) {
+        slot->count = mie_jvs_coin_meter(slot);
+    }
+    else {
+        slot->count = prev_count;
+    }
+}
+
+bool mie_extract_coin(const uint8_t *data, int len, uint16_t *raw, int max_slots) {
+    static const uint8_t ior_off[] = {2, 0, 4};
+    const uint8_t *base;
+    int i;
+    int slots;
+
+    assert(data);
+    assert(raw);
+    assert(max_slots > 0);
+
+    base = data + MIE_IOR_RESP_COIN_OFF;
+    slots = max_slots;
+    if(slots > MIE_JVS_COIN_SLOTS) {
+        slots = MIE_JVS_COIN_SLOTS;
+    }
+    if(slots > (int)(sizeof(ior_off) / sizeof(ior_off[0]))) {
+        slots = (int)(sizeof(ior_off) / sizeof(ior_off[0]));
+    }
+
+    for(i = 0; i < slots; i++) {
+        if(base + ior_off[i] + 2 > data + len ||
+                base + ior_off[i] + 2 > data + MIE_IOR_RESP_ANALOG_OFF) {
+            return i > 0;
+        }
+        raw[i] = mie_read_jvs_u16(base + ior_off[i]);
+    }
+
+    return true;
+}
+
+bool mie_extract_analog(const uint8_t *data, int len, uint16_t *analog) {
+    const uint8_t *p;
+    int i;
+
+    assert(data);
+    assert(analog);
+
+    p = data + MIE_IOR_RESP_ANALOG_OFF;
+    if(p + MIE_JVS_ANALOG_CHANNELS * 2 > data + len) {
+        return false;
+    }
+
+    for(i = 0; i < MIE_JVS_ANALOG_CHANNELS; i++) {
+        analog[i] = mie_read_jvs_u16(p + i * 2);
+    }
+    return true;
+}
+
+bool mie_extract_panel(const uint8_t *data, int len, mie_jvs_panel_t *panel) {
+    uint8_t b;
+
+    assert(data);
+    assert(panel);
+
+    panel->dip.raw = 0;
+    panel->psw.raw = 0;
+
+    if(len < MIE_IOR_RESP_PANEL_OFF + 1) {
+        return false;
+    }
+
+    b = data[MIE_IOR_RESP_PANEL_OFF];
+    /* DIP switches and panel buttons are active-low in the IOR buffer. */
+    panel->dip.raw = (uint8_t)(~b & GENMASK(MIE_JVS_PANEL_DIP_COUNT - 1, 0));
+    if((b & MIE_IOR_RESP_PANEL_TEST_BIT) == 0) {
+        panel->psw.test = 1;
+    }
+    if((b & MIE_IOR_RESP_PANEL_SERVICE_BIT) == 0) {
+        panel->psw.service = 1;
+    }
+    return true;
+}
+
+bool mie_extract_sw(const uint8_t *data, int len, uint8_t *sys, uint16_t *p1,
+                    uint16_t *p2) {
+    assert(data);
+    assert(p1);
+    assert(p2);
+
+    if(len < MIE_IOR_RESP_SW_MIN_LEN) {
+        return false;
+    }
+
+    if(sys) {
+        *sys = data[MIE_IOR_RESP_SYS_OFF];
+    }
+
+    *p1 = mie_read_jvs_u16(data + MIE_IOR_RESP_P1_SW_OFF);
+    *p2 = mie_read_jvs_u16(data + MIE_IOR_RESP_P2_SW_OFF);
+    return true;
+}
+
+int mie_copy_id(maple_response_t *resp, char *buf, int buf_len) {
+    int out_len = 0;
+    int i;
+    uint32_t part_len;
+    uint32_t copy_len;
+
+    assert(resp);
+    assert(buf);
+    assert(buf_len > 0);
+
+    /* GET_ID may span two chained maple response blocks. */
+    for(i = 0; i < 2; i++) {
+        part_len = resp->data_len * 4;
+
+        if(!part_len) {
+            break;
+        }
+
+        copy_len = part_len;
+        if(out_len + (int)copy_len >= buf_len) {
+            copy_len = (uint32_t)(buf_len - out_len - 1);
+        }
+
+        memcpy(buf + out_len, resp->data, copy_len);
+        out_len += (int)copy_len;
+        resp = (maple_response_t *)(&resp->data[part_len]);
+    }
+
+    buf[out_len] = '\0';
+    return out_len;
+}

--- a/kernel/arch/dreamcast/include/arch/init_flags.h
+++ b/kernel/arch/dreamcast/include/arch/init_flags.h
@@ -73,6 +73,9 @@ __BEGIN_DECLS
     KOS_INIT_FLAG(flags, INIT_SIP, sip_shutdown); \
     KOS_INIT_FLAG(flags, INIT_DREAMEYE, dreameye_init); \
     KOS_INIT_FLAG(flags, INIT_DREAMEYE, dreameye_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_MIE, mie_init); \
+    KOS_INIT_FLAG(flags, INIT_MIE, mie_shutdown); \
+    KOS_INIT_FLAG(flags, INIT_MIE, mie_init_scan); \
     KOS_INIT_FLAG(flags, INIT_MAPLE_ALL, maple_wait_scan); \
     KOS_INIT_FLAG(flags, INIT_MAPLE_ALL, maple_init); \
     KOS_INIT_FLAG(flags, INIT_MAPLE_ALL, maple_shutdown)
@@ -93,7 +96,13 @@ __BEGIN_DECLS
 #define INIT_DEFAULT_ARCH   (INIT_MAPLE_ALL | INIT_CDROM)
 
 /** \brief Enable all Maple peripheral drivers. */
-#define INIT_MAPLE_ALL      (INIT_CONTROLLER | INIT_KEYBOARD | INIT_MOUSE    | \
+#if defined(_arch_sub_naomi)
+#define INIT_MAPLE_ALL      (INIT_MAPLE_PERIPH | INIT_MIE)
+#else
+#define INIT_MAPLE_ALL      INIT_MAPLE_PERIPH
+#endif
+
+#define INIT_MAPLE_PERIPH   (INIT_CONTROLLER | INIT_KEYBOARD | INIT_MOUSE    | \
                              INIT_LIGHTGUN   | INIT_VMU      | INIT_PURUPURU | \
                              INIT_SIP        | INIT_DREAMEYE)
 
@@ -105,6 +114,7 @@ __BEGIN_DECLS
 #define INIT_PURUPURU       0x00080000  /**< \brief Enable Puru Puru maple driver */
 #define INIT_SIP            0x00100000  /**< \brief Enable Sound input maple driver */
 #define INIT_DREAMEYE       0x00200000  /**< \brief Enable DreamEye maple driver */
+#define INIT_MIE            0x00400000  /**< \brief Enable MIE/JVS maple driver */
 
 #define INIT_CDROM          0x01000000  /**< \brief Enable CD-ROM support */
 

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -3,6 +3,7 @@
    dc/maple.h
    Copyright (C) 2002 Megan Potter
    Copyright (C) 2015 Lawrence Sebald
+   Copyright (C) 2026 Ruslan Rostovtsev
 
    This new driver's design is based loosely on the LinuxDC maple
    bus driver.
@@ -32,6 +33,7 @@
 
     \author Megan Potter
     \author Lawrence Sebald
+    \author Ruslan Rostovtsev
 
     \see    dc/maple/controller.h
     \see    dc/maple/dreameye.h
@@ -87,12 +89,12 @@ __BEGIN_DECLS
     @{
 */
 #define MAPLE_BASE      0xa05f6c00          /**< \brief Maple register base */
-#define MAPLE_DMAADDR   (MAPLE_BASE+0x04)   /**< \brief DMA address register */
-#define MAPLE_RESET2    (MAPLE_BASE+0x10)   /**< \brief Reset register #2 */
+#define MAPLE_DMA_ADDR  (MAPLE_BASE+0x04)   /**< \brief DMA address register */
+#define MAPLE_DMA_TSEL  (MAPLE_BASE+0x10)   /**< \brief Maple DMA trigger select (bit 0) */
 #define MAPLE_ENABLE    (MAPLE_BASE+0x14)   /**< \brief Enable register */
 #define MAPLE_STATE     (MAPLE_BASE+0x18)   /**< \brief Status register */
 #define MAPLE_SPEED     (MAPLE_BASE+0x80)   /**< \brief Speed register */
-#define MAPLE_RESET1    (MAPLE_BASE+0x8c)   /**< \brief Reset register #1 */
+#define MAPLE_DMA_PROT  (MAPLE_BASE+0x8c)   /**< \brief Allowed DMA buffer address range */
 /** @} */
 
 /** \defgroup maple_reg_values      Register Values
@@ -104,19 +106,19 @@ __BEGIN_DECLS
 
     @{
 */
-#define MAPLE_RESET2_MAGIC      0               /**< \brief 2nd reset value */
+#define MAPLE_DMA_TSEL_SOFTWARE 0               /**< \brief DMA initiated by software */
+#define MAPLE_DMA_TSEL_VBLANK   1               /**< \brief DMA initiated at V-Blank */
 #define MAPLE_ENABLE_ENABLED    1               /**< \brief Enable Maple */
 #define MAPLE_ENABLE_DISABLED   0               /**< \brief Disable Maple */
 #define MAPLE_STATE_IDLE        0               /**< \brief Idle state */
 #define MAPLE_STATE_DMA         1               /**< \brief DMA in-progress */
-#define MAPLE_SPEED_2MBPS       0               /**< \brief 2Mbps bus speed */
+#define MAPLE_SPEED_1MBPS       0x0100          /**< \brief 1Mbps bus speed */
+#define MAPLE_SPEED_2MBPS       0x0000          /**< \brief 2Mbps bus speed */
+#define MAPLE_SPEED_4MBPS       0x0200          /**< \brief 4Mbps bus speed */
+#define MAPLE_SPEED_8MBPS       0x0300          /**< \brief 8Mbps bus speed */
 #define MAPLE_SPEED_TIMEOUT(n)  ((n) << 16)     /**< \brief Bus timeout macro */
 
-#ifndef _arch_sub_naomi
-#define MAPLE_RESET1_MAGIC      0x6155404f      /**< \brief First reset value */
-#else
-#define MAPLE_RESET1_MAGIC      0x6155405f
-#endif
+#define MAPLE_DMA_PROT_MAGIC    0x61550000      /**< \brief Key in bits 31-16; lo/hi bytes set the allowed range */
 
 /** @} */
 

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -179,6 +179,7 @@ __BEGIN_DECLS
 #define MAPLE_FUNC_ARGUN        0x20000000  /**< \brief AR gun? */
 #define MAPLE_FUNC_KEYBOARD     0x40000000  /**< \brief Keyboard */
 #define MAPLE_FUNC_LIGHTGUN     0x80000000  /**< \brief Lightgun */
+#define MAPLE_FUNC_MIE          0x00000001  /**< \brief Naomi MIE/JVS bridge */
 #define MAPLE_FUNC_ANY          0xffffffff  /**< \brief Match/request any */
 /** @} */
 
@@ -446,6 +447,9 @@ typedef struct maple_state_str {
 
     /** \brief  Mask of ports that completed the initial scan */
     volatile uint8_t            scan_ready_mask;
+
+    /** \brief  Port A is MIE (skip autodetect on port 0). */
+    uint8_t                     port0_mie;
 
     /** \brief  Our vblank handler handle */
     int                         vbl_handle;

--- a/kernel/arch/dreamcast/include/dc/maple/mie.h
+++ b/kernel/arch/dreamcast/include/dc/maple/mie.h
@@ -1,0 +1,826 @@
+/* KallistiOS ##version##
+
+   dc/maple/mie.h
+   Copyright (C) 2026 Ruslan Rostovtsev
+
+   NAOMI and NAOMI 2 MIE-JVS bridge Maple device driver.
+*/
+
+/** \file    dc/maple/mie.h
+    \brief   Definitions for the NAOMI MIE-JVS bridge Maple device.
+    \ingroup mie
+
+    This file contains the public API for the MIE (Maple I/O Emulator) driver
+    for NAOMI and NAOMI 2, which bridges the Maple bus to a JVS I/O board.
+
+    \author Ruslan Rostovtsev
+*/
+
+#ifndef __DC_MAPLE_MIE_H
+#define __DC_MAPLE_MIE_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <kos/regfield.h>
+#include <dc/maple.h>
+#include <dc/maple/controller.h>
+
+/** \defgroup mie MIE
+    \brief    NAOMI and NAOMI 2 MIE-JVS bridge Maple device
+    \ingroup  peripherals
+
+    The MIE (Maple I/O Emulator) is a Z80-based bridge that connects the Maple
+    bus to a JVS I/O board. It normally occupies Maple port A, unit 0. Player
+    inputs from the JVS board are mapped to a standard Dreamcast controller
+    state structure (\ref cont_state_t), as well as the original native JVS
+    inputs structure (\ref mie_jvs_inputs_t).
+
+    Port A can be switched between JVS mode and a regular Dreamcast Maple port.
+    The driver detects which mode is active and either handles JVS input or
+    yields port A to the standard Maple autodetect (controller, VMU, etc.).
+
+    \author Ruslan Rostovtsev
+
+    @{
+*/
+
+/** \defgroup mie_jvs_inputs JVS Inputs
+    \brief    Native JVS input state structures and masks
+    \ingroup  mie
+
+    Decoded JVS switch, analog, coin, and panel state from the I/O board.
+    Fetch the latest values by casting maple_dev_status() on an MIE device
+    to \ref mie_state_t and reading the \p jvs member.
+*/
+
+/** \defgroup mie_jvs_limits Limits
+    \brief    JVS channel and buffer size constants
+    \ingroup  mie_jvs_inputs
+
+    @{
+*/
+#define MIE_JVS_PLAYER_SLOTS    2       /**< \brief Max player switch banks. */
+#define MIE_JVS_ANALOG_CHANNELS 8       /**< \brief Number of JVS analog channels. */
+#define MIE_JVS_ANALOG_RAW_MASK (GENMASK(6, 0) | GENMASK(15, 8))
+#define MIE_JVS_COIN_SLOTS      2       /**< \brief Max JVS coin slots. */
+#define MIE_JVS_PANEL_DIP_COUNT 4       /**< \brief Number of cabinet DIP switches. */
+#define MIE_JVS_OUTPUT_COUNT    24      /**< \brief Max JVS general purpose outputs. */
+#define MIE_EEPROM_SIZE         128     /**< \brief MIE on-board EEPROM size in bytes. */
+#define MIE_ID_SIZE             64      /**< \brief MIE board identifier buffer size. */
+/** @} */
+
+/** \defgroup mie_jvs_masks Input Masks
+    \brief    Bit masks for mie_jvs_callback() and native switch fields
+    \ingroup  mie_jvs_inputs
+
+    For player inputs, use \p MIE_JVS_*_BIT with \p MIE_JVS_IN_P1 or
+    \p MIE_JVS_IN_P2. First-byte switches are \p start, \p service, directions,
+    and push switches 1–2; second-byte switches (\p sw9 through \p sw16) are
+    push switches 3–10.
+
+    For \p MIE_JVS_IN_SYSTEM, use \p MIE_JVS_SYS_*_BIT.
+    For the cabinet panel, use \p MIE_JVS_PANEL_DIP*_BIT
+    or \p MIE_JVS_PANEL_*_BIT with the matching \ref mie_jvs_input_t value.
+
+    @{
+*/
+#define MIE_JVS_SW1_BIT            BIT(8)  /**< \brief Push switch 2. */
+#define MIE_JVS_SW2_BIT            BIT(9)  /**< \brief Push switch 1. */
+#define MIE_JVS_RIGHT_BIT          BIT(10) /**< \brief Right switch (JVS SW3). */
+#define MIE_JVS_LEFT_BIT           BIT(11) /**< \brief Left switch (JVS SW4). */
+#define MIE_JVS_DOWN_BIT           BIT(12) /**< \brief Down switch (JVS SW5). */
+#define MIE_JVS_UP_BIT             BIT(13) /**< \brief Up switch (JVS SW6). */
+#define MIE_JVS_SERVICE_BIT        BIT(14) /**< \brief Service switch (JVS SW7). */
+#define MIE_JVS_START_BIT          BIT(15) /**< \brief Start switch (JVS SW8). */
+#define MIE_JVS_SW9_BIT            BIT(0)  /**< \brief Push switch 3. */
+#define MIE_JVS_SW10_BIT           BIT(1)  /**< \brief Push switch 4. */
+#define MIE_JVS_SW11_BIT           BIT(2)  /**< \brief Push switch 5. */
+#define MIE_JVS_SW12_BIT           BIT(3)  /**< \brief Push switch 6. */
+#define MIE_JVS_SW13_BIT           BIT(4)  /**< \brief Push switch 7. */
+#define MIE_JVS_SW14_BIT           BIT(5)  /**< \brief Push switch 8. */
+#define MIE_JVS_SW15_BIT           BIT(6)  /**< \brief Push switch 9. */
+#define MIE_JVS_SW16_BIT           BIT(7)  /**< \brief Push switch 10. */
+#define MIE_JVS_COIN_INSERT_BIT    BIT(0)  /**< \brief Coin slot insert edge for MIE_JVS_IN_COIN*. */
+#define MIE_JVS_PANEL_DIP1_BIT     BIT(0)  /**< \brief Panel DIP switch 1. */
+#define MIE_JVS_PANEL_DIP2_BIT     BIT(1)  /**< \brief Panel DIP switch 2. */
+#define MIE_JVS_PANEL_DIP3_BIT     BIT(2)  /**< \brief Panel DIP switch 3. */
+#define MIE_JVS_PANEL_DIP4_BIT     BIT(3)  /**< \brief Panel DIP switch 4. */
+#define MIE_JVS_PANEL_TEST_BIT     BIT(0)  /**< \brief Panel test switch (PSW1). */
+#define MIE_JVS_PANEL_SERVICE_BIT  BIT(1)  /**< \brief Panel service switch (PSW2). */
+#define MIE_JVS_SYS_TILT3_BIT      BIT(4)  /**< \brief Tilt switch 3. */
+#define MIE_JVS_SYS_TILT2_BIT      BIT(5)  /**< \brief Tilt switch 2. */
+#define MIE_JVS_SYS_TILT1_BIT      BIT(6)  /**< \brief Tilt switch 1. */
+#define MIE_JVS_SYS_TEST_BIT       BIT(7)  /**< \brief Test switch. */
+/** @} */
+
+/** \defgroup mie_jvs_coin_status Coin Status Flags
+    \brief    COININP status bits in the upper word
+    \ingroup  mie_jvs_inputs
+
+    @{
+*/
+#define MIE_JVS_COIN_STUFF           0x4000  /**< \brief Coin chute stuffed. */
+#define MIE_JVS_COIN_COUNTER_BREAK   0x8000  /**< \brief Coin counter fault. */
+#define MIE_JVS_COIN_BUSY            (MIE_JVS_COIN_STUFF | MIE_JVS_COIN_COUNTER_BREAK)
+#define MIE_JVS_COIN_DEC_LIMIT       0x1000  /**< \brief Auto COINDEC when meter exceeds this. */
+/** @} */
+
+/** \brief   Parsed JVS coin slot state.
+    \ingroup mie_jvs_inputs
+
+    Updated from JVS COININP (0x21) during periodic polling. Use
+    mie_read_coin_input() to copy the latest cached slots; that function does
+    not issue a separate bus transaction.
+
+    Each slot is a 16-bit meter value in JVS wire order. Status flags
+    \ref MIE_JVS_COIN_STUFF and \ref MIE_JVS_COIN_COUNTER_BREAK occupy bits
+    14..15 (\ref MIE_JVS_COIN_BUSY). When either flag is set the driver keeps
+    the previous \p count and sets mie_jvs_inputs_t::coin_fault for that frame.
+
+    On a normal reading, \p count is \p raw with status bits cleared
+    (\c raw & ~MIE_JVS_COIN_BUSY). Coin inserts are detected as positive
+    deltas against the previous \p count.
+*/
+typedef struct mie_jvs_coin_slot {
+    uint16_t raw;       /**< \brief Raw 16-bit COININP word. */
+    uint16_t count;     /**< \brief Last good meter (status bits cleared). */
+} mie_jvs_coin_slot_t;
+
+/** \brief   One player JVS switch bank.
+    \ingroup mie_jvs_inputs
+
+    A 1 bit indicates that the corresponding switch is active.
+    See \ref mie_jvs_masks for the usual arcade assignment of each switch.
+*/
+typedef struct mie_jvs_player_sw {
+    union {
+        uint16_t raw;             /**< \brief Raw 16-bit JVS switch word. */
+        struct {
+            uint16_t sw9: 1;      /**< \brief Push switch 3 value. */
+            uint16_t sw10: 1;     /**< \brief Push switch 4 value. */
+            uint16_t sw11: 1;     /**< \brief Push switch 5 value. */
+            uint16_t sw12: 1;     /**< \brief Push switch 6 value. */
+            uint16_t sw13: 1;     /**< \brief Push switch 7 value. */
+            uint16_t sw14: 1;     /**< \brief Push switch 8 value. */
+            uint16_t sw15: 1;     /**< \brief Push switch 9 value. */
+            uint16_t sw16: 1;     /**< \brief Push switch 10 value. */
+            uint16_t sw1: 1;      /**< \brief Push switch 2 value. */
+            uint16_t sw2: 1;      /**< \brief Push switch 1 value. */
+            uint16_t right: 1;    /**< \brief Right switch (JVS SW3). */
+            uint16_t left: 1;     /**< \brief Left switch (JVS SW4). */
+            uint16_t down: 1;     /**< \brief Down switch (JVS SW5). */
+            uint16_t up: 1;       /**< \brief Up switch (JVS SW6). */
+            uint16_t service: 1;  /**< \brief Service switch (JVS SW7). */
+            uint16_t start: 1;    /**< \brief Start switch (JVS SW8). */
+        };
+    };
+} mie_jvs_player_sw_t;
+
+/** \brief   Panel DIP switch bank.
+    \ingroup mie_jvs_inputs
+*/
+typedef struct mie_jvs_panel_dip {
+    union {
+        uint8_t raw;        /**< \brief Raw DIP switch byte. */
+        struct {
+            uint8_t sw1: 1; /**< \brief DIP switch 1 value. */
+            uint8_t sw2: 1; /**< \brief DIP switch 2 value. */
+            uint8_t sw3: 1; /**< \brief DIP switch 3 value. */
+            uint8_t sw4: 1; /**< \brief DIP switch 4 value. */
+            uint8_t: 4;
+        };
+    };
+} mie_jvs_panel_dip_t;
+
+/** \brief   JVS SWINP system switch byte.
+    \ingroup mie_jvs_inputs
+
+    A set bit means the switch is active. See \ref mie_jvs_masks for
+    \p MIE_JVS_SYS_*_BIT values.
+*/
+typedef struct mie_jvs_system {
+    union {
+        uint8_t raw;            /**< \brief Raw JVS system switch byte. */
+        struct {
+            uint8_t: 4;
+            uint8_t tilt3: 1;   /**< \brief Tilt switch 3. */
+            uint8_t tilt2: 1;   /**< \brief Tilt switch 2. */
+            uint8_t tilt1: 1;   /**< \brief Tilt switch 1. */
+            uint8_t test: 1;    /**< \brief Test switch. */
+        };
+    };
+} mie_jvs_system_t;
+
+/** \brief   Cabinet panel switches.
+    \ingroup mie_jvs_inputs
+*/
+typedef struct mie_jvs_panel {
+    mie_jvs_panel_dip_t dip;    /**< \brief Cabinet DIP switches. */
+    union {
+        uint8_t raw;            /**< \brief Raw panel service switch byte. */
+        struct {
+            uint8_t test: 1;    /**< \brief Panel test switch (PSW1). */
+            uint8_t service: 1; /**< \brief Panel service switch (PSW2). */
+            uint8_t: 6;
+        };
+    } psw;
+} mie_jvs_panel_t;
+
+/** \brief   Decoded JVS input state.
+    \ingroup mie_jvs_inputs
+
+    Full native JVS input snapshot for two players, the cabinet panel, analog
+    channels, and coin slots. Analog channel names follow the default racing
+    layout; use the \p analog array for generic access.
+
+    \sa mie_state_t
+*/
+typedef struct mie_jvs_inputs {
+    mie_jvs_system_t system;    /**< \brief JVS SWINP system switch byte. */
+    mie_jvs_panel_t panel;      /**< \brief Cabinet panel switches. */
+    mie_jvs_player_sw_t p1;     /**< \brief Player 1 switch bank. */
+    mie_jvs_player_sw_t p2;     /**< \brief Player 2 switch bank. */
+    union {
+        uint16_t analog[MIE_JVS_ANALOG_CHANNELS]; /**< \brief Raw analog channel values. */
+        struct {
+            uint16_t wheel;     /**< \brief Steering wheel analog channel. */
+            uint16_t accel;     /**< \brief Accelerator pedal analog channel. */
+            uint16_t brake;     /**< \brief Brake pedal analog channel. */
+            uint16_t ch3;       /**< \brief Analog channel 3. */
+            uint16_t ch4;       /**< \brief Analog channel 4. */
+            uint16_t ch5;       /**< \brief Analog channel 5. */
+            uint16_t ch6;       /**< \brief Analog channel 6. */
+            uint16_t ch7;       /**< \brief Analog channel 7. */
+        };
+    };
+    mie_jvs_coin_slot_t coin[MIE_JVS_COIN_SLOTS]; /**< \brief Coin slot meters. */
+    uint8_t coin_pulse; /**< \brief One-shot insert flags (bit N = slot N). */
+    uint8_t coin_fault; /**< \brief Fault flags (bit N = slot N, raw & BUSY). */
+} mie_jvs_inputs_t;
+
+/** \brief   MIE device status.
+    \ingroup mie
+
+    Contains the latest decoded player inputs from the JVS board.
+    Cast maple_dev_status() on an MIE device to obtain this structure.
+
+    \headerfile dc/maple/mie.h
+    \sa mie_jvs_inputs, maple_dev_status
+*/
+typedef struct mie_state {
+    cont_state_t cont;          /**< \brief Mapped Dreamcast controller state. */
+    mie_jvs_inputs_t jvs;       /**< \brief Native JVS input state. */
+} mie_state_t;
+
+/** \defgroup mie_mapping Controller Mapping
+    \brief    JVS to Dreamcast controller translation
+    \ingroup  mie
+
+    During polling the driver fills \ref mie_state_t::cont from native JVS
+    inputs using the active mapper. Pass NULL to mie_set_cont_map() to restore
+    the built-in default layout below.
+
+    Default JVS to \ref cont_state_t mapping:
+
+    - p1.start / p2.start -> CONT_START
+    - p1.up / p2.up -> CONT_DPAD_UP
+    - p1.down / p2.down -> CONT_DPAD_DOWN
+    - p1.left / p2.left -> CONT_DPAD_LEFT
+    - p1.right / p2.right -> CONT_DPAD_RIGHT
+    - p1.sw16 / p2.sw16 -> CONT_A
+    - p1.sw2 / p2.sw2 -> CONT_B
+    - p1.sw1 / p2.sw1 -> CONT_X
+    - p1.sw14 / p2.sw14 -> CONT_Y
+    - p1.service / p2.service -> CONT_Z
+    - panel.psw.test -> CONT_C
+    - panel.psw.service -> CONT_D
+    - wheel -> joyx (-128 to 127)
+    - accel -> rtrig (0 to 255)
+    - brake -> ltrig (0 to 255)
+
+    The default mapper skips wheel and pedals when wheel and accel raw values
+    differ by no more than 0x500.
+*/
+
+/** \brief   JVS inputs to Dreamcast controller mapper.
+    \ingroup mie_mapping
+
+    Installed with mie_set_cont_map(). Receives decoded native JVS state and
+    fills a \ref cont_state_t compatible structure for use with the standard
+    controller API.
+
+    \param  jvs             Decoded JVS input state.
+    \param  cont            Controller state to fill.
+
+    \sa mie_set_cont_map
+*/
+typedef void (*mie_cont_map_fn_t)(const mie_jvs_inputs_t *jvs,
+                                  cont_state_t *cont);
+
+/** \defgroup mie_callbacks Callbacks
+    \brief    Automatic input notification callbacks
+    \ingroup  mie
+
+    Callbacks are invoked on a dedicated worker thread when the requested input
+    transitions from released to pressed. Pass NULL as the callback pointer to
+    uninstall a registration with the same key.
+*/
+
+/** \brief   Mapped controller button callback type.
+    \ingroup mie_callbacks
+
+    Called when the mapped \ref cont_state_t buttons matching the registered
+    mask become pressed.
+
+    \param  btns            Current mapped button bitmask (\ref controller_input_masks).
+
+    \sa mie_btn_callback
+*/
+typedef void (*mie_btn_callback_t)(uint32_t btns);
+
+/** \brief   Native JVS input source for mie_jvs_callback().
+    \ingroup mie_callbacks
+*/
+typedef enum mie_jvs_input {
+    MIE_JVS_IN_SYSTEM,      /**< \brief JVS SWINP system switch byte. */
+    MIE_JVS_IN_P1,          /**< \brief Player 1 switch bank. */
+    MIE_JVS_IN_P2,          /**< \brief Player 2 switch bank. */
+    MIE_JVS_IN_PANEL_DIP,   /**< \brief Cabinet DIP switches. */
+    MIE_JVS_IN_PANEL_PSW,   /**< \brief Cabinet panel service switches. */
+    MIE_JVS_IN_COIN1,       /**< \brief Coin slot 1 (COIN SW 1) meter insert. */
+    MIE_JVS_IN_COIN2        /**< \brief Coin slot 2 (COIN SW 2) meter insert. */
+} mie_jvs_input_t;
+
+/** \brief   Native JVS input callback type.
+    \ingroup mie_callbacks
+
+    \param  input           Input source that triggered the callback.
+    \param  mask            Active bits from the matched mask.
+
+    \sa mie_jvs_callback, mie_jvs_masks
+*/
+typedef void (*mie_jvs_callback_t)(mie_jvs_input_t input, uint32_t mask);
+
+/** \defgroup mie_port0 Port A Mode
+    \brief    NAOMI port A wiring detection
+    \ingroup  mie
+*/
+
+/** \defgroup mie_analog Analog Calibration
+    \brief    JVS wheel and pedal calibration
+    \ingroup  mie
+
+    The driver maps the JVS wheel and pedal channels into \ref mie_state_t::cont
+    (\p joyx, \p rtrig, \p ltrig). With a valid calibration installed the values
+    are normalized (\p joyx -128 to 127, triggers 0 to 255); otherwise a built-in
+    legacy mapping is used. While an interactive calibration session is running,
+    the raw channel values are passed through to \p cont unchanged.
+
+    Use mie_analog_calib_start() and mie_analog_calib_capture() to run the
+    interactive flow, then persist the result obtained with
+    mie_analog_calib_get() and restore it later with mie_analog_calib_set().
+
+    For raw \ref mie_jvs_inputs_t values use mie_analog_norm_wheel(),
+    mie_analog_norm_accel(), and mie_analog_norm_brake().
+*/
+
+/** \brief   Per-axis JVS analog calibration data.
+    \ingroup mie_analog
+
+    For pedals only \p min and \p max are used. For the wheel, \p center must lie
+    strictly between \p min and \p max.
+*/
+typedef struct mie_analog_axis_calib {
+    uint16_t min;       /**< \brief Raw value at the minimum position. */
+    uint16_t center;    /**< \brief Raw center value (wheel only). */
+    uint16_t max;       /**< \brief Raw value at the maximum position. */
+} mie_analog_axis_calib_t;
+
+/** \brief   Wheel and pedal calibration set.
+    \ingroup mie_analog
+*/
+typedef struct mie_analog_calib {
+    mie_analog_axis_calib_t wheel;      /**< \brief Steering wheel calibration. */
+    mie_analog_axis_calib_t accel;      /**< \brief Accelerator pedal calibration. */
+    mie_analog_axis_calib_t brake;      /**< \brief Brake pedal calibration. */
+} mie_analog_calib_t;
+
+/** \brief   Interactive calibration step.
+    \ingroup mie_analog
+
+    Returned by mie_analog_calib_current() to drive the UI prompts. Each step
+    is confirmed with mie_analog_calib_capture().
+*/
+typedef enum mie_analog_calib_step {
+    MIE_ANALOG_CALIB_IDLE = 0,      /**< \brief No session running. */
+    MIE_ANALOG_CALIB_WHEEL,         /**< \brief Turn the wheel fully both ways. */
+    MIE_ANALOG_CALIB_WHEEL_CENTER,  /**< \brief Hold the wheel centered. */
+    MIE_ANALOG_CALIB_ACCEL,         /**< \brief Release then fully press accelerator. */
+    MIE_ANALOG_CALIB_BRAKE          /**< \brief Release then fully press brake. */
+} mie_analog_calib_step_t;
+
+/** \brief   NAOMI port A wiring mode.
+    \ingroup mie_port0
+
+    Port A can be wired to the MIE/JVS bridge or switched to a regular
+    Dreamcast Maple port. On retail Dreamcast, mie_port0_mode() always returns
+    \p MIE_PORT0_MAPLE.
+*/
+typedef enum mie_port0_mode {
+    MIE_PORT0_UNKNOWN = 0,      /**< \brief Probing not finished yet. */
+    MIE_PORT0_JVS,              /**< \brief Port A is MIE/JVS bridge. */
+    MIE_PORT0_MAPLE             /**< \brief Port A is standard Maple autodetect. */
+} mie_port0_mode_t;
+
+/** \brief   Query NAOMI port A wiring mode.
+    \ingroup mie_port0
+
+    Returns the mode selected after MIE probing during maple_wait_scan().
+    When \p MIE_PORT0_MAPLE is active, port A is handled by the standard Maple
+    autodetect path instead of this driver.
+
+    \return                 Current port A wiring mode.
+*/
+mie_port0_mode_t mie_port0_mode(void);
+
+/** \defgroup mie_coin Coin Control
+    \brief    JVS coin slot meter access and commands
+    \ingroup  mie
+*/
+
+/** \brief   Read cached coin slot meter.
+    \ingroup mie_coin
+
+    Returns the parsed cumulative count for the given coin slot from the latest
+    driver poll. Does not perform a synchronous bus transaction.
+
+    \param  slot            Coin slot index (0 = first slot).
+    \return                 Coin meter count, or 0 for an invalid slot.
+
+    \sa mie_read_coin_input, mie_jvs_coin_slot_t
+*/
+uint16_t mie_get_coin_meter(uint8_t slot);
+
+/** \brief   Copy cached coin slot state from the last poll.
+    \ingroup mie_coin
+
+    Copies the parsed per-slot data already obtained by the periodic input
+    poll. Does not send a standalone JVS COININP (0x21) command.
+
+    \param  out             Per-slot parsed data (up to \p MIE_JVS_COIN_SLOTS).
+    \param  max_slots       Number of coin slots to copy (1 or 2).
+    \retval true            Arguments valid and JVS initialized.
+    \retval false           Invalid arguments or JVS not initialized.
+
+    \sa mie_get_coin_meter, mie_jvs_coin_slot_t, mie_jvs_inputs_t::coin_fault
+*/
+bool mie_read_coin_input(mie_jvs_coin_slot_t *out, int max_slots);
+
+/** \brief   Send JVS COINDEC (0x30) for a coin slot.
+    \ingroup mie_coin
+
+    Subtracts credits from the specified coin slot meter on the JVS board.
+
+    \param  slot            Coin slot index (0 = first slot).
+    \param  amount          Credits to subtract.
+    \param  block           \c true to wait for completion; \c false to queue only.
+    \retval true            Command completed or queued successfully.
+    \retval false           Invalid arguments, JVS not initialized, busy, or I/O failed.
+*/
+bool mie_coin_decrease(uint8_t slot, uint16_t amount, bool block);
+
+/** \brief   Send JVS COINADD (0x35) for a coin slot.
+    \ingroup mie_coin
+
+    Adds credits to the specified coin slot meter on the JVS board.
+
+    \param  slot            Coin slot index (0 = first slot).
+    \param  amount          Credits to add.
+    \param  block           \c true to wait for completion; \c false to queue only.
+    \retval true            Command completed or queued successfully.
+    \retval false           Invalid arguments, JVS not initialized, busy, or I/O failed.
+*/
+bool mie_coin_add(uint8_t slot, uint16_t amount, bool block);
+
+/** \defgroup mie_output General Purpose Output
+    \brief    JVS general purpose output (lamps, solenoids)
+    \ingroup  mie
+
+    The JVS I/O board exposes up to \ref MIE_JVS_OUTPUT_COUNT general purpose
+    output lines, driven with the JVS general-purpose output command (0x32). They
+    are used for cabinet lamps, start button lights, solenoids, and similar
+    actuators.
+
+    Output state is a \c uint32_t bitmask in JVS wire order: output \p n is
+    bit \c (31 - n). The driver keeps a cached copy so individual lines can be
+    toggled with mie_jvs_set_output() without affecting the others.
+
+    @{
+*/
+
+/** \brief Bit mask for JVS output index \p index (output 0 = bit 31). */
+#define MIE_JVS_OUTPUT_MASK(index) BIT(31 - (index))
+
+/** \brief All \ref MIE_JVS_OUTPUT_COUNT outputs enabled. */
+#define MIE_JVS_OUTPUT_ALL GENMASK(31, 32 - MIE_JVS_OUTPUT_COUNT)
+
+/** \brief Bitmask for the first \p count JVS outputs (output 0 = bit 31). */
+#define MIE_JVS_OUTPUT_MASK_COUNT(count) GENMASK(31, 32 - (count))
+
+/** \brief   Number of JVS outputs reported by the I/O board.
+    \return                 Output count from the last function check (0x14),
+                            or \ref MIE_JVS_OUTPUT_COUNT if unknown.
+
+    \sa mie_jvs_set_outputs
+*/
+uint8_t mie_jvs_driver_outputs(void);
+
+/** \brief   Set all JVS general purpose outputs at once.
+    \param  outputs         Output bitmask in JVS wire order.
+    \param  block           \c true to wait for completion; \c false to queue only.
+    \retval true            Command completed or queued successfully.
+    \retval false           JVS not initialized, busy, or I/O failed.
+
+    \sa mie_jvs_set_output, mie_jvs_get_outputs
+*/
+bool mie_jvs_set_outputs(uint32_t outputs, bool block);
+
+/** \brief   Set a single JVS general purpose output.
+
+    \param  index           Output index (0 to \ref MIE_JVS_OUTPUT_COUNT - 1).
+    \param  on              \c true to turn the output on; \c false to turn it off.
+    \param  block           \c true to wait for completion; \c false to queue only.
+    \retval true            Command completed or queued successfully.
+    \retval false           Invalid index, JVS not initialized, busy, or I/O failed.
+
+    \sa mie_jvs_set_outputs, mie_jvs_get_outputs
+*/
+bool mie_jvs_set_output(uint8_t index, bool on, bool block);
+
+/** \brief   Get the cached JVS general purpose output state.
+    \return                 Last applied output bitmask in JVS wire order.
+
+    \sa mie_jvs_set_outputs
+*/
+uint32_t mie_jvs_get_outputs(void);
+
+/** @} */
+
+/** \brief   Set an automatic mapped button press callback.
+    \ingroup mie_callbacks
+
+    Registers a callback invoked when the mapped controller buttons in \p btns
+    transition from not-all-pressed to all-pressed. The callback runs on a
+    worker thread, not in the Maple IRQ context.
+
+    \param  btns            Button mask to match (\ref controller_input_masks).
+    \param  cb              Callback to invoke, or NULL to uninstall callbacks
+                            registered for the same \p btns value.
+    \retval 0               On success.
+    \retval -1              On allocation or thread creation failure.
+
+    \sa mie_btn_callback_t, mie_jvs_callback
+*/
+int mie_btn_callback(uint32_t btns, mie_btn_callback_t cb);
+
+/** \brief   Set an automatic native JVS input callback.
+    \ingroup mie_callbacks
+
+    Registers a callback invoked when the selected native input source has all
+    bits in \p mask transition from not-all-active to all-active. The callback
+    runs on a worker thread, not in the Maple IRQ context.
+
+    For \p MIE_JVS_IN_P1, \p MIE_JVS_IN_P2, \p MIE_JVS_IN_SYSTEM,
+    \p MIE_JVS_IN_PANEL_DIP, and \p MIE_JVS_IN_PANEL_PSW, \p mask uses the
+    matching \ref mie_jvs_masks constants.
+    For \p MIE_JVS_IN_COIN1 and \p MIE_JVS_IN_COIN2, use \p MIE_JVS_COIN_INSERT_BIT.
+    These fire when the JVS COININP meter for that slot increases after a physical
+    coin insert on COIN SW 1/2. The I/O board updates the meter automatically;
+    do not call mie_coin_add() again for the same insert.
+
+    \param  input           Native JVS input source to watch.
+    \param  mask            Bit mask within that source.
+    \param  cb              Callback to invoke, or NULL to uninstall callbacks
+                            registered for the same \p input and \p mask pair.
+    \retval 0               On success.
+    \retval -1              On allocation or thread creation failure.
+
+    \sa mie_jvs_callback_t, mie_btn_callback
+*/
+int mie_jvs_callback(mie_jvs_input_t input, uint32_t mask,
+                     mie_jvs_callback_t cb);
+
+/** \brief   Install a custom JVS-to-controller mapper.
+    \ingroup mie_mapping
+
+    Replaces the built-in default mapping applied during polling. Pass NULL to
+    restore the default mapper documented in \ref mie_mapping.
+
+    \param  fn              Mapper function, or NULL for the built-in default.
+
+    \sa mie_cont_map_fn_t, mie_state_t
+*/
+void mie_set_cont_map(mie_cont_map_fn_t fn);
+
+/** \defgroup mie_device Device Access
+    \brief    MIE board identification, EEPROM, and firmware init
+    \ingroup  mie
+*/
+
+/** \brief   Read the MIE board identifier string.
+    \ingroup mie_device
+
+    Sends the MIE GET ID command and copies the response into \p dst.
+
+    \param  dst             Destination buffer (\p MIE_ID_SIZE bytes).
+    \return                 \p dst on success, NULL on failure.
+
+    \sa MIE_ID_SIZE
+*/
+char *mie_get_id(char *dst);
+
+/** \brief   Read the MIE on-board EEPROM.
+    \ingroup mie_device
+
+    Performs a synchronous EEPROM fetch over the MIE IO protocol.
+
+    \param  dst             Destination buffer (\p MIE_EEPROM_SIZE bytes).
+    \retval true            Read succeeded.
+    \retval false           Invalid buffer or I/O failed.
+
+    \sa MIE_EEPROM_SIZE, mie_set_eeprom
+*/
+bool mie_get_eeprom(void *dst);
+
+/** \brief   Write the MIE on-board EEPROM.
+    \ingroup mie_device
+
+    Performs a synchronous EEPROM write over the MIE IO protocol. Data is
+    written in 16-byte chunks with pacing between transfers.
+
+    \param  eeprom          Source buffer (\p MIE_EEPROM_SIZE bytes).
+    \retval true            Write succeeded.
+    \retval false           Invalid buffer or I/O failed.
+
+    \sa MIE_EEPROM_SIZE, mie_get_eeprom
+*/
+bool mie_set_eeprom(uint8_t *eeprom);
+
+/** \brief   Compute Sega NAOMI EEPROM CRC-16.
+    \ingroup mie_device
+
+    CRC-16-CCITT variant with seed \c 0xDEBDEB00 and an extra round over a
+    trailing \c 0x00 byte. Used by MIE EEPROM and NAOMI backup SRAM
+    bookkeeping blocks.
+
+    \param  buf             Data to checksum.
+    \param  size            Length in bytes.
+    \return                 CRC-16 value.
+
+    \sa mie_eeprom_fix_crc
+*/
+uint16_t mie_eeprom_crc16(const uint8_t *buf, size_t size);
+
+/** \brief   Recompute NAOMI EEPROM CRC fields in a 128-byte buffer.
+    \ingroup mie_device
+
+    Updates the duplicated CRC16 headers for the system-settings block
+    (bytes \c 0–\c 17) and the game-settings block (bytes \c 36–\c 43).
+
+    \param  eeprom          Buffer to update (\p MIE_EEPROM_SIZE bytes).
+
+    \sa mie_eeprom_crc16, mie_get_eeprom, mie_set_eeprom
+*/
+void mie_eeprom_fix_crc(uint8_t *eeprom);
+
+/** \brief   Get the active driver calibration.
+    \ingroup mie_analog
+
+    \return                 Pointer to the current calibration. Use
+                            mie_analog_calib_valid() to check whether it is usable.
+*/
+const mie_analog_calib_t *mie_analog_calib_get(void);
+
+/** \brief   Install a calibration set.
+    \ingroup mie_analog
+
+    \param  calib           Calibration to copy into the driver. Invalid ranges
+                            fall back to the legacy mapping.
+*/
+void mie_analog_calib_set(const mie_analog_calib_t *calib);
+
+/** \brief   Check whether the active calibration has usable ranges.
+    \ingroup mie_analog
+
+    \retval true            Wheel and pedal ranges are valid.
+    \retval false           At least one axis range is invalid.
+*/
+bool mie_analog_calib_valid(void);
+
+/** \brief   Clear the active calibration and any running session.
+    \ingroup mie_analog
+*/
+void mie_analog_calib_reset(void);
+
+/** \brief   Start the interactive calibration session.
+    \ingroup mie_analog
+
+    Begins at \ref MIE_ANALOG_CALIB_WHEEL. While a session runs the driver tracks
+    channel extremes automatically and feeds raw values to \ref mie_state_t::cont.
+*/
+void mie_analog_calib_start(void);
+
+/** \brief   Cancel a running calibration session.
+    \ingroup mie_analog
+
+    The previously active calibration is left untouched.
+*/
+void mie_analog_calib_cancel(void);
+
+/** \brief   Check whether a calibration session is running.
+    \ingroup mie_analog
+
+    \retval true            A session is active.
+    \retval false           No session is running.
+*/
+bool mie_analog_calib_active(void);
+
+/** \brief   Query the current calibration step.
+    \ingroup mie_analog
+
+    \return                 The active \ref mie_analog_calib_step_t.
+*/
+mie_analog_calib_step_t mie_analog_calib_current(void);
+
+/** \brief   Confirm the current step and advance the session.
+    \ingroup mie_analog
+
+    For the wheel and pedal range steps the tracked extremes are kept. For the
+    center step the latest raw wheel value is stored. On the final step the
+    result is validated and, when valid, installed as the active calibration.
+
+    \retval true            The session finished. Inspect mie_analog_calib_get()
+                            for the result (unchanged if invalid).
+    \retval false           Advanced to the next step.
+*/
+bool mie_analog_calib_capture(void);
+
+/** \brief   Normalize a raw JVS wheel value.
+    \ingroup mie_analog
+
+    Uses the active calibration when valid, otherwise the built-in legacy
+    mapping. Does not pass raw values through during a calibration session;
+    use \ref mie_state_t::jvs or \ref mie_state_t::cont for live capture.
+
+    \return                 Normalized wheel position (-128 to 127).
+*/
+int mie_analog_norm_wheel(uint16_t raw);
+
+/** \brief   Normalize a raw JVS accelerator value.
+    \ingroup mie_analog
+
+    \return                 Normalized pedal position (0 to 255).
+*/
+int mie_analog_norm_accel(uint16_t raw);
+
+/** \brief   Normalize a raw JVS brake value.
+    \ingroup mie_analog
+
+    \return                 Normalized pedal position (0 to 255).
+*/
+int mie_analog_norm_brake(uint16_t raw);
+
+/** \brief   Initialize MIE/JVS, uploading Z80 firmware when needed.
+    \ingroup mie_device
+
+    Registers the driver if needed, probes whether the Z80 bridge is already
+    active (for example after the original NAOMI BIOS or DreamShell),
+    and uploads \p fw_path when JVS communication is not yet available.
+
+    Intended for early boot on NAOMI hardware before the normal Maple scan
+    completes JVS setup. Returns false on retail Dreamcast.
+
+    \param  fw_path         Path to mie_z80.bin firmware image.
+    \retval true            Z80/JVS initialization succeeded.
+    \retval false           Invalid path, not NAOMI hardware, or init failed.
+
+    \sa mie_init_scan
+*/
+bool mie_init_fw(const char *fw_path);
+
+/* \cond */
+void mie_init(void);
+void mie_shutdown(void);
+void mie_init_scan(void);
+void mie_scan_complete(void);
+/* \endcond */
+
+/** @} */
+
+__END_DECLS
+
+#endif


### PR DESCRIPTION
The Maple device driver for the NAOMI and NAOMI 2 Maple I/O emulator (MIE) on port A.
This port can operate in two modes: Maple and MIE; the type is detected and switched automatically.
The MIE mode polls bundled JVS responses (player switches, system test, panel DIP and service switches, coin meters, and analog channels) and exposes native state alongside a mapped cont_state_t for existing code.
Also Z80 firmware init (hot and cold), wheel and pedal calibration, outputs control, EEPROM read/write, input callbacks and example are included.

Tested SEGA JVS I/O Type 1 board on:
- NAOMI 2 King of Route 66 (Upright cabinet) for wheel and pedals.
- NAOMI Universal Cabinet for 2 players.
- MP12-IONA-SB JVS->USB adapter for USB gamepads.