### PR TITLE
Update gldc examples with new library.

### DIFF
--- a/examples/dreamcast/cpp/gltest/Makefile
+++ b/examples/dreamcast/cpp/gltest/Makefile
@@ -18,7 +18,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS)
-	kos-c++ -o $(TARGET) $(OBJS) -lGL -lkosutils
+	kos-c++ -o $(TARGET) $(OBJS) -lGL -lGLU -lkosutils
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/gldc/basic/gl/Makefile
+++ b/examples/dreamcast/gldc/basic/gl/Makefile
@@ -19,7 +19,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -lGL -lpcx -lkosutils
+	kos-cc -o $(TARGET) $(OBJS) -lGL -lGLU -lpcx -lkosutils
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/gldc/basic/vq/Makefile
+++ b/examples/dreamcast/gldc/basic/vq/Makefile
@@ -14,7 +14,7 @@ rm-elf:
 	-rm -f $(TARGET)
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL
+	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL -lGLU
 
 fruit.o: fruit.vq
 	$(KOS_BASE)/utils/bin2o/bin2o fruit.vq fruit fruit.o

--- a/examples/dreamcast/gldc/nehe/nehe02/Makefile
+++ b/examples/dreamcast/gldc/nehe/nehe02/Makefile
@@ -18,7 +18,7 @@ rm-elf:
 	-rm -f $(TARGET)
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL
+	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL -lGLU
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/gldc/nehe/nehe05/Makefile
+++ b/examples/dreamcast/gldc/nehe/nehe05/Makefile
@@ -18,7 +18,7 @@ rm-elf:
 	-rm -f $(TARGET)
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL
+	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL -lGLU
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/gldc/nehe/nehe06/Makefile
+++ b/examples/dreamcast/gldc/nehe/nehe06/Makefile
@@ -19,7 +19,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL
+	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL -lGLU
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/gldc/nehe/nehe08/Makefile
+++ b/examples/dreamcast/gldc/nehe/nehe08/Makefile
@@ -19,7 +19,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL
+	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL -lGLU
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/gldc/nehe/nehe09/Makefile
+++ b/examples/dreamcast/gldc/nehe/nehe09/Makefile
@@ -19,7 +19,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL
+	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL -lGLU
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/gldc/nehe/nehe16/Makefile
+++ b/examples/dreamcast/gldc/nehe/nehe16/Makefile
@@ -19,7 +19,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL
+	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL -lGLU
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/examples/dreamcast/gldc/nehe/nehe26/Makefile
+++ b/examples/dreamcast/gldc/nehe/nehe26/Makefile
@@ -20,7 +20,7 @@ rm-elf:
 	-rm -f $(TARGET) romdisk.*
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL
+	kos-cc -o $(TARGET) $(OBJS) -L$(KOS_BASE)/lib -lGL -lGLU
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)


### PR DESCRIPTION
https://gitlab.com/simulant/GLdc/-/merge_requests/174 split out libGLU into its own library. In order to use those functions now it's required to link in that library as well.