### PR TITLE
maple: Controller and accessories detach triggering

### DIFF
--- a/examples/dreamcast/rumble/rumble.c
+++ b/examples/dreamcast/rumble/rumble.c
@@ -52,8 +52,8 @@ void print_rumble_fields(purupuru_effect_t fields) {
   printf("  .inc    =  %u,\n", fields.inc);
 }
 /* This blocks waiting for a specified device to be present and valid */
-void wait_for_dev_attach(maple_device_t **dev_ptr, unsigned int func) {
-    maple_device_t *dev = *dev_ptr;
+void wait_for_dev_attach(maple_device_t **cont_dev_ptr, maple_device_t **puru_dev_ptr) {
+    maple_device_t *dev = *puru_dev_ptr;
     point_t w = {40.0f, 200.0f, 10.0f, 0.0f};
 
     /* If we already have it, and it's still valid, leave */
@@ -69,20 +69,20 @@ void wait_for_dev_attach(maple_device_t **dev_ptr, unsigned int func) {
 
     plx_fcxt_begin(cxt);
     plx_fcxt_setpos_pnt(cxt, &w);
-    if(func == MAPLE_FUNC_CONTROLLER)
-        plx_fcxt_draw(cxt, "Please attach a controller!");
-    else if(func == MAPLE_FUNC_PURUPURU)
-        plx_fcxt_draw(cxt, "Please attach a rumbler!");
+    plx_fcxt_draw(cxt, "Please attach a rumbler!");
     plx_fcxt_end(cxt);
 
     pvr_scene_finish();
 
     /* Repeatedly check until we find one and it's valid */
     while((dev == NULL) || !dev->valid) {
-        *dev_ptr = maple_enum_type(0, func);
-        dev = *dev_ptr;
+        *puru_dev_ptr = maple_enum_type(0, MAPLE_FUNC_PURUPURU);
+        dev = *puru_dev_ptr;
         usleep(50);
     }
+
+    /* Now that we have a rumbler, grab its parent */
+    *cont_dev_ptr = maple_enum_dev(dev->port, 0);
 }
 
 
@@ -136,8 +136,7 @@ int main(int argc, char *argv[]) {
 
         /* Before drawing the screen, trap into these functions to be
            sure that there's at least one controller and one rumbler */
-        wait_for_dev_attach(&contdev, MAPLE_FUNC_CONTROLLER);
-        wait_for_dev_attach(&purudev, MAPLE_FUNC_PURUPURU);
+        wait_for_dev_attach(&contdev, &purudev);
 
         /* Start drawing and draw the header */
         pvr_scene_begin();
@@ -173,8 +172,12 @@ int main(int argc, char *argv[]) {
         state = (cont_state_t *)maple_dev_status(contdev);
 
         /* Make sure we can rely on the state, otherwise loop. */
-        if(state == NULL)
+        if(state == NULL) {
+            /* Finish things up */
+            plx_fcxt_end(cxt);
+            pvr_scene_finish();
             continue;
+        }
 
         rel_buttons = (old_buttons ^ state->buttons);
 

--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -114,7 +114,7 @@ int maple_driver_attach(maple_frame_t *det) {
             /* Try to attach if we need to then finish up. */
             if(!i->attach || (i->attach(i, dev) >= 0)) {
                 dev->drv = i;
-                dev->valid = true;
+                dev->valid = MAPLE_DEV_VALID_TIMEOUT;
 
                 if(i->user_attach)
                     i->user_attach(dev, i->user_attach_data);
@@ -139,7 +139,7 @@ int maple_driver_detach(int p, int u) {
     if(!dev)
         return -1;
 
-    dev->valid = false;
+    dev->valid = 0;
 
     if(dev->drv) {
         if(dev->drv->user_detach)

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -130,8 +130,14 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     if(resp->response == MAPLE_RESPONSE_NONE) {
         /* No device, or not functioning properly; check for removal */
         if(u == 0) {
-            if(dev && dev->dev_mask == 0)
-                vbl_chk_disconnect(state, p, 0);
+            if(dev) {
+                /* Top-level device -- detach all sub-devices as well */
+                for(u = 0; u < MAPLE_UNIT_COUNT; u++) {
+                    vbl_chk_disconnect(state, p, u);
+                }
+
+                dev->dev_mask = 0;
+            }
 
             state->scan_ready_mask |= 1 << p;
         }

--- a/kernel/arch/dreamcast/hardware/maple/maple_irq.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_irq.c
@@ -128,6 +128,18 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
     dev = maple_enum_dev(p, u);
 
     if(resp->response == MAPLE_RESPONSE_NONE) {
+
+        /* Don't try to disconnect unless we get MAPLE_DEV_VALID_TIMEOUT failed
+         * autodetects. A vmu being plugged in, or a puru doing certain sorts
+         * of rumbles cause the controller they're in to be unresponsive for
+         * a little bit. Having this timeout prevents them all from being
+         * disconnected only to be reconnected shortly after. */
+        if(dev && (dev->valid > 1)) {
+            dev->valid--;
+            maple_frame_unlock(frm);
+            return;
+        }
+
         /* No device, or not functioning properly; check for removal */
         if(u == 0) {
             if(dev) {
@@ -165,6 +177,9 @@ static void vbl_autodet_callback(maple_state_t *state, maple_frame_t *frm) {
             dev->info.function_data[0] = devinfo->function_data[0];
             dev->info.function_data[1] = devinfo->function_data[1];
             dev->info.function_data[2] = devinfo->function_data[2];
+
+            /* Since we got a response, reset the timeout */
+            dev->valid = MAPLE_DEV_VALID_TIMEOUT;
         }
 
         /* If this is a top-level port, then also check any

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -262,6 +262,11 @@ typedef struct maple_response {
     uint8_t   data[];     /**< \brief Data (if any) */
 } maple_response_t;
 
+/* \cond */
+/* Number of failed autodetects before detaching a device. */
+#define MAPLE_DEV_VALID_TIMEOUT 30
+/* \endcond */
+
 /** \brief   One maple device.
     \ingroup maple
 
@@ -272,7 +277,7 @@ typedef struct maple_response {
 */
 typedef struct maple_device {
     /* Public */
-    bool            valid;  /**< \brief Is this a valid device? */
+    uint8_t         valid;  /**< \brief Is this a valid device? 0 for no */
     int             port;   /**< \brief Maple bus port connected to */
     int             unit;   /**< \brief Unit number, off of the port */
     maple_devinfo_t info;   /**< \brief Device info struct */


### PR DESCRIPTION
See #1464 .

This first reverts #1258 as it was only preventing the issue from #806 by accidentally suppressing controller detaching entirely when there were subunits connected to it. Devices attached to a disconnected controller would never be probed again once it was disconnected, and it would never get detached because it would wait for all attached devices to report that they were disconnected as well.

In order to work around the issue instead add a counter to the autodetect failures, requiring that a device be unresponsive for multiple successive autodetects before being actually disconnected.

Originally I had set the timeout count to 10 and that was sufficient for plugging in a VMU to a controller with a puru also in it, but an empty controller would still trip it. At 16-17 it would *usually* work, but only at 18 did I stop seeing it ever happen.