### PR TITLE
Fix GCC15, 16 ICE with -O3.

### DIFF
--- a/kernel/arch/dreamcast/include/arch/cache.h
+++ b/kernel/arch/dreamcast/include/arch/cache.h
@@ -81,14 +81,19 @@ static inline void arch_dcache_alloc_line_with_value(void *src, uintptr_t value)
 }
 
 static inline void arch_dcache_alloc_line(void *src) {
-#if __GNUC__ <= 9
-    /* Avoid ICE on GCC 9 */
-    uint32_t r0 = 0;
-#else
-    register uint32_t r0 __asm__("r0");
-#endif
+    uintptr_t *ptr = (uintptr_t *)src;
 
-    arch_dcache_alloc_line_with_value(src, r0);
+    __asm__ ("movca.l r0, @%8\n\t"
+             : "=m"(ptr[0]),
+               "=m"(ptr[1]),
+               "=m"(ptr[2]),
+               "=m"(ptr[3]),
+               "=m"(ptr[4]),
+               "=m"(ptr[5]),
+               "=m"(ptr[6]),
+               "=m"(ptr[7])
+             : "r" (ptr)
+    );
 }
 
 static inline void arch_dcache_zero_alloc_line(void *src) {


### PR DESCRIPTION
snd_stream.c was ICE-ing due to register allocator issues with dcache_purge_range(). Was able to resolve this and get rid of the ugly GCC9 de-ICE check by simply making arch_dcache_alloc_line() not take r0 as an input constraint--which should be fine, since we don't actually care what it contains within this context, we simply want to allocate the cache block.

Here was the error:
```
In file included from /opt/toolchains/dc/kos/include/kos/cache.h:31,
                 from snd_stream.c:21:
In function ‘arch_dcache_alloc_line_with_value’,
    inlined from ‘arch_dcache_alloc_line’ at /opt/toolchains/dc/kos/kernel/arch/dreamcast/include/arch/cache.h:91:5,
    inlined from ‘arch_dcache_purge_all’ at /opt/toolchains/dc/kos/kernel/arch/dreamcast/include/arch/cache.h:196:13,
    inlined from ‘arch_dcache_purge_range’ at /opt/toolchains/dc/kos/kernel/arch/dreamcast/include/arch/cache.h:208:9,
    inlined from ‘dcache_purge_range’ at /opt/toolchains/dc/kos/include/kos/cache.h:177:5,
    inlined from ‘snd_stream_transfer’ at snd_stream.c:661:5:
/opt/toolchains/dc/kos/kernel/arch/dreamcast/include/arch/cache.h:70:5: error: cannot find a register in class ‘R0_REGS’ while reloading ‘asm’
   70 |     __asm__ ("movca.l r0, @%8\n\t"
      |     ^~~~~~~
snd_stream.c: In function ‘snd_stream_transfer’:
snd_stream.c:688:1: error: unable to find a register to spill in class ‘R0_REGS’
  688 | }
      | ^
snd_stream.c:688:1: error: this is the insn:
(insn 350 348 351 30 (set (reg:SI 147 t)
        (eq:SI (reg:SI 1 r1 [orig:224 pretmp_128 ] [224])
            (const_int 2 [0x2]))) "snd_stream.c":663:7 12 {cmpeqsi_t}
     (nil))
snd_stream.c:688: confused by earlier errors, bailing out
```
