### PR TITLE
maple: Fix detach/shutdown bugs, tidy IRQ code and docs

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -147,11 +147,11 @@ int maple_driver_detach(int p, int u) {
 
         if(dev->drv->detach)
             dev->drv->detach(dev->drv, dev);
-    }
 
-    if(dev->drv->status_size) {
-        free(dev->status);
-        dev->status = NULL;
+        if(dev->drv->status_size) {
+            free(dev->status);
+            dev->status = NULL;
+        }
     }
 
     dev->probe_mask = 0;

--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -144,6 +144,7 @@ int maple_driver_detach(int p, int u) {
     if(dev->drv) {
         if(dev->drv->user_detach)
             dev->drv->user_detach(dev, dev->drv->user_detach_data);
+
         if(dev->drv->detach)
             dev->drv->detach(dev->drv, dev);
     }

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -1,6 +1,6 @@
 /* KallistiOS ##version##
 
-   maple_init.c
+   maple_init_shutdown.c
    Copyright (C) 2002 Megan Potter
  */
 

--- a/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_init_shutdown.c
@@ -187,6 +187,7 @@ void maple_hw_shutdown(void) {
             cnt += !maple_driver_detach(p, u);
 
             free(maple_state.ports[p].units[u]);
+            maple_state.ports[p].units[u] = NULL;
         }
     }
 

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -16,6 +16,7 @@
 #include <dc/asic.h>
 #include <dc/pvr.h>
 #include <kos/dbglog.h>
+#include <kos/regfield.h>
 #include <kos/thread.h>
 
 /*********************************************************************/
@@ -66,12 +67,12 @@ static void vbl_chk_next_subdev(maple_state_t *state, maple_frame_t *frm, int p)
 
     if(dev && dev->probe_mask) {
         int u = __builtin_ffs(dev->probe_mask);
-        dev->probe_mask &= ~(1 << (u - 1));
+        dev->probe_mask &= ~BIT(u - 1);
 
         vbl_send_devinfo(frm, p, u);
     } else {
         /* Nothing else to probe on this port */
-        state->scan_ready_mask |= 1 << p;
+        state->scan_ready_mask |= BIT(p);
     }
 }
 
@@ -79,18 +80,18 @@ static void vbl_dev_probed(int p, int u) {
     maple_device_t *dev = maple_enum_dev(p, 0);
 
     if(dev)
-        dev->dev_mask |= 1 << (u - 1);
+        dev->dev_mask |= BIT(u - 1);
 }
 
 /* Check the sub-devices for a top-level port */
 static void vbl_chk_subdevs(maple_state_t *state, int p, uint8_t newmask) {
     maple_device_t *dev = maple_enum_dev(p, 0);
 
-    newmask &= (1 << (MAPLE_UNIT_COUNT - 1)) - 1;
+    newmask &= BIT(MAPLE_UNIT_COUNT - 1) - 1;
 
     /* Disconnect any device that disappeared */
     for(size_t u = 1; u < MAPLE_UNIT_COUNT; u++) {
-        if(dev->dev_mask & ~newmask & (1 << (u - 1))) {
+        if(dev->dev_mask & ~newmask & BIT(u - 1)) {
             vbl_chk_disconnect(state, p, u);
         }
     }
@@ -133,7 +134,7 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
             if(dev && dev->dev_mask == 0)
                 vbl_chk_disconnect(state, p, 0);
 
-            state->scan_ready_mask |= 1 << p;
+            state->scan_ready_mask |= BIT(p);
         }
         else {
             /* Not a top-level device -- only detach this device */
@@ -176,7 +177,7 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     else {
         dbglog(DBG_DEBUG, "maple: unknown response %d on device %c%c\n",
             resp->response, 'A'+p, '0'+u);
-        state->scan_ready_mask |= 1 << p;
+        state->scan_ready_mask |= BIT(p);
         maple_frame_unlock(frm);
     }
 }

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -21,6 +21,15 @@
     accessed through the functions here. Most of the drivers have their own
     functionality that is implemented in their header files, as well.
 
+    \bug    Sending a rumble (PuruPuru / Jump Pack) command can cause VMUs
+            plugged into any controller to beep. This is a hardware-level side
+            effect and not something KOS can prevent in software.
+
+    \bug    Inserting a VMU can cause its parent controller to briefly disconnect
+            and re-enumerate on the Maple bus, producing a detach/attach event for
+            the controller as well as the VMU. This is another hardware-level side
+            effect and not something KOS can prevent in software.
+
     \author Megan Potter
     \author Lawrence Sebald
 


### PR DESCRIPTION
While trying to chase a maple shutdown issue that I ultimately could not reproduce I found a few things that needed to be fixed. Mainly:

1. examples/dreamcast/maple.elf example does not detect attach/detach of controllers that have VMU/Rumble in them
2. Fixed a dangling pointer
3. Moved an if-block of code to protect against NULL dereferences.