### PR TITLE
net_tcp: Send a window-update ACK when the receive window reopens

### DIFF
--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -1281,13 +1281,14 @@ static ssize_t net_tcp_recvfrom(net_socket_t *hnd, void *buffer, size_t length,
         sock->data.rcv.wnd += size;
         sock->data.rcvbuf_cur_sz -= size;
 
-        /* BUG FIX: When the receive window was zero, the sender has
-           entered TCP persist mode (zero-window probing). We must send
-           a window-update ACK so it knows the window has reopened.
-           Without this, the sender never learns and the connection
-           deadlocks permanently. */
-        if(old_wnd == 0 && sock->data.rcv.wnd > 0) {
+        /* Send a window-update ACK once the read has reopened the window,
+           so the sender doesn't stall waiting for the next delayed ACK.
+           Fire when it reopens from zero (sender in TCP persist mode) or
+           by at least one MSS (SWS avoidance). */
+        if((old_wnd == 0 && sock->data.rcv.wnd > 0) ||
+                sock->data.rcv.wnd >= old_wnd + sock->data.snd.mss) {
             tcp_send_ack(sock);
+            sock->data.ack_pending = 0;
         }
         /* Flush any pending delayed ACK now that the app has read.
            This gets the ACK out immediately instead of waiting up to


### PR DESCRIPTION
When using @Bruceleeto's ftp example I'd get these huge stalls, but only when uploading big files *to* the Dreamcast.

During an upload, the Dreamcast has to tell the sender how much room is left in its receive buffer which it does that by ACKing. When the receive buffer is read and frees up space, we usually never told the sender. We only sent a window-update ACK when the window had hit exactly zero, or when an ACK was already pending. So if the window had just shrunk to something small (but not zero), the sender never heard that room had opened back up and just sat there stalling.

Now we also send a window-update ACK whenever a read reopens the window by at least one MSS (largest amount of payload TCP puts in one packet). The sender stays informed and stops stalling.