### PR TITLE
wav2adpcm: Fix off-by-one in `pcm2adpcm` encoder.

### DIFF
--- a/utils/wav2adpcm/wav2adpcm.c
+++ b/utils/wav2adpcm/wav2adpcm.c
@@ -119,10 +119,16 @@ void pcm2adpcm(uint8_t *outbuffer, int16_t *buffer, size_t bytes) {
         adpcm_sample = CLAMP(adpcm_sample, 0, 7);
         if(step < 0)
             adpcm_sample |= 8;
+        /* jn64 - Pack low nibble first to match adpcm2pcm() (and AICA behavior),
+           which decodes the low nibble of each byte before the high nibble. The
+           previous order wrote sample 0 into the high nibble, leaving a null low
+           nibble, so encode->decode was offset by one sample (a leading zero
+           sample, everything shifted, last sample dropped). Even samples go in
+           the low nibble, odd samples in the high nibble. */
         if(!nibble)
-            *outbuffer++ = buf_sample | (adpcm_sample<<4);
+            buf_sample = adpcm_sample & 0x0F;
         else
-            buf_sample = (adpcm_sample & 15);
+            *outbuffer++ = buf_sample | (adpcm_sample << 4);
         nibble ^= 1;
         ymz_step(adpcm_sample, &history, &step_size);
     }


### PR DESCRIPTION
`pcm2adpcm` had an off-by-one in the order of low and high nibbles when emitting bytes. This was effectively forcing the first "encoded" nibble to always be `0`.

I tested against a group of 52 mono 44khz sound effect WAVs from Sonic Mania.

The average SNR measured for the decoded ADPCM WAVs:
current `pcm2adpcm` : `6.58 dB`
fixed `pcm2adpcm` : `20.43 dB`
improvement: `+13.86 dB`

Getting rid of the time-shift makes it possible to better measure the output quality against other ADPCM encoders and may lead to some better encodings when the first few PCM samples are especially difficult for delta encoding to represent.