### PR TITLE
modplug_test: Close up the file and free the buffer.

### DIFF
--- a/examples/dreamcast/cpp/modplug_test/example.cpp
+++ b/examples/dreamcast/cpp/modplug_test/example.cpp
@@ -44,6 +44,7 @@ int main(int argc, char **argv) {
 
     if(!mod_buffer) {
         printf("Not enough memory\n");
+        fs_close(hnd);
         return 0;
     }
 
@@ -51,11 +52,13 @@ int main(int argc, char **argv) {
 
     if(fs_read(hnd, mod_buffer, fs_total(hnd)) != fs_total(hnd)) {
         printf("Read error\n");
+        fs_close(hnd);
         free(mod_buffer);
         return 0;
     }
 
     printf("File read\n");
+    fs_close(hnd);
 
     soundfile = new CSoundFile;
 
@@ -79,9 +82,6 @@ int main(int argc, char **argv) {
     printf("Type: %li\n", soundfile->GetType());
     printf("Title: %s\n", soundfile->GetTitle());
 
-    /*fs_close(hnd);
-    free(mod_buffer);*/
-
     snd_stream_hnd_t shnd = snd_stream_alloc(mod_callback, SND_STREAM_BUFFER_MAX);
     snd_stream_start(shnd, 44100, 1);
 
@@ -101,6 +101,7 @@ int main(int argc, char **argv) {
         thd_sleep(10);
     }
 
+    free(mod_buffer);
     delete soundfile;
 
     snd_stream_destroy(shnd);


### PR DESCRIPTION
Do proper cleanup. Noticed these while testing with malloc stats on against KallistiOS/kos-ports#169