### PR TITLE
kos-chain: Force C++14 to build GCC

### DIFF
--- a/utils/kos-chain/scripts/gcc-pass1.mk
+++ b/utils/kos-chain/scripts/gcc-pass1.mk
@@ -23,9 +23,8 @@ $(build_gcc_pass1): logdir
 	      $(gcc_pass1_configure_args) \
 	      $(macos_gcc_configure_args) \
 	      MAKEINFO=missing \
-	      CC="$(CC)" \
-	      CXX="$(CXX)" \
-	      CFLAGS="$(CFLAGS) -std=gnu17" \
+	      CC="$(CC) -std=gnu17" \
+	      CXX="$(CXX) -std=gnu++14" \
 	      $(static_flag) \
 	      $(to_log)
 	$(MAKE) $(jobs_arg) -C $(build) DESTDIR=$(DESTDIR) $(to_log)

--- a/utils/kos-chain/scripts/gcc-pass2.mk
+++ b/utils/kos-chain/scripts/gcc-pass2.mk
@@ -23,9 +23,8 @@ $(build_gcc_pass2): logdir
           $(gcc_pass2_configure_args) \
           $(macos_gcc_configure_args) \
           MAKEINFO=missing \
-          CC="$(CC)" \
-          CXX="$(CXX)" \
-          CFLAGS="$(CFLAGS) -std=gnu17" \
+          CC="$(CC) -std=gnu17" \
+          CXX="$(CXX) -std=gnu++14" \
           $(static_flag) \
           $(to_log)
 	$(MAKE) $(jobs_arg) -C $(build) DESTDIR=$(DESTDIR) $(to_log)


### PR DESCRIPTION
Newer host compiler default to C++23, which cannot compile some versions of GCC properly. Force C++14 to fix that.

Note that the -std= argument is passed to the CC/CXX variables. This means that CFLAGS/CXXFLAGS are not overriden, which caused problems when building libcody.

Edit: Above comment direct from commit from pceruei. For extra context the issue was reported by a user on Arch which has a default host gcc of 16. [Starting with version 16 C++20](https://gcc.gnu.org/projects/cxx-status.html#cxx20) became the default language standard, which breaks building target gcc<16. The issue manifested with problems building libcody. I attempted using the same pattern previously in place for CFLAGS passing CXXFLAGS with the std but doing so caused some individual libraries to break either in their configure or by preventing the application of their own C(XX)FLAGS.

By adding the flags as part of the call to CC/CXX it not only prevents intended flags from being overridden, but effectively *only* changes the default language standard because other manual definitions of language standard would always come after this one. The previous CFLAGS version, even when not overriding cflags would prevent individual libraries from having set their own language standard as it would come last in the list (and should have been `CFLAGS += -std $CFLAGS` instead)