### PR TITLE
ci: Update missed actions/checkout to v7

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -41,7 +41,7 @@ jobs:
       profile: ${{ fromJSON(matrix.toolchain).profile }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: dorny/paths-filter@v4
       id: filter


### PR DESCRIPTION
I missed one in the last PR. 