### PR TITLE
Collection of misc cleanups

### DIFF
--- a/kernel/arch/dreamcast/hardware/hardware.c
+++ b/kernel/arch/dreamcast/hardware/hardware.c
@@ -101,11 +101,11 @@ void hardware_shutdown(void) {
             g2_dma_shutdown();
             spu_shutdown();
             vid_shutdown();
-            /* fallthru */
+            __fallthrough;
         case 1:
             vblank_shutdown();
             asic_shutdown();
-            /* fallthru */
+            __fallthrough;
         case 0:
             return;
     }

--- a/kernel/arch/dreamcast/hardware/sq.c
+++ b/kernel/arch/dreamcast/hardware/sq.c
@@ -90,22 +90,16 @@ uint32_t *sq_lock(void *dest) {
 }
 
 void sq_unlock(void) {
-    sq_state_t *tmp_state;
-    bool with_mmu;
-
     if(sq_mutex.count == 0) {
         dbglog(DBG_WARNING, "sq_unlock: Called without any lock\n");
         return;
     }
 
-    tmp_state = &sq_state_cache[sq_mutex.count - 1];
-
     /* If we aren't the last entry, set the regs back where they belong */
     if(sq_mutex.count - 1) {
-        tmp_state = &sq_state_cache[sq_mutex.count - 2];
-        with_mmu = mmu_enabled();
+        sq_state_t *tmp_state = &sq_state_cache[sq_mutex.count - 2];
 
-        if(with_mmu)
+        if(mmu_enabled())
             mmu_set_sq_addr((void *)tmp_state->dest);
         else
             SET_QACR_REGS(tmp_state->dest, tmp_state->dest);

--- a/kernel/arch/dreamcast/hardware/video.c
+++ b/kernel/arch/dreamcast/hardware/video.c
@@ -226,9 +226,9 @@ int8_t vid_check_cable(void) {
 /*-----------------------------------------------------------------------------*/
 void vid_set_mode(int dm, vid_pixel_mode_t pm) {
     vid_mode_t mode;
-    int i, ct, found, mb;
+    int i, found, mb;
 
-    ct = vid_check_cable();
+    int8_t ct = vid_check_cable();
 
     /* Remove the multi-buffering flag from the mode, if its present, and save
        the state of that flag. */
@@ -311,12 +311,10 @@ static const unsigned int vid_bpp_to_pvr_cfg2[] = {
 
 /*-----------------------------------------------------------------------------*/
 void vid_set_mode_ex(vid_mode_t *mode) {
-    uint16_t ct;
     uint32_t data;
 
-
     /* Verify cable type for video mode. */
-    ct = vid_check_cable();
+    int8_t ct = vid_check_cable();
 
     if(mode->cable_type != CT_ANY) {
         if(mode->cable_type != ct) {

--- a/kernel/arch/dreamcast/include/dc/video.h
+++ b/kernel/arch/dreamcast/include/dc/video.h
@@ -165,7 +165,7 @@ typedef struct vid_mode {
     uint16_t  height;     /**< \brief Height of the display, in pixels */
     uint32_t  flags;      /**< \brief Combination of one or more VID_* flags */
 
-    int16_t   cable_type; /**< \brief Allowed cable type */
+    int8_t    cable_type; /**< \brief Allowed cable type */
     vid_pixel_mode_t  pm; /**< \brief Pixel mode */
 
     uint16_t  scanlines;  /**< \brief Number of scanlines */

--- a/kernel/arch/dreamcast/kernel/stack.c
+++ b/kernel/arch/dreamcast/kernel/stack.c
@@ -127,7 +127,7 @@ void arch_stk_setup(kthread_t *nt) {
 /* Do a stack trace from the current function; leave off the first n frames
    (i.e., in assert()). */
 void arch_stk_trace(int n) {
-    register uintptr_t sp asm("r15");
+    register uintptr_t sp __asm__("r15");
 
     arch_stk_trace_at(sp, n);
 }

--- a/kernel/thread/sem.c
+++ b/kernel/thread/sem.c
@@ -51,8 +51,6 @@ int sem_destroy(semaphore_t *sm) {
 
 /* Wait on a semaphore, with timeout (in milliseconds) */
 int sem_wait_timed(semaphore_t *sm, unsigned int timeout) {
-    int rv = 0;
-
     /* Make sure we're not inside an interrupt */
     assert(!irq_inside_int()); /* Only usable outside IRQ handlers */
     assert(sm->initialized == 1);
@@ -65,7 +63,7 @@ int sem_wait_timed(semaphore_t *sm, unsigned int timeout) {
     /* If there's enough count left, then let the thread proceed */
     if(sm->count < 0) {
         /* Block us until we're signaled */
-        rv = genwait_wait(sm, timeout ? "sem_wait_timed" : "sem_wait", timeout);
+        int rv = genwait_wait(sm, timeout ? "sem_wait_timed" : "sem_wait", timeout);
 
         /* Did we fail to get the lock? */
         if(rv < 0) {


### PR DESCRIPTION
- sq_unlock had some dead code after the last changes to it.
- sem_wait_timed had a variable being set and never used.
- hardware had a switch with intentional fallthroughs without the appropriate macro to denote them.
- stack was using `asm` rather than `__asm__`.
- video had the `cable_type` value passed around as int8, int16, and uint16.

Aside from the last one's change to the size of the vid_mode struct, I don't think there should be any observable functional differences as the first two gcc should have been able to discard anyways, the second two are compatibility/warning related, and the last didn't have any case where it could have caused a problem from the type changes.