### PR TITLE
kos: Add NULL checks for unchecked allocations

### DIFF
--- a/addons/libpthread/pthread_getname_np.c
+++ b/addons/libpthread/pthread_getname_np.c
@@ -15,7 +15,7 @@ int pthread_getname_np(pthread_t thread, char *buf, size_t buflen) {
     kthread_t *thd = (kthread_t *)thread;
     int old;
 
-    if(!thd)
+    if(!thd || buflen == 0)
         return EINVAL;
 
     if(!buf)

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_mem.c
@@ -96,6 +96,9 @@ pvr_ptr_t __weak_symbol pvr_mem_malloc(size_t size) {
 
     if(__is_defined(PVR_KM_DBG)) {
         ctl = malloc(sizeof(memctl_t));
+        if(!ctl)
+            return (pvr_ptr_t)rv32;
+
         ctl->size = size;
         ctl->thread = thd_current->tid;
         ctl->addr = arch_get_ret_addr();

--- a/kernel/arch/dreamcast/kernel/mmu.c
+++ b/kernel/arch/dreamcast/kernel/mmu.c
@@ -236,6 +236,8 @@ static void mmu_page_map_single(mmucontext_t *context,
 
     if(sub == NULL) {
         sub = (mmusubcontext_t *)malloc(sizeof(mmusubcontext_t));
+        if(sub == NULL)
+            return;
 
         for(i = 0; i < MMU_SUB_PAGES; i++)
             sub->page[i].valid = 0;

--- a/kernel/arch/dreamcast/sound/snd_sfxmgr.c
+++ b/kernel/arch/dreamcast/sound/snd_sfxmgr.c
@@ -507,6 +507,9 @@ sfxhnd_t snd_sfx_load_fd(file_t fd, size_t len, uint32_t rate, uint16_t bitsize,
     if(read_len > 0) {
         tmp_buff = aligned_alloc(32, read_len);
 
+        if(!tmp_buff)
+            goto err_occurred;
+
         if(fs_read(fd, tmp_buff, read_len) <= 0) {
             goto err_occurred;
         }
@@ -664,6 +667,8 @@ sfxhnd_t snd_sfx_load_raw_buf(char *buf, size_t len, uint32_t rate, uint16_t bit
     read_len = chan_len;
     if(read_len > 0) {
         tmp_buff = aligned_alloc(32, read_len);
+        if(!tmp_buff)
+            goto err_occurred;
         memcpy(tmp_buff, buf, read_len);
         bufidx += read_len;
 

--- a/kernel/arch/dreamcast/sound/snd_stream.c
+++ b/kernel/arch/dreamcast/sound/snd_stream.c
@@ -173,6 +173,8 @@ void snd_stream_filter_add(snd_stream_hnd_t hnd, snd_stream_filter_t filtfunc, v
     CHECK_HND(hnd);
 
     f = malloc(sizeof(filter_t));
+    assert(f != NULL);
+
     f->func = filtfunc;
     f->data = obj;
     TAILQ_INSERT_TAIL(&streams[hnd].filters, f, lent);


### PR DESCRIPTION
cppcheck and clang found a few allocations that were used without checking for NULL, plus a zero-length underflow in pthread_getname_np. This adds guards for them.