### PR TITLE
kos-chain: Move -mcpu=arm7di from Newlib patch to AICA's profile

### DIFF
--- a/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
+++ b/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
@@ -7,7 +7,7 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/configure.host newlib-4.6.0.20260
    arm*)
 -	machine_dir=arm
 -	libm_machine_dir=arm
-+	newlib_cflags="${newlib_cflags} -mcpu=arm7di -DREENTRANT_SYSCALLS_PROVIDED -DMALLOC_PROVIDED -DABORT_PROVIDED -DHAVE_FCNTL -ffunction-sections -fdata-sections"
++	newlib_cflags="${newlib_cflags} -DREENTRANT_SYSCALLS_PROVIDED -DMALLOC_PROVIDED -DABORT_PROVIDED -DHAVE_FCNTL -ffunction-sections -fdata-sections"
  	;;
    avr*)
  	newlib_cflags="${newlib_cflags} -DPREFER_SIZE_OVER_SPEED -mcall-prologues"

--- a/utils/kos-chain/profiles/aica/stable.mk
+++ b/utils/kos-chain/profiles/aica/stable.mk
@@ -41,3 +41,4 @@ auto_fixup_newlib=0
 
 gcc_pass1_configure_args=CFLAGS_FOR_TARGET="-mcpu=arm7di -marm"
 gcc_pass2_configure_args=CFLAGS_FOR_TARGET="-mcpu=arm7di -marm"
+newlib_extra_configure_args=CFLAGS_FOR_TARGET="-mcpu=arm7di -O2 -g"


### PR DESCRIPTION
Because darc said so.