### PR TITLE
fat: Fix fs_fat_mount() crash when mounting an exFAT volume

### DIFF
--- a/addons/libkosfat/bpb.c
+++ b/addons/libkosfat/bpb.c
@@ -191,7 +191,8 @@ int fat_read_boot(fat_superblock_t *sb, kos_blockdev_t *bd) {
     }
 
     /* Make sure it looks sane... */
-    if(bb.ebpb.fat16.boot_sig[0] != 0x55 || bb.ebpb.fat16.boot_sig[1] != 0xAA) {
+    if(bb.ebpb.fat16.boot_sig[0] != 0x55 || bb.ebpb.fat16.boot_sig[1] != 0xAA ||
+       bb.bpb.num_fats == 0) {
         return -EINVAL;
     }
 


### PR DESCRIPTION
exFAT carries the same 0x55AA boot signature as FAT16/32, so it slipped past fat_read_boot()'s signature check and into fat_parse_boot(). There its zeroed BPB fields (bytes_per_sector, sectors_per_cluster) are used as divisors, so instead of failing cleanly the parse hit a divide-by-zero and crashed.

Fix is to require a non-zero FAT count before accepting the volume: a real FAT filesystem always has at least one FAT.

Verified fix on hardware with SDXC exFAT formatted card. It fails cleanly now instead of crashing.