### PR TITLE
fs: Make stat()/fstat() succeed on the VFS root directory

### DIFF
--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -821,12 +821,12 @@ ssize_t fs_readlink(const char *path, char *buf, size_t bufsize) {
     }
 }
 
-int fs_stat(const char *path, struct stat *buf, int flag) {
+int fs_stat(const char *path, struct stat *st, int flag) {
     vfs_handler_t *vfs;
     char fullpath[PATH_MAX];
 
     /* Verify the input... */
-    if(!buf || !path) {
+    if(!st || !path) {
         errno = EFAULT;
         return -1;
     }
@@ -847,12 +847,12 @@ int fs_stat(const char *path, struct stat *buf, int flag) {
     }
 
     if(vfs->stat) {
-        return vfs->stat(vfs, fullpath + strlen(vfs->nmmgr.pathname), buf,
+        return vfs->stat(vfs, fullpath + strlen(vfs->nmmgr.pathname), st,
                          flag);
     }
     else if(!strcmp(path, vfs->nmmgr.pathname)) {
         /* no vfs->stat - handle stat() on the mount folder */
-        *buf = (struct stat){
+        *st = (struct stat) {
             .st_mode = S_IFDIR | S_IRWXU | S_IRWXG | S_IRWXO,
         };
         return 0;

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -838,6 +838,16 @@ int fs_stat(const char *path, struct stat *st, int flag) {
     if(!fs_normalize_path(path, fullpath))
         return -1;
 
+    /* The VFS root has no backing handler so stat it directly as a directory */
+    if(!strcmp(fullpath, "/")) {
+        *st = (struct stat) {
+            .st_mode = S_IFDIR | S_IRWXU | S_IRWXG | S_IRWXO,
+            .st_size = -1,
+            .st_nlink = 2
+        };
+        return 0;
+    }
+
     /* Look for the handler */
     vfs = fs_verify_handler(fullpath);
 
@@ -895,8 +905,13 @@ int fs_fstat(file_t fd, struct stat *st) {
         return -1;
     }
 
+    /* The VFS root has no backing handler so stat it directly as a directory */
     if(h->handler == NULL) {
-        h->hnd = (void *)0;
+        *st = (struct stat) {
+            .st_mode = S_IFDIR | S_IRWXU | S_IRWXG | S_IRWXO,
+            .st_size = -1,
+            .st_nlink = 2
+        };
         return 0;
     }
 

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -854,6 +854,8 @@ int fs_stat(const char *path, struct stat *st, int flag) {
         /* no vfs->stat - handle stat() on the mount folder */
         *st = (struct stat) {
             .st_mode = S_IFDIR | S_IRWXU | S_IRWXG | S_IRWXO,
+            .st_size = -1,
+            .st_nlink = 2
         };
         return 0;
     }


### PR DESCRIPTION
I was playing around with a simple FTP server named lftpd provided by @pcercuei / @Bruceleeto. The connection would drop whenever I tried to cd to the root directory (cd .. back up to /, or cd /). Turns out lftpd calls stat("/") on navigation, and that fails on KOS. lftpd treats the failure as fatal and closes the connection.

So I added special-cases for the VFS root in both stat() and fstat() to just report a directory, the same way the mount-folder case already does. 

Tested on hardware with the FTP server — cd-ing to / works now and the connection stays up.