### PR TITLE
select: Return the correct ready-fd count

### DIFF
--- a/kernel/libc/koslib/select.c
+++ b/kernel/libc/koslib/select.c
@@ -83,18 +83,18 @@ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *errorfds,
 
         if(pollfds[i].revents & POLLIN) {
             FD_SET(pollfds[i].fd, readfds);
-            ++j;
+            ++rv;
         }
         if(pollfds[i].revents & POLLOUT) {
             FD_SET(pollfds[i].fd, writefds);
-            ++j;
+            ++rv;
         }
         if((pollfds[i].events & POLLPRI) &&
            (pollfds[i].revents & (POLLPRI | POLLERR | POLLHUP))) {
             FD_SET(pollfds[i].fd, errorfds);
-            ++j;
+            ++rv;
         }
     }
 
-    return j;
+    return rv;
 }


### PR DESCRIPTION
j holds the number of descriptors handed to poll(), which is why it is used as the loop bound when scanning the results. The bug is that the same loop increments j for each ready condition it finds -- so it both walks past the entries poll() filled and returns that inflated value instead of the real count.