### PR TITLE
net: TCP/IP stack speedup enhancements & bug fixes (+ IP_TOS)

### DIFF
--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -32,12 +32,12 @@ __BEGIN_DECLS
 #include <inttypes.h>
 #include <sys/socket.h>
 
-/** \brief   16-bit type used to store a value for an internet port. 
+/** \brief   16-bit type used to store a value for an internet port.
     \ingroup networking_ip
 */
 typedef uint16_t in_port_t;
 
-/** \brief   32-bit value used to store an IPv4 address. 
+/** \brief   32-bit value used to store an IPv4 address.
     \ingroup networking_ipv4
 */
 typedef uint32_t in_addr_t;
@@ -177,17 +177,17 @@ extern const struct in6_addr in6addr_any;
 */
 extern const struct in6_addr in6addr_loopback;
 
-/** \brief   Length of a string form of a maximal IPv4 address. 
+/** \brief   Length of a string form of a maximal IPv4 address.
     \ingroup networking_ipv4
 */
 #define INET_ADDRSTRLEN 16
 
-/** \brief   Length of a string form of a maximal IPv6 address. 
+/** \brief   Length of a string form of a maximal IPv6 address.
     \ingroup networking_ipv6
 */
 #define INET6_ADDRSTRLEN 46
 
-/** \brief   Internet Protocol Version 4. 
+/** \brief   Internet Protocol Version 4.
     \ingroup networking_ip
 */
 #define IPPROTO_IP      0
@@ -197,22 +197,22 @@ extern const struct in6_addr in6addr_loopback;
 */
 #define IPPROTO_ICMP    1
 
-/** \brief   Transmission Control Protocol. 
+/** \brief   Transmission Control Protocol.
     \ingroup networking_ip
 */
 #define IPPROTO_TCP     6
 
-/** \brief   User Datagram Protocol. 
+/** \brief   User Datagram Protocol.
     \ingroup networking_ip
 */
 #define IPPROTO_UDP     17
 
-/** \brief   Internet Protocol Version 6. 
+/** \brief   Internet Protocol Version 6.
     \ingroup networking_ip
 */
 #define IPPROTO_IPV6    41
 
-/** \brief   Lightweight User Datagram Protocol. 
+/** \brief   Lightweight User Datagram Protocol.
     \ingroup networking_ip
 */
 #define IPPROTO_UDPLITE 136
@@ -276,7 +276,7 @@ extern const struct in6_addr in6addr_loopback;
     unspecified address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is unspecified, 0 otherwise.
 */
 #define IN6_IS_ADDR_UNSPECIFIED(a)  \
@@ -292,7 +292,7 @@ extern const struct in6_addr in6addr_loopback;
     loopback address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is a loopback, 0 otherwise.
 */
 #define IN6_IS_ADDR_LOOPBACK(a)  \
@@ -310,7 +310,7 @@ extern const struct in6_addr in6addr_loopback;
     mapped address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is IPv4 mapped, 0 otherwise.
 */
 #define IN6_IS_ADDR_V4MAPPED(a)  \
@@ -326,7 +326,7 @@ extern const struct in6_addr in6addr_loopback;
     compatibility address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is IPv4 compat, 0 otherwise.
 */
 #define IN6_IS_ADDR_V4COMPAT(a)  \
@@ -343,7 +343,7 @@ extern const struct in6_addr in6addr_loopback;
     address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is link-local, 0 otherwise.
 */
 #define IN6_IS_ADDR_LINKLOCAL(a)  \
@@ -357,7 +357,7 @@ extern const struct in6_addr in6addr_loopback;
     address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is site-local, 0 otherwise.
 */
 #define IN6_IS_ADDR_SITELOCAL(a)  \
@@ -371,7 +371,7 @@ extern const struct in6_addr in6addr_loopback;
     address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is multicast, 0 otherwise.
 */
 #define IN6_IS_ADDR_MULTICAST(a)  \
@@ -384,7 +384,7 @@ extern const struct in6_addr in6addr_loopback;
     multicast address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is a node-local multicast
                         address, 0 otherwise.
 */
@@ -399,7 +399,7 @@ extern const struct in6_addr in6addr_loopback;
     multicast address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is a link-local multicast
                         address, 0 otherwise.
 */
@@ -414,7 +414,7 @@ extern const struct in6_addr in6addr_loopback;
     multicast address.
 
     \param  a           The address to test (struct in6_addr *)
-    
+
     \return             Nonzero if the address is a site-local multicast
                         address, 0 otherwise.
 */

--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -237,6 +237,7 @@ extern const struct in6_addr in6addr_loopback;
 */
 
 #define IP_TTL              24  /**< \brief TTL for unicast (get/set) */
+#define IP_TOS              26  /**< \brief Type of service (get/set) */
 
 /** @} */
 

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -504,7 +504,7 @@ static void bba_dma_cb(void *p) {
     if(next_len) {
         g2_dma_transfer(next_dst, next_src, next_len, 0,
                         bba_dma_cb, 0,  /* callback */
-                        1,  /* dir = 1, we're *reading* from the g2 bus */
+                        G2_DMA_TO_SH4,
                         0, G2_DMA_CHAN_BBA, 0);
         next_len = 0;
     }
@@ -536,7 +536,7 @@ static int bba_copy_packet(uint8_t *dst, uint32_t s, int len) {
             dma_used = 1;
             g2_dma_transfer(dst, src, len, 0,
                             bba_dma_cb, 0,  /* callback */
-                            1,  /* dir = 1, we're *reading* from the g2 bus */
+                            G2_DMA_TO_SH4,
                             0, G2_DMA_CHAN_BBA, 0);
         }
         else if(next_len) {

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -8,6 +8,7 @@
 
  */
 
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,7 +17,6 @@
 #include <dc/net/broadband_adapter.h>
 #include <dc/asic.h>
 #include <dc/g2bus.h>
-#include <dc/sq.h>
 #include <dc/flashrom.h>
 #include <dc/memory.h>
 #include <kos/cache.h>
@@ -439,7 +439,7 @@ static uint8_t *rxbuff;
 static uint32_t rxbuff_pos;
 static int rxin;
 static int rxout;
-static int dma_used;
+static atomic_int dma_used;
 
 static uint32_t rx_size;
 
@@ -492,7 +492,9 @@ static void rx_finish_enq(int room) {
     if(room > 0 && (((rxin + 1) % MAX_PKTS) != rxout)) {
         rxin = (rxin + 1) % MAX_PKTS;
         thd_worker_wakeup(rx_worker);
-        thd_schedule(true);
+        /* Only in IRQ context (unsafe from the TX drain). */
+        if(irq_inside_int())
+            thd_schedule(true);
     }
 }
 
@@ -611,6 +613,44 @@ static int bba_can_tx(void *d) {
     return 1;
 }
 
+/* Copy a large outbound frame into the current TX buffer with G2 DMA. Keep interrupts
+   active until the transfer is complete */
+static bool bba_tx_dma(const uint8_t *pkt, int len) {
+    size_t total = __align_up(len, 4);
+    size_t aligned = __align_down(total, 32);
+    size_t remainder = total - aligned;
+    int expected = 0;
+
+    /* Take the single shared BBA DMA channel, if available. */
+    if(!atomic_compare_exchange_strong(&dma_used, &expected, 1))
+        return false;
+
+    dcache_wback_range((uintptr_t)pkt, aligned);
+
+    /* Blocking DMA copy into the current TX buffer. Keep interrupts active to
+       queue up RX packets. */
+    g2_dma_transfer((void *)pkt, (void *)txdesc[rtl.cur_tx], aligned,
+                    1,             /* block */
+                    NULL, NULL,    /* no callback */
+                    G2_DMA_TO_G2,
+                    0, G2_DMA_CHAN_BBA, 0);
+
+    if(remainder) {
+        g2_fifo_wait();
+        g2_write_block_32((uint32_t *)(pkt + aligned),
+                          txdesc[rtl.cur_tx] + aligned, remainder >> 2);
+    }
+
+    irq_disable_scoped();
+    dma_used = 0;
+
+    /* Drain any queued RX packets received during TX transfer. */
+    if(!(g2_read_8(NIC(RT_CHIPCMD)) & RT_CMD_RX_BUF_EMPTY))
+        bba_rx();
+
+    return true;
+}
+
 /* Transmit a single packet */
 static int bba_rtx(const uint8_t *pkt, int len, int wait)
 {
@@ -632,12 +672,12 @@ static int bba_rtx(const uint8_t *pkt, int len, int wait)
     }
 
     /* Copy the packet out to RTL memory */
-    /* XXX could use store queues or memcpy8 here */
-
-    //g2_write_block_8(pkt, txdesc[rtl.cur_tx], len);
-
     assert(__is_aligned((uintptr_t)pkt, 32));
-    g2_write_block_32((uint32_t *) pkt, txdesc[rtl.cur_tx], (len + 3) >> 2);
+
+    /* Large frames go out via G2 DMA when the channel is free. Interrupt
+       context, small frames, or a channel busy with RX fall back to PIO. */
+    if(irq_inside_int() || len < DMA_THRESHOLD || !bba_tx_dma(pkt, len))
+        g2_write_block_32((uint32_t *)pkt, txdesc[rtl.cur_tx], (len + 3) >> 2);
 
     /* All packets must be at least 60 bytes, pad them with null bytes if
        they are not already of an appropriate size. */

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -139,17 +139,17 @@ static int gaps_init(void) {
        there is a VERY good chance it will never change. */
 
     /* VEN:DEV is 11db:1234 (vendor code is "Sega Enterprises, LTD")
-       The GAPS bridge is really just an MMU with a memory buffer that maps 
-       the RTL8139C to the Dreamcast's memory space, so these are actually 
-       the PCI configuration registers for the RTL8139, not GAPS (those are 
+       The GAPS bridge is really just an MMU with a memory buffer that maps
+       the RTL8139C to the Dreamcast's memory space, so these are actually
+       the PCI configuration registers for the RTL8139, not GAPS (those are
        just the 0x1400 regs).
 
-       It has a custom ven:dev ID, but the class ID in 0x1608 indicates a 
-       network controller (byte 0x160b = 0x02 = network controller, 
+       It has a custom ven:dev ID, but the class ID in 0x1608 indicates a
+       network controller (byte 0x160b = 0x02 = network controller,
        0x160a = 0x00 = Ethernet controller)
 
-       See PCI Local Bus Specification 2.2 (2.3 has all the 2.2 stuff in 
-       it and the RTL8139C uses 2.2). This is also documented in the 
+       See PCI Local Bus Specification 2.2 (2.3 has all the 2.2 stuff in
+       it and the RTL8139C uses 2.2). This is also documented in the
        RTL8139C's datasheet, under "PCI Configuration Space Registers"
     */
 
@@ -188,8 +188,8 @@ static int gaps_init(void) {
 
             if(g2_read_32(GAPS_BASE + 0x141c) == 0xaa5500ff) {
                 g2_write_32(GAPS_BASE + 0x141c, 0x41474553);
-                /* I think GAPS automatically pulls RSTB low for 120ns, which 
-                   causes the EEPROM to autoload all the registers initially. 
+                /* I think GAPS automatically pulls RSTB low for 120ns, which
+                   causes the EEPROM to autoload all the registers initially.
                    So we don't need to worry about it.
                 */
                 return 0;
@@ -320,7 +320,7 @@ static int bba_hw_init(void) {
     g2_write_32(NIC(RT_MAR0), 0x55aaff00);
     g2_write_32(NIC(RT_MAR4), 0xaa5500ff);
 
-    if((g2_read_32(NIC(RT_MAR0)) == 0x55aaff00) && 
+    if((g2_read_32(NIC(RT_MAR0)) == 0x55aaff00) &&
        (g2_read_32(NIC(RT_MAR4)) == 0xaa5500ff)) {
         /* Enable receive and transmit functions */
         g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RX_ENABLE | RT_CMD_TX_ENABLE);
@@ -345,7 +345,7 @@ static int bba_hw_init(void) {
     g2_write_8(NIC(RT_CFG9346), 0xc0);
 
     /* Old style would turn of LWACT and on DVRLOAD. New also disables LED0 and enables LED1 */
-    g2_write_8(NIC(RT_CONFIG1), (g2_read_8(NIC(RT_CONFIG1)) & 
+    g2_write_8(NIC(RT_CONFIG1), (g2_read_8(NIC(RT_CONFIG1)) &
         ~(RT_CONFIG1_LWACT | RT_CONFIG1_LED0)) | RT_CONFIG1_DVRLOAD | RT_CONFIG1_LED1);
 
     /* Enable FIFO auto-clear */

--- a/kernel/net/net_icmp.c
+++ b/kernel/net/net_icmp.c
@@ -111,7 +111,7 @@ static void net_icmp_input_8(netif_t *src, const ip_hdr_t *ip, icmp_hdr_t *icmp,
     /* Set the destination to the original source, and substitute in our IP
        for the src (done this way so that pings that are broadcasted get an
        appropriate reply), and send it away. */
-    net_ipv4_send(src, d, s, ip->packet_id, 255, 1, ip->dest, ip->src);
+    net_ipv4_send(src, d, s, ip->packet_id, 255, 0, 1, ip->dest, ip->src);
 }
 
 int net_icmp_input(netif_t *src, const ip_hdr_t *ip, const uint8_t *d, size_t s) {
@@ -199,7 +199,7 @@ int net_icmp_send_echo(netif_t *net, const uint8_t ipaddr[4], uint16_t ident,
         src = net_ipv4_address(net->ip_addr);
     }
 
-    r = net_ipv4_send(net, databuf, sz, seq, 255, 1, htonl(src),
+    r = net_ipv4_send(net, databuf, sz, seq, 255, 0, 1, htonl(src),
                       htonl(net_ipv4_address(ipaddr)));
 
     return r;
@@ -226,7 +226,7 @@ int net_icmp_send_dest_unreach(netif_t *net, uint8_t code, const uint8_t *msg) {
     icmp->checksum = net_ipv4_checksum(databuf, sizeof(icmp_hdr_t) + sz, 0);
 
     /* Send the packet away */
-    return net_ipv4_send(net, databuf, sizeof(icmp_hdr_t) + sz, 0, 255, 1,
+    return net_ipv4_send(net, databuf, sizeof(icmp_hdr_t) + sz, 0, 255, 0, 1,
                          orig_msg->dest, orig_msg->src);
 }
 
@@ -251,6 +251,6 @@ int net_icmp_send_time_exceeded(netif_t *net, uint8_t code, const uint8_t *msg) 
     icmp->checksum = net_ipv4_checksum(databuf, sizeof(icmp_hdr_t) + sz, 0);
 
     /* Send the packet away */
-    return net_ipv4_send(net, databuf, sizeof(icmp_hdr_t) + sz, 0, 255, 1,
+    return net_ipv4_send(net, databuf, sizeof(icmp_hdr_t) + sz, 0, 255, 0, 1,
                          orig_msg->dest, orig_msg->src);
 }

--- a/kernel/net/net_icmp6.c
+++ b/kernel/net/net_icmp6.c
@@ -531,7 +531,7 @@ int net_icmp6_send_echo(netif_t *net, const struct in6_addr *dst, uint16_t ident
     cs = net_ipv6_checksum_pseudo(&src, dst, sz, IPV6_HDR_ICMP);
     echo->checksum = net_ipv4_checksum(databuf, sz, cs);
 
-    return net_ipv6_send(net, databuf, sz, 0, IPV6_HDR_ICMP, &src, dst);
+    return net_ipv6_send(net, databuf, sz, 0, 0, IPV6_HDR_ICMP, &src, dst);
 }
 
 /* Send a Neighbor Solicitation packet on the specified device */
@@ -593,7 +593,7 @@ int net_icmp6_send_nsol(netif_t *net, const struct in6_addr *dst,
     cs = net_ipv6_checksum_pseudo(&src, dst, size, IPV6_HDR_ICMP);
     pkt->checksum = net_ipv4_checksum(databuf, size, cs);
 
-    return net_ipv6_send(net, databuf, size, 255, IPV6_HDR_ICMP, &src, dst);
+    return net_ipv6_send(net, databuf, size, 255, 0, IPV6_HDR_ICMP, &src, dst);
 }
 
 /* Send a Neighbor Advertisement packet on the specified device */
@@ -638,7 +638,7 @@ int net_icmp6_send_nadv(netif_t *net, const struct in6_addr *dst,
     cs = net_ipv6_checksum_pseudo(&src, dst, size, IPV6_HDR_ICMP);
     pkt->checksum = net_ipv4_checksum(databuf, size, cs);
 
-    return net_ipv6_send(net, databuf, size, 255, IPV6_HDR_ICMP, &src, dst);
+    return net_ipv6_send(net, databuf, size, 255, 0, IPV6_HDR_ICMP, &src, dst);
 }
 
 /* Send a Router Solicitation request on the specified interface */
@@ -683,7 +683,7 @@ int net_icmp6_send_rsol(netif_t *net) {
                                   IPV6_HDR_ICMP);
     pkt->checksum = net_ipv4_checksum(databuf, size, cs);
 
-    return net_ipv6_send(net, databuf, size, 255, IPV6_HDR_ICMP, &src,
+    return net_ipv6_send(net, databuf, size, 255, 0, IPV6_HDR_ICMP, &src,
                          &in6addr_linklocal_allrouters);
 }
 
@@ -740,7 +740,7 @@ static int send_err_pkt(netif_t *net, uint8_t buf[1240], int ptr,
     pkt->checksum = net_ipv4_checksum(buf, size, cs);
 
     /* Send it away */
-    return net_ipv6_send(net, buf, size, 0, IPV6_HDR_ICMP, &src, &osrc);
+    return net_ipv6_send(net, buf, size, 0, 0, IPV6_HDR_ICMP, &src, &osrc);
 }
 
 /* Send an ICMPv6 Destination Unreachable about the given packet. */

--- a/kernel/net/net_ipv4.c
+++ b/kernel/net/net_ipv4.c
@@ -201,6 +201,95 @@ int net_ipv4_send(netif_t *net, const uint8_t *data, size_t size, int id, int tt
     return net_ipv4_frag_send(net, &hdr, data, size);
 }
 
+int net_ipv4_send_inplace(netif_t *net, uint8_t *frame, size_t size, int id,
+                          int ttl, int proto, uint32_t src, uint32_t dst) {
+    eth_hdr_t *ehdr = (eth_hdr_t *)frame;
+    ip_hdr_t *hdr = (ip_hdr_t *)(frame + sizeof(eth_hdr_t));
+    uint8_t *data = frame + NET_IPV4_FRAME_HDR_SIZE;
+    uint8_t dest_ip[4];
+    uint8_t dest_mac[6];
+    int err;
+
+    if(!net) {
+        net = net_default_dev;
+
+        if(!net) {
+            errno = ENETDOWN;
+            return -1;
+        }
+    }
+
+    /* If the ID is -1, generate a random ID value that can be used in case the
+       packet gets fragmented. */
+    if(id == -1)
+        id = rand() & 0xFFFF;
+
+    /* Match net_ipv6_send()'s handling of an unset hop limit. */
+    if(ttl <= 0)
+        ttl = net->hop_limit ? net->hop_limit : 255;
+
+    /* Build the IPv4 header in place, directly in front of the segment. */
+    hdr->version_ihl = 0x45;
+    hdr->tos = 0;
+    hdr->length = htons(size + sizeof(ip_hdr_t));
+    hdr->packet_id = id;
+    hdr->flags_frag_offs = 0;
+    hdr->ttl = ttl;
+    hdr->protocol = proto;
+    hdr->checksum = 0;
+    hdr->src = src;
+    hdr->dest = dst;
+    hdr->checksum = net_ipv4_checksum((uint8_t *)hdr, sizeof(ip_hdr_t), 0);
+
+    net_ipv4_parse_address(ntohl(dst), dest_ip);
+
+    /* Only handle a single unfragmented frame on an ethernet link. Loopback,
+       header-less links (e.g. PPP), and anything that would need fragmentation
+       needs to go through the copy-based path */
+    if((net->flags & NETIF_NOETH) || dest_ip[0] == 0x7F ||
+       (size + sizeof(ip_hdr_t)) > (size_t)net->mtu)
+        return net_ipv4_frag_send(net, hdr, data, size);
+
+    /* Are we sending a broadcast packet? */
+    if(dst == 0xFFFFFFFF || is_broadcast(dest_ip, net->broadcast)) {
+        memset(dest_mac, 0xFF, 6);
+    }
+    else {
+        /* Is it in our network? */
+        if(!is_in_network(net->ip_addr, dest_ip, net->netmask))
+            memcpy(dest_ip, net->gateway, 4);
+
+        /* Get our destination's MAC address. If we do not have the MAC address
+           cached, return a distinguished error to the upper-level protocol so
+           that it can decide what to do. */
+        err = net_arp_lookup(net, dest_ip, dest_mac, hdr, data, size);
+
+        if(err == -1) {
+            errno = ENETUNREACH;
+            ++ipv4_stats.pkt_send_failed;
+            return -1;
+        }
+        else if(err == -2) {
+            /* It'll send when the ARP reply comes in (assuming one does), so
+               return success. */
+            return 0;
+        }
+    }
+
+    /* Put the IP header / data into our ethernet packet */
+    memcpy(ehdr->dest, dest_mac, 6);
+    memcpy(ehdr->src, net->mac_addr, 6);
+    ehdr->type[0] = 0x08;
+    ehdr->type[1] = 0x00;
+
+    ++ipv4_stats.pkt_sent;
+
+    /* Send it away */
+    net->if_tx(net, frame, NET_IPV4_FRAME_HDR_SIZE + size, NETIF_BLOCK);
+
+    return 0;
+}
+
 int net_ipv4_input(netif_t *src, const uint8_t *pkt, size_t pktsize,
                    const eth_hdr_t *eth) {
     const ip_hdr_t *ip;

--- a/kernel/net/net_ipv4.c
+++ b/kernel/net/net_ipv4.c
@@ -28,32 +28,31 @@
 
 static net_ipv4_stats_t ipv4_stats = { 0 };
 
-static inline uint16_t checksum_one(uint16_t val, uint16_t sum) {
-    uint16_t result;
-
-    return __builtin_add_overflow(val, sum, &result) + result;
-}
-
 /* Perform an IP-style checksum on a block of data */
 uint16_t __pure net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t sum) {
     typedef uint16_t __attribute__((may_alias)) alias_u16_t;
+    uint32_t acc_sum = sum;
 
     /* Make sure we don't do any unaligned memory accesses */
     if((uintptr_t)data & 1) {
-        sum = checksum_one(*data, sum);
+        acc_sum += *data;
         bytes--;
         data++;
     }
 
     /* Compute checksum two bytes at a time */
     for(; bytes > 1; bytes -= 2, data += 2)
-        sum = checksum_one(*(const alias_u16_t *)data, sum);
+        acc_sum += *(const alias_u16_t *)data;
 
     /* Handle the last byte, if we have an odd byte count */
     if(bytes)
-        sum = checksum_one(*data, sum);
+        acc_sum += *data;
 
-    return ~sum;
+    /* Take care of any carry bits */
+    while(acc_sum >> 16)
+        acc_sum = (acc_sum >> 16) + (acc_sum & 0xFFFF);
+
+    return (uint16_t)~acc_sum;
 }
 
 /* Determine if a given IP is in the current network */

--- a/kernel/net/net_ipv4.c
+++ b/kernel/net/net_ipv4.c
@@ -175,7 +175,7 @@ int net_ipv4_send_packet(netif_t *net, ip_hdr_t *hdr, const uint8_t *data,
 }
 
 int net_ipv4_send(netif_t *net, const uint8_t *data, size_t size, int id, int ttl,
-                  int proto, uint32_t src, uint32_t dst) {
+                  int tos, int proto, uint32_t src, uint32_t dst) {
     ip_hdr_t hdr;
 
     /* If the ID is -1, generate a random ID value that can be used in case the
@@ -186,7 +186,7 @@ int net_ipv4_send(netif_t *net, const uint8_t *data, size_t size, int id, int tt
 
     /* Fill in the IPv4 Header */
     hdr.version_ihl = 0x45;
-    hdr.tos = 0;
+    hdr.tos = tos;
     hdr.length = htons(size + 20);
     hdr.packet_id = id;
     hdr.flags_frag_offs = 0;
@@ -202,7 +202,7 @@ int net_ipv4_send(netif_t *net, const uint8_t *data, size_t size, int id, int tt
 }
 
 int net_ipv4_send_inplace(netif_t *net, uint8_t *frame, size_t size, int id,
-                          int ttl, int proto, uint32_t src, uint32_t dst) {
+                          int ttl, int tos, int proto, uint32_t src, uint32_t dst) {
     eth_hdr_t *ehdr = (eth_hdr_t *)frame;
     ip_hdr_t *hdr = (ip_hdr_t *)(frame + sizeof(eth_hdr_t));
     uint8_t *data = frame + NET_IPV4_FRAME_HDR_SIZE;
@@ -230,7 +230,7 @@ int net_ipv4_send_inplace(netif_t *net, uint8_t *frame, size_t size, int id,
 
     /* Build the IPv4 header in place, directly in front of the segment. */
     hdr->version_ihl = 0x45;
-    hdr->tos = 0;
+    hdr->tos = tos;
     hdr->length = htons(size + sizeof(ip_hdr_t));
     hdr->packet_id = id;
     hdr->flags_frag_offs = 0;

--- a/kernel/net/net_ipv4.h
+++ b/kernel/net/net_ipv4.h
@@ -25,11 +25,17 @@ typedef struct {
     uint16_t length;
 } __packed ipv4_pseudo_hdr_t;
 
+/* Headroom for the in-place ethernet (14) + IP (20) headers written in front
+   of the segment. */
+#define NET_IPV4_FRAME_HDR_SIZE (sizeof(eth_hdr_t) + sizeof(ip_hdr_t))
+
 uint16_t __pure net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t start);
 int net_ipv4_send_packet(netif_t *net, ip_hdr_t *hdr, const uint8_t *data,
                          size_t size);
 int net_ipv4_send(netif_t *net, const uint8_t *data, size_t size, int id, int ttl,
                   int proto, uint32_t src, uint32_t dst);
+int net_ipv4_send_inplace(netif_t *net, uint8_t *frame, size_t size, int id,
+                          int ttl, int proto, uint32_t src, uint32_t dst);
 int net_ipv4_input(netif_t *src, const uint8_t *pkt, size_t pktsize,
                    const eth_hdr_t *eth);
 int net_ipv4_input_proto(netif_t *net, const ip_hdr_t *ip, const uint8_t *data);

--- a/kernel/net/net_ipv4.h
+++ b/kernel/net/net_ipv4.h
@@ -33,9 +33,9 @@ uint16_t __pure net_ipv4_checksum(const uint8_t *data, size_t bytes, uint16_t st
 int net_ipv4_send_packet(netif_t *net, ip_hdr_t *hdr, const uint8_t *data,
                          size_t size);
 int net_ipv4_send(netif_t *net, const uint8_t *data, size_t size, int id, int ttl,
-                  int proto, uint32_t src, uint32_t dst);
+                  int tos, int proto, uint32_t src, uint32_t dst);
 int net_ipv4_send_inplace(netif_t *net, uint8_t *frame, size_t size, int id,
-                          int ttl, int proto, uint32_t src, uint32_t dst);
+                          int ttl, int tos,int proto, uint32_t src, uint32_t dst);
 int net_ipv4_input(netif_t *src, const uint8_t *pkt, size_t pktsize,
                    const eth_hdr_t *eth);
 int net_ipv4_input_proto(netif_t *net, const ip_hdr_t *ip, const uint8_t *data);

--- a/kernel/net/net_ipv6.c
+++ b/kernel/net/net_ipv6.c
@@ -145,7 +145,7 @@ int net_ipv6_send_packet(netif_t *net, ipv6_hdr_t *hdr, const uint8_t *data,
 }
 
 int net_ipv6_send(netif_t *net, const uint8_t *data, size_t data_size,
-                  int hop_limit, int proto, const struct in6_addr *src,
+                  int hop_limit, int tos, int proto, const struct in6_addr *src,
                   const struct in6_addr *dst) {
     ipv6_hdr_t hdr;
 
@@ -172,7 +172,7 @@ int net_ipv6_send(netif_t *net, const uint8_t *data, size_t data_size,
        send function to do the rest. Note that only V4-mapped addresses are
        supported here (::ffff:x.y.z.w) */
     if(IN6_IS_ADDR_V4MAPPED(src) && IN6_IS_ADDR_V4MAPPED(dst)) {
-        return net_ipv4_send(net, data, data_size, -1, hop_limit, proto,
+        return net_ipv4_send(net, data, data_size, -1, hop_limit, tos, proto,
                              src->__s6_addr.__s6_addr32[3],
                              dst->__s6_addr.__s6_addr32[3]);
     }
@@ -181,8 +181,8 @@ int net_ipv6_send(netif_t *net, const uint8_t *data, size_t data_size,
         return -1;
     }
 
-    hdr.version_lclass = 0x60;
-    hdr.hclass_lflow = 0;
+    hdr.version_lclass = 0x60 | ((tos >> 4) & 0x0F);  /* version 6 + TC high nibble */
+    hdr.hclass_lflow = (tos & 0x0F) << 4;  /* TC low nibble (flow label = 0) */
     hdr.lclass = 0;
     hdr.length = ntohs(data_size);
     hdr.next_header = proto;

--- a/kernel/net/net_ipv6.h
+++ b/kernel/net/net_ipv6.h
@@ -38,7 +38,7 @@ typedef struct ipv6_pseudo_hdr_s {
 int net_ipv6_send_packet(netif_t *net, ipv6_hdr_t *hdr, const uint8_t *data,
                          size_t data_size);
 int net_ipv6_send(netif_t *net, const uint8_t *data, size_t data_size,
-                  int hop_limit, int proto, const struct in6_addr *src,
+                  int hop_limit, int tos, int proto, const struct in6_addr *src,
                   const struct in6_addr *dst);
 int net_ipv6_input(netif_t *src, const uint8_t *pkt, size_t pktsize,
                    const eth_hdr_t *eth);

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -154,6 +154,7 @@ struct tcp_sock {
     int state;
     mutex_t mutex;
     int hop_limit;
+    int tos;
     uint32_t rcvbuf_sz;
     uint32_t sndbuf_sz;
 
@@ -1580,6 +1581,9 @@ static int net_tcp_getsockopt(net_socket_t *hnd, int level, int option_name,
                 case IP_TTL:
                     tmp = sock->hop_limit;
                     goto copy_int;
+                case IP_TOS:
+                    tmp = sock->tos;
+                    goto copy_int;
             }
 
             break;
@@ -1718,6 +1722,18 @@ static int net_tcp_setsockopt(net_socket_t *hnd, int level, int option_name,
                         sock->hop_limit = TCP_DEFAULT_HOPS;
                     else
                         sock->hop_limit = tmp;
+
+                    goto ret_success;
+                case IP_TOS:
+                    if(option_len != sizeof(int))
+                        goto ret_inval;
+
+                    tmp = *((int *)option_value);
+
+                    if(tmp < 0 || tmp > 255)
+                        goto ret_inval;
+                    else
+                        sock->tos = tmp;
 
                     goto ret_success;
             }
@@ -2074,7 +2090,7 @@ static void tcp_rst(netif_t *net, const struct in6_addr *src,
     c = net_ipv6_checksum_pseudo(src, dst, sizeof(tcp_hdr_t), IPPROTO_TCP);
     pkt.checksum = net_ipv4_checksum((const uint8_t *)&pkt, sizeof(tcp_hdr_t), c);
 
-    net_ipv6_send(net, (const uint8_t *)&pkt, sizeof(tcp_hdr_t), 0, IPPROTO_TCP,
+    net_ipv6_send(net, (const uint8_t *)&pkt, sizeof(tcp_hdr_t), 0, 0, IPPROTO_TCP,
                   src, dst);
 }
 
@@ -2115,7 +2131,7 @@ static void tcp_bpkt_rst(netif_t *net, const struct in6_addr *src,
     pkt.checksum = net_ipv4_checksum((const uint8_t *)&pkt, sizeof(tcp_hdr_t),
                                      cs);
 
-    net_ipv6_send(net, (const uint8_t *)&pkt, sizeof(tcp_hdr_t), 0, IPPROTO_TCP,
+    net_ipv6_send(net, (const uint8_t *)&pkt, sizeof(tcp_hdr_t), 0, 0, IPPROTO_TCP,
                   dst, src);
 }
 
@@ -2154,7 +2170,7 @@ static int tcp_send_syn(struct tcp_sock *sock, int ack) {
     hdr->checksum = net_ipv4_checksum(rawpkt, sizeof(tcp_hdr_t) + 4, cs);
 
     return net_ipv6_send(sock->data.net, rawpkt, sizeof(tcp_hdr_t) + 4,
-                         sock->hop_limit, IPPROTO_TCP,
+                         sock->hop_limit, sock->tos, IPPROTO_TCP,
                          &sock->local_addr.sin6_addr,
                          &sock->remote_addr.sin6_addr);
 }
@@ -2181,7 +2197,7 @@ static void tcp_send_fin_ack(struct tcp_sock *sock) {
     hdr->checksum = net_ipv4_checksum(rawpkt, sizeof(tcp_hdr_t), cs);
 
     net_ipv6_send(sock->data.net, rawpkt, sizeof(tcp_hdr_t), sock->hop_limit,
-                  IPPROTO_TCP, &sock->local_addr.sin6_addr,
+                  sock->tos, IPPROTO_TCP, &sock->local_addr.sin6_addr,
                   &sock->remote_addr.sin6_addr);
 }
 
@@ -2206,7 +2222,7 @@ static void tcp_send_ack(struct tcp_sock *sock) {
     hdr.checksum = net_ipv4_checksum((const uint8_t *)&hdr, sizeof(tcp_hdr_t), c);
 
     net_ipv6_send(sock->data.net, (const uint8_t *)&hdr, sizeof(tcp_hdr_t),
-                  sock->hop_limit, IPPROTO_TCP, &sock->local_addr.sin6_addr,
+                  sock->hop_limit, sock->tos, IPPROTO_TCP, &sock->local_addr.sin6_addr,
                   &sock->remote_addr.sin6_addr);
 }
 
@@ -2296,9 +2312,9 @@ static void tcp_send_data(struct tcp_sock *sock, int resend) {
 
         if(v4)
             net_ipv4_send_inplace(sock->data.net, frame, sz, -1,
-                                  sock->hop_limit, IPPROTO_TCP, v4src, v4dst);
+                                  sock->hop_limit, sock->tos, IPPROTO_TCP, v4src, v4dst);
         else
-            net_ipv6_send(sock->data.net, seg, sz, sock->hop_limit, IPPROTO_TCP,
+            net_ipv6_send(sock->data.net, seg, sz, sock->hop_limit, sock->tos, IPPROTO_TCP,
                           &sock->local_addr.sin6_addr,
                           &sock->remote_addr.sin6_addr);
     }

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -2212,12 +2212,15 @@ static void tcp_send_ack(struct tcp_sock *sock) {
 
 static void tcp_send_data(struct tcp_sock *sock, int resend) {
     uint32_t wnd = sock->data.snd.wnd, snd;
-    int sz = sizeof(tcp_hdr_t);
-    uint8_t rawpkt[1500];
-    tcp_hdr_t *hdr = (tcp_hdr_t *)rawpkt;
+    int sz;
+    alignas(32) uint8_t frame[NET_IPV4_FRAME_HDR_SIZE + 1500];
+    uint8_t *seg = frame + NET_IPV4_FRAME_HDR_SIZE;
+    tcp_hdr_t *hdr = (tcp_hdr_t *)seg;
     uint16_t cs;
     uint8_t *sb, *buf;
     uint32_t seq, unacked, head;
+    int v4;
+    uint32_t v4src = 0, v4dst = 0;
 
     if(!resend) {
         seq = sock->data.snd.nxt;
@@ -2234,6 +2237,15 @@ static void tcp_send_data(struct tcp_sock *sock, int resend) {
     if(!wnd)
         wnd = 1;
 
+    /* Use the zero-extra-copy IPv4 path when both ends are V4-mapped. */
+    v4 = IN6_IS_ADDR_V4MAPPED(&sock->local_addr.sin6_addr) &&
+         IN6_IS_ADDR_V4MAPPED(&sock->remote_addr.sin6_addr);
+
+    if(v4) {
+        v4src = sock->local_addr.sin6_addr.__s6_addr.__s6_addr32[3];
+        v4dst = sock->remote_addr.sin6_addr.__s6_addr.__s6_addr32[3];
+    }
+
     /* Fill in the base packet */
     hdr->src_port = sock->local_addr.sin6_port;
     hdr->dst_port = sock->remote_addr.sin6_port;
@@ -2246,7 +2258,7 @@ static void tcp_send_data(struct tcp_sock *sock, int resend) {
     while(sock->data.sndbuf_cur_sz - unacked && wnd) {
         hdr->seq = htonl(seq);
         hdr->checksum = 0;
-        buf = rawpkt + sizeof(tcp_hdr_t);
+        buf = seg + sizeof(tcp_hdr_t);
         sb = sock->data.sndbuf + head;
         snd = wnd;
 
@@ -2256,7 +2268,7 @@ static void tcp_send_data(struct tcp_sock *sock, int resend) {
         if(snd > sock->data.sndbuf_cur_sz - unacked)
             snd = sock->data.sndbuf_cur_sz - unacked;
 
-        /* Copy in the data */
+        /* Copy in the data(unavoidable copy) */
         if(head + snd <= sock->sndbuf_sz) {
             memcpy(buf, sb, snd);
             head += snd;
@@ -2280,11 +2292,15 @@ static void tcp_send_data(struct tcp_sock *sock, int resend) {
         cs = net_ipv6_checksum_pseudo(&sock->local_addr.sin6_addr,
                                       &sock->remote_addr.sin6_addr, sz,
                                       IPPROTO_TCP);
-        hdr->checksum = net_ipv4_checksum(rawpkt, sz, cs);
+        hdr->checksum = net_ipv4_checksum(seg, sz, cs);
 
-        net_ipv6_send(sock->data.net, rawpkt, sz, sock->hop_limit, IPPROTO_TCP,
-                      &sock->local_addr.sin6_addr,
-                      &sock->remote_addr.sin6_addr);
+        if(v4)
+            net_ipv4_send_inplace(sock->data.net, frame, sz, -1,
+                                  sock->hop_limit, IPPROTO_TCP, v4src, v4dst);
+        else
+            net_ipv6_send(sock->data.net, seg, sz, sock->hop_limit, IPPROTO_TCP,
+                          &sock->local_addr.sin6_addr,
+                          &sock->remote_addr.sin6_addr);
     }
 
     sock->data.timer = timer_ms_gettime64();

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -153,6 +153,7 @@ struct tcp_sock {
     file_t sock;
     int state;
     mutex_t mutex;
+    short poll_pending; /* Accumulated POLL* events while mutex is held */
     int hop_limit;
     int tos;
     uint32_t rcvbuf_sz;
@@ -2467,7 +2468,7 @@ static int listen_pkt(netif_t *src, const struct in6_addr *srca,
         s->listen.tail = 0;
 
     /* Signal the condvar, in case anyone's waiting */
-    __poll_event_trigger(s->sock, POLLRDNORM);
+    s->poll_pending |= POLLRDNORM;
     cond_signal(&s->listen.cv);
 
     /* We're done, return success. */
@@ -2503,7 +2504,7 @@ static int synsent_pkt(netif_t *src, const struct in6_addr *srca,
     if(flags & TCP_FLAG_RST) {
         if(gotack) {
             s->state = TCP_STATE_CLOSED | TCP_STATE_RESET;
-            __poll_event_trigger(s->sock, POLLHUP);
+            s->poll_pending |= POLLHUP;
             cond_signal(&s->data.recv_cv);
             cond_signal(&s->data.send_cv);
             return 0;
@@ -2560,14 +2561,14 @@ static int synsent_pkt(netif_t *src, const struct in6_addr *srca,
             if(SEQ_GT(ack, s->data.snd.iss)) {
                 s->state = TCP_STATE_ESTABLISHED;
                 tcp_send_ack(s);
-                __poll_event_trigger(s->sock, POLLWRNORM | POLLWRBAND);
+                s->poll_pending |= (POLLWRNORM | POLLWRBAND);
                 cond_signal(&s->data.send_cv);
             }
         }
         else {
             s->state = TCP_STATE_SYN_RECEIVED;
             tcp_send_syn(s, 1);
-            __poll_event_trigger(s->sock, POLLWRNORM | POLLWRBAND);
+            s->poll_pending |= (POLLWRNORM | POLLWRBAND);
             cond_signal(&s->data.send_cv);
         }
     }
@@ -2713,7 +2714,7 @@ static int process_pkt(netif_t *src, const struct in6_addr *srca,
         }
         else {
             s->state = TCP_STATE_RESET | TCP_STATE_CLOSED;
-            __poll_event_trigger(s->sock, POLLHUP);
+            s->poll_pending |= POLLHUP;
             cond_signal(&s->data.recv_cv);
             cond_signal(&s->data.send_cv);
             return 0;
@@ -2752,7 +2753,7 @@ static int process_pkt(netif_t *src, const struct in6_addr *srca,
         s->data.sndbuf_acked += (int32_t)(ack - s->data.snd.una - acksyn);
         s->data.sndbuf_cur_sz -= (int32_t)(ack - s->data.snd.una - acksyn);
         s->data.snd.una = ack;
-        __poll_event_trigger(s->sock, POLLWRNORM | POLLWRBAND);
+        s->poll_pending |= (POLLWRNORM | POLLWRBAND);
         cond_signal(&s->data.send_cv);
 
         if(s->data.sndbuf_acked >= s->sndbuf_sz)
@@ -2866,7 +2867,7 @@ static int process_pkt(netif_t *src, const struct in6_addr *srca,
                     }
                 }
 
-                __poll_event_trigger(s->sock, POLLRDNORM);
+                s->poll_pending |= POLLRDNORM;
                 cond_signal(&s->data.recv_cv);
 
                 /* Delayed ACK: ACK every 2nd in-order segment to
@@ -2911,7 +2912,7 @@ static int process_pkt(netif_t *src, const struct in6_addr *srca,
         /* ACK the FIN */
         ++s->data.rcv.nxt;
         tcp_send_ack(s);
-        __poll_event_trigger(s->sock, POLLRDNORM);
+        s->poll_pending |= POLLRDNORM;
         cond_signal(&s->data.recv_cv);
 
         /* Do the various processing that needs to be done based on our state */
@@ -3032,7 +3033,16 @@ static int net_tcp_input(netif_t *src, int domain, const void *hdr,
                 break;
         }
 
+        short poll_ev = s->poll_pending;
+        file_t poll_fd = s->sock;
+        s->poll_pending = 0;
+
         mutex_unlock(&s->mutex);
+
+        /* Fire poll wakeups after releasing sock->mutex to avoid the
+           poll-mutex / sock->mutex ABBA deadlock. */
+        if(poll_ev)
+            __poll_event_trigger(poll_fd, poll_ev);
     }
 
     rwsem_read_unlock(&tcp_sem);

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -1263,8 +1263,27 @@ static ssize_t net_tcp_recvfrom(net_socket_t *hnd, void *buffer, size_t length,
                request... */
             while(sock->data.rcvbuf_cur_sz < length) {
                 cond_wait(&sock->data.recv_cv, &sock->mutex);
+
+                /* Connection closed or reset while waiting; stop blocking forever. */
+                if(sock->state == TCP_STATE_CLOSED ||
+                   sock->state == TCP_STATE_CLOSE_WAIT ||
+                   sock->state == TCP_STATE_CLOSING ||
+                   sock->state == TCP_STATE_LAST_ACK ||
+                   sock->state == TCP_STATE_TIME_WAIT ||
+                   (sock->state & TCP_STATE_RESET))
+                    break;
             }
         }
+    }
+
+    /* Nothing buffered: report reset as error, otherwise signal end-of-stream. */
+    if(sock->data.rcvbuf_cur_sz == 0) {
+        if(sock->state & TCP_STATE_RESET) {
+            errno = ECONNRESET;
+            size = -1;
+        }
+
+        goto out;
     }
 
     /* Figure out how much we're going to give the user. */

--- a/kernel/net/net_tcp.c
+++ b/kernel/net/net_tcp.c
@@ -1688,11 +1688,13 @@ static int net_tcp_setsockopt(net_socket_t *hnd, int level, int option_name,
                         goto ret_inval;
 
                     tmp = *(uint32_t *)option_value;
-                    /* Send buffer size must be in the range 2048 - 65535 */
+                    /* Local staging send buffer size for outbound data
+                       (unsent + unacked). Not a wire value, so unlike SO_RCVBUF
+                       it isn't bound by the 16-bit window field. */
                     if(tmp < 2048)
                         tmp = 2048;
-                    else if(tmp > 65535)
-                        tmp = 65535;
+                    else if(tmp > 1024 * 1024)
+                        tmp = 1024 * 1024;
 
                     new_ptr = realloc(sock->data.sndbuf, tmp);
                     if(!new_ptr) {

--- a/kernel/net/net_udp.c
+++ b/kernel/net/net_udp.c
@@ -61,6 +61,7 @@ struct udp_sock {
     int domain;
     int proto;
     int hop_limit;
+    int tos;
     file_t sock;
 
     struct {
@@ -79,7 +80,7 @@ static net_udp_stats_t udp_stats = { 0 };
 
 static int net_udp_send_raw(netif_t *net, const struct sockaddr_in6 *src,
                             const struct sockaddr_in6 *dst, const uint8_t *data,
-                            size_t size, uint32_t flags, int hops,
+                            size_t size, uint32_t flags, int hops, int tos,
                             uint32_t iflags, int proto, uint16_t cscov);
 
 static int net_udp_accept(net_socket_t *hnd, struct sockaddr *addr,
@@ -411,7 +412,7 @@ static ssize_t net_udp_sendto(net_socket_t *hnd, const void *message,
     struct sockaddr_in *realaddr;
     struct sockaddr_in6 realaddr6;
     uint32_t sflags, iflags;
-    int hops, proto;
+    int hops, proto, tos;
     uint16_t cscov;
     struct sockaddr_in6 local_addr;
 
@@ -506,11 +507,12 @@ static ssize_t net_udp_sendto(net_socket_t *hnd, const void *message,
     iflags = udpsock->int_flags;
     hops = udpsock->hop_limit;
     proto = udpsock->proto;
+    tos = udpsock->tos;
     cscov = udpsock->udp_lite.send_cscov;
     mutex_unlock(&udp_mutex);
 
     return net_udp_send_raw(NULL, &local_addr, &realaddr6,
-                            (const uint8_t *)message, length, sflags, hops,
+                            (const uint8_t *)message, length, sflags, hops, tos,
                             iflags, proto, cscov);
 err:
     mutex_unlock(&udp_mutex);
@@ -652,6 +654,9 @@ static int net_udp_getsockopt(net_socket_t *hnd, int level, int option_name,
                 case IP_TTL:
                     tmp = sock->hop_limit;
                     goto copy_int;
+                case IP_TOS:
+                    tmp = sock->tos;
+                    goto copy_int;
             }
 
             break;
@@ -772,6 +777,19 @@ static int net_udp_setsockopt(net_socket_t *hnd, int level, int option_name,
                         sock->hop_limit = UDP_DEFAULT_HOPS;
                     else
                         sock->hop_limit = tmp;
+
+                    goto ret_success;
+
+                case IP_TOS:
+                    if(option_len != sizeof(int))
+                        goto ret_inval;
+
+                    tmp = *((int *)option_value);
+
+                    if(tmp < 0 || tmp > 255)
+                        goto ret_inval;
+                    else
+                        sock->tos = tmp;
 
                     goto ret_success;
             }
@@ -1387,7 +1405,7 @@ static int net_udp_input(netif_t *src, int domain, const void *hdr,
 /* XXX */
 static int net_udp_send_raw(netif_t *net, const struct sockaddr_in6 *src,
                             const struct sockaddr_in6 *dst, const uint8_t *data,
-                            size_t size, uint32_t flags, int hops,
+                            size_t size, uint32_t flags, int hops, int tos,
                             uint32_t iflags, int proto, uint16_t cscov) {
     uint8_t buf[size + sizeof(udp_hdr_t)];
     udp_hdr_t *hdr = (udp_hdr_t *)buf;
@@ -1464,7 +1482,7 @@ static int net_udp_send_raw(netif_t *net, const struct sockaddr_in6 *src,
     }
 
     /* Pass everything off to the network layer to do the rest. */
-    err = net_ipv6_send(net, buf, size, hops, proto, &srcaddr,
+    err = net_ipv6_send(net, buf, size, hops, tos, proto, &srcaddr,
                         &dst->sin6_addr);
 
     if(err < 0) {

--- a/kernel/net/net_udp.c
+++ b/kernel/net/net_udp.c
@@ -1240,9 +1240,13 @@ static int net_udp_input4(netif_t *src, const ip_hdr_t *ip, const uint8_t *data,
         TAILQ_INSERT_TAIL(&sock->packets, pkt, pkt_queue);
 
         ++udp_stats.pkt_recv;
-        __poll_event_trigger(sock->sock, POLLRDNORM);
         genwait_wake_one(sock);
+
+        /* Fire poll wakeups after releasing udp_mutex to avoid the
+           poll-mutex / udp_mutex ABBA deadlock. */
+        file_t poll_fd = sock->sock;
         mutex_unlock(&udp_mutex);
+        __poll_event_trigger(poll_fd, POLLRDNORM);
 
         return 0;
     }
@@ -1376,9 +1380,13 @@ static int net_udp_input6(netif_t *src, const ipv6_hdr_t *ip, const uint8_t *dat
         TAILQ_INSERT_TAIL(&sock->packets, pkt, pkt_queue);
 
         ++udp_stats.pkt_recv;
-        __poll_event_trigger(sock->sock, POLLRDNORM);
         genwait_wake_one(sock);
+
+        /* Fire poll wakeups after releasing udp_mutex to avoid the
+           poll-mutex / udp_mutex ABBA deadlock. */
+        file_t poll_fd = sock->sock;
         mutex_unlock(&udp_mutex);
+        __poll_event_trigger(poll_fd, POLLRDNORM);
 
         return 0;
     }


### PR DESCRIPTION
This PR adds speedup enhancements and bug fixes to the KOS TCP/IP stack and the Broadband Adapter driver, plus a new `IP_TOS` socket option.

## Speedups:

- **IPv4 checksum**: Bring back @gyrovorbis deferred carry folding approach to the current algorithm. The IPv4 checksum is ~2.2× faster at typical sizes — 1.55× on a 20-byte IP header, 2.22× at the 1460-byte TCP MSS.

- **Zero-copy TCP/IPv4 send**: Build the IP/eth headers in place in front of the TCP segment (`net_ipv4_send_inplace`) instead of copying header+payload into a staging buffer. Header-less links (PPP), loopback, and fragmentation still take the copy path. This increased TX speed by 4%. Mentioned here (https://github.com/KallistiOS/KallistiOS/issues/116)

- **Raise the `SO_SNDBUF` cap 64 KB → 1 MB** (default unchanged): It's only a local staging buffer with no protocol limit (unlike the receive window, which stays clamped at 64 KB). The old cap starved TX because the buffer has to hold onto packets that have been sent but haven't been acked yet; a 512 KB buffer measured ~+20% download.

- **BBA TX via G2 DMA.**: `bba_rtx()`copied each frame into the adapter TX FIFO with PIO (`g2_write_block_32`); use the G2 DMA instead. Measured DC→PC download: 64 KB `SO_SNDBUF` 3.75 → 6.41 MB/s (+71%); 512 KB 3.75 → 6.62 MB/s (+76%).

## Bug fixes
- **MSG_WAITALL recv no longer blocks forever**: When the connection drops mid-receive it returns what it has instead of hanging. Mentioned here (https://github.com/KallistiOS/KallistiOS/issues/116)

- **Defer `poll()` wakeups until after the socket / UDP mutex is released** (`net_tcp`, `net_udp`): Waking waiters under the lock inverted the socket-vs-poll lock order (ABBA), hanging `poll()`. This is what caused hangs when trying to use libsmb2.

## New Option
- **IP_TOS socket option**: For DSCP/ToS marking (IPv4 ToS byte + IPv6 traffic class). It lets apps mark some of its internet traffic as “high priority” so that a network may handle it faster or with less delay.

## Testing
- HW-measured on real Dreamcast over the BBA and WIZnet W5500(SCIF).
- Validated against all network examples, Meese's network testsuite (5000 attempts), libsmb2, and FTP (liblftpd).
