### PR TITLE
dcload: Don't block IRQs across the dcload syscall

### DIFF
--- a/kernel/arch/dreamcast/hardware/dcload.c
+++ b/kernel/arch/dreamcast/hardware/dcload.c
@@ -30,7 +30,7 @@ static int dcload_syscall(dcload_cmd_t cmd, void *param1, void *param2, void *pa
 
     /* Ensure that the FIFO buffer is clear */
     /* XXX - Is this needed? It seems like something only for serial. */
-    while(FIFO_STATUS & FIFO_SH4)            ;
+    while(FIFO_STATUS & FIFO_SH4);
 
     /* Make the call */
     return syscall(cmd, param1, param2, param3);

--- a/kernel/arch/dreamcast/hardware/dcload.c
+++ b/kernel/arch/dreamcast/hardware/dcload.c
@@ -12,9 +12,12 @@
 #include <dc/dcload.h>
 #include <dc/memory.h>
 #include <kos/irq.h>
+#include <kos/mutex.h>
 
 /* This is the address where the function pointer for the dcload syscall is fetched from */
 #define VEC_DCLOAD        (MEM_AREA_P1_BASE | 0x0C004008)
+
+static mutex_t mutex = RECURSIVE_MUTEX_INITIALIZER;
 
 /*
     This is the single syscall dcload provides. It is then multiplexed out based on the `cmd`
@@ -24,16 +27,22 @@
 static int dcload_syscall(dcload_cmd_t cmd, void *param1, void *param2, void *param3) {
     uintptr_t *syscall_ptr = (uintptr_t *)VEC_DCLOAD;
     int (*syscall)() = (int (*)())(*syscall_ptr);
+    int ret;
 
-    /* Disable IRQs until the syscall returns */
-    irq_disable_scoped();
+    /* Serialize callers */
+    if(mutex_lock_irqsafe(&mutex))
+        return -1;
 
     /* Ensure that the FIFO buffer is clear */
     /* XXX - Is this needed? It seems like something only for serial. */
     while(FIFO_STATUS & FIFO_SH4);
 
     /* Make the call */
-    return syscall(cmd, param1, param2, param3);
+    ret = syscall(cmd, param1, param2, param3);
+
+    mutex_unlock(&mutex);
+
+    return ret;
 }
 
 ssize_t dcload_read(uint32_t hnd, uint8_t *data, size_t len) {


### PR DESCRIPTION
A dcload syscall is a slow (millisecond) round-trip to the host, and the old code disabled IRQs for its whole duration to guard against re-entrancy. Holding IRQs off that long starves other modules that rely on interrupts to make progress. I hit this running the speedtest example over dc-load-serial: an upload would hang the machine because the example's printf logging kept IRQs disabled long enough for the BBA's 16 KB RX ring to overflow before its interrupt could drain it.

Use a mutex instead, it gives the same re-entrancy protection while leaving IRQs enabled, and the syscall now refuses to run from interrupt context, where blocking on a mutex isn't allowed anyway.

This takes care of a portion of https://github.com/KallistiOS/KallistiOS/issues/1176 and I think https://github.com/KallistiOS/KallistiOS/issues/788 since WDT depends on interrupts to update and the user is printfing while checking the time.