### PR TITLE
maple: Fix unplug detection

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -58,6 +58,13 @@ static void vbl_chk_disconnect(maple_state_t *state, int p, int u) {
         if(maple_driver_detach(p, u) >= 0) {
             assert(!maple_dev_valid(p, u));
         }
+
+        if(u > 0) {
+            maple_device_t *dev = maple_enum_dev(p, 0);
+
+            if(dev)
+                dev->dev_mask &= ~BIT(u - 1);
+        }
     }
 }
 
@@ -130,8 +137,20 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     if(resp->response == MAPLE_RESPONSE_NONE) {
         /* No device, or not functioning properly; check for removal */
         if(u == 0) {
-            if(dev && dev->dev_mask == 0)
-                vbl_chk_disconnect(state, p, 0);
+            if(dev) {
+                if(dev->dev_mask == 0) {
+                    /* No sub-devices remaining - we can disconnect the parent */
+                    vbl_chk_disconnect(state, p, 0);
+                }
+                else {
+                    maple_frame_unlock(frm);
+
+                    /* Unit 0 unplugged? Re-probe all devices */
+                    dev->probe_mask = dev->dev_mask;
+                    vbl_chk_next_subdev(state, frm, p);
+                    return;
+                }
+            }
 
             state->scan_ready_mask |= 1 << p;
         }


### PR DESCRIPTION
When plugging out a controller with peripherals, the maple driver would not properly report the event.

The top device (unit 0) would be reported as disconnected only after all sub-devices were reported as disconnected, but:
- at that point the sub-devices were not probed anymore, as they are only probed when the unit 0 device still responds;
- any sub-device being marked as unplugged would not update the device mask in the parent device.

Fix this issue by updating the parent device's mask when sub-devices are unplugged, and by making sure that we probe any sub-devices when the top device is detected as unplugged.