### PR TITLE
genwait bugfix and cleanup

### DIFF
--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -106,7 +106,17 @@ int genwait_wait(void *obj, const char *mesg, unsigned int timeout) {
 }
 
 /* Removes a thread from its wait queue; assumes ints are disabled. */
-static void __nonnull_all genwait_unqueue(kthread_t *thd) {
+static void __nonnull_all genwait_unqueue(kthread_t *thd, int err) {
+
+    /* Set the wake return value */
+    if(err) {
+        CONTEXT_RET(thd->context) = -1;
+        thd->thd_errno = err;
+    }
+    else {
+        CONTEXT_RET(thd->context) = 0;
+    }
+
     /* Remove it from the queue */
     TAILQ_REMOVE(&slpque[LOOKUP(thd->wait_obj)], thd, thdq);
 
@@ -140,16 +150,7 @@ static int genwait_wake_thd_cnt(const void *obj, int cntmax, kthread_t *thd, int
         /* Is this thread a match? */
         if(t->wait_obj == obj && (!thd || t == thd)) {
             /* Yes, remove it from the wait queue */
-            genwait_unqueue(t);
-
-            /* Set the wake return value */
-            if(err) {
-                CONTEXT_RET(t->context) = -1;
-                t->thd_errno = err;
-            }
-            else {
-                CONTEXT_RET(t->context) = 0;
-            }
+            genwait_unqueue(t, err);
 
             /* Check to see if we've filled our quota */
             if(cntmax > 0) {
@@ -197,12 +198,8 @@ void genwait_check_timeouts(uint64_t tm) {
         if(t->wait_timeout > tm)
             return;
 
-        /* Set an error code */
-        t->thd_errno = EAGAIN;  /* This is fairly close */
-        CONTEXT_RET(t->context) = -1;
-
-        /* Re-activate it */
-        genwait_unqueue(t);
+        /* Re-activate it with an error code */
+        genwait_unqueue(t, EAGAIN);
     }
 }
 

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -191,9 +191,7 @@ int genwait_wake_thd(const void *obj, kthread_t *thd, int err) {
 void genwait_check_timeouts(uint64_t tm) {
     kthread_t   *t;
 
-    t = tq_next();
-
-    while(t) {
+    while((t = tq_next())) {
         /* If the next timeout is beyond our current time, then
            forget about it. */
         if(t->wait_timeout > tm)
@@ -205,9 +203,6 @@ void genwait_check_timeouts(uint64_t tm) {
 
         /* Re-activate it */
         genwait_unqueue(t);
-
-        /* Get the next one */
-        t = tq_next();
     }
 }
 

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -135,18 +135,14 @@ static void __nonnull_all genwait_unqueue(kthread_t *thd, int err) {
 }
 
 static int genwait_wake_thd_cnt(const void *obj, int cntmax, kthread_t *thd, int err) {
-    kthread_t       * t, * nt;
-    struct slpquehead   * qp;
+    kthread_t       *t, *nt;
     int         cnt = 0;
 
     /* Twiddle interrupt state */
     irq_disable_scoped();
 
-    /* Find the queue */
-    qp = &slpque[LOOKUP(obj)];
-
     /* Go through and find any matching entries */
-    TAILQ_FOREACH_SAFE(t, qp, thdq, nt) {
+    TAILQ_FOREACH_SAFE(t, &slpque[LOOKUP(obj)], thdq, nt) {
         /* Is this thread a match? */
         if(t->wait_obj == obj && (!thd || t == thd)) {
             /* Yes, remove it from the wait queue */
@@ -204,9 +200,7 @@ void genwait_check_timeouts(uint64_t tm) {
 }
 
 uint64_t genwait_next_timeout(void) {
-    kthread_t *t;
-
-    t = tq_next();
+    kthread_t *t = tq_next();
 
     if(t == NULL)
         return 0;
@@ -215,9 +209,7 @@ uint64_t genwait_next_timeout(void) {
 }
 
 int genwait_init(void) {
-    int i;
-
-    for(i = 0; i < TABLESIZE; i++)
+    for(size_t i = 0; i < TABLESIZE; i++)
         TAILQ_INIT(&slpque[i]);
 
     TAILQ_INIT(&timer_queue);

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -107,23 +107,21 @@ int genwait_wait(void *obj, const char *mesg, unsigned int timeout) {
 
 /* Removes a thread from its wait queue; assumes ints are disabled. */
 static void __nonnull_all genwait_unqueue(kthread_t *thd) {
-    if(thd->wait_obj) {
-        /* Remove it from the queue */
-        TAILQ_REMOVE(&slpque[LOOKUP(thd->wait_obj)], thd, thdq);
+    /* Remove it from the queue */
+    TAILQ_REMOVE(&slpque[LOOKUP(thd->wait_obj)], thd, thdq);
 
-        /* Also remove it from the timer queue if applicable */
-        if(thd->wait_timeout)
-            tq_remove(thd);
+    /* Also remove it from the timer queue if applicable */
+    if(thd->wait_timeout)
+        tq_remove(thd);
 
-        /* Clean up wait stuff */
-        thd->wait_obj = NULL;
-        thd->wait_msg = NULL;
-        thd->wait_timeout = 0;
+    /* Clean up wait stuff */
+    thd->wait_obj = NULL;
+    thd->wait_msg = NULL;
+    thd->wait_timeout = 0;
 
-        /* Make it runnable again */
-        thd->state = STATE_READY;
-        thd_add_to_runnable(thd, 0);
-    }
+    /* Make it runnable again */
+    thd->state = STATE_READY;
+    thd_add_to_runnable(thd, 0);
 }
 
 static int genwait_wake_thd_cnt(const void *obj, int cntmax, kthread_t *thd, int err) {


### PR DESCRIPTION
Fixes a bug where `genwait_wait(NULL, anything, timeout >0)` would cause a hang. Details in the first commit. From there performed a few other small cleanups.

It seemed pretty straightforward, but if anyone thinks that `obj == NULL` should be *reserved* for the unset state, then we could instead fail to wait if asked to wait on `NULL`, assert if passed to the wake functions, and set `__nonnull` on those params. I couldn't think of any real benefit to doing that though