### PR TITLE
fs: Correct fs shutdown order and have prevent vfs from leaving orphaned FDs

### DIFF
--- a/addons/libkosext2fs/fs_ext2.c
+++ b/addons/libkosext2fs/fs_ext2.c
@@ -2073,7 +2073,8 @@ int fs_ext2_shutdown(void) {
     while(i) {
         next = LIST_NEXT(i, entry);
 
-        /* XXXX: We should probably do something with open files... */
+        /* Request open files be closed */
+        fs_vfs_shutdown(i->vfsh);
         nmmgr_handler_remove(&i->vfsh->nmmgr);
         ext2_fs_shutdown(i->fs);
         free(i->vfsh);

--- a/addons/libkosfat/fs_fat.c
+++ b/addons/libkosfat/fs_fat.c
@@ -1501,7 +1501,8 @@ int fs_fat_shutdown(void) {
     while(i) {
         next = LIST_NEXT(i, entry);
 
-        /* XXXX: We should probably do something with open files... */
+        /* Request open files be closed */
+        fs_vfs_shutdown(i->vfsh);
         nmmgr_handler_remove(&i->vfsh->nmmgr);
         fat_fs_shutdown(i->fs);
         free(i->vfsh);

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -663,10 +663,20 @@ file_t fs_open_handle(vfs_handler_t *vfs, void *hnd);
     code, as it is meant for use internally.
 
     \param  fd              The file descriptor to retrieve the handler for.
-    
+
     \return                 The VFS' handler structure.
 */
 vfs_handler_t *fs_get_handler(file_t fd);
+
+/** \brief   Close all FDs for a VFS Handler.
+
+    This function goes through all open fds and closes any that use the given
+    VFS Handler. This should be called during the shutdown of a vfs to ensure
+    the top-level fs is aware that the handler is gone.
+
+    \param  vfs             The VFS that is being shut down.
+*/
+void fs_vfs_shutdown(vfs_handler_t *vfs);
 
 /** \brief   Retrieve the internal handle for a file descriptor.
 

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -665,6 +665,16 @@ file_t fs_open_handle(vfs_handler_t *vfs, void *hnd);
 */
 vfs_handler_t *fs_get_handler(file_t fd);
 
+/** \brief   Close all FDs for a VFS Handler.
+
+    This function goes through all open fds and closes any that use the given
+    VFS Handler. This should be called during the shutdown of a vfs to ensure
+    the top-level fs is aware that the handler is gone.
+
+    \param  vfs             The VFS that is being shut down.
+*/
+void fs_vfs_shutdown(vfs_handler_t *vfs);
+
 /** \brief   Retrieve the internal handle for a file descriptor.
 
     This function retrieves the internal file handle data of the specified file

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -491,5 +491,6 @@ void fs_dcload_shutdown(void) {
         free(dcload_wrkmem);
     }
 
+    fs_vfs_shutdown(&vh);
     nmmgr_handler_remove(&vh.nmmgr);
 }

--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -485,5 +485,6 @@ void fs_dcload_shutdown(void) {
         free(dcload_wrkmem);
     }
 
+    fs_vfs_shutdown(&vh);
     nmmgr_handler_remove(&vh.nmmgr);
 }

--- a/kernel/arch/dreamcast/fs/fs_dclsocket.c
+++ b/kernel/arch/dreamcast/fs/fs_dclsocket.c
@@ -871,6 +871,9 @@ void fs_dclsocket_shutdown(void) {
     if(!strcmp(dbgio_dev_get(), "fs_dclsocket"))
         dbgio_disable();
 
+    /* Close out any still open files */
+    fs_vfs_shutdown(&vh);
+
     /* Send dc-tool an exit packet */
     memcpy(cmd.id, "DC00", 4);
 

--- a/kernel/arch/dreamcast/fs/fs_iso9660.c
+++ b/kernel/arch/dreamcast/fs/fs_iso9660.c
@@ -1301,6 +1301,9 @@ void fs_iso9660_shutdown(void) {
     /* De-register with vblank */
     vblank_handler_remove(iso_vblank_hnd);
 
+    /* Close out any still open files */
+    fs_vfs_shutdown(&vh);
+
     /* Dealloc cache block space */
     free(cache_data);
     free(caches);

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -250,6 +250,7 @@ void  __weak_symbol arch_auto_shutdown(void) {
 
     KOS_INIT_FLAG_CALL(library_shutdown);
 
+    KOS_INIT_FLAG_CALL(fs_shutdown);
     KOS_INIT_FLAG_CALL(fs_dcload_shutdown);
     KOS_INIT_FLAG_CALL(vmu_fs_shutdown);
     if (!KOS_PLATFORM_IS_NAOMI)
@@ -261,11 +262,6 @@ void  __weak_symbol arch_auto_shutdown(void) {
     KOS_INIT_FLAG_CALL(fs_romdisk_shutdown);
     KOS_INIT_FLAG_CALL(fs_null_shutdown);
     KOS_INIT_FLAG_CALL(fs_dev_shutdown);
-
-    /* As a workaround, shut down the base FS before fs_pty
-       to avoid triggering bugs. */
-    KOS_INIT_FLAG_CALL(fs_shutdown);
-
     KOS_INIT_FLAG_CALL(fs_pty_shutdown);
 
     thd_shutdown();

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -248,6 +248,7 @@ void  __weak_symbol arch_auto_shutdown(void) {
 
     KOS_INIT_FLAG_CALL(library_shutdown);
 
+    KOS_INIT_FLAG_CALL(fs_shutdown);
     KOS_INIT_FLAG_CALL(fs_dcload_shutdown);
     KOS_INIT_FLAG_CALL(vmu_fs_shutdown);
     if (!KOS_PLATFORM_IS_NAOMI)
@@ -259,11 +260,6 @@ void  __weak_symbol arch_auto_shutdown(void) {
     KOS_INIT_FLAG_CALL(fs_romdisk_shutdown);
     KOS_INIT_FLAG_CALL(fs_null_shutdown);
     KOS_INIT_FLAG_CALL(fs_dev_shutdown);
-
-    /* As a workaround, shut down the base FS before fs_pty
-       to avoid triggering bugs. */
-    KOS_INIT_FLAG_CALL(fs_shutdown);
-
     KOS_INIT_FLAG_CALL(fs_pty_shutdown);
 
     thd_shutdown();

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -336,6 +336,15 @@ int fs_close(file_t fd) {
     return retval ? -1 : 0;
 }
 
+void fs_vfs_shutdown(vfs_handler_t *vfs) {
+
+    for(size_t i = 0; i < FD_SETSIZE; i++) {
+        if(fd_table[i] && (fd_table[i]->handler == vfs)) {
+            fs_close(i);
+        }
+    }
+}
+
 /* The rest of these pretty much map straight through */
 ssize_t fs_read(file_t fd, void *buffer, size_t cnt) {
     fs_hnd_t *h = fs_map_hnd(fd);

--- a/kernel/fs/fs.c
+++ b/kernel/fs/fs.c
@@ -287,31 +287,21 @@ void *fs_get_handle(file_t fd) {
 
 file_t fs_dup(file_t oldfd) {
     /* Make sure it exists */
-    if(oldfd < 0 || oldfd >= FD_SETSIZE || oldfd == FILEHND_INVALID) {
-        errno = EBADF;
-        return FILEHND_INVALID;
-    }
-    else if(!fd_table[oldfd]) {
-        errno = EBADF;
-        return FILEHND_INVALID;
-    }
+    fs_hnd_t *hnd = fs_map_hnd(oldfd);
 
-    return fs_hnd_assign(fd_table[oldfd]);
+    if(!hnd)
+        return FILEHND_INVALID;
+
+    return fs_hnd_assign(hnd);
 }
 
 file_t fs_dup2(file_t oldfd, file_t newfd) {
-    fs_hnd_t *prev;
+    fs_hnd_t *prev = fs_map_hnd(newfd);
+    fs_hnd_t *oldhnd = fs_map_hnd(oldfd);
 
-    /* Make sure the descriptors are valid */
-    if(oldfd < 0 || oldfd >= FD_SETSIZE || oldfd == FILEHND_INVALID ||
-       newfd < 0 || newfd >= FD_SETSIZE || newfd == FILEHND_INVALID) {
-        errno = EBADF;
+    /* If the old one couldn't be found, or either errored */
+    if((oldhnd == NULL) || (errno == EBADF))
         return FILEHND_INVALID;
-    }
-    else if(!fd_table[oldfd]) {
-        errno = EBADF;
-        return FILEHND_INVALID;
-    }
 
     if(oldfd == newfd)
         goto out_get_ref;

--- a/kernel/fs/fs_dev.c
+++ b/kernel/fs/fs_dev.c
@@ -192,6 +192,7 @@ void fs_dev_init(void) {
 }
 
 void fs_dev_shutdown(void) {
+    fs_vfs_shutdown(&vh);
     memset(&dev_root_hnd, 0, sizeof(dev_root_hnd));
     nmmgr_handler_remove(&vh.nmmgr);
 }

--- a/kernel/fs/fs_null.c
+++ b/kernel/fs/fs_null.c
@@ -256,6 +256,8 @@ void fs_null_init(void) {
 void fs_null_shutdown(void) {
     null_fh_t *c, *n;
 
+    fs_vfs_shutdown(&vh);
+
     mutex_lock(&fh_mutex);
 
     /* First, clean up any open files */

--- a/kernel/fs/fs_pty.c
+++ b/kernel/fs/fs_pty.c
@@ -839,27 +839,16 @@ void fs_pty_init(void) {
 
 /* De-init the file system */
 void fs_pty_shutdown(void) {
-    ptyhalf_t *n, *c;
-
     if(!initted)
         return;
+
+    fs_vfs_shutdown(&vh);
 
     /* If we fail, we proceed anyways */
     mutex_trylock(&list_mutex);
 
-    /* Go through and free all the pty entries */
-    c = LIST_FIRST(&ptys);
-
-    while(c != NULL) {
-        n = LIST_NEXT(c, list);
-
-        cond_destroy(&c->ready_read);
-        cond_destroy(&c->ready_write);
-        mutex_destroy(&c->mutex);
-        free(c);
-
-        c = n;
-    }
+    /* fs_vfs_shutdown should have cleared these all out */
+    assert(LIST_EMPTY(&ptys));
 
     nmmgr_handler_remove(&vh.nmmgr);
 

--- a/kernel/fs/fs_ramdisk.c
+++ b/kernel/fs/fs_ramdisk.c
@@ -895,16 +895,15 @@ void fs_ramdisk_init(void) {
 /* De-init the file system */
 void fs_ramdisk_shutdown(void) {
     rd_file_t   *f1, *f2;
-    rd_fd_t     *fd1, *fd2;
 
     /* Test if initted */
     if(rootdir == NULL)
         return;
 
-    /* First free up the open handles */
-    TAILQ_FOREACH_SAFE(fd1, &rd_fd_queue, next, fd2) {
-        ramdisk_close(fd1);
-    }
+    fs_vfs_shutdown(&vh);
+
+    /* fs_vfs_shutdown should have cleared these all out */
+    assert(TAILQ_EMPTY(&rd_fd_queue));
 
     /* For now assume there's only the root dir, since mkdir and
        rmdir aren't even implemented... */

--- a/kernel/fs/fs_random.c
+++ b/kernel/fs/fs_random.c
@@ -4,6 +4,7 @@
    Copyright (C) 2023 Luke Benstead
 */
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -322,16 +323,11 @@ void fs_rnd_init(void) {
 }
 
 void fs_rnd_shutdown(void) {
-    rnd_fh_t *c, *n;
+    fs_vfs_shutdown(&vh);
 
-    mutex_lock(&fh_mutex);
+    /* fs_vfs_shutdown should have cleared these all out */
+    assert(TAILQ_EMPTY(&rnd_fh));
 
-    /* First, clean up any open files */
-    TAILQ_FOREACH_SAFE(c, &rnd_fh, listent, n) {
-        free(c);
-    }
-
-    mutex_unlock(&fh_mutex);
     mutex_destroy(&fh_mutex);
 
     nmmgr_handler_remove(&vh.nmmgr);

--- a/kernel/fs/fs_socket.c
+++ b/kernel/fs/fs_socket.c
@@ -10,6 +10,7 @@
 #include <kos/fs_socket.h>
 #include <kos/net.h>
 
+#include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
@@ -153,19 +154,15 @@ int fs_socket_init(void) {
 }
 
 int fs_socket_shutdown(void) {
-    net_socket_t *c, *n;
     fs_socket_proto_t *i, *j;
 
     if(initted == 0)
         return 0;
 
-    c = LIST_FIRST(&sockets);
+    fs_vfs_shutdown(&vh);
 
-    while(c != NULL) {
-        n = LIST_NEXT(c, sock_list);
-        fs_close(c->fd);
-        c = n;
-    }
+    /* fs_vfs_shutdown should have cleared these all out */
+    assert(LIST_EMPTY(&sockets));
 
     if(nmmgr_handler_remove(&vh.nmmgr) < 0)
         return -1;


### PR DESCRIPTION
The current ordering has the vfs shut down first, then the upper-level fs system, which is just wrong. In that order, a vfs will clear out all the backing handles for files that are still open, destroy its mutexes, unload it's memory, etc but has no way to inform the upper-level fs about its departure. When the upper-level fs shuts down, its FDs still have their vfs listed and it will attempt to call the `fs_close` on each resulting in issues for any files still open.

Address this by making two adjustments:
First: the upper-level fs will now shut down prior to any individual vfs. This means that each FD will have the functionality of its vfs available to do whatever is needed for `fs_close`. (Subject to review, an alternative behavior would be to clear out the handler and otherwise mark the fd as not having a handler. That would keep the fd # in use until the user calls `fs_close` or the whole fs system is shut down. It would be more complex and require some modification as fs assumes all fds have a vfs, but would have the benefit of preventing access of the wrong file if a new file is opened and takes the fd)

Second: a new function is added to request from a vfs that the upper-level fs close out all its files. With this in place the order of the shutdowns is actually irrelevant, which is what would be expected as the user should be able to init/shutdown individual vfs as needed. This allows for the removal of the custom cleanups of dynamically allocated handle lists in the vfs as they should all have been removed when calling `fs_vfs_shutdown()`.

A quick place to test this is with the cpp/modplug_test example (prior to #1482 ). Without the change, on shutdown it will assert because the mutex for the romdisk vfs will have been closed out during `romdisk_shutdown` but `fs_shutdown` tries to close out the orphaned FD that still points to the romdisk vfs.

I had mentioned this as needing to be done in #1007 and just dropped it from discussion at the time.

The one vfs not updated with this is vmu as its shutdown behavior differs with the caching and does not write out its files on shutdown currently. It will continue to behave as it always has and could perhaps be a subject of a future update.