### PR TITLE
speedtest: Update example to push the limits of network stack

### DIFF
--- a/examples/dreamcast/network/speedtest/handle_request.c
+++ b/examples/dreamcast/network/speedtest/handle_request.c
@@ -9,13 +9,13 @@
 #include "speedtest.h"
 
 /*
-   This file defines the handle_request function, which processes HTTP requests 
-   received by the speed test server. It parses the request, determines the HTTP 
-   method (GET or POST), and routes the request to the appropriate handler based 
-   on the requested path. It supports GET requests to serve files such as 
-   index.html and handles download and upload test endpoints to measure network 
+   This file defines the handle_request function, which processes HTTP requests
+   received by the speed test server. It parses the request, determines the HTTP
+   method (GET or POST), and routes the request to the appropriate handler based
+   on the requested path. It supports GET requests to serve files such as
+   index.html and handles download and upload test endpoints to measure network
    speed.
- 
+
    Key paths:
    - "/": serves the speed test HTML page (index.html).
    - "/download-test?size=": initiates a download test of the requested size.
@@ -105,7 +105,7 @@ find_length:
                             if(found) {
                                 buf_ptr = found;
                                 got_content_length = true;
-                                
+
                                 goto find_body;
                             }
                         }
@@ -116,7 +116,7 @@ find_length:
                             buf_ptr--;
                             bytes_left++;
                             /* Fall through to find_body */
-                        } 
+                        }
                         else /* bytes_left == 0 */
                             goto refresh_buffer;
                     }
@@ -131,7 +131,7 @@ find_body:
                         hr->read_content_length = total_bytes - (hr->body - buf_start);
                         if(got_content_length)
                             hr->rem_content_length -= hr->read_content_length;
-                        
+
                         goto done_parsing;
                     }
                     else if(bytes_left > 0) /* Start over */ {

--- a/examples/dreamcast/network/speedtest/handle_request.c
+++ b/examples/dreamcast/network/speedtest/handle_request.c
@@ -29,7 +29,7 @@ bool prefix_match(const char *path, const char *pattern);
 int send_ok(http_state_t *h, const char *ct);
 void send_code(int socket, uint16_t code, const char *message);
 
-#define BUFSIZE 1024
+#define BUFSIZE 4096
 #define REQUEST_LINE_SIZE 160
 #define HEADER_BUF_SIZE  512
 
@@ -37,7 +37,7 @@ void *handle_request(void *p) {
     char request_line[REQUEST_LINE_SIZE] = {0};
     char *buf_ptr = request_line;
     char *path_end;
-    size_t total_bytes = 0;
+    ssize_t total_bytes = 0;
     http_state_t *hr = (http_state_t *)p;
 
     /* Read the max we expect the request line to be */
@@ -70,8 +70,6 @@ void *handle_request(void *p) {
     hr->path = buf_ptr;
     buf_ptr = path_end + 1;
 
-    printf("%s\n", hr->path);
-
     if(hr->method == METHOD_POST) {
         char *content_length_key = "Content-Length: ";
         char *cl_key_ptr = content_length_key;
@@ -85,8 +83,6 @@ void *handle_request(void *p) {
         char *buf_start = request_line;
         bool got_content_length = false;
         size_t bytes_left = total_bytes - (buf_ptr - buf_start);
-
-        printf("RL: %s\n", buf_ptr);
 
         /* Look for Content-Length header(optional) and start of the body */
         while(true) {
@@ -237,7 +233,9 @@ done_parsing:
     else { /* POST */
         if(exact_match(hr->path, "/upload-test")) {
             while(hr->rem_content_length) {
-                total_bytes = recv(hr->socket, response_buf, HEADER_BUF_SIZE - 1, MSG_NONE);
+                total_bytes = recv(hr->socket, response_buf, BUFSIZE, MSG_NONE);
+                if(total_bytes <= 0)
+                    break;
 
                 hr->rem_content_length -= total_bytes;
             }

--- a/examples/dreamcast/network/speedtest/romdisk/index.html
+++ b/examples/dreamcast/network/speedtest/romdisk/index.html
@@ -48,15 +48,17 @@
     <div class="speed-test-container">
         <h2>Dreamcast Network Speed Test</h2>
         <div class="speed-text" id="download-speed">Download: -- MB/s</div>
-        <div class="speed-text" id="upload-speed">Upload: -- KB/s</div>
+        <div class="speed-text" id="upload-speed">Upload: -- MB/s</div>
         <div class="test-type" id="test-status">Ready</div>
         <button onclick="startTest()">Start Test</button>
     </div>
 
     <script>
-        const downloadUrl = '/download-test?size=1048576'; // 1 MB
+        const DOWNLOAD_SIZE = 2 * 1024 * 1024; // 2 MB
+        const UPLOAD_SIZE   = 2 * 1024 * 1024; // 2 MB
+        const downloadUrl = `/download-test?size=${DOWNLOAD_SIZE}`;
         const uploadUrl = '/upload-test';
-        const numRuns = 5;
+        const numRuns = 3;
 
         async function measureDownloadSpeed() {
             const startTime = Date.now();
@@ -64,20 +66,18 @@
             const data = await response.blob();
             const endTime = Date.now();
             const duration = (endTime - startTime) / 1000; // time in seconds
-            const fileSize = data.size / (1024 * 1024); // size in MB
-            const speed = fileSize / duration; // speed in MB/s
-            return speed;
+            const sizeMB = data.size / (1024 * 1024);
+            return sizeMB / duration; // speed in MB/s
         }
 
         async function measureUploadSpeed() {
-            const data = new ArrayBuffer(10 * 1024); // 10 KB
+            const data = new ArrayBuffer(UPLOAD_SIZE);
             const startTime = Date.now();
             await fetch(uploadUrl, { method: 'POST', body: data });
             const endTime = Date.now();
             const duration = (endTime - startTime) / 1000; // time in seconds
-            const fileSize = data.byteLength / 1024; // size in KB
-            const speed = fileSize / duration; // speed in KB/s
-            return speed;
+            const sizeMB = data.byteLength / (1024 * 1024);
+            return sizeMB / duration; // speed in MB/s
         }
 
         async function runTests() {
@@ -98,18 +98,18 @@
                 document.getElementById('test-status').textContent = `Upload test ${i + 1}/${numRuns}`;
                 const uploadSpeed = await measureUploadSpeed();
                 uploadTotal += uploadSpeed;
-                console.log(`Upload test ${i + 1}: ${uploadSpeed.toFixed(2)} KB/s`);
+                console.log(`Upload test ${i + 1}: ${uploadSpeed.toFixed(2)} MB/s`);
             }
-            
+
             const avgUpload = (uploadTotal / numRuns).toFixed(2);
-            document.getElementById('upload-speed').textContent = `Upload: ${avgUpload} KB/s`;
+            document.getElementById('upload-speed').textContent = `Upload: ${avgUpload} MB/s`;
 
             document.getElementById('test-status').textContent = 'Test complete';
         }
 
         async function startTest() {
             document.getElementById('download-speed').textContent = 'Download: -- MB/s';
-            document.getElementById('upload-speed').textContent = 'Upload: -- KB/s';
+            document.getElementById('upload-speed').textContent = 'Upload: -- MB/s';
             document.getElementById('test-status').textContent = 'Starting tests...';
             await runTests();
         }

--- a/examples/dreamcast/network/speedtest/server.c
+++ b/examples/dreamcast/network/speedtest/server.c
@@ -56,10 +56,6 @@ void *server_thread(void *p) {
             goto server_cleanup;
         }
 
-        uint32_t new_buf_sz = 65535;
-        setsockopt(hr->socket, SOL_SOCKET, SO_SNDBUF, &new_buf_sz, sizeof(new_buf_sz));
-        setsockopt(hr->socket, SOL_SOCKET, SO_RCVBUF, &new_buf_sz, sizeof(new_buf_sz));
-
         /* Create thread for new client */
         thd_create(DETACHED_THREAD, handle_request, hr);
     }

--- a/examples/dreamcast/network/speedtest/speedtest.c
+++ b/examples/dreamcast/network/speedtest/speedtest.c
@@ -53,6 +53,9 @@ int main(int argc, char **argv) {
             return 0;
 
         MAPLE_FOREACH_END()
+
+        /* Poll the controller once per frame. */
+        thd_sleep(17);
     }
 
     return 0;

--- a/examples/dreamcast/network/speedtest/speedtest.c
+++ b/examples/dreamcast/network/speedtest/speedtest.c
@@ -17,6 +17,7 @@
 
 #include <kos/init.h>
 #include <kos/dbgio.h>
+#include <kos/net.h>
 
 #include <dc/video.h>
 #include <dc/biosfont.h>
@@ -30,7 +31,18 @@ KOS_INIT_FLAGS(INIT_DEFAULT | INIT_NET);
 int main(int argc, char **argv) {
     vid_clear(23,86,155);
     bfont_draw_str(vram_s + 20 * 640 + 20, 640, 0, "SpeedTest Server active");
-    bfont_draw_str(vram_s + 44 * 640 + 20, 640, 0, "Press START to shutdown.");
+
+    /* Show the URL the user should open in their browser. */
+    if(net_default_dev) {
+        uint8_t *ip = net_default_dev->ip_addr;
+        bfont_draw_str_fmt(vram_s + 44 * 640 + 20, 640, 0,
+                           "Open http://%d.%d.%d.%d/ in a web browser",
+                           ip[0], ip[1], ip[2], ip[3]);
+    }
+    else {
+        bfont_draw_str(vram_s + 44 * 640 + 20, 640, 0, "No network device found");
+    }
+    bfont_draw_str(vram_s + 68 * 640 + 20, 640, 0, "Press START to shutdown.");
 
     thd_create(DETACHED_THREAD, server_thread, NULL);
 

--- a/examples/dreamcast/network/speedtest/speedtest.c
+++ b/examples/dreamcast/network/speedtest/speedtest.c
@@ -6,12 +6,12 @@
 */
 
 /*
-   This file sets up the Dreamcast network speed test server, which listens 
-   for HTTP requests on the network and performs download and upload speed tests. 
-   It creates a thread to handle incoming client connections and displays a basic 
+   This file sets up the Dreamcast network speed test server, which listens
+   for HTTP requests on the network and performs download and upload speed tests.
+   It creates a thread to handle incoming client connections and displays a basic
    status message on the Dreamcast screen. The browser-based front-end (index.html)
-   is used to run the test and display the results. The user can press the "START" 
-   button on the Dreamcast controller to shut down the server and exit the 
+   is used to run the test and display the results. The user can press the "START"
+   button on the Dreamcast controller to shut down the server and exit the
    application.
 */
 


### PR DESCRIPTION
KOS stack has improved a bunch since I first created this example.  We can now send and receive more data at a time. I increased the payloads for download and upload to 2MB. I also increased the input buffer so less recv calls are needed to receive the full payload. I also display the url the user should visit in order to run the tests.

@Bruceleeto: I know you've edited this example before to get better output. Did I miss anything?