### PR TITLE
Scoped asic disable, vblank cleanup

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -1093,7 +1093,7 @@ int iso_reset(void) {
    foreground, so instead we'll just set a "dead" flag and next
    time someone calls in it'll get reset. */
 static int iso_last_status;
-static int iso_vblank_hnd;
+static vblhnd_t *iso_vblank_hnd;
 static void iso_vblank(uint32_t evt, void *data) {
     int status, disc_type;
 

--- a/kernel/arch/dreamcast/hardware/asic.c
+++ b/kernel/arch/dreamcast/hardware/asic.c
@@ -93,6 +93,7 @@
 
  */
 
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -103,10 +104,6 @@
 #include <kos/irq.h>
 #include <kos/regfield.h>
 #include <kos/worker_thread.h>
-
-/* XXX These based on g1ata.c and pvr.h and should be replaced by a standardized method */
-#define IN32(addr)         (* ( (volatile uint32_t *)(addr) ) )
-#define OUT32(addr, data)  IN32(addr) = (data)
 
 /* The set of asic regs are spaced by 0x10 with 0x4 between each sub reg */
 #define ASIC_EVT_REG_ADDR(irq, sub) (ASIC_IRQD_A + ((irq) * 0x10) + ((sub) * 0x4))
@@ -157,8 +154,8 @@ static void handler_irq9(irq_t source, irq_context_t *context, void *data) {
     /* Go through each event register and look for pending events */
     for(reg = 0; reg < ASIC_EVT_REGS; reg++) {
         /* Read the event mask and clear pending */
-        uint32_t mask = IN32(ASIC_ACK_A + (reg * 0x4));
-        OUT32(ASIC_ACK_A + (reg * 0x4), mask);
+        uint32_t addr = ASIC_ACK_A + (reg * 0x4);
+        uint32_t mask = atomic_fetch_add((atomic_uint *)addr, 0);
 
         /* Short circuit going through the table if none on this reg */
         if(mask == 0) continue;
@@ -179,7 +176,7 @@ void asic_evt_disable_all(void) {
 
     for(irq = 0; irq < ASIC_IRQ_MAX; irq++) {
         for(sub = 0; sub < ASIC_EVT_REGS; sub++) {
-            OUT32(ASIC_EVT_REG_ADDR(irq, sub), 0);
+            atomic_store((atomic_uint *)ASIC_EVT_REG_ADDR(irq, sub), 0);
         }
     }
 }
@@ -194,8 +191,7 @@ void asic_evt_disable(uint16_t code, uint8_t irqlevel) {
     evt = code & 0xff;
 
     uint32_t addr = ASIC_EVT_REG_ADDR(irqlevel, evtreg);
-    uint32_t val = IN32(addr);
-    OUT32(addr, val & ~BIT(evt));
+    atomic_fetch_and((atomic_uint *)addr, ~BIT(evt));
 }
 
 /* Enable a particular G2 event */
@@ -208,17 +204,16 @@ void asic_evt_enable(uint16_t code, uint8_t irqlevel) {
     evt = code & 0xff;
 
     uint32_t addr = ASIC_EVT_REG_ADDR(irqlevel, evtreg);
-    uint32_t val = IN32(addr);
-    OUT32(addr, val | BIT(evt));
+    atomic_fetch_or((atomic_uint *)addr, BIT(evt));
 }
 
 /* Initialize events */
 static void asic_evt_init(void) {
     /* Clear any pending interrupts and disable all events */
     asic_evt_disable_all();
-    OUT32(ASIC_ACK_A, 0xffffffff);
-    OUT32(ASIC_ACK_B, 0xffffffff);
-    OUT32(ASIC_ACK_C, 0xffffffff);
+    atomic_store((atomic_uint *)ASIC_ACK_A, 0xffffffff);
+    atomic_store((atomic_uint *)ASIC_ACK_B, 0xffffffff);
+    atomic_store((atomic_uint *)ASIC_ACK_C, 0xffffffff);
 
     /* Clear out the event table */
     memset(asic_evt_handlers, 0, sizeof(asic_evt_handlers));

--- a/kernel/arch/dreamcast/hardware/cdrom.c
+++ b/kernel/arch/dreamcast/hardware/cdrom.c
@@ -66,7 +66,7 @@ static bool dma_blocking = false;
 static bool dma_auto_unlock = false;
 static semaphore_t dma_done = SEM_INITIALIZER(0);
 static asic_evt_handler_entry_t old_dma_irq = {NULL, NULL};
-static int vblank_hnd = -1;
+static vblhnd_t *vblank_hnd;
 
 /* Streaming */
 static bool stream_enabled = false;

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_internal.h
@@ -18,6 +18,7 @@
 
 #include <stdbool.h>
 #include <kos/sem.h>
+#include <dc/vblank.h>
 
 /**** State stuff ***************************************************/
 
@@ -200,7 +201,7 @@ typedef struct {
     size_t   vtx_buf_used_max;           // Maximum used vertex buffer size
 
     // Handle for the vblank interrupt
-    int     vbl_handle;
+    vblhnd_t    *vbl_handle;
 
     // Non-zero if FSAA was enabled at init time.
     int     fsaa;

--- a/kernel/arch/dreamcast/hardware/vblank.c
+++ b/kernel/arch/dreamcast/hardware/vblank.c
@@ -21,18 +21,16 @@
 /* Our list of handlers */
 struct vblhnd {
     TAILQ_ENTRY(vblhnd) listent;
-    int         id;
     asic_evt_handler    handler;
     void *data;
 };
 static TAILQ_HEAD(vhlist, vblhnd) vblhnds;
-static int vblid_high;
 
 static mutex_t vbl_tailq_mutex = MUTEX_INITIALIZER;
 
 /* Our internal IRQ handler */
 static void vblank_handler(uint32_t src, void *data) {
-    struct vblhnd *t;
+    vblhnd_t *t;
 
     (void)data;
 
@@ -41,22 +39,18 @@ static void vblank_handler(uint32_t src, void *data) {
     }
 }
 
-int vblank_handler_add(asic_evt_handler hnd, void *data) {
-    struct vblhnd *vh = malloc(sizeof(struct vblhnd));
+vblhnd_t *vblank_handler_add(asic_evt_handler hnd, void *data) {
+    vblhnd_t *vh = malloc(sizeof(vblhnd_t));
 
     if(!vh) {
         errno = ENOMEM;
-        return -1;
+        return NULL;
     }
 
     /* Ensure thread safety for tailq access */
     mutex_lock_scoped(&vbl_tailq_mutex);
     /* Disable events until we're done manipulating the tailq */
     asic_evt_disable_scoped(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);
-
-    /* Find a new ID */
-    vh->id = vblid_high;
-    vblid_high++;
 
     /* Finish filling the struct */
     vh->handler = hnd;
@@ -65,33 +59,23 @@ int vblank_handler_add(asic_evt_handler hnd, void *data) {
     /* Add it to the list */
     TAILQ_INSERT_TAIL(&vblhnds, vh, listent);
 
-    return vh->id;
+    return vh;
 }
 
-int vblank_handler_remove(int handle) {
-    struct vblhnd *t;
-
+void vblank_handler_remove(vblhnd_t *handle) {
     /* Ensure thread safety for tailq access */
     mutex_lock_scoped(&vbl_tailq_mutex);
     /* Disable events until we're done manipulating the tailq */
     asic_evt_disable_scoped(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);
 
-    /* Look for it */
-    TAILQ_FOREACH(t, &vblhnds, listent) {
-        if(t->id == handle) {
-            TAILQ_REMOVE(&vblhnds, t, listent);
-            free(t);
-            return 0;
-        }
-    }
-    return -1;
+    TAILQ_REMOVE(&vblhnds, handle, listent);
+    free(handle);
 }
 
 int vblank_init(void) {
     /* Setup our data structures */
     TAILQ_INIT(&vblhnds);
     mutex_init(&vbl_tailq_mutex, MUTEX_TYPE_NORMAL);
-    vblid_high = 1;
 
     /* Hook and enable the interrupt */
     asic_evt_set_handler(ASIC_EVT_PVR_VBLANK_BEGIN, vblank_handler, NULL);
@@ -101,7 +85,7 @@ int vblank_init(void) {
 }
 
 int vblank_shutdown(void) {
-    struct vblhnd * c, * n;
+    vblhnd_t *c, *n;
 
     /* Disable and unhook the interrupt */
     asic_evt_disable(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);

--- a/kernel/arch/dreamcast/hardware/vblank.c
+++ b/kernel/arch/dreamcast/hardware/vblank.c
@@ -94,12 +94,9 @@ int vblank_shutdown(void) {
     mutex_lock(&vbl_tailq_mutex);
 
     /* Free any allocated handlers */
-    c = TAILQ_FIRST(&vblhnds);
-
-    while(c != NULL) {
-        n = TAILQ_NEXT(c, listent);
+    TAILQ_FOREACH_SAFE(c, &vblhnds, listent, n) {
+        TAILQ_REMOVE(&vblhnds, c, listent);
         free(c);
-        c = n;
     }
 
     mutex_unlock(&vbl_tailq_mutex);
@@ -109,5 +106,4 @@ int vblank_shutdown(void) {
 
     return 0;
 }
-
 

--- a/kernel/arch/dreamcast/hardware/vblank.c
+++ b/kernel/arch/dreamcast/hardware/vblank.c
@@ -6,10 +6,10 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <errno.h>
 #include <sys/queue.h>
 
 #include <kos/mutex.h>
+#include <dc/asic.h>
 #include <dc/vblank.h>
 
 /*
@@ -22,7 +22,7 @@
 struct vblhnd {
     TAILQ_ENTRY(vblhnd) listent;
     asic_evt_handler    handler;
-    void *data;
+    void                *data;
 };
 static TAILQ_HEAD(vhlist, vblhnd) vblhnds;
 
@@ -42,10 +42,7 @@ static void vblank_handler(uint32_t src, void *data) {
 vblhnd_t *vblank_handler_add(asic_evt_handler hnd, void *data) {
     vblhnd_t *vh = malloc(sizeof(vblhnd_t));
 
-    if(!vh) {
-        errno = ENOMEM;
-        return NULL;
-    }
+    if(!vh) return NULL;
 
     /* Ensure thread safety for tailq access */
     mutex_lock_scoped(&vbl_tailq_mutex);
@@ -106,4 +103,3 @@ int vblank_shutdown(void) {
 
     return 0;
 }
-

--- a/kernel/arch/dreamcast/hardware/vblank.c
+++ b/kernel/arch/dreamcast/hardware/vblank.c
@@ -9,7 +9,7 @@
 #include <errno.h>
 #include <sys/queue.h>
 
-#include <kos/irq.h>
+#include <kos/mutex.h>
 #include <dc/vblank.h>
 
 /*
@@ -28,9 +28,11 @@ struct vblhnd {
 static TAILQ_HEAD(vhlist, vblhnd) vblhnds;
 static int vblid_high;
 
+static mutex_t vbl_tailq_mutex = MUTEX_INITIALIZER;
+
 /* Our internal IRQ handler */
 static void vblank_handler(uint32_t src, void *data) {
-    struct vblhnd * t;
+    struct vblhnd *t;
 
     (void)data;
 
@@ -40,18 +42,17 @@ static void vblank_handler(uint32_t src, void *data) {
 }
 
 int vblank_handler_add(asic_evt_handler hnd, void *data) {
-    struct vblhnd * vh;
-    int old;
-
-    vh = malloc(sizeof(struct vblhnd));
+    struct vblhnd *vh = malloc(sizeof(struct vblhnd));
 
     if(!vh) {
         errno = ENOMEM;
         return -1;
     }
 
-    /* Disable ints just in case */
-    old = irq_disable();
+    /* Ensure thread safety for tailq access */
+    mutex_lock_scoped(&vbl_tailq_mutex);
+    /* Disable events until we're done manipulating the tailq */
+    asic_evt_disable_scoped(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);
 
     /* Find a new ID */
     vh->id = vblid_high;
@@ -64,39 +65,32 @@ int vblank_handler_add(asic_evt_handler hnd, void *data) {
     /* Add it to the list */
     TAILQ_INSERT_TAIL(&vblhnds, vh, listent);
 
-    /* Restore ints */
-    irq_restore(old);
-
     return vh->id;
 }
 
 int vblank_handler_remove(int handle) {
-    struct vblhnd * t;
-    int old, rv;
+    struct vblhnd *t;
 
-    /* Disable ints just in case */
-    old = irq_disable();
+    /* Ensure thread safety for tailq access */
+    mutex_lock_scoped(&vbl_tailq_mutex);
+    /* Disable events until we're done manipulating the tailq */
+    asic_evt_disable_scoped(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);
 
     /* Look for it */
-    rv = -1;
     TAILQ_FOREACH(t, &vblhnds, listent) {
         if(t->id == handle) {
             TAILQ_REMOVE(&vblhnds, t, listent);
             free(t);
-            rv = 0;
-            break;
+            return 0;
         }
     }
-
-    /* Restore ints */
-    irq_restore(old);
-
-    return rv;
+    return -1;
 }
 
 int vblank_init(void) {
     /* Setup our data structures */
     TAILQ_INIT(&vblhnds);
+    mutex_init(&vbl_tailq_mutex, MUTEX_TYPE_NORMAL);
     vblid_high = 1;
 
     /* Hook and enable the interrupt */
@@ -113,6 +107,8 @@ int vblank_shutdown(void) {
     asic_evt_disable(ASIC_EVT_PVR_VBLANK_BEGIN, ASIC_IRQ_DEFAULT);
     asic_evt_remove_handler(ASIC_EVT_PVR_VBLANK_BEGIN);
 
+    mutex_lock(&vbl_tailq_mutex);
+
     /* Free any allocated handlers */
     c = TAILQ_FIRST(&vblhnds);
 
@@ -121,6 +117,9 @@ int vblank_shutdown(void) {
         free(c);
         c = n;
     }
+
+    mutex_unlock(&vbl_tailq_mutex);
+    mutex_destroy(&vbl_tailq_mutex);
 
     TAILQ_INIT(&vblhnds);
 

--- a/kernel/arch/dreamcast/include/dc/asic.h
+++ b/kernel/arch/dreamcast/include/dc/asic.h
@@ -277,6 +277,31 @@ void asic_evt_disable(uint16_t code, uint8_t irqlevel);
  */
 void asic_evt_enable(uint16_t code, uint8_t irqlevel);
 
+/** \cond */
+static inline void __asic_evt_disable_scoped_cleanup(uint32_t *param) {
+    asic_evt_enable(*param & 0xffff, (*param >> 16) & 0xff);
+}
+
+#define ___asic_evt_disable_scoped(c, i, l) \
+    uint32_t __scoped_param_##l __attribute__((cleanup(__asic_evt_disable_scoped_cleanup))) = (c | (i << 16)); \
+    asic_evt_disable(c, i);
+
+#define __asic_evt_disable_scoped(c, i, l) ___asic_evt_disable_scoped(c, i, l)
+/** \endcond */
+
+/** \brief  Disable one ASIC event with scope management
+
+    This macro will disable one ASIC event, similarly to asic_evt_disable, with
+    the difference that the event will automatically be enabled once the
+    execution exits the functional block in which the macro was called.
+
+    \param  code            The ASIC event code to unhook (see
+                            \ref asic_events).
+    \param  irqlevel        The IRQ level it was hooked on (see
+                            \ref asic_irq_lv).
+*/
+#define asic_evt_disable_scoped(c, i) __asic_evt_disable_scoped((c), (i), __LINE__)
+
 /** \cond   Enable ASIC events */
 void asic_init(void);
 /* Shutdown ASIC events, disabling all hooks. */

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -54,6 +54,7 @@ __BEGIN_DECLS
 #include <stdint.h>
 #include <arch/types.h>
 #include <sys/queue.h>
+#include <dc/vblank.h>
 
 /** \defgroup maple Maple Bus
     \brief          Driver for the Dreamcast's Maple Peripheral Bus
@@ -457,7 +458,7 @@ typedef struct maple_state_str {
     uint8_t                     port0_mie;
 
     /** \brief  Our vblank handler handle */
-    int                         vbl_handle;
+    vblhnd_t                    *vbl_handle;
 
     /** \brief  The port to read for lightgun status, if any. */
     int                         gun_port;

--- a/kernel/arch/dreamcast/include/dc/maple.h
+++ b/kernel/arch/dreamcast/include/dc/maple.h
@@ -53,6 +53,7 @@ __BEGIN_DECLS
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/queue.h>
+#include <dc/vblank.h>
 
 /** \defgroup maple Maple Bus
     \brief          Driver for the Dreamcast's Maple Peripheral Bus
@@ -456,7 +457,7 @@ typedef struct maple_state_str {
     uint8_t                     port0_mie;
 
     /** \brief  Our vblank handler handle */
-    int                         vbl_handle;
+    vblhnd_t                    *vbl_handle;
 
     /** \brief  The port to read for lightgun status, if any. */
     int                         gun_port;

--- a/kernel/arch/dreamcast/include/dc/vblank.h
+++ b/kernel/arch/dreamcast/include/dc/vblank.h
@@ -31,6 +31,13 @@ __BEGIN_DECLS
     @{
 */
 
+struct vblhnd;
+
+/** \struct  vblhnd_t
+    \brief   Opaque structure describing one vblank handler.
+*/
+typedef struct vblhnd vblhnd_t;
+
 /** \brief  Add a vblank handler.
 
     This function adds a handler to the vblank handler list. The function will
@@ -39,22 +46,19 @@ __BEGIN_DECLS
 
     \param  hnd             The handler to add.
     \param  data            A user pointer that will be passed to the callback.
-    
-    \return                 The handle id on success, or <0 on failure.
+
+    \return                 The handle on success, or NULL on failure.
 */
-int vblank_handler_add(asic_evt_handler hnd, void *data);
+vblhnd_t *vblank_handler_add(asic_evt_handler hnd, void *data);
 
 /** \brief  Remove a vblank handler.
 
     This function removes the specified handler from the vblank handler list.
 
-    \param  handle          The handle id to remove (returned by
+    \param  handle          The handle to remove (returned by
                             vblank_handler_add() when the handler was added).
-    
-    \retval 0               On success.
-    \retval -1              On failure.
 */
-int vblank_handler_remove(int handle);
+void vblank_handler_remove(vblhnd_t *handle);
 
 /* \cond */
 /** Initialize the vblank handler. This must be called after the asic module

--- a/kernel/arch/dreamcast/include/dc/vblank.h
+++ b/kernel/arch/dreamcast/include/dc/vblank.h
@@ -31,6 +31,13 @@ __BEGIN_DECLS
     @{
 */
 
+struct vblhnd;
+
+/** \struct  vblhnd_t
+    \brief   Opaque structure describing one vblank handler.
+*/
+typedef struct vblhnd vblhnd_t;
+
 /** \brief  Add a vblank handler.
 
     This function adds a handler to the vblank handler list. The function will
@@ -40,21 +47,18 @@ __BEGIN_DECLS
     \param  hnd             The handler to add.
     \param  data            A user pointer that will be passed to the callback.
 
-    \return                 The handle id on success, or <0 on failure.
+    \return                 The handle on success, or NULL on failure.
 */
-int vblank_handler_add(asic_evt_handler hnd, void *data);
+vblhnd_t *vblank_handler_add(asic_evt_handler hnd, void *data);
 
 /** \brief  Remove a vblank handler.
 
     This function removes the specified handler from the vblank handler list.
 
-    \param  handle          The handle id to remove (returned by
+    \param  handle          The handle to remove (returned by
                             vblank_handler_add() when the handler was added).
-
-    \retval 0               On success.
-    \retval -1              On failure.
 */
-int vblank_handler_remove(int handle);
+void vblank_handler_remove(vblhnd_t *handle);
 
 /* \cond */
 /** Initialize the vblank handler. This must be called after the asic module


### PR DESCRIPTION
This was meant to be merely a cleanup of vblank, but while doing so I had the thought for a pattern that might be helpful elsewhere. Added a scoped asic disable to better encourage and support the temporary disabling of an event rather than the older more brute-force method of just disabling IRQs. In vlbank, it is used in order to prevent the vblank handler from triggering while a new entry is being added/removed from it. It should also be useful for bba/gdrom/pvr code where we are currently disabling irqs wholesale.

The changes for vblank are:
- Instead of disabling IRQs when adding/removing, take a lock and disable the vblank asic event until done.
- Instead of having numbered IDs for the handlers, pass out pointers to them.
- Whitespace cleanups
- Use FOREACH_SAFE macro rather than replicating it from scratch.
- Drop the return value for removing the handler as there's no longer a failure state without intentional tampering.

Additionally, as offered by @pcercuei , moving asic to use atomics in order to allow it to be safe to use without IRQs disabled.