### PR TITLE
kos-chain: Add PS2/IOP/DVP toolchain support

### DIFF
--- a/utils/kos-chain/.gitignore
+++ b/utils/kos-chain/.gitignore
@@ -1,10 +1,12 @@
 logs
 *.tar.*
-binutils-*
-gcc-*
-newlib-*
-gdb-*
-build-*
+# Anchored to this directory: these ignore the unpacked source trees and build
+# dirs, and must not swallow the tracked patches under patches/targets/.
+/binutils-*
+/gcc-*
+/newlib-*
+/gdb-*
+/build-*
 *.stamp
 config.guess
 config.sub

--- a/utils/kos-chain/Makefile.aica.cfg
+++ b/utils/kos-chain/Makefile.aica.cfg
@@ -5,9 +5,12 @@
 #########################
 
 # One of the supported platforms:
-# - dreamcast:    Build a toolchain for the SEGA Dreamcast
-# - aica:         Build a toolchain for the Dreamcast's AICA co-processor
-# - gamecube:     Build a toolchain for the Nintendo GameCube
+# - dreamcast:      Build a toolchain for the SEGA Dreamcast
+# - aica:           Build a toolchain for the Dreamcast's AICA co-processor
+# - gamecube:       Build a toolchain for the Nintendo GameCube
+# - playstation2:   Build a toolchain for the PlayStation 2 Emotion Engine
+# - iop:            Build a toolchain for the PlayStation 2 I/O Processor
+# - dvp:            Build a toolchain for the PlayStation 2 Vector Processing Unit
 platform=aica
 
 # Choose a toolchain profile from the following available options:

--- a/utils/kos-chain/Makefile.dreamcast.cfg
+++ b/utils/kos-chain/Makefile.dreamcast.cfg
@@ -5,9 +5,12 @@
 #########################
 
 # One of the supported platforms:
-# - dreamcast:    Build a toolchain for the SEGA Dreamcast
-# - aica:         Build a toolchain for the Dreamcast's AICA co-processor
-# - gamecube:     Build a toolchain for the Nintendo GameCube
+# - dreamcast:      Build a toolchain for the SEGA Dreamcast
+# - aica:           Build a toolchain for the Dreamcast's AICA co-processor
+# - gamecube:       Build a toolchain for the Nintendo GameCube
+# - playstation2:   Build a toolchain for the PlayStation 2 Emotion Engine
+# - iop:            Build a toolchain for the PlayStation 2 I/O Processor
+# - dvp:            Build a toolchain for the PlayStation 2 Vector Processing Unit
 platform=dreamcast
 
 # Choose a toolchain profile from the following available options:

--- a/utils/kos-chain/Makefile.dvp.cfg
+++ b/utils/kos-chain/Makefile.dvp.cfg
@@ -1,0 +1,51 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+#########################
+### TOOLCHAIN PROFILE ###
+#########################
+
+# One of the supported platforms:
+# - dreamcast:      Build a toolchain for the SEGA Dreamcast
+# - aica:           Build a toolchain for the Dreamcast's AICA co-processor
+# - gamecube:       Build a toolchain for the Nintendo GameCube
+# - playstation2:   Build a toolchain for the PlayStation 2 Emotion Engine
+# - iop:            Build a toolchain for the PlayStation 2 I/O Processor
+# - dvp:            Build a toolchain for the PlayStation 2 Vector Processing Unit
+platform=dvp
+
+# Choose a toolchain profile from the following available options:
+# - stable:       Stable: Well-tested; based on Binutils 2.46.1.
+# If unsure, select stable. See README.md for more detailed descriptions.
+toolchain_profile=stable
+
+########################
+### DOWNLOAD OPTIONS ###
+########################
+
+### Download protocol (http|https|ftp)
+download_protocol=https
+
+### Force downloader (curl|wget)
+#force_downloader=wget
+
+### Specify GNU mirror override
+#gnu_mirror=mirrors.kernel.org
+
+#####################
+### BUILD OPTIONS ###
+#####################
+
+### Toolchains install path
+toolchain_path=/opt/toolchains/ps2/dvp-elf
+
+### Make jobs (n|<empty>)
+makejobs=
+
+### Verbose (1|0)
+verbose=1
+
+### Erase (1|0)
+erase=1
+
+### Install toolchain debug symbols (1|0)
+#toolchain_debug=1

--- a/utils/kos-chain/Makefile.gamecube.cfg
+++ b/utils/kos-chain/Makefile.gamecube.cfg
@@ -5,9 +5,12 @@
 #########################
 
 # One of the supported platforms:
-# - dreamcast:    Build a toolchain for the SEGA Dreamcast
-# - aica:         Build a toolchain for the Dreamcast's AICA co-processor
-# - gamecube:     Build a toolchain for the Nintendo GameCube
+# - dreamcast:      Build a toolchain for the SEGA Dreamcast
+# - aica:           Build a toolchain for the Dreamcast's AICA co-processor
+# - gamecube:       Build a toolchain for the Nintendo GameCube
+# - playstation2:   Build a toolchain for the PlayStation 2 Emotion Engine
+# - iop:            Build a toolchain for the PlayStation 2 I/O Processor
+# - dvp:            Build a toolchain for the PlayStation 2 Vector Processing Unit
 platform=gamecube
 
 # Choose a toolchain profile from the following available options:

--- a/utils/kos-chain/Makefile.iop.cfg
+++ b/utils/kos-chain/Makefile.iop.cfg
@@ -1,0 +1,128 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+#########################
+### TOOLCHAIN PROFILE ###
+#########################
+
+# One of the supported platforms:
+# - dreamcast:      Build a toolchain for the SEGA Dreamcast
+# - aica:           Build a toolchain for the Dreamcast's AICA co-processor
+# - gamecube:       Build a toolchain for the Nintendo GameCube
+# - playstation2:   Build a toolchain for the PlayStation 2 Emotion Engine
+# - iop:            Build a toolchain for the PlayStation 2 I/O Processor
+# - dvp:            Build a toolchain for the PlayStation 2 Vector Processing Unit
+platform=iop
+
+# Choose a toolchain profile from the following available options:
+# Release toolchains:
+# - stable:       Stable: Based on GCC 16.1.0, released 2026-04-22.
+# Development toolchains:
+# - 17.0.0-dev:   Bleeding edge GCC 17 series from git.
+# If unsure, select stable. See README.md for more detailed descriptions.
+toolchain_profile=stable
+
+########################
+### DOWNLOAD OPTIONS ###
+########################
+
+### Download protocol (http|https|ftp)
+# Specify the protocol you want to use for downloading package files.
+download_protocol=https
+
+### Force downloader (curl|wget)
+# Specify here if you'd prefer to use 'wget' or 'curl'. If neither is specified,
+# a web downloader tool will be auto-detected in the following order: cURL, Wget
+# You must have either Wget or cURL installed to use kos-chain.
+#force_downloader=wget
+
+### Specify GNU mirror override
+# The default mirror for GNU sources is 'ftpmirror.gnu.org'
+# This setting overrides the default mirror with a preferred mirror.
+#gnu_mirror=mirrors.kernel.org
+
+#####################
+### BUILD OPTIONS ###
+#####################
+
+### Toolchains install path
+# Specify the directory where the toolchain will be installed. This setting
+# must match the KOS_CC_BASE setting in your KOS "environ.sh" configuration.
+toolchain_path=/opt/toolchains/ps2/mipsel-elf
+
+### Make jobs (n|<empty>)
+# Set this value to the number of parallel jobs you want to run with make.
+# Leave it empty to use a number of parallel jobs that corresponds to the
+# number of CPU threads available.
+# Using multiple jobs may cause issues in certain environments and may be
+# automatically disabled. If you encounter errors building your toolchain,
+# reduce the number of jobs to 1 to avoid issues and ease troubleshooting.
+makejobs=
+
+### Verbose (1|0)
+# Choose whether to actively display compilation messages on the screen.
+# Messages are saved to the build log files regardless of this setting.
+verbose=1
+
+### Erase (1|0)
+# Erase build directories as toolchain components are installed to save space.
+erase=1
+
+### Install toolchain debug symbols (1|0)
+# Choose whether to keep the debugging symbols for the toolchain.
+# This is only useful if you wish to debug the toolchain itself.
+#toolchain_debug=1
+
+########################
+### LANGUAGE OPTIONS ###
+########################
+
+### Enable C++
+# Builds C++ support, including the C++ compiler and its standard library.
+enable_cpp=1
+
+### Enable Objective-C
+# Builds Objective-C support, including the Obj-C compiler and runtime.
+enable_objc=0
+
+### Enable Objective C++
+# Builds Objective C++ support, the hybrid language allowing both C++ and Obj-C
+# methods to be called from both contexts.
+enable_objcpp=0
+
+###################
+### GCC OPTIONS ###
+###################
+
+### GCC threading model (single)
+# The IOP is a constrained R3000A processor; single threading is appropriate.
+thread_model=single
+
+### Automatic patching for KallistiOS (1|0)
+# Uncomment this option if you want to disable applying KallistiOS patches to
+# toolchain source files before building. Only do this if you understand what
+# you are doing.
+#use_kos_patches=0
+
+### Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Uncomment this option to disable NLS and force GCC to output in English.
+#disable_nls=1
+
+# Note: The IOP toolchain builds without newlib (GCC pass 1 only).
+# The IOP gets its C library from KOS, not newlib.
+
+#######################
+### WINDOWS OPTIONS ###
+#######################
+
+### MinGW/MSYS
+# Standalone binaries (1|0)
+# Uncomment this option if you want static binaries that are standalone and
+# require no dependencies. This is NOT recommended; only do this if you know
+# what you are doing.
+#standalone_binary=1
+
+### Force installation of BFD (1|0)
+# Uncomment this option if you want to force installation of 'libbfd'. This is
+# required for MinGW/MSYS and can't be disabled in that scenario.
+#sh_force_libbfd_installation=1

--- a/utils/kos-chain/Makefile.iop.cfg
+++ b/utils/kos-chain/Makefile.iop.cfg
@@ -1,0 +1,124 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+#########################
+### TOOLCHAIN PROFILE ###
+#########################
+
+# One of the supported platforms:
+# - dreamcast:      Build a toolchain for the SEGA Dreamcast
+# - aica:           Build a toolchain for the Dreamcast's AICA co-processor
+# - gamecube:       Build a toolchain for the Nintendo GameCube
+# - playstation2:   Build a toolchain for the PlayStation 2 Emotion Engine
+# - iop:            Build a toolchain for the PlayStation 2 I/O Processor
+# - dvp:            Build a toolchain for the PlayStation 2 Vector Processing Unit
+platform=iop
+
+# Choose a toolchain profile from the following available options:
+# Release toolchains:
+# - stable:       Stable: Based on GCC 16.1.0, released 2026-04-22.
+# Development toolchains:
+# - 17.0.0-dev:   Bleeding edge GCC 17 series from git.
+# If unsure, select stable. See README.md for more detailed descriptions.
+toolchain_profile=stable
+
+########################
+### DOWNLOAD OPTIONS ###
+########################
+
+### Download protocol (http|https|ftp)
+# Specify the protocol you want to use for downloading package files.
+download_protocol=https
+
+### Force downloader (curl|wget)
+# Specify here if you'd prefer to use 'wget' or 'curl'. If neither is specified,
+# a web downloader tool will be auto-detected in the following order: cURL, Wget
+# You must have either Wget or cURL installed to use kos-chain.
+#force_downloader=wget
+
+### Specify GNU mirror override
+# The default mirror for GNU sources is 'ftpmirror.gnu.org'
+# This setting overrides the default mirror with a preferred mirror.
+#gnu_mirror=mirrors.kernel.org
+
+#####################
+### BUILD OPTIONS ###
+#####################
+
+### Toolchains install path
+# Specify the directory where the toolchain will be installed. This setting
+# must match the KOS_CC_BASE setting in your KOS "environ.sh" configuration.
+toolchain_path=/opt/toolchains/ps2/mipsel-elf
+
+### Make jobs (n|<empty>)
+# Set this value to the number of parallel jobs you want to run with make.
+# Leave it empty to use a number of parallel jobs that corresponds to the
+# number of CPU threads available.
+# Using multiple jobs may cause issues in certain environments and may be
+# automatically disabled. If you encounter errors building your toolchain,
+# reduce the number of jobs to 1 to avoid issues and ease troubleshooting.
+makejobs=
+
+### Verbose (1|0)
+# Choose whether to actively display compilation messages on the screen.
+# Messages are saved to the build log files regardless of this setting.
+verbose=1
+
+### Erase (1|0)
+# Erase build directories as toolchain components are installed to save space.
+erase=1
+
+### Install toolchain debug symbols (1|0)
+# Choose whether to keep the debugging symbols for the toolchain.
+# This is only useful if you wish to debug the toolchain itself.
+#toolchain_debug=1
+
+########################
+### LANGUAGE OPTIONS ###
+########################
+
+### Enable Objective-C
+# Builds Objective-C support, including the Obj-C compiler and runtime.
+enable_objc=0
+
+### Enable Objective C++
+# Builds Objective C++ support, the hybrid language allowing both C++ and Obj-C
+# methods to be called from both contexts.
+enable_objcpp=0
+
+###################
+### GCC OPTIONS ###
+###################
+
+### GCC threading model (single)
+# The IOP is a constrained R3000A processor; single threading is appropriate.
+thread_model=single
+
+### Automatic patching for KallistiOS (1|0)
+# Uncomment this option if you want to disable applying KallistiOS patches to
+# toolchain source files before building. Only do this if you understand what
+# you are doing.
+#use_kos_patches=0
+
+### Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Uncomment this option to disable NLS and force GCC to output in English.
+#disable_nls=1
+
+# Note: The IOP toolchain builds without newlib (GCC pass 1 only).
+# The IOP gets its C library from KOS, not newlib.
+
+#######################
+### WINDOWS OPTIONS ###
+#######################
+
+### MinGW/MSYS
+# Standalone binaries (1|0)
+# Uncomment this option if you want static binaries that are standalone and
+# require no dependencies. This is NOT recommended; only do this if you know
+# what you are doing.
+#standalone_binary=1
+
+### Force installation of BFD (1|0)
+# Uncomment this option if you want to force installation of 'libbfd'. This is
+# required for MinGW/MSYS and can't be disabled in that scenario.
+#sh_force_libbfd_installation=1

--- a/utils/kos-chain/Makefile.playstation2.cfg
+++ b/utils/kos-chain/Makefile.playstation2.cfg
@@ -1,0 +1,152 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+#########################
+### TOOLCHAIN PROFILE ###
+#########################
+
+# One of the supported platforms:
+# - dreamcast:      Build a toolchain for the SEGA Dreamcast
+# - aica:           Build a toolchain for the Dreamcast's AICA co-processor
+# - gamecube:       Build a toolchain for the Nintendo GameCube
+# - playstation2:   Build a toolchain for the PlayStation 2 Emotion Engine
+# - iop:            Build a toolchain for the PlayStation 2 I/O Processor
+# - dvp:            Build a toolchain for the PlayStation 2 Vector Processing Unit
+platform=playstation2
+
+# Choose a toolchain profile from the following available options:
+# Release toolchains:
+# - stable:       Stable: Based on GCC 16.1.0, released 2026-04-22.
+# Development toolchains:
+# - 17.0.0-dev:   Bleeding edge GCC 17 series from git.
+# If unsure, select stable. See README.md for more detailed descriptions.
+toolchain_profile=stable
+
+########################
+### DOWNLOAD OPTIONS ###
+########################
+
+### Download protocol (http|https|ftp)
+# Specify the protocol you want to use for downloading package files.
+download_protocol=https
+
+### Force downloader (curl|wget)
+# Specify here if you'd prefer to use 'wget' or 'curl'. If neither is specified,
+# a web downloader tool will be auto-detected in the following order: cURL, Wget
+# You must have either Wget or cURL installed to use kos-chain.
+#force_downloader=wget
+
+### Specify GNU mirror override
+# The default mirror for GNU sources is 'ftpmirror.gnu.org'
+# This setting overrides the default mirror with a preferred mirror.
+#gnu_mirror=mirrors.kernel.org
+
+#####################
+### BUILD OPTIONS ###
+#####################
+
+### Toolchains install path
+# Specify the directory where the toolchains will be installed. This setting
+# must match the KOS_CC_BASE setting in your KOS "environ.sh" configuration.
+toolchain_path=/opt/toolchains/ps2/mips-elf
+
+### Make jobs (n|<empty>)
+# Set this value to the number of parallel jobs you want to run with make.
+# Leave it empty to use a number of parallel jobs that corresponds to the
+# number of CPU threads available.
+# Using multiple jobs may cause issues in certain environments and may be
+# automatically disabled. If you encounter errors building your toolchain,
+# reduce the number of jobs to 1 to avoid issues and ease troubleshooting.
+makejobs=
+
+### Verbose (1|0)
+# Choose whether to actively display compilation messages on the screen.
+# Messages are saved to the build log files regardless of this setting.
+verbose=1
+
+### Erase (1|0)
+# Erase build directories as toolchain components are installed to save space.
+erase=1
+
+### Install toolchain debug symbols (1|0)
+# Choose whether to keep the debugging symbols for the toolchain.
+# This is only useful if you wish to debug the toolchain itself.
+#toolchain_debug=1
+
+########################
+### LANGUAGE OPTIONS ###
+########################
+
+### Enable C++
+# Builds C++ support, including the C++ compiler and its standard library.
+enable_cpp=1
+
+### Enable Objective-C
+enable_objc=0
+
+### Enable Objective C++
+enable_objcpp=0
+
+### Enable D
+#enable_d=1
+
+### Enable Ada
+#enable_ada=1
+
+### Enable Rust
+#enable_rust=1
+
+### Enable libgccjit
+#enable_libgccjit=1
+
+###################
+### GCC OPTIONS ###
+###################
+
+### GCC threading model (single|kos)
+# KallistiOS patches to GCC provide a 'kos' thread model, which should be used.
+# If you want to disable threading support for C++, Objective-C, and so forth,
+# you can set this option to 'single'.
+thread_model=kos
+
+### Automatic patching for KallistiOS (1|0)
+#use_kos_patches=0
+
+### Disable GCC Native Language Support (1|0)
+#disable_nls=1
+
+######################
+### NEWLIB OPTIONS ###
+######################
+
+### Automatic patching for Newlib (1|0)
+#auto_fixup_newlib=0
+
+### C99 format specifier support (1|0)
+newlib_c99_formats=1
+
+### Multibyte character set support (1|0)
+#newlib_multibyte=1
+
+### iconv() character encoding conversions support (encoding list)
+#newlib_iconv_encodings=us_ascii,utf8,utf16,ucs_2_internal,ucs_4_internal
+
+### Optimize Newlib for space (1|0)
+#newlib_opt_space=1
+
+###################
+### C++ OPTIONS ###
+###################
+
+### Timezone database support (1|0|path)
+#libstdcxx_tzdb=1
+
+#######################
+### WINDOWS OPTIONS ###
+#######################
+
+### MinGW/MSYS
+# Standalone binaries (1|0)
+#standalone_binary=1
+
+### Force installation of BFD (1|0)
+#sh_force_libbfd_installation=1

--- a/utils/kos-chain/README.md
+++ b/utils/kos-chain/README.md
@@ -28,6 +28,15 @@ toolchain is optional and only necessary for compiling custom AICA drivers.
 - **GameCube**: `powerpc-eabi` toolchain, the cross-compiler toolchain targeting
 the **IBM Gekko PowerPC (PPC) CPU** in the Nintendo GameCube. GameCube support
 is coming soon to KallistiOS.
+- **playstation2**: `mips64r5900el-ps2-elf` toolchain, targeting the **Emotion
+Engine (EE)**, the MIPS R5900 primary CPU of the Sony PlayStation 2. This
+toolchain is required for PlayStation 2 development.
+- **iop**: `mipsel-elf` toolchain, targeting the PlayStation 2's **I/O Processor
+(IOP)**, a MIPS R3000A core that handles I/O and the SPU. This toolchain is
+built without newlib; the IOP gets its C library from KallistiOS.
+- **dvp**: `dvp-elf` toolchain, targeting the PlayStation 2's **Vector Processing
+Units (VU)**. This is a binutils-only toolchain (assembler and linker for VU
+microcode) and is only necessary for compiling custom VU code.
 
 ## Getting started
 

--- a/utils/kos-chain/README.md
+++ b/utils/kos-chain/README.md
@@ -28,6 +28,9 @@ toolchain is optional and only necessary for compiling custom AICA drivers.
 - **GameCube**: `powerpc-eabi` toolchain, the cross-compiler toolchain targeting
 the **IBM Gekko PowerPC (PPC) CPU** in the Nintendo GameCube. GameCube support
 is coming soon to KallistiOS.
+- **playstation2**: `mips64r5900el-ps2-elf` toolchain, targeting the **Emotion
+Engine (EE)**, the MIPS R5900 primary CPU of the Sony PlayStation 2. This
+toolchain is required for PlayStation 2 development.
 
 ## Getting started
 

--- a/utils/kos-chain/README.md
+++ b/utils/kos-chain/README.md
@@ -31,6 +31,9 @@ is coming soon to KallistiOS.
 - **playstation2**: `mips64r5900el-ps2-elf` toolchain, targeting the **Emotion
 Engine (EE)**, the MIPS R5900 primary CPU of the Sony PlayStation 2. This
 toolchain is required for PlayStation 2 development.
+- **iop**: `mipsel-elf` toolchain, targeting the PlayStation 2's **I/O Processor
+(IOP)**, a MIPS R3000A core that handles I/O and the SPU. This toolchain is
+built without newlib; the IOP gets its C library from KallistiOS.
 
 ## Getting started
 

--- a/utils/kos-chain/README.md
+++ b/utils/kos-chain/README.md
@@ -34,6 +34,10 @@ toolchain is required for PlayStation 2 development.
 - **iop**: `mipsel-elf` toolchain, targeting the PlayStation 2's **I/O Processor
 (IOP)**, a MIPS R3000A core that handles I/O and the SPU. This toolchain is
 built without newlib; the IOP gets its C library from KallistiOS.
+- **dvp**: `dvp-elf` toolchain, providing **dvp-as** (installed as
+`dvp-elf-as`), an assembler for the PlayStation 2's **Vector Processing Units
+(VU)**. It assembles the VU microcode instruction set and the VIF/GIF/DMA
+container layer, and is only necessary for compiling custom VU code.
 
 ## Getting started
 

--- a/utils/kos-chain/doc/CHANGELOG.md
+++ b/utils/kos-chain/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Date<br/>_____________ | Author(s)<br/>_____________ | Changes<br/>_____________ |
 |:-----------------------|:----------------------------|---------------------------|
+| 2026-07-06 | Andress Barajas | Add support for PS2/IOP/DVP toolchains and add PS2 profiles |
 | 2026-06-30 | Eric Fradella | Bump GCC series 14/15/16/17 profiles to latest available versions, update LRA testing toolchain |
 | 2026-06-30 | Eric Fradella | Update binutils to 2.46.1 for most profiles |
 | 2026-02-07 | Eric Fradella | Rename to KallistiOS Toolchain Builder, move to utils/kos-chain, stabilize GCC 15.2.0, various bug fixes |

--- a/utils/kos-chain/doc/CHANGELOG.md
+++ b/utils/kos-chain/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Date<br/>_____________ | Author(s)<br/>_____________ | Changes<br/>_____________ |
 |:-----------------------|:----------------------------|---------------------------|
+| 2026-08-19 | Andy Barajas | Add support for PS2/IOP/DVP toolchains and add PS2 profiles |
 | 2026-08-07 | Eric Fradella | Update GCC 16 series to 16.2.0, update binutils to 2.47 for most profiles |
 | 2026-06-30 | Eric Fradella | Bump GCC series 14/15/16/17 profiles to latest available versions, update LRA testing toolchain |
 | 2026-06-30 | Eric Fradella | Update binutils to 2.46.1 for most profiles |

--- a/utils/kos-chain/patches/targets/binutils-2.46.1-kos.diff
+++ b/utils/kos-chain/patches/targets/binutils-2.46.1-kos.diff
@@ -1,0 +1,8264 @@
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/archures.c binutils-2.46.1-kos/bfd/archures.c
+--- binutils-2.46.1/bfd/archures.c	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/archures.c	2026-07-06 18:45:40
+@@ -197,6 +197,11 @@
+ .#define bfd_mach_mipsisa64r5		68
+ .#define bfd_mach_mipsisa64r6		69
+ .#define bfd_mach_mips_micromips	96
++.#define bfd_mach_dvp_dma		42000
++.#define bfd_mach_dvp_vif		42001
++.#define bfd_mach_dvp_vu		42002
++.#define bfd_mach_dvp_gif		42003
++.#define bfd_mach_dvp_p(mach) ((mach) >= 42000 && (mach) <= 42003)
+ .  bfd_arch_i386,      {* Intel 386.  *}
+ .#define bfd_mach_i386_intel_syntax	(1 << 0)
+ .#define bfd_mach_i386_i8086		(1 << 1)
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/bfd-in2.h binutils-2.46.1-kos/bfd/bfd-in2.h
+--- binutils-2.46.1/bfd/bfd-in2.h	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/bfd-in2.h	2026-07-06 18:45:40
+@@ -1426,6 +1426,11 @@
+ #define bfd_mach_mipsisa64r5           68
+ #define bfd_mach_mipsisa64r6           69
+ #define bfd_mach_mips_micromips        96
++#define bfd_mach_dvp_dma               42000
++#define bfd_mach_dvp_vif               42001
++#define bfd_mach_dvp_vu                42002
++#define bfd_mach_dvp_gif               42003
++#define bfd_mach_dvp_p(mach) ((mach) >= 42000 && (mach) <= 42003)
+   bfd_arch_i386,      /* Intel 386.  */
+ #define bfd_mach_i386_intel_syntax     (1 << 0)
+ #define bfd_mach_i386_i8086            (1 << 1)
+@@ -3821,6 +3826,23 @@
+   /* This is a 16bit pcrel reloc for the mn10300, offset by two bytes in
+      the instruction.  */
+   BFD_RELOC_MN10300_16_PCREL,
++
++  /* MIPS DVP Relocations.
++     This is an 11-bit pc relative reloc.  The recorded address is for the
++     lower instruction word, and the value is in 128 bit units.  */
++  BFD_RELOC_MIPS_DVP_11_PCREL ,
++
++  /* This is a 27 bit address left shifted by 4.  */
++  BFD_RELOC_MIPS_DVP_27_S4 ,
++
++  /* This is the 11 bit offset operand of ilw/stw instructions
++     left shifted by 4.  */
++  BFD_RELOC_MIPS_DVP_11_S4 ,
++
++  /* This is the 15 bit unsigned immediate operand of the iaddiu instruction
++     left shifted by 3.  */
++  BFD_RELOC_MIPS_DVP_U15_S3 ,
++
+ 
+   /* i386/elf relocations.  */
+   BFD_RELOC_386_GOT32,
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/config.bfd binutils-2.46.1-kos/bfd/config.bfd
+--- binutils-2.46.1/bfd/config.bfd	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/config.bfd	2026-07-06 18:45:40
+@@ -234,6 +234,9 @@
+ *)		 targ_archs=bfd_${targ_cpu}_arch ;;
+ esac
+ 
++case "${targ}" in
++  mips64*-scei*-elf*) targ_archs="${targ_archs} bfd_dvp_arch" ;;
++esac
+ 
+ # WHEN ADDING ENTRIES TO THIS MATRIX:
+ #  Make sure that the left side always has two dashes.  Otherwise you
+@@ -509,6 +512,11 @@
+     targ_underscore=yes
+     ;;
+ #endif
++
++  dvp-*-*)
++    targ_defvec=mips_elf32_le_vec
++    targ_selvecs="mips_elf64_le_vec"
++    ;;
+ 
+   epiphany-*-*)
+     targ_defvec=epiphany_elf32_vec
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/configure binutils-2.46.1-kos/bfd/configure
+--- binutils-2.46.1/bfd/configure	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/configure	2026-07-06 18:46:34
+@@ -15422,7 +15422,6 @@
+   with_zstd=auto
+ fi
+ 
+-
+ if test "$with_zstd" != no; then :
+ 
+ pkg_failed=no
+@@ -15814,6 +15813,9 @@
+     esac
+ done
+ selvecs="$f"
++
++# dvp is really mips, but we need to distinguish it from mips for opcodes
++selarchs=`echo $selarchs | sed -e s/dvp/mips/g`
+ 
+ # uniq the architectures in all the configured targets.
+ f=""
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/configure.ac binutils-2.46.1-kos/bfd/configure.ac
+--- binutils-2.46.1/bfd/configure.ac	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/configure.ac	2026-07-06 18:46:01
+@@ -356,6 +356,9 @@
+ done
+ selvecs="$f"
+ 
++# dvp is really mips, but we need to distinguish it from mips for opcodes
++selarchs=`echo $selarchs | sed -e s/dvp/mips/g`
++
+ # uniq the architectures in all the configured targets.
+ f=""
+ for i in $selarchs ; do
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/cpu-mips.c binutils-2.46.1-kos/bfd/cpu-mips.c
+--- binutils-2.46.1/bfd/cpu-mips.c	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/cpu-mips.c	2026-07-06 18:45:40
+@@ -96,6 +96,10 @@
+   I_mipsisa64r3,
+   I_mipsisa64r5,
+   I_mipsisa64r6,
++  I_dvp_dma,
++  I_dvp_vif,
++  I_dvp_vu,
++  I_dvp_gif,
+   I_sb1,
+   I_loongson_2e,
+   I_loongson_2f,
+@@ -165,7 +169,11 @@
+   N (32, 32, bfd_mach_mips_interaptiv_mr2, "mips:interaptiv-mr2", false,
+      NN(I_interaptiv_mr2)),
+   N (32, 32, bfd_mach_mips_allegrex, "mips:allegrex", false, NN(I_allegrex)),
+-  N (64, 64, bfd_mach_mips_micromips, "mips:micromips", false, NULL)
++  N (64, 64, bfd_mach_mips_micromips, "mips:micromips", false, NULL),
++  N (32, 32, bfd_mach_dvp_dma, "dvp:dma",         false, NN(I_dvp_dma)),
++  N (32, 32, bfd_mach_dvp_vif, "dvp:vif",         false, NN(I_dvp_vif)),
++  N (32, 32, bfd_mach_dvp_vu, "dvp:vu",           false, NN(I_dvp_vu)),
++  N (32, 32, bfd_mach_dvp_gif, "dvp:gif",         false, NN(I_dvp_gif)),
+ };
+ 
+ /* The default architecture is mips:3000, but with a machine number of
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/elf32-mips.c binutils-2.46.1-kos/bfd/elf32-mips.c
+--- binutils-2.46.1/bfd/elf32-mips.c	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/elf32-mips.c	2026-07-06 18:45:40
+@@ -70,6 +70,8 @@
+   (bfd *, const char *);
+ static bfd_reloc_status_type mips16_gprel_reloc
+   (bfd *, arelent *, asymbol *, void *, asection *, bfd *, char **);
++static bfd_reloc_status_type dvp_u15_s3_reloc
++  (bfd *, arelent *, asymbol *, void *, asection *, bfd *, char **);
+ static bfd_reloc_status_type mips_elf_final_gp
+   (bfd *, asymbol *, bool, char **, bfd_vma *);
+ static bool mips_elf_assign_gp
+@@ -2972,6 +2974,66 @@
+ 	 true),			/* pcrel_offset */
+ };
+ 
++/* DVP relocations.
++   Note that partial_inplace and pcrel_offset are backwards from the
++   mips port.  This is intentional as it seems more reasonable.  */
++static reloc_howto_type elf_mips_dvp_11_pcrel_howto =
++  HOWTO (R_MIPS_DVP_11_PCREL,   /* type */
++         3,                     /* rightshift */
++         2,                     /* size (0 = byte, 1 = short, 2 = long) */
++         11,                    /* bitsize */
++         true,                  /* pc_relative */
++         0,                     /* bitpos */
++         complain_overflow_signed, /* complain_on_overflow */
++         bfd_elf_generic_reloc, /* special_function */
++         "R_MIPS_DVP_11_PCREL", /* name */
++         false,                 /* partial_inplace */
++         0x7ff,                 /* src_mask */
++         0x7ff,                 /* dst_mask */
++         true);                 /* pcrel_offset */
++static reloc_howto_type elf_mips_dvp_27_s4_howto =
++  HOWTO (R_MIPS_DVP_27_S4,      /* type */
++         4,                     /* rightshift */
++         2,                     /* size (0 = byte, 1 = short, 2 = long) */
++         27,                    /* bitsize */
++         false,                 /* pc_relative */
++         4,                     /* bitpos */
++         complain_overflow_unsigned, /* complain_on_overflow */
++         bfd_elf_generic_reloc, /* special_function */
++         "R_MIPS_DVP_27_S4",    /* name */
++         false,                 /* partial_inplace */
++         0x7ffffff0,            /* src_mask */
++         0x7ffffff0,            /* dst_mask */
++         false);                /* pcrel_offset */
++static reloc_howto_type elf_mips_dvp_11_s4_howto =
++  HOWTO (R_MIPS_DVP_11_S4,      /* type */
++         4,                     /* rightshift */
++         2,                     /* size (0 = byte, 1 = short, 2 = long) */
++         11,                    /* bitsize */
++         false,                 /* pc_relative */
++         0,                     /* bitpos */
++         complain_overflow_signed, /* complain_on_overflow */
++         bfd_elf_generic_reloc, /* special_function */
++         "R_MIPS_DVP_11_S4",    /* name */
++         false,                 /* partial_inplace */
++         0x03ff,                /* src_mask */
++         0x03ff,                /* dst_mask */
++         false);                /* pcrel_offset */
++static reloc_howto_type elf_mips_dvp_u15_s3_howto =
++  HOWTO (R_MIPS_DVP_U15_S3,     /* type */
++         3,                     /* rightshift */
++         2,                     /* size (0 = byte, 1 = short, 2 = long) */
++         15,                    /* bitsize */
++         false,                 /* pc_relative */
++         0,                     /* bitpos */
++         complain_overflow_unsigned, /* complain_on_overflow */
++         dvp_u15_s3_reloc,      /* special_function */
++         "R_MIPS_DVP_U15_S3",   /* name */
++         false,                 /* partial_inplace */
++         0xf03ff,               /* src_mask */
++         0xf03ff,               /* dst_mask */
++         false);                /* pcrel_offset */
++
+ /* 16 bit offset for pc-relative branches.  */
+ static reloc_howto_type elf_mips_gnu_rel16_s2 =
+   HOWTO (R_MIPS_GNU_REL16_S2,	/* type */
+@@ -3422,6 +3484,52 @@
+   return ret;
+ }
+ 
++/* Handle a dvp R_MIPS_DVP_U15_S3 reloc.
++   This is needed because the bits aren't contiguous.  */
++
++static bfd_reloc_status_type
++dvp_u15_s3_reloc (bfd *abfd, arelent *reloc_entry, asymbol *symbol, void *data,
++                  asection *input_section, bfd *output_bfd,
++                  char **error_message ATTRIBUTE_UNUSED)
++{
++  bfd_vma relocation;
++  bfd_vma x;
++
++  /* If we're relocating, and this is an external symbol with no
++     addend, we don't want to change anything.  We will only have an
++     addend if this is a newly created reloc, not read from an ELF
++     file.  See bfd_elf_generic_reloc.  */
++  if (output_bfd != NULL
++      && (symbol->flags & BSF_SECTION_SYM) == 0
++      /* partial_inplace is FALSE, so this test always succeeds,
++         but for clarity and consistency with bfd_elf_generic_reloc
++         this is left as is.  */
++      && (! reloc_entry->howto->partial_inplace
++          || reloc_entry->addend == 0))
++    {
++      reloc_entry->address += input_section->output_offset;
++      return bfd_reloc_ok;
++    }
++
++  if (reloc_entry->address > bfd_get_section_limit (abfd, input_section))
++    return bfd_reloc_outofrange;
++
++  relocation = (symbol->value
++                + symbol->section->output_section->vma
++                + symbol->section->output_offset);
++  relocation += reloc_entry->addend;
++  relocation >>= 3;
++
++  x = bfd_get_32 (abfd, (bfd_byte *) data + reloc_entry->address);
++  x |= (((relocation & 0x7800) << 10)
++        | (relocation & 0x7ff));
++  bfd_put_32 (abfd, x, (bfd_byte *) data + reloc_entry->address);
++
++  if (relocation & ~(bfd_vma) 0x7fff)
++    return bfd_reloc_overflow;
++  return bfd_reloc_ok;
++}
++
+ /* A mapping from BFD reloc types to MIPS ELF reloc types.  */
+ 
+ struct elf_reloc_map {
+@@ -3583,6 +3691,14 @@
+       else
+ 	return &howto_table[(int) R_MIPS_32];
+ 
++    case BFD_RELOC_MIPS_DVP_11_PCREL:
++      return &elf_mips_dvp_11_pcrel_howto;
++    case BFD_RELOC_MIPS_DVP_27_S4:
++      return &elf_mips_dvp_27_s4_howto;
++    case BFD_RELOC_MIPS_DVP_11_S4:
++      return &elf_mips_dvp_11_s4_howto;
++    case BFD_RELOC_MIPS_DVP_U15_S3:
++      return &elf_mips_dvp_u15_s3_howto;
+     case BFD_RELOC_VTABLE_INHERIT:
+       return &elf_mips_gnu_vtinherit_howto;
+     case BFD_RELOC_VTABLE_ENTRY:
+@@ -3707,6 +3823,14 @@
+ 
+   switch (r_type)
+     {
++    case R_MIPS_DVP_11_PCREL:
++      return &elf_mips_dvp_11_pcrel_howto;
++    case R_MIPS_DVP_27_S4:
++      return &elf_mips_dvp_27_s4_howto;
++    case R_MIPS_DVP_11_S4:
++      return &elf_mips_dvp_11_s4_howto;
++    case R_MIPS_DVP_U15_S3:
++      return &elf_mips_dvp_u15_s3_howto;
+     case R_MIPS_GNU_VTINHERIT:
+       return &elf_mips_gnu_vtinherit_howto;
+     case R_MIPS_GNU_VTENTRY:
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/elfn32-mips.c binutils-2.46.1-kos/bfd/elfn32-mips.c
+--- binutils-2.46.1/bfd/elfn32-mips.c	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/elfn32-mips.c	2026-07-06 18:45:40
+@@ -64,6 +64,8 @@
+   (bfd *, arelent *, asymbol *, void *, asection *, bfd *, char **);
+ static bfd_reloc_status_type mips16_gprel_reloc
+   (bfd *, arelent *, asymbol *, void *, asection *, bfd *, char **);
++static bfd_reloc_status_type dvp_u15_s3_reloc
++  (bfd *, arelent *, asymbol *, void *, asection *, bfd *, char **);
+ static reloc_howto_type *bfd_elf32_bfd_reloc_type_lookup
+   (bfd *, bfd_reloc_code_real_type);
+ static bool mips_info_to_howto_rel
+@@ -3065,6 +3067,69 @@
+ 	 true),			/* pcrel_offset */
+ };
+ 
++/* DVP relocations.
++   Note that partial_inplace and pcrel_offset are backwards from the
++   mips port.  This is intentional as it seems more reasonable.  */
++static reloc_howto_type elf_mips_dvp_11_pcrel_howto =
++  HOWTO (R_MIPS_DVP_11_PCREL,   /* type */
++     3,                     /* rightshift */
++     2,                     /* size (0 = byte, 1 = short, 2 = long) */
++     11,                    /* bitsize */
++     true,                  /* pc_relative */
++     0,                     /* bitpos */
++     complain_overflow_signed, /* complain_on_overflow */
++     bfd_elf_generic_reloc, /* special_function */
++     "R_MIPS_DVP_11_PCREL", /* name */
++     false,                 /* partial_inplace */
++     0x7ff,                 /* src_mask */
++     0x7ff,                 /* dst_mask */
++     true);                 /* pcrel_offset */
++
++static reloc_howto_type elf_mips_dvp_27_s4_howto =
++  HOWTO (R_MIPS_DVP_27_S4,      /* type */
++     4,                     /* rightshift */
++     2,                     /* size (0 = byte, 1 = short, 2 = long) */
++     27,                    /* bitsize */
++     false,                 /* pc_relative */
++     4,                     /* bitpos */
++     complain_overflow_unsigned, /* complain_on_overflow */
++     bfd_elf_generic_reloc, /* special_function */
++     "R_MIPS_DVP_27_S4",    /* name */
++     false,                 /* partial_inplace */
++     0x7ffffff0,            /* src_mask */
++     0x7ffffff0,            /* dst_mask */
++     false);                /* pcrel_offset */
++
++static reloc_howto_type elf_mips_dvp_11_s4_howto =
++  HOWTO (R_MIPS_DVP_11_S4,      /* type */
++     4,                     /* rightshift */
++     2,                     /* size (0 = byte, 1 = short, 2 = long) */
++     11,                    /* bitsize */
++     false,                 /* pc_relative */
++     0,                     /* bitpos */
++     complain_overflow_signed, /* complain_on_overflow */
++     bfd_elf_generic_reloc, /* special_function */
++     "R_MIPS_DVP_11_S4",    /* name */
++     false,                 /* partial_inplace */
++     0x03ff,                /* src_mask */
++     0x03ff,                /* dst_mask */
++     false);                /* pcrel_offset */
++
++static reloc_howto_type elf_mips_dvp_u15_s3_howto =
++  HOWTO (R_MIPS_DVP_U15_S3,     /* type */
++     3,                     /* rightshift */
++     2,                     /* size (0 = byte, 1 = short, 2 = long) */
++     15,                    /* bitsize */
++     false,                 /* pc_relative */
++     0,                     /* bitpos */
++     complain_overflow_unsigned, /* complain_on_overflow */
++     dvp_u15_s3_reloc,      /* special_function */
++     "R_MIPS_DVP_U15_S3",   /* name */
++     false,                 /* partial_inplace */
++     0xf03ff,               /* src_mask */
++     0xf03ff,               /* dst_mask */
++     false);                /* pcrel_offset */
++
+ /* GNU extension to record C++ vtable hierarchy */
+ static reloc_howto_type elf_mips_gnu_vtinherit_howto =
+   HOWTO (R_MIPS_GNU_VTINHERIT,	/* type */
+@@ -3514,7 +3579,53 @@
+ 
+   return ret;
+ }
+-
++
++/* Handle a dvp R_MIPS_DVP_U15_S3 reloc.
++   This is needed because the bits aren't contiguous.  */
++
++static bfd_reloc_status_type
++dvp_u15_s3_reloc (bfd *abfd, arelent *reloc_entry, asymbol *symbol, void *data,
++                  asection *input_section, bfd *output_bfd,
++                  char **error_message ATTRIBUTE_UNUSED)
++{
++  bfd_vma relocation;
++  bfd_vma x;
++
++  /* If we're relocating, and this is an external symbol with no
++     addend, we don't want to change anything.  We will only have an
++     addend if this is a newly created reloc, not read from an ELF
++     file.  See bfd_elf_generic_reloc.  */
++  if (output_bfd != NULL
++      && (symbol->flags & BSF_SECTION_SYM) == 0
++      /* partial_inplace is FALSE, so this test always succeeds,
++         but for clarity and consistency with bfd_elf_generic_reloc
++         this is left as is.  */
++      && (! reloc_entry->howto->partial_inplace
++          || reloc_entry->addend == 0))
++    {
++      reloc_entry->address += input_section->output_offset;
++      return bfd_reloc_ok;
++    }
++
++  if (reloc_entry->address > bfd_get_section_limit (abfd, input_section))
++    return bfd_reloc_outofrange;
++
++  relocation = (symbol->value
++                + symbol->section->output_section->vma
++                + symbol->section->output_offset);
++  relocation += reloc_entry->addend;
++  relocation >>= 3;
++
++  x = bfd_get_32 (abfd, (bfd_byte *) data + reloc_entry->address);
++  x |= (((relocation & 0x7800) << 10)
++        | (relocation & 0x7ff));
++  bfd_put_32 (abfd, x, (bfd_byte *) data + reloc_entry->address);
++
++  if (relocation & ~(bfd_vma) 0x7fff)
++    return bfd_reloc_overflow;
++  return bfd_reloc_ok;
++}
++
+ /* A mapping from BFD reloc types to MIPS ELF reloc types.  */
+ 
+ struct elf_reloc_map {
+@@ -3677,6 +3788,14 @@
+ 
+   switch (code)
+     {
++    case BFD_RELOC_MIPS_DVP_11_PCREL:
++      return &elf_mips_dvp_11_pcrel_howto;
++    case BFD_RELOC_MIPS_DVP_27_S4:
++      return &elf_mips_dvp_27_s4_howto;
++    case BFD_RELOC_MIPS_DVP_11_S4:
++      return &elf_mips_dvp_11_s4_howto;
++    case BFD_RELOC_MIPS_DVP_U15_S3:
++      return &elf_mips_dvp_u15_s3_howto;
+     case BFD_RELOC_VTABLE_INHERIT:
+       return &elf_mips_gnu_vtinherit_howto;
+     case BFD_RELOC_VTABLE_ENTRY:
+@@ -3754,6 +3873,14 @@
+ 
+   switch (r_type)
+     {
++    case R_MIPS_DVP_11_PCREL:
++      return &elf_mips_dvp_11_pcrel_howto;
++    case R_MIPS_DVP_27_S4:
++      return &elf_mips_dvp_27_s4_howto;
++    case R_MIPS_DVP_11_S4:
++      return &elf_mips_dvp_11_s4_howto;
++    case R_MIPS_DVP_U15_S3:
++      return &elf_mips_dvp_u15_s3_howto;
+     case R_MIPS_GNU_VTINHERIT:
+       return &elf_mips_gnu_vtinherit_howto;
+     case R_MIPS_GNU_VTENTRY:
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/elfxx-mips.c binutils-2.46.1-kos/bfd/elfxx-mips.c
+--- binutils-2.46.1/bfd/elfxx-mips.c	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/elfxx-mips.c	2026-07-06 18:45:40
+@@ -7621,7 +7621,18 @@
+       break;
+     case SHT_MIPS_XHASH:
+       if (strcmp (name, ".MIPS.xhash") != 0)
+-	return false;
++        return false;
++      break;
++    case SHT_DVP_OVERLAY_TABLE:
++      if (strcmp (name, SHNAME_DVP_OVERLAY_TABLE) != 0)
++        return false;
++      break;
++    case SHT_DVP_OVERLAY:
++      if (strncmp (name, SHNAME_DVP_OVERLAY_PREFIX,
++                   sizeof (SHNAME_DVP_OVERLAY_PREFIX) - 1)
++          != 0)
++        return false;
++      break;
+     default:
+       break;
+     }
+@@ -7870,6 +7881,17 @@
+       hdr->sh_flags |= SHF_ALLOC;
+       hdr->sh_entsize = get_elf_backend_data(abfd)->s->arch_size == 64 ? 0 : 4;
+     }
++  else if (strcmp (name, SHNAME_DVP_OVERLAY_TABLE) == 0)
++    {
++      hdr->sh_type = SHT_DVP_OVERLAY_TABLE;
++      hdr->sh_entsize = sizeof (Elf32_Dvp_External_Overlay);
++      /* The sh_link field is set in final_write_processing.  */
++    }
++  else if (strcmp (name, SHNAME_DVP_OVERLAY_STRTAB) == 0)
++    hdr->sh_type = SHT_STRTAB;
++  else if (strncmp (name, SHNAME_DVP_OVERLAY_PREFIX,
++                    sizeof (SHNAME_DVP_OVERLAY_PREFIX) - 1) == 0)
++    hdr->sh_type = SHT_DVP_OVERLAY;
+ 
+   /* The generic elf_fake_sections will set up REL_HDR using the default
+    kind of relocations.  We used to set up a second header for the
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/libbfd.h binutils-2.46.1-kos/bfd/libbfd.h
+--- binutils-2.46.1/bfd/libbfd.h	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/libbfd.h	2026-07-06 18:45:40
+@@ -1408,6 +1408,11 @@
+   "BFD_RELOC_MN10300_TLS_TPOFF",
+   "BFD_RELOC_MN10300_32_PCREL",
+   "BFD_RELOC_MN10300_16_PCREL",
++  "BFD_RELOC_MIPS_DVP_11_PCREL ",
++  "BFD_RELOC_MIPS_DVP_27_S4 ",
++  "BFD_RELOC_MIPS_DVP_11_S4 ",
++  "BFD_RELOC_MIPS_DVP_U15_S3 ",
++
+   "BFD_RELOC_386_GOT32",
+   "BFD_RELOC_386_PLT32",
+   "BFD_RELOC_386_GOTOFF",
+diff -x .DS_Store -ruN binutils-2.46.1/bfd/reloc.c binutils-2.46.1-kos/bfd/reloc.c
+--- binutils-2.46.1/bfd/reloc.c	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/bfd/reloc.c	2026-07-06 18:45:40
+@@ -2326,6 +2326,28 @@
+ ENUMDOC
+   This is a 16bit pcrel reloc for the mn10300, offset by two bytes in
+   the instruction.
++COMMENT
++ENUM
++  BFD_RELOC_MIPS_DVP_11_PCREL
++ENUMDOC
++  MIPS DVP Relocations.
++  This is an 11-bit pc relative reloc.  The recorded address is for the
++  lower instruction word, and the value is in 128 bit units.
++ENUM
++  BFD_RELOC_MIPS_DVP_27_S4
++ENUMDOC
++  This is a 27 bit address left shifted by 4.
++ENUM
++  BFD_RELOC_MIPS_DVP_11_S4
++ENUMDOC
++  This is the 11 bit offset operand of ilw/stw instructions
++  left shifted by 4.
++ENUM
++  BFD_RELOC_MIPS_DVP_U15_S3
++ENUMDOC
++  This is the 15 bit unsigned immediate operand of the iaddiu instruction
++  left shifted by 3.
++COMMENT
+ 
+ ENUM
+   BFD_RELOC_386_GOT32
+diff -x .DS_Store -ruN binutils-2.46.1/config.sub binutils-2.46.1-kos/config.sub
+--- binutils-2.46.1/config.sub	2026-07-06 18:45:01
++++ binutils-2.46.1-kos/config.sub	2026-07-06 18:45:40
+@@ -893,6 +893,10 @@
+ 		vendor=atari
+ 		basic_os=mint
+ 		;;
++	dvp)
++		cpu=dvp
++		vendor=scei
++		;;
+ 	news-3600 | risc-news)
+ 		cpu=mips
+ 		vendor=sony
+@@ -1297,6 +1301,7 @@
+ 			| d30v \
+ 			| dlx \
+ 			| dsp16xx \
++			| dvp \
+ 			| e2k \
+ 			| elxsi \
+ 			| epiphany \
+@@ -1832,6 +1837,10 @@
+ 		;;
+ 	*-siemens)
+ 		os=sysv4
++		;;
++	dvp-*)
++		os=
++		obj=elf
+ 		;;
+ 	mips*-cisco)
+ 		os=
+diff -x .DS_Store -ruN binutils-2.46.1/configure binutils-2.46.1-kos/configure
+--- binutils-2.46.1/configure	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/configure	2026-07-06 18:45:40
+@@ -4036,6 +4036,9 @@
+   d30v-*-*)
+     noconfigdirs="$noconfigdirs gdb"
+     ;;
++  dvp-*-*)
++    noconfigdirs="$noconfigdirs ld gdb target-libgloss gprof sim"
++    ;;
+   fr30-*-elf*)
+     noconfigdirs="$noconfigdirs gdb"
+     ;;
+@@ -4189,6 +4192,8 @@
+   mips*-*-ultrix* | mips*-*-osf* | mips*-*-ecoff* | mips*-*-pe* \
+   | mips*-*-irix* | mips*-*-lnews* | mips*-*-riscos*)
+     noconfigdirs="$noconfigdirs ld gas gprof"
++    ;;
++  mips64r5900el-ps2-elf)
+     ;;
+   mips*-*-*)
+     noconfigdirs="$noconfigdirs gprof"
+diff -x .DS_Store -ruN binutils-2.46.1/configure.ac binutils-2.46.1-kos/configure.ac
+--- binutils-2.46.1/configure.ac	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/configure.ac	2026-07-06 18:45:40
+@@ -1205,6 +1205,9 @@
+   d30v-*-*)
+     noconfigdirs="$noconfigdirs gdb"
+     ;;
++  dvp-*-*)
++    noconfigdirs="$noconfigdirs ld gdb target-libgloss gprof sim"
++    ;;
+   fr30-*-elf*)
+     noconfigdirs="$noconfigdirs gdb"
+     ;;
+@@ -1358,6 +1361,8 @@
+   mips*-*-ultrix* | mips*-*-osf* | mips*-*-ecoff* | mips*-*-pe* \
+   | mips*-*-irix* | mips*-*-lnews* | mips*-*-riscos*)
+     noconfigdirs="$noconfigdirs ld gas gprof"
++    ;;
++  mips64r5900el-ps2-elf)
+     ;;
+   mips*-*-*)
+     noconfigdirs="$noconfigdirs gprof"
+diff -x .DS_Store -ruN binutils-2.46.1/gas/Makefile.am binutils-2.46.1-kos/gas/Makefile.am
+--- binutils-2.46.1/gas/Makefile.am	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/gas/Makefile.am	2026-07-06 18:45:40
+@@ -156,6 +156,7 @@
+ 	config/tc-d10v.c \
+ 	config/tc-d30v.c \
+ 	config/tc-dlx.c \
++	config/tc-dvp.c \
+ 	config/tc-epiphany.c \
+ 	config/tc-fr30.c \
+ 	config/tc-frv.c \
+@@ -231,6 +232,7 @@
+ 	config/tc-d10v.h \
+ 	config/tc-d30v.h \
+ 	config/tc-dlx.h \
++	config/tc-dvp.h \
+ 	config/tc-epiphany.h \
+ 	config/tc-fr30.h \
+ 	config/tc-frv.h \
+diff -x .DS_Store -ruN binutils-2.46.1/gas/Makefile.in binutils-2.46.1-kos/gas/Makefile.in
+--- binutils-2.46.1/gas/Makefile.in	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/gas/Makefile.in	2026-07-06 18:45:40
+@@ -658,6 +658,7 @@
+ 	config/tc-d10v.c \
+ 	config/tc-d30v.c \
+ 	config/tc-dlx.c \
++	config/tc-dvp.c \
+ 	config/tc-epiphany.c \
+ 	config/tc-fr30.c \
+ 	config/tc-frv.c \
+@@ -733,6 +734,7 @@
+ 	config/tc-d10v.h \
+ 	config/tc-d30v.h \
+ 	config/tc-dlx.h \
++	config/tc-dvp.h \
+ 	config/tc-epiphany.h \
+ 	config/tc-fr30.h \
+ 	config/tc-frv.h \
+@@ -1129,6 +1131,8 @@
+ 	config/$(DEPDIR)/$(am__dirstamp)
+ config/tc-dlx.$(OBJEXT): config/$(am__dirstamp) \
+ 	config/$(DEPDIR)/$(am__dirstamp)
++config/tc-dvp.$(OBJEXT): config/$(am__dirstamp) \
++	config/$(DEPDIR)/$(am__dirstamp)
+ config/tc-epiphany.$(OBJEXT): config/$(am__dirstamp) \
+ 	config/$(DEPDIR)/$(am__dirstamp)
+ config/tc-fr30.$(OBJEXT): config/$(am__dirstamp) \
+@@ -1393,6 +1397,7 @@
+ @AMDEP_TRUE@@am__include@ @am__quote@config/$(DEPDIR)/tc-d10v.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@config/$(DEPDIR)/tc-d30v.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@config/$(DEPDIR)/tc-dlx.Po@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@config/$(DEPDIR)/tc-dvp.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@config/$(DEPDIR)/tc-epiphany.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@config/$(DEPDIR)/tc-fr30.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@config/$(DEPDIR)/tc-frv.Po@am__quote@
+diff -x .DS_Store -ruN binutils-2.46.1/gas/config/tc-dvp.c binutils-2.46.1-kos/gas/config/tc-dvp.c
+--- binutils-2.46.1/gas/config/tc-dvp.c	1969-12-31 16:00:00
++++ binutils-2.46.1-kos/gas/config/tc-dvp.c	2026-07-06 18:45:40
+@@ -0,0 +1,3438 @@
++/* tc-dvp.c -- Assembler for the DVP
++   Copyright (C) 1997, 1998 Free Software Foundation.
++
++   This file is part of GAS, the GNU Assembler.
++
++   GAS is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 2, or (at your option)
++   any later version.
++
++   GAS is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with GAS; see the file COPYING.  If not, write to
++   the Free Software Foundation, 59 Temple Place - Suite 330,
++   Boston, MA 02111-1307, USA.  */
++
++#include "as.h"
++#include "config.h"
++#include "symbols.h"
++#include "subsegs.h"
++#include "safe-ctype.h"
++/* Needed by opcode/dvp.h.  */
++#include "dis-asm.h"
++#include "opcode/dvp.h"
++#include "elf/mips.h"
++
++#include <stdarg.h>
++
++void do_s_func (int end_p, const char *default_prefix);
++int vif_get_mpgloc (void);
++
++/* Value of VIF `nop' instruction.  */
++#define VIFNOP 0
++
++#define MIN(a,b) ((a) < (b) ? (a) : (b))
++
++/* Compute DMA operand index number of OP.  */
++#define DMA_OPERAND_INDEX(op) ((op) - dma_operands)
++
++/* Our local label prefix.  */
++#define DVP_LOCAL_LABEL_PREFIX ".L"
++/* Label prefix for end markers used in autocounts.  */
++#define END_LABEL_PREFIX ".L.end."
++/* Label to use for unique labels.  */
++#define UNIQUE_LABEL_PREFIX ".L.dvptmp."
++/* Prefix for mips version of labels defined in vu code.
++   Note that symbols that begin with '$' are local symbols
++   on mips targets, so we can't begin it with '$'.  */
++#define VU_LABEL_PREFIX "_$"
++/* Prefix for symbols at start of vu overlays, in r5900 space.  */
++#define VUOVERLAY_START_PREFIX "__start_"
++
++static long parse_float (char **, const char **);
++static symbolS * create_label (const char *, const char *);
++static symbolS * create_colon_label (int, const char *, const char *);
++static char * unique_name (const char *);
++static int vuoverlay_section_p (segT);
++static char * vuoverlay_section_name (symbolS *);
++static void create_vuoverlay_section (const char *, symbolS *,
++					      symbolS *, symbolS *);
++static symbolS * compute_mpgloc (symbolS *, symbolS *, symbolS *);
++static int compute_nloop (gif_type, int, int);
++static void check_nloop (gif_type, int, int, int,
++				 const char *, unsigned int);
++static long eval_expr (dvp_cpu, int, int, const char *, ...);
++static long parse_dma_addr_autocount (const dvp_opcode *opcode,
++                                      const dvp_operand *operand, int mods,
++                                      DVP_INSN *insn_buf, char **pstr,
++                                      const char **errmsg);
++static void inline_dma_data (int, DVP_INSN *);
++static void setup_dma_autocount (const char *, DVP_INSN *, int);
++
++static void insert_operand
++     (dvp_cpu, const dvp_opcode *, const dvp_operand *, int,
++	      DVP_INSN *, offsetT, const char **);
++static void insert_operand_final
++     (dvp_cpu, const dvp_operand *, int,
++	      DVP_INSN *, offsetT, const char *, unsigned int);
++
++static void insert_mpg_marker (unsigned long);
++static void insert_unpack_marker (unsigned long);
++static int insert_file (const char *,
++				void (*) (unsigned long),
++				unsigned long, int);
++
++static int vif_insn_type (char);
++static int vif_length_value (char, int, int, int);
++static void install_vif_length (char *, int);
++
++const char comment_chars[] = ";";
++const char line_comment_chars[] = "#";
++const char line_separator_chars[] = "!";
++const char EXP_CHARS[] = "eE";
++const char FLT_CHARS[] = "dD";
++
++/* Last label seen.
++   When we see a .dmastart, any immediately preceding label is
++   automagically aligned as well.  */
++static symbolS *last_label_seen;
++/* Labels for vu code are duplicated, one in vu space, one in normal space.
++   This records the label in vu space.  */
++static symbolS *last_label_seen2;
++
++/* Current assembler state.
++   Instructions like mpg and direct are followed by a restricted set of
++   instructions.  In the case of a '*' length argument an end marker must
++   be provided.  (e.g. mpg is followed by vu insns until a .EndMpg is
++   seen).
++
++   Allowed state transitions:
++   ASM_INIT <--> ASM_MPG
++                 ASM_DIRECT <--> ASM_GIF
++                 ASM_UNPACK <--> ASM_GIF
++                 ASM_VU
++		 ASM_GIF
++
++   FIXME: Make the ASM_INIT -> ASM_VU a one way transition.
++   ".vu" must be seen at the top of the file,
++   and cannot be switched out of.
++*/
++
++typedef enum {
++  ASM_INIT, ASM_DIRECT, ASM_MPG, ASM_UNPACK, ASM_VU, ASM_GIF, ASM_MAX
++} asm_state;
++
++/* We need to maintain a stack of the current and previous status to handle
++   such things as "direct ...; gifpacked ... ; .endgif ; .enddirect".  */
++#define MAX_STATE_DEPTH 2
++static asm_state asm_state_stack[MAX_STATE_DEPTH];
++/* Current state's index in the stack.  */
++static int cur_state_level;
++/* Macro to fetch the current state.  */
++#define CUR_ASM_STATE (asm_state_stack[cur_state_level])
++
++/* Functions to push/pop the state stack.  */
++static void push_asm_state (asm_state);
++static void pop_asm_state (int);
++static void set_asm_state (asm_state, const char *);
++
++/* Set to non-zero if any non-vu insn seen.
++   Used to control type of relocations emitted.  */
++static int non_vu_insn_seen_p = 0;
++
++/* Current cpu (machine variant) type state.
++   We copy the mips16 way of recording what the current machine type is in
++   the code.  A label is created whenever necessary and has an "other" value
++   the denotes the machine type.  */
++static dvp_cpu cur_cpu;
++/* Record the current mach type.  */
++static void record_mach (dvp_cpu, int);
++/* Force emission of mach type label at next insn.
++   This isn't static as TC_START_LABEL uses it.  */
++int force_mach_label (void);
++/* Given a dvp_cpu value, return the STO_DVP value to use.  */
++static int cpu_sto (dvp_cpu, const char **);
++
++/* Nonzero if inside .DmaData.  */
++static int dma_data_state = 0;
++/* Label of .DmaData (internally generated for inline data).  */
++static const char *dma_data_name;
++
++/* Variable length VIF insn support.  */
++/* Label at start of insn's data.  */
++static symbolS *vif_data_start;
++/* Label at end of insn's data.  */
++static symbolS *vif_data_end;
++
++/* Special symbol $.mpgloc.  The value is in bytes.
++   This value is kept absolute, for simplicity.
++   The st_other field for this must always be set to STO_DVP_VU because
++   symbols computed from this will get their st_other field clobbered
++   with this one (via resolve_symbol_value,copy_symbol_attributes).  */
++static symbolS *mpgloc_sym;
++
++/* Handle of the current vu overlay section.  */
++static segT vuoverlay_section;
++
++/* The overlay table section is a table mapping lma's to vma's.  */
++static segT vuoverlay_table_section;
++/* String table to record section names in the overlay table.  */
++static segT vuoverlay_string_section;
++
++/* Table to map vu space labels to their overlay sections.
++   Labels in vu space are first put in the ABS section to simplify
++   PC relative branch calculations (s1 - s2 isn't supported if they're
++   in different sections).  Before the file is written out the labels
++   are moved to their overlay section.  */
++typedef struct ovlysym {
++  struct ovlysym *next;
++  segT sec;
++  symbolS *sym;
++} ovlysymS;
++static ovlysymS *ovlysym_table;
++
++/* GIF insn support.  */
++/* Type of insn.  */
++static int gif_insn_type;
++/* Name of label of insn's data.  */
++static const char *gif_data_name;
++/* Pointer to frag of insn.  */
++static fragS *gif_insn_frag;
++/* Pointer to current gif insn in gif_insn_frag.  */
++static char *gif_insn_frag_loc;
++/* The length value specified in the insn, or -1 if '*'.  */
++static int gif_user_value ATTRIBUTE_UNUSED;
++
++/* Count of vu insns seen since the last mpg.
++   Set to -1 to disable automatic mpg insertion.  */
++static int vu_count;
++
++/* Non-zero if packing vif instructions in dma tags.  */
++static int dma_pack_vif_p;
++
++/* Non-zero if dma insns are to be included in the output.
++   This is the default, but writing "if (! no_dma)" is klunky.  */
++static int output_dma = 1;
++/* Non-zero if vif insns are to be included in the output.  */
++static int output_vif = 1;
++
++/* When merging MIPS objects BFD will warn if PIC flags are mismatched  */
++static int enable_abicalls = 1;
++
++/* Current opcode/operand for use by md_operand.  */
++static const dvp_opcode *cur_opcode;
++static const dvp_operand *cur_operand;
++
++/* Options for the `caller' argument to s_endmpg.  */
++typedef enum { ENDMPG_USER, ENDMPG_INTERNAL, ENDMPG_MIDDLE } endmpg_caller;
++
++/* Relaxation support.  */
++#define RELAX_MPG 1
++#define RELAX_DIRECT 2
++/* vu insns aren't relaxed, but they use machine dependent frags so we
++   must handle them during relaxation */
++#define RELAX_VU 3
++#define RELAX_ENCODE(type, growth) (10 + (growth))
++#define RELAX_GROWTH(state) ((state) - 10)
++/* Return non-zero if STATE represents a relaxed state.  */
++#define RELAX_DONE_P(state) ((state) >= 10)
++
++/* The ABI to use.  */
++enum mips_abi_level
++{
++  NO_ABI = 0,
++  O32_ABI,
++  O64_ABI,
++  N32_ABI,
++  N64_ABI,
++  EABI_ABI
++};
++
++static symbolS *
++expr_build_binary (operatorT op, symbolS *s1, symbolS *s2)
++{
++  expressionS e;
++
++  e.X_op = op;
++  e.X_add_symbol = s1;
++  e.X_op_symbol = s2;
++  e.X_add_number = 0;
++  return make_expr_symbol (&e);
++}
++
++/* MIPS ABI we are using for this output file.
++   We default to N32_ABI since this is the default for the new toolchain.  */
++static enum mips_abi_level mips_abi = N32_ABI;
++
++const char md_shortopts[] = "";
++
++const struct option md_longopts[] =
++{
++#define OPTION_NO_DMA     (OPTION_MD_BASE + 1)
++  { "no-dma", no_argument, NULL, OPTION_NO_DMA },
++#define OPTION_NO_DMA_VIF (OPTION_MD_BASE + 2)
++  { "no-dma-vif", no_argument, NULL, OPTION_NO_DMA_VIF },
++#define OPTION_MABI       (OPTION_MD_BASE + 3)
++  { "mabi", required_argument, NULL, OPTION_MABI },
++#define OPTION_32 	      (OPTION_MD_BASE + 4)
++  { "32", no_argument, NULL, OPTION_32 },
++#define OPTION_N32 	      (OPTION_MD_BASE + 5)
++  { "n32", no_argument, NULL, OPTION_N32 },
++#define OPTION_64         (OPTION_MD_BASE + 6)
++  { "64", no_argument, NULL, OPTION_64 },
++#define OPTION_NO_ABICALLS (OPTION_MD_BASE + 7)
++  { "no-abicalls", no_argument, NULL, OPTION_NO_ABICALLS },
++
++  { NULL, no_argument, NULL, 0 }
++};
++const size_t md_longopts_size = sizeof (md_longopts);
++
++int
++md_parse_option (int c, const char *arg)
++{
++  switch (c)
++    {
++    case OPTION_NO_DMA :
++      output_dma = 0;
++      break;
++    case OPTION_NO_DMA_VIF :
++      output_dma = 0;
++      output_vif = 0;
++      break;
++    case OPTION_NO_ABICALLS :
++      enable_abicalls = 0;
++      break;
++      /* The -32, -n32 and -64 options are shortcuts for -mabi=32, -mabi=n32
++	 and -mabi=64.  */
++    case OPTION_32:
++      mips_abi = O32_ABI;
++      break;
++    case OPTION_N32:
++      mips_abi = N32_ABI;
++      break;
++    case OPTION_64:
++      mips_abi = N64_ABI;
++      break;
++    case OPTION_MABI:
++      if (strcmp (arg, "32") == 0)
++	mips_abi = O32_ABI;
++      else if (strcmp (arg, "o64") == 0)
++	mips_abi = O64_ABI;
++      else if (strcmp (arg, "n32") == 0)
++	mips_abi = N32_ABI;
++      else if (strcmp (arg, "64") == 0)
++	mips_abi = N64_ABI;
++      else if (strcmp (arg, "eabi") == 0)
++	mips_abi = EABI_ABI;
++      else
++	{
++	  as_fatal (_("invalid abi -mabi=%s"), arg);
++	  return 0;
++	}
++      break;
++    default :
++      return 0;
++    }
++  return 1;
++}
++
++static void
++show (FILE *stream, const char *string, int *col_p, int *first_p)
++{
++  if (*first_p)
++    {
++      fprintf (stream, "%24s", "");
++      *col_p = 24;
++    }
++  else
++    {
++      fprintf (stream, ", ");
++      *col_p += 2;
++    }
++
++  if (*col_p + strlen (string) > 72)
++    {
++      fprintf (stream, "\n%24s", "");
++      *col_p = 24;
++    }
++
++  fprintf (stream, "%s", string);
++  *col_p += strlen (string);
++
++  *first_p = 0;
++}
++
++void
++md_show_usage (stream)
++  FILE *stream;
++{
++  int column, first;
++  fprintf (stream, "\
++DVP options:\n\
++-no-dma			do not include DMA instructions in the output\n\
++-no-dma-vif		do not include DMA or VIF instructions in the output\n\
++-no-abicalls		do not mark header as PIC\n\
++-mabi=ABI		create ABI conformant object file for:\n");
++
++  first = 1;
++
++  show (stream, "32", &column, &first);
++  show (stream, "o64", &column, &first);
++  show (stream, "n32", &column, &first);
++  show (stream, "64", &column, &first);
++  show (stream, "eabi", &column, &first);
++
++  fputc ('\n', stream);
++
++  fprintf (stream, "\
++-32			create o32 ABI object file\n\
++-n32			create n32 ABI object file (default)\n\
++-64			create 64 ABI object file\n");
++}
++
++static void s_dmadata (int);
++static void s_enddmadata (int);
++static void s_dmapackvif (int);
++static void s_enddirect (int);
++static void s_endmpg (int);
++static void s_endunpack (int);
++static void s_endgif (int);
++static void s_vu (int);
++static void s_dvp_func (int);
++
++/* The target specific pseudo-ops which we support.  */
++const pseudo_typeS md_pseudo_table[] =
++{
++  { "word", cons, 4 },
++  { "quad", cons, 16 },
++  { "dmadata", s_dmadata, 0 },
++  { "dmapackvif", s_dmapackvif, 0 },
++  { "enddirect", s_enddirect, 0 },
++  { "enddmadata", s_enddmadata, 0 },
++  { "endmpg", s_endmpg, ENDMPG_USER },
++  { "endunpack", s_endunpack, 0 },
++  { "endgif", s_endgif, 0 },
++  { "vu", s_vu, 0 },
++  /* We need to intercept .func/.endfunc so that we can prepend _$.
++     ??? Not sure this is right though as _$foo is the lma version.  */
++  { "func", s_dvp_func, 0 },
++  { "endfunc", s_dvp_func, 1 },
++  { NULL, NULL, 0 }
++};
++
++void
++md_begin ()
++{
++  /* Force a mach type label for the first insn.  */
++  force_mach_label ();
++
++  /* Initialize the parsing state.  */
++  set_asm_state (ASM_INIT, NULL);
++
++  /* Pack vif insns in dma tags by default.  */
++  dma_pack_vif_p = 1;
++
++  /* Disable automatic mpg insertion.  */
++  vu_count = -1;
++
++  /* Initialize $.mpgloc.  */
++  mpgloc_sym = expr_build_uconstant (0);
++  S_SET_OTHER (mpgloc_sym, STO_DVP_VU);
++
++  /* Create the vu overlay table section.  */
++  {
++    /* Must preserve the current seg/subseg.  It is the initial one.  */
++    segT orig_seg = now_seg;
++    subsegT orig_subseg = now_subseg;
++
++    vuoverlay_table_section = subseg_new (SHNAME_DVP_OVERLAY_TABLE, 0);
++    record_alignment (now_seg, 2);
++    vuoverlay_string_section = subseg_new (SHNAME_DVP_OVERLAY_STRTAB, 0);
++    /* Ensure first byte in executable is zero.  So what if we waste
++       a few bytes.  */
++    FRAG_APPEND_1_CHAR (0);
++
++    subseg_set (orig_seg, orig_subseg);
++  }
++
++  /* Set the type of the output file to r5900.  */
++  bfd_set_arch_mach (stdoutput, bfd_arch_mips, 5900);
++
++  /* Set the MIPS ELF ABI flags.  */
++  if (mips_abi == O32_ABI)
++    elf_elfheader (stdoutput)->e_flags |= E_MIPS_ABI_O32;
++  else if (mips_abi == O64_ABI)
++    elf_elfheader (stdoutput)->e_flags |= E_MIPS_ABI_O64;
++  else if (mips_abi == EABI_ABI)
++    elf_elfheader (stdoutput)->e_flags |= E_MIPS_ABI_EABI32;
++  else if (mips_abi == N32_ABI)
++    elf_elfheader (stdoutput)->e_flags |= EF_MIPS_ABI2;
++
++  /* This doesn't make much sense for the DVP, but it's required to suppress
++   the mismatched abicall warning from the EEs linker  */
++  if(enable_abicalls)
++    elf_elfheader (stdoutput)->e_flags |= EF_MIPS_CPIC;
++}
++
++/* We need to keep a list of fixups.  We can't simply generate them as
++   we go, because that would require us to first create the frag, and
++   that would screw up references to ``.''.  */
++
++struct dvp_fixup
++{
++  /* the cpu this fixup is associated with */
++  dvp_cpu cpu;
++  /* index into `dvp_operands' */
++  int opindex;
++  /* byte offset from beginning of instruction */
++  int offset;
++  /* user specified value [when there is one] */
++  int user_value;
++  /* wl,cl values, only used with unpack insn */
++  short wl,cl;
++  /* the expression */
++  expressionS exp;
++};
++
++#define MAX_FIXUPS 5
++
++static int fixup_count;
++static struct dvp_fixup fixups[MAX_FIXUPS];
++
++/* Given a cpu type and operand number, return a temporary reloc type
++   for use in generating the fixup that encodes the cpu type and operand.  */
++static bfd_reloc_code_real_type encode_fixup_reloc_type (dvp_cpu, int);
++/* Given an encoded fixup reloc type, decode it into cpu and operand.  */
++static void decode_fixup_reloc_type (int, dvp_cpu *,
++					     const dvp_operand **);
++
++static void assemble_dma (char *);
++static void assemble_gif (char *);
++static void assemble_vif (char *);
++static void assemble_vu (char *);
++static const dvp_opcode *assemble_one_insn (dvp_cpu, const dvp_opcode *,
++                                            const dvp_operand *, int, int,
++                                            char **, DVP_INSN *);
++
++/* Main entry point for assembling an instruction.  */
++
++void
++md_assemble (char *str)
++{
++  /* Skip leading white space.  */
++  while (ISSPACE (*str))
++    str++;
++
++  /* After a gif tag, no insns can appear until a .endgif is seen.  */
++  if (CUR_ASM_STATE == ASM_GIF)
++    {
++      as_bad ("missing .endgif");
++      pop_asm_state (1);
++      /* We still parse the instruction.  */
++    }
++
++  if (CUR_ASM_STATE == ASM_INIT)
++    {
++      if (strncasecmp (str, "dma", 3) == 0)
++	assemble_dma (str);
++      else if (strncasecmp (str, "gif", 3) == 0)
++	assemble_gif (str);
++      else
++	assemble_vif (str);
++      non_vu_insn_seen_p = 1;
++    }
++  else if (CUR_ASM_STATE == ASM_DIRECT
++	   || CUR_ASM_STATE == ASM_UNPACK)
++    {
++      assemble_gif (str);
++      non_vu_insn_seen_p = 1;
++    }
++  else if (CUR_ASM_STATE == ASM_VU
++	   || CUR_ASM_STATE == ASM_MPG)
++    assemble_vu (str);
++  else
++    as_fatal ("internal error: unknown parse state");
++}
++
++/* Subroutine of md_assemble to assemble DMA instructions.  */
++
++static void
++assemble_dma (char *str)
++{
++  DVP_INSN insn_buf[2];
++  /* Pointer to allocated frag.  */
++  char *f;
++  int i;
++  const dvp_opcode *opcode;
++
++  if (output_dma)
++    {
++      /* Do an implicit alignment to a 16 byte boundary.
++	 Do it now so that inline dma data labels are at the right place.  */
++      /* ??? One can certainly argue all this implicit alignment is
++	 questionable.  The thing is assembler programming is all that will
++	 mostly likely ever be done and not doing so forces an extra [and
++	 arguably unnecessary] burden on the programmer.
++	 ??? On the other hand this automagic alignment requires the supremely
++	 grotesque last_label_seen hack.  Assembler macros may have been a
++	 better way to go.  */
++      frag_align (4, 0, 0);
++      record_alignment (now_seg, 4);
++
++      /* Advance up the immediately preceding label if present.  */
++      if (last_label_seen)
++        {
++          gas_assert (S_GET_SEGMENT (last_label_seen) == now_seg);
++          symbol_set_value_now(last_label_seen);
++        }
++    }
++
++  /* This is the DMA tag.  */
++  insn_buf[0] = 0;
++  insn_buf[1] = 0;
++
++  opcode = assemble_one_insn (DVP_DMA, dma_opcodes, dma_operands, 0, 0, &str,
++                              insn_buf);
++  if (opcode == NULL)
++    return;
++  if (!output_dma)
++    return;
++
++  record_mach (DVP_DMA, 0);
++
++  f = frag_more (8);
++
++  /* Write out the DMA instruction. */
++  for (i = 0; i < 2; ++i)
++    md_number_to_chars (f + i * 4, insn_buf[i], 4);
++
++  /* Create any fixups.  */
++  /* FIXME: It might eventually be possible to combine all the various
++     copies of this bit of code.  */
++  for (i = 0; i < fixup_count; ++i)
++    {
++      int op_type, reloc_type, offset;
++      const dvp_operand *operand;
++
++      /* Create a fixup for this operand.
++	 At this point we do not use a bfd_reloc_code_real_type for
++	 operands residing in the insn, but instead just use the
++	 operand index.  This lets us easily handle fixups for any
++	 operand type, although that is admittedly not a very exciting
++	 feature.  We pick a BFD reloc type in md_apply_fix.  */
++
++      op_type = fixups[i].opindex;
++      offset = fixups[i].offset;
++      reloc_type = encode_fixup_reloc_type (DVP_DMA, op_type);
++      operand = &dma_operands[op_type];
++      fix_new_exp (frag_now, f + offset - frag_now->fr_literal, 4,
++		   &fixups[i].exp,
++		   (operand->flags & DVP_OPERAND_RELATIVE_BRANCH) != 0,
++		   (bfd_reloc_code_real_type) reloc_type);
++    }
++
++  /* The upper two words are vif insns.  */
++  record_mach (DVP_VIF, 0);
++
++  /* If not doing dma/vif packing, fill out the insn with vif nops.
++     ??? We take advantage of the fact that the default fill value of zero
++     is the vifnop insn.  This occurs for example when handling mpg
++     alignment.  It also occurs when one dma tag immediately follows the
++     previous one.  */
++  if (! dma_pack_vif_p)
++    {
++      f = frag_more (8);
++      md_number_to_chars (f + 0, VIFNOP, 4);
++      md_number_to_chars (f + 4, VIFNOP, 4);
++    }
++}
++
++/* Subroutine of md_assemble to assemble VIF instructions.  */
++
++static void
++assemble_vif (char *str)
++{
++  /* Space for the instruction.
++     The variable length insns can require much more space than this.
++     It is allocated later, when we know we have such an insn.  */
++  DVP_INSN insn_buf[5];
++  /* Insn's length, in 32 bit words.  */
++  int len;
++  /* Pointer to allocated frag.  */
++  char *f;
++  int i,wl,cl;
++  const dvp_opcode *opcode;
++  fragS * insn_frag;
++  /* Name of file to read data from.  */
++  const char *file;
++  /* Length in 32 bit words.  */
++  int data_len;
++  /* Macro expansion, if there is one.  */
++  char * macstr;
++
++  /* First check for macros.  */
++  macstr = dvp_expand_macro (vif_macros, vif_macro_count, str);
++  if (macstr)
++    {
++      /* The macro may expand into several insns (delimited with '\n'),
++	 so loop.  */
++      char * next = macstr;
++      do
++	{
++	  char *p = strchr (next, '\n');
++	  if (p)
++	    *p = 0;
++	  assemble_vif (next);
++	  next = p ? p + 1 : 0;
++	}
++      while (next);
++      free (macstr);
++      return;
++    }
++
++  opcode = assemble_one_insn (DVP_VIF, vif_opcodes, vif_operands, 0, 0, &str,
++                              insn_buf);
++  if (opcode == NULL)
++    return;
++
++  if (opcode->flags & VIF_OPCODE_LENVAR)
++    len = 1; /* actual data follows later */
++  else if (opcode->flags & VIF_OPCODE_LEN2)
++    len = 2;
++  else if (opcode->flags & VIF_OPCODE_LEN5)
++    len = 5;
++  else
++    len = 1;
++
++  /* We still have to switch modes (if mpg for example) so we can't exit
++     early if -no-vif.  */
++
++  if (output_vif)
++    {
++      /* Record the mach before doing the alignment so that we properly
++	 disassemble any inserted vifnop's.  For mpg and direct insns
++	 force the recording of the mach type for the next insn.  The data
++	 will switch the mach type and we want to ensure it's switched
++	 back.  */
++
++      if (opcode->flags & (VIF_OPCODE_MPG | VIF_OPCODE_DIRECT))
++	record_mach (DVP_VIF, 1);
++      else
++	record_mach (DVP_VIF, 0);
++
++      /* For variable length instructions record a fixup that is the symbol
++	 marking the end of the data.  eval_expr will queue the fixup
++	 which will then be emitted later.  */
++      if (opcode->flags & VIF_OPCODE_LENVAR)
++	{
++	  char *name;
++
++	  asprintf (&name, "%s%s", DVP_LOCAL_LABEL_PREFIX,
++		    unique_name ("varlen"));
++	  vif_data_end = symbol_new (name, now_seg, 0, 0);
++	  symbol_table_insert (vif_data_end);
++	  fixups[fixup_count].cpu = DVP_VIF;
++	  fixups[fixup_count].exp.X_op = O_symbol;
++	  fixups[fixup_count].exp.X_add_symbol = vif_data_end;
++	  fixups[fixup_count].exp.X_add_number = 0;
++	  fixups[fixup_count].opindex = vif_operand_datalen_special;
++	  fixups[fixup_count].offset = 0;
++
++	  /* See what the user specified.  */
++	  vif_get_var_data (&file, &data_len);
++	  if (file)
++	    data_len = -1;
++	  fixups[fixup_count].user_value = data_len;
++	  /* Get the wl,cl values.  Only useful for the unpack insn but
++	     it doesn't hurt to always record them.  */
++	  vif_get_wl_cl (&wl, &cl);
++	  fixups[fixup_count].wl = wl;
++	  fixups[fixup_count].cl = cl;
++	  ++fixup_count;
++	}
++
++      /* Obtain space in which to store the instruction.  */
++
++      if (opcode->flags & VIF_OPCODE_MPG)
++	{
++	  /* The data must be aligned on a 64 bit boundary (so the mpg insn
++	     comes just before that 64 bit boundary).
++	     Do this by putting the mpg insn in a relaxable fragment
++	     with a symbol that marks the beginning of the aligned data.  */
++
++	  /* Ensure relaxable fragments are in their own fragment.
++	     Otherwise md_apply_fix3 mishandles fixups to insns earlier
++	     in the fragment (because we set fr_opcode for the `mpg' insn
++	     because it can move in the fragment).  */
++	  frag_wane (frag_now);
++	  frag_new (0);
++
++	  /* One could combine the previous two lines with the following.
++	     They're not for clarity: keep separate the actions being
++	     performed.  */
++
++	  /* This dance with frag_grow is so we can record frag_now in
++	     insn_frag.  frag_var always changes frag_now.  We must allocate
++	     the maximal amount of space we need so there's room to move
++	     the insn in the frag during relaxation.  */
++	  frag_grow (8);
++	  /* Allocate space for the fixed part.  */
++	  f = frag_more (4);
++	  insn_frag = frag_now;
++
++	  frag_var (rs_machine_dependent,
++		    4, /* max chars */
++		    0, /* variable part is empty at present */
++		    RELAX_MPG, /* subtype */
++		    NULL, /* no symbol */
++		    0, /* offset */
++		    f); /* opcode */
++
++	  frag_align (3, 0, 0);
++	  record_alignment (now_seg, 3);
++
++	  /* Put a symbol at the start of data.  The relaxation code uses
++	     this to figure out how many bytes to insert.  $.mpgloc
++	     calculations use it.  The disassembler uses it.  The overlay
++	     tracking table uses it.
++	     Update $.mpgloc.
++	     Create an overlay section.  */
++	  {
++	    int mpgloc = vif_get_mpgloc ();
++	    const char * section_name;
++
++	    /* Update $.mpgloc if explicitly set.
++	       Otherwise just use the current value.  */
++	    if (mpgloc != -1)
++	      {
++		/* The value is recorded in bytes, mpgloc is in dwords.  */
++		mpgloc_sym = expr_build_uconstant (mpgloc * 8);
++		S_SET_OTHER (mpgloc_sym, STO_DVP_VU);
++	      }
++
++	    section_name = vuoverlay_section_name (mpgloc_sym);
++	    vif_data_start = create_colon_label (STO_DVP_VU,
++#if 0
++						 VUOVERLAY_START_PREFIX,
++#else
++						 DVP_LOCAL_LABEL_PREFIX,
++#endif
++						 section_name);
++	    insn_frag->fr_symbol = vif_data_start;
++
++	    create_vuoverlay_section (section_name, mpgloc_sym,
++				      vif_data_start, vif_data_end);
++	  }
++	}
++      else if (opcode->flags & VIF_OPCODE_DIRECT)
++	{
++	  /* The data must be aligned on a 128 bit boundary (so the direct insn
++	     comes just before that 128 bit boundary).
++	     Do this by putting the direct insn in a relaxable fragment.
++	     with a symbol that marks the beginning of the aligned data.  */
++
++	  /* Ensure relaxable fragments are in their own fragment.
++	     Otherwise md_apply_fix3 mishandles fixups to insns earlier
++	     in the fragment (because we set fr_opcode for the `direct' insn
++	     because it can move in the fragment).  */
++	  frag_wane (frag_now);
++	  frag_new (0);
++
++	  /* One could combine the previous two lines with the following.
++	     They're not for clarity: keep separate the actions being
++	     performed.  */
++
++	  /* This dance with frag_grow is so we can record frag_now in
++	     insn_frag.  frag_var always changes frag_now.  We must allocate
++	     the maximal amount of space we need so there's room to move
++	     the insn in the frag during relaxation.  */
++	  frag_grow (16);
++	  /* Allocate space for the fixed part.  */
++	  f = frag_more (4);
++	  insn_frag = frag_now;
++
++	  frag_var (rs_machine_dependent,
++		    12, /* max chars */
++		    0, /* variable part is empty at present */
++		    RELAX_DIRECT, /* subtype */
++		    NULL, /* no symbol */
++		    0, /* offset */
++		    f); /* opcode */
++
++	  frag_align (4, 0, 0);
++	  record_alignment (now_seg, 4);
++
++	  /* Put a symbol at the start of data.  The relaxation code uses
++	     this to figure out how many bytes to insert.  */
++	  vif_data_start = create_colon_label (0, DVP_LOCAL_LABEL_PREFIX,
++					       unique_name ("direct"));
++	  insn_frag->fr_symbol = vif_data_start;
++	}
++      else if (opcode->flags & VIF_OPCODE_UNPACK)
++	{
++	  f = frag_more (len * 4);
++	  insn_frag = frag_now;
++	  /* Put a symbol at the start of data.  $.unpackloc calculations
++	     use it.  */
++	  /* ??? $.unpackloc is gone.  Is this also used for data length
++	     verification?  */
++	  vif_data_start = create_colon_label (STO_DVP_VIF, DVP_LOCAL_LABEL_PREFIX,
++					       unique_name ("unpack"));
++	}
++      else
++	{
++	  /* Reminder: it is important to fetch enough space in one call to
++	     `frag_more'.  We use (f - frag_now->fr_literal) to compute where
++	     we are and we don't want frag_now to change between calls.  */
++	  f = frag_more (len * 4);
++	  insn_frag = frag_now;
++	}
++
++      /* Write out the instruction.  */
++      for (i = 0; i < len; ++i)
++	md_number_to_chars (f + i * 4, insn_buf[i], 4);
++
++      /* Create any fixups.  */
++      /* FIXME: It might eventually be possible to combine all the various
++	 copies of this bit of code.  */
++      for (i = 0; i < fixup_count; ++i)
++	{
++	  int op_type, reloc_type, offset;
++	  const dvp_operand *operand;
++	  fixS *fixP;
++
++	  /* Create a fixup for this operand.
++	     At this point we do not use a bfd_reloc_code_real_type for
++	     operands residing in the insn, but instead just use the
++	     operand index.  This lets us easily handle fixups for any
++	     operand type, although that is admittedly not a very exciting
++	     feature.  We pick a BFD reloc type in md_apply_fix.  */
++
++	  op_type = fixups[i].opindex;
++	  offset = fixups[i].offset;
++	  reloc_type = encode_fixup_reloc_type (DVP_VIF, op_type);
++	  operand = &vif_operands[op_type];
++	  fixP = fix_new_exp (insn_frag, f + offset - insn_frag->fr_literal, 4,
++			      &fixups[i].exp,
++			      (operand->flags & DVP_OPERAND_RELATIVE_BRANCH) != 0,
++			      (bfd_reloc_code_real_type) reloc_type);
++	  fixP->tc_fix_data.user_value = fixups[i].user_value;
++	  fixP->tc_fix_data.wl = fixups[i].wl;
++	  fixP->tc_fix_data.cl = fixups[i].cl;
++
++	  /* Set fx_tcbit so other parts of the code know this fixup is for
++	     a vif insn.  */
++	  fixP->fx_tcbit = 1;
++	}
++    }
++
++  /* Handle variable length insns.  */
++
++  if (opcode->flags & VIF_OPCODE_LENVAR)
++    {
++      /* See what the user specified.  */
++      vif_get_var_data (&file, &data_len);
++
++      if (file)
++	{
++	  int byte_len ATTRIBUTE_UNUSED;
++
++	  /* The handling for each of mpg,direct,unpack is basically the same:
++	     - emit a label to set the mach type for the data we're inserting
++	     - switch to the new assembler state
++	     - insert the file
++	     - call the `end' handler  */
++
++	  if (opcode->flags & VIF_OPCODE_MPG)
++	    {
++	      record_mach (DVP_VUUP, 1);
++	      set_asm_state (ASM_MPG, "mpg");
++	      byte_len = insert_file (file, insert_mpg_marker, 0, 256 * 8);
++	      s_endmpg (ENDMPG_INTERNAL);
++	    }
++	  else if (opcode->flags & VIF_OPCODE_DIRECT)
++	    {
++	      record_mach (DVP_GIF, 1);
++	      set_asm_state (ASM_DIRECT, "direct");
++	      byte_len = insert_file (file, NULL, 0, 0);
++	      s_enddirect (1);
++	    }
++	  else if (opcode->flags & VIF_OPCODE_UNPACK)
++	    {
++	      int max_len = 0; /*unpack_max_byte_len (insn_buf[0]);*/
++	      set_asm_state (ASM_UNPACK, "unpack");
++	      byte_len = insert_file (file, NULL /*insert_unpack_marker*/,
++				      insn_buf[0], max_len);
++	      s_endunpack (1);
++	    }
++	  else
++	    as_fatal ("internal error: unknown cpu type for variable length vif insn");
++	}
++      else /* file == NULL */
++	{
++	  /* data_len == -1 means the value must be computed from
++	     the data.  */
++	  if (data_len <= -2)
++	    as_bad ("invalid data length");
++
++	  if (output_vif && data_len != -1)
++	    install_vif_length (f, data_len);
++
++	  if (opcode->flags & VIF_OPCODE_MPG)
++	    {
++	      set_asm_state (ASM_MPG, "mpg");
++	      /* Enable automatic mpg insertion every 256 insns.  */
++	      vu_count = 0;
++	    }
++	  else if (opcode->flags & VIF_OPCODE_DIRECT)
++	    set_asm_state (ASM_DIRECT, "direct");
++	  else if (opcode->flags & VIF_OPCODE_UNPACK)
++	    set_asm_state (ASM_UNPACK, "unpack");
++	}
++    }
++}
++
++/* Subroutine of md_assemble to assemble GIF instructions.
++   We assume CUR_ASM_STATE is one of ASM_{INIT,DIRECT,UNPACK}.  */
++
++static void
++assemble_gif (char *str)
++{
++  DVP_INSN insn_buf[4];
++  const dvp_opcode *opcode;
++  char *f;
++  int i;
++
++  insn_buf[0] = insn_buf[1] = insn_buf[2] = insn_buf[3] = 0;
++
++  opcode = assemble_one_insn (DVP_GIF, gif_opcodes, gif_operands, 0, 0, &str,
++                              insn_buf);
++  if (opcode == NULL)
++    return;
++
++  /* Do an implicit alignment to a 16 byte boundary.  */
++  frag_align (4, 0, 0);
++  record_alignment (now_seg, 4);
++
++  /* Advance up the immediately preceding label if present.  */
++  if (last_label_seen)
++    {
++      gas_assert (S_GET_SEGMENT (last_label_seen) == now_seg);
++      symbol_set_value_now(last_label_seen);
++    }
++
++  /* Insert a label so we can compute the number of quadwords when the
++     .endgif is seen.  This is put before the mach type label because gif
++     insns are followed by data and we don't want the disassembler to try
++     to disassemble them as mips insns (since it uses the st_other field)
++     of the closest label to choose the mach type and since we don't have
++     a special st_other value for "data".  */
++  gif_data_name = S_GET_NAME (create_colon_label (0, DVP_LOCAL_LABEL_PREFIX,
++						  unique_name ("gifdata")));
++
++  record_mach (DVP_GIF, 1);
++
++  gif_insn_frag_loc = f = frag_more (16);
++  gif_insn_frag = frag_now;
++  for (i = 0; i < 4; ++i)
++    md_number_to_chars (f + i * 4, insn_buf[i], 4);
++
++  /* Record the type of the gif tag so we know how to compute nloop
++     in s_endgif.  */
++  if (strcmp (opcode->mnemonic, "gifpacked") == 0)
++    gif_insn_type = GIF_PACKED;
++  else if (strcmp (opcode->mnemonic, "gifreglist") == 0)
++    gif_insn_type = GIF_REGLIST;
++  else if (strcmp (opcode->mnemonic, "gifimage") == 0)
++    gif_insn_type = GIF_IMAGE;
++  else
++    abort ();
++  push_asm_state (ASM_GIF);
++}
++
++/* Subroutine of md_assemble to assemble VU instructions.  */
++
++static void
++assemble_vu (char *str)
++{
++  int i;
++  char *f;
++  const dvp_opcode *opcode;
++  /* The lower instruction has the lower address so insns[0] = lower insn,
++     insns[1] = upper insn.  */
++  DVP_INSN insns[2];
++  fragS * insn_frag;
++
++  /* Handle automatic mpg insertion if enabled.  */
++  if (CUR_ASM_STATE == ASM_MPG
++      && vu_count == 256)
++    insert_mpg_marker (0);
++
++  /* Do an implicit alignment to a 8 byte boundary.  */
++  frag_align (3, 0, 0);
++  record_alignment (now_seg, 3);
++
++  /* Advance up the immediately preceding label if present.  */
++  if (last_label_seen)
++    {
++      gas_assert (S_GET_SEGMENT (last_label_seen) == now_seg);
++      symbol_set_value_now(last_label_seen);
++
++      /* Do the same for the copy in vu space.
++         Note that there won't be one if the file is all vu code.  */
++      if (last_label_seen2)
++        {
++          symbolS *cur_mpgloc
++              = compute_mpgloc (mpgloc_sym, vif_data_start, expr_build_dot ());
++          symbol_set_value_expression (
++              last_label_seen2, symbol_get_value_expression (cur_mpgloc));
++        }
++    }
++
++  record_mach (DVP_VUUP, 0);
++
++#ifdef VERTICAL_BAR_SEPARATOR
++  char *p = strchr (str, '|');
++
++  if (p == NULL)
++    {
++      as_bad ("lower instruction missing");
++      return;
++    }
++
++  *p = 0;
++  opcode = assemble_one_insn (DVP_VUUP, vu_upper_opcodes, vu_operands, 0, 4,
++                              &str, &insns[1]);
++  *p = '|';
++  str = p + 1;
++#else
++  opcode = assemble_one_insn (DVP_VUUP, vu_upper_opcodes, vu_operands, 0, 4,
++                              &str, &insns[1]);
++#endif
++
++  /* Don't assemble next one if we couldn't assemble the first.  */
++  if (opcode == NULL)
++    return;
++
++  if (*str == 0)
++    {
++      as_bad ("lower instruction missing");
++      return;
++    }
++
++  /* Assemble the lower insn.
++     Pass `fixup_count' for `init_fixup_count' so that we don't clobber
++     any fixups the upper insn had.  */
++  opcode = assemble_one_insn (DVP_VULO, vu_lower_opcodes, vu_operands,
++                              fixup_count, 0, &str, &insns[0]);
++  if (opcode == NULL)
++    return;
++
++  /* If there were fixups and we're inside mpg, create a machine dependent
++     fragment so that we can record the current value of $.mpgloc in fr_symbol.
++     Reminder: it is important to fetch enough space in one call to
++     `frag_more'.  We use (f - frag_now->fr_literal) to compute where
++     we are and we don't want frag_now to change between calls.  */
++  if (fixup_count != 0
++      && CUR_ASM_STATE == ASM_MPG)
++    {
++      symbolS * cur_mpgloc;
++
++      /* Ensure we get a new frag.  */
++      frag_wane (frag_now);
++      frag_new (0);
++
++      /* Compute the current $.mpgloc.  */
++      cur_mpgloc = compute_mpgloc (mpgloc_sym, vif_data_start,
++				   expr_build_dot ());
++
++      /* We need to use frag_now afterwards, so we can't just call frag_var.
++	 Instead we use frag_more and save the value of frag_now in
++	 insn_frag.  */
++      f = frag_more (8);
++      insn_frag = frag_now;
++      /* Turn the frag into a machine dependent frag.  */
++      frag_variant (rs_machine_dependent,
++		    0, /* max chars */
++		    0, /* no variable part */
++		    RELAX_VU, /* subtype */
++		    cur_mpgloc, /* $.mpgloc */
++		    0, /* offset */
++		    NULL); /* opcode */
++    }
++  else
++    {
++      f = frag_more (8);
++      insn_frag = frag_now;
++    }
++
++  /* Write out the instructions.  */
++  md_number_to_chars (f, insns[0], 4);
++  md_number_to_chars (f + 4, insns[1], 4);
++
++  /* Create any fixups.  */
++  for (i = 0; i < fixup_count; ++i)
++    {
++      int op_type, reloc_type;
++      const dvp_operand *operand;
++      dvp_cpu cpu;
++
++      /* Create a fixup for this operand.
++	 At this point we do not use a bfd_reloc_code_real_type for
++	 operands residing in the insn, but instead just use the
++	 operand index.  This lets us easily handle fixups for any
++	 operand type, although that is admittedly not a very exciting
++	 feature.  We pick a BFD reloc type in md_apply_fix.  */
++
++      cpu = fixups[i].cpu;
++      op_type = fixups[i].opindex;
++      reloc_type = encode_fixup_reloc_type (cpu, op_type);
++      operand = &vu_operands[op_type];
++
++      /* Branch operands inside mpg have to be handled specially.
++	 We want a pc relative relocation in a section different from our own.
++	 See the br-2.s dejagnu testcase for a good example.  */
++      if (CUR_ASM_STATE == ASM_MPG
++	  && (operand->flags & DVP_OPERAND_RELATIVE_BRANCH) != 0)
++	{
++	  symbolS *e1,*e2,*diff_expr;
++
++	  /* For "br foo" we want "foo - (. + 8)".  */
++	  e1 = expr_build_binary (O_add, insn_frag->fr_symbol,
++				  expr_build_uconstant (8));
++	  e2 = make_expr_symbol (&fixups[i].exp);
++	  diff_expr = expr_build_binary (O_subtract, e2, e1);
++	  fixups[i].exp.X_op = O_symbol;
++	  fixups[i].exp.X_add_symbol = diff_expr;
++	  fixups[i].exp.X_add_number = 0;
++	}
++
++      fix_new_exp (insn_frag, f + fixups[i].offset - insn_frag->fr_literal, 4,
++		   &fixups[i].exp,
++		   CUR_ASM_STATE == ASM_MPG /* pcrel */
++		   ? 0
++		   : (operand->flags & DVP_OPERAND_RELATIVE_BRANCH) != 0,
++		   (bfd_reloc_code_real_type) reloc_type);
++    }
++
++  /* If this was the "loi" pseudo-insn, we need to set the `i' bit.  */
++  if (strcmp (opcode->mnemonic, "loi") == 0)
++    f[7] |= 0x80;
++
++  /* Increment the vu insn counter.
++     If get reach 256 we need to insert an `mpg'.  */
++  ++vu_count;
++}
++
++/* Assemble one instruction at *PSTR.
++   CPU indicates what component we're assembling for.
++   The assembled instruction is stored in INSN_BUF.
++   OPCODE is a pointer to the head of the hash chain.
++   INIT_FIXUP_COUNT is the initial value for `fixup_count'.
++   It exists to allow the fixups for multiple calls to this insn to be
++   queued up before actually emitting them.
++   *PSTR is updated to point passed the parsed instruction.
++
++   If the insn is successfully parsed the result is a pointer to the opcode
++   entry that successfully matched and *PSTR is updated to point passed
++   the parsed insn.  If an error occurs the result is NULL and *PSTR is left
++   at some random point in the string (??? may wish to leave it pointing where
++   the error occured).  */
++
++static const dvp_opcode *
++assemble_one_insn (dvp_cpu cpu, const dvp_opcode *opcode,
++                   const dvp_operand *operand_table, int init_fixup_count,
++                   int fixup_offset, char **pstr, DVP_INSN *insn_buf)
++{
++  char *start, *str;
++
++  /* Keep looking until we find a match.  */
++
++  start = str = *pstr;
++  for ( ; opcode && opcode->mnemonic; opcode++)
++    {
++      int past_opcode_p;
++      const unsigned char *syn;
++
++      /* Ensure the mnemonic part matches.  */
++      for (str = start, syn = (unsigned char*)opcode->mnemonic; *syn != '\0'; ++str, ++syn)
++	if (TOLOWER (*str) != TOLOWER (*syn))
++	  break;
++      if (*syn != '\0')
++	continue;
++
++      /* Scan the syntax string.  If it doesn't match, try the next one.  */
++
++      dvp_opcode_init_parse ();
++      insn_buf[opcode->opcode_word] = opcode->value;
++      fixup_count = init_fixup_count;
++      past_opcode_p = 0;
++
++      /* We don't check for (*str != '\0') here because we want to parse
++	 any trailing fake arguments in the syntax string.  */
++      for (/*str = start, */ syn = opcode->syntax; *syn != '\0'; )
++	{
++	  int mods,index;
++	  const dvp_operand *operand;
++	  const char *errmsg;
++	  long value;
++
++	  /* Non operand chars must match exactly.
++	     Operand chars that are letters are not part of symbols
++	     and are case insensitive.  */
++	  if (*syn < 128)
++	    {
++	      if (TOLOWER (*str) == TOLOWER (*syn))
++		{
++		  if (*syn == ' ')
++		    past_opcode_p = 1;
++		  ++syn;
++		  ++str;
++		}
++	      else
++		break;
++	      continue;
++	    }
++
++	  /* We have a suffix or an operand.  Pick out any modifiers.  */
++	  mods = 0;
++	  index = DVP_OPERAND_INDEX (*syn);
++	  while (DVP_MOD_P (operand_table[index].flags))
++	    {
++	      mods |= operand_table[index].flags & DVP_MOD_BITS;
++	      ++syn;
++	      index = DVP_OPERAND_INDEX (*syn);
++	    }
++	  operand = operand_table + index;
++
++	  if (operand->flags & DVP_OPERAND_FAKE)
++	    {
++	      long op_value = 0;
++
++	      if (operand->flags & DVP_OPERAND_DMA_INLINE)
++		{
++		  inline_dma_data ((mods & DVP_OPERAND_AUTOCOUNT) != 0,
++				  insn_buf);
++		  ++syn;
++		  continue;
++		}
++
++	      if (operand->parse)
++		{
++		  errmsg = NULL;
++		  op_value = (*operand->parse) (opcode, operand, mods,
++					     &str, &errmsg);
++		  if (errmsg)
++		    break;
++		}
++	      if (operand->insert)
++		{
++		  errmsg = NULL;
++		  (*operand->insert) (opcode, operand, mods, insn_buf,
++				      (offsetT) op_value, &errmsg);
++		  /* If we get an error, go on to try the next insn.  */
++		  if (errmsg)
++		    break;
++		}
++	      ++syn;
++	      continue;
++	    }
++
++	  /* Are we finished with suffixes?  */
++	  if (!past_opcode_p)
++	    {
++	      long suf_value;
++
++	      if (!(operand->flags & DVP_OPERAND_SUFFIX))
++		as_fatal ("internal error: bad opcode table, missing suffix flag");
++
++	      /* Parse the suffix.  If we're at a space in the input string
++		 there are no more suffixes.  Suffix parse routines must be
++		 prepared to deal with this.  */
++	      errmsg = NULL;
++	      suf_value = (*operand->parse) (opcode, operand, mods, &str,
++					     &errmsg);
++	      if (errmsg)
++		{
++		  /* This can happen, for example, in ARC's in "blle foo" and
++		     we're currently using the template "b%q%.n %j".  The "bl"
++		     insn occurs later in the table so "lle" isn't an illegal
++		     suffix.  */
++		  break;
++		}
++
++	      /* Insert the suffix's value into the insn.  */
++	      insert_operand (cpu, opcode, operand, mods, insn_buf,
++			      (offsetT) suf_value, &errmsg);
++
++	      ++syn;
++	      continue;
++	    }
++
++	  /* This is an operand, either a register or an expression of
++	     some kind.  */
++
++	  value = 0;
++
++	  if (operand->flags & DVP_OPERAND_SUFFIX)
++	    as_fatal ("internal error: bad opcode table, suffix wrong");
++
++	  /* Is there anything left to parse?
++	     We don't check for this at the top because we want to parse
++	     any trailing fake arguments in the syntax string.  */
++	  /* ??? This doesn't allow operands with a legal value of "".  */
++	  if (*str == '\0')
++	    break;
++
++	  /* Parse the operand.  */
++	  if (operand->flags & DVP_OPERAND_FLOAT)
++	    {
++	      errmsg = 0;
++	      value = parse_float (&str, &errmsg);
++	      if (errmsg)
++		break;
++	    }
++	  else if ((operand->flags & DVP_OPERAND_DMA_ADDR)
++		   && (mods & DVP_OPERAND_AUTOCOUNT))
++	    {
++	      errmsg = 0;
++	      value = parse_dma_addr_autocount (opcode, operand, mods,
++						insn_buf, &str, &errmsg);
++	      if (errmsg)
++		break;
++	    }
++	  else
++	    {
++	      char *origstr,*hold;
++	      expressionS exp;
++
++	      /* First see if there is a special parser.  */
++	      origstr = str;
++	      if (operand->parse)
++		{
++		  errmsg = NULL;
++		  value = (*operand->parse) (opcode, operand, mods,
++					     &str, &errmsg);
++		  if (errmsg)
++		    break;
++		}
++
++	      /* If there wasn't a special parser, or there was and it
++		 left the input stream unchanged, use the general
++		 expression parser.  */
++	      if (str == origstr)
++		{
++		  hold = input_line_pointer;
++		  input_line_pointer = str;
++		  /* Set cur_{opcode,operand} for md_operand.  */
++		  cur_opcode = opcode;
++		  cur_operand = operand;
++		  expression (&exp);
++		  cur_opcode = NULL;
++		  str = input_line_pointer;
++		  input_line_pointer = hold;
++
++		  if (exp.X_op == O_illegal
++		      || exp.X_op == O_absent)
++		    break;
++		  else if (exp.X_op == O_constant)
++		    value = exp.X_add_number;
++		  else if (exp.X_op == O_register)
++		    as_fatal ("internal error: got O_register");
++		  else
++		    {
++		      /* We need to generate a fixup for this expression.  */
++		      if (fixup_count >= MAX_FIXUPS)
++			as_fatal ("internal error: too many fixups");
++		      fixups[fixup_count].cpu = cpu;
++		      fixups[fixup_count].exp = exp;
++		      fixups[fixup_count].opindex = index;
++		      /* FIXME: Revisit.  Do we really need operand->word?
++			 The endianness of a 128 bit DMAtag is rather
++			 twisted.  How about defining word 0 as the word with
++			 the lowest address and basing operand-shift off that.
++			 operand->word could then be deleted.  */
++		      fixups[fixup_count].offset = fixup_offset;
++		      if (operand->word != 0)
++			fixups[fixup_count].offset += operand->word * 4;
++		      else
++			fixups[fixup_count].offset += (operand->shift / 32) * 4;
++		      ++fixup_count;
++		      value = 0;
++		    }
++		}
++	    }
++
++	  /* Insert the register or expression into the instruction.  */
++	  errmsg = NULL;
++	  insert_operand (cpu, opcode, operand, mods, insn_buf,
++			  (offsetT) value, &errmsg);
++	  if (errmsg != (const char *) NULL)
++	    break;
++
++	  ++syn;
++	}
++
++      /* If we're at the end of the syntax string, we're done.  */
++      if (*syn == '\0')
++	{
++	  /* For the moment we assume a valid `str' can only contain blanks
++	     now.  IE: We needn't try again with a longer version of the
++	     insn and it is assumed that longer versions of insns appear
++	     before shorter ones (eg: lsr r2,r3,1 vs lsr r2,r3).  */
++
++	  while (ISSPACE (*str))
++	    ++str;
++
++	  if (*str != '\0'
++#ifndef VERTICAL_BAR_SEPARATOR
++	      && cpu != DVP_VUUP
++#endif
++	      )
++	    as_bad ("junk at end of line: `%s'", str);
++
++	  /* It's now up to the caller to emit the instruction and any
++	     relocations.  */
++	  *pstr = str;
++	  return opcode;
++	}
++
++      /* Try the next entry.  */
++    }
++
++  as_bad ("bad instruction `%s'", start);
++  return 0;
++}
++
++/* Given a dvp cpu type, return it's STO_DVP value.
++   The label prefix to use is stored in *PNAME.  */
++
++static int
++cpu_sto (dvp_cpu cpu, const char **pname)
++{
++  switch (cpu)
++    {
++    case DVP_DMA : *pname = ".dma."; return STO_DVP_DMA;
++    case DVP_VIF : *pname = ".vif."; return STO_DVP_VIF;
++    case DVP_GIF : *pname = ".gif."; return STO_DVP_GIF;
++    case DVP_VUUP : *pname = ".vu."; return STO_DVP_VU;
++    case DVP_UNKNOWN:
++    case DVP_VULO:
++      abort ();
++    }
++  abort ();
++}
++
++/* Record the current mach type in the object file.
++   If FORCE_NEXT_P is non-zero, force a label to be emitted the next time
++   we're called.  This is useful for variable length instructions that can
++   have labels embedded within them.  */
++
++static void
++record_mach (dvp_cpu cpu, int force_next_p)
++{
++  symbolS *label ATTRIBUTE_UNUSED;
++  const char *name;
++  int sto;
++
++  if (cpu == cur_cpu)
++    return;
++
++  sto = cpu_sto (cpu, &name);
++
++  label = create_colon_label (sto, "", unique_name (name));
++
++  if (force_next_p)
++    cur_cpu = DVP_UNKNOWN;
++  else
++    cur_cpu = cpu;
++}
++
++/* Force emission of mach type label at next insn.
++   This isn't static as TC_START_LABEL uses it.
++   The result is the value of TC_START_LABEL.  */
++
++int
++force_mach_label (void)
++{
++  cur_cpu = DVP_UNKNOWN;
++  return 1;
++}
++
++/* Push the current parsing state to NEW_STATE.  */
++
++static void
++push_asm_state (asm_state new_state)
++{
++  ++cur_state_level;
++  if (cur_state_level == MAX_STATE_DEPTH)
++    as_fatal ("internal error: unexpected state push");
++  asm_state_stack[cur_state_level] = new_state;
++}
++
++/* TOP_OK_P is non-zero if it's ok that we're at the top of the stack.
++   If so we reset the state to ASM_INIT.  */
++
++static void
++pop_asm_state (int top_ok_p)
++{
++  if (cur_state_level == 0)
++    {
++      if (! top_ok_p)
++	as_fatal ("internal error: unexpected state pop");
++      CUR_ASM_STATE = ASM_INIT;
++    }
++  else
++    --cur_state_level;
++}
++
++/* Set the top level assembler state.  */
++
++static void
++set_asm_state (asm_state state, const char *insn_name)
++{
++  if (insn_name)
++    {
++      if (CUR_ASM_STATE != ASM_INIT)
++	as_bad ("illegal place for `%s' instruction", insn_name);
++    }
++  cur_state_level = 0;
++  CUR_ASM_STATE = state;
++}
++
++void
++md_operand (expressionS *expressionP)
++{
++  /* Check if this is a '*' for mpgloc.  */
++  if (cur_opcode
++      && (cur_opcode->flags & VIF_OPCODE_MPG) != 0
++      && (cur_operand->flags & DVP_OPERAND_VU_ADDRESS) != 0
++      && *input_line_pointer == '*')
++    {
++      expressionP->X_op = O_symbol;
++      expressionP->X_add_symbol = mpgloc_sym;
++      expressionP->X_add_number = 0;
++
++      /* Advance over the '*'.  */
++      ++input_line_pointer;
++      return;
++    }
++}
++
++valueT
++md_section_align (asection *seg, valueT size)
++{
++  int align = bfd_section_alignment (seg);
++  return ((size + (1 << align) - 1) & (((unsigned)-1) << align));
++}
++
++symbolS *
++md_undefined_symbol (char *name ATTRIBUTE_UNUSED)
++{
++  return 0;
++}
++
++/* Called before parsing each line via md_start_line_hook.  */
++
++void
++dvp_start_line_hook (void)
++{
++  /* If we've advanced since the last label seen, reset it.  */
++  if (last_label_seen
++      && (now_seg != S_GET_SEGMENT (last_label_seen)
++	  || frag_now != symbol_get_frag(last_label_seen)
++	  || frag_now_fix () != S_GET_VALUE (last_label_seen)))
++    {
++      last_label_seen = NULL;
++      last_label_seen2 = NULL;
++    }
++}
++
++/* Called after parsing the file via md_after_pass_hook.  */
++
++void
++dvp_after_pass_hook (void)
++{
++  /* If doing dma packing, ensure the last dma tag is filled out.  */
++  if (dma_pack_vif_p)
++    {
++      /* Nothing to do as vifnops are zero and frag_align at beginning
++	 of dmatag is all we need.  */
++    }
++
++#if 0 /* ??? Doesn't work unless we keep track of the nested include file
++	 level.  */
++  /* Check for missing .EndMpg, and supply one if necessary.  */
++  if (CUR_ASM_STATE == ASM_MPG)
++    s_endmpg (ENDMPG_INTERNAL);
++  else if (CUR_ASM_STATE == ASM_DIRECT)
++    s_enddirect (0);
++  else if (CUR_ASM_STATE == ASM_UNPACK)
++    s_endunpack (0);
++#endif
++}
++
++/* Called after parsing all files via md_end.  */
++
++void
++dvp_end (void)
++{
++  /* Check for missing .EndMpg, etc.  */
++  if (CUR_ASM_STATE == ASM_MPG)
++    as_bad ("missing `.endmpg'");
++  else if (CUR_ASM_STATE == ASM_DIRECT)
++    as_bad ("missing `.enddirect'");
++  else if (CUR_ASM_STATE == ASM_UNPACK)
++    as_bad ("missing `.endunpack'");
++}
++
++/* Called via tc_frob_label when a label is defined.  */
++
++void
++dvp_frob_label (symbolS *sym)
++{
++  const char * name = S_GET_NAME (sym);
++  /* Non-zero if SYM is a user specified label.  */
++  int user_label_p =
++    (
++     /* Not sure how we can distinguish them other than by some prefix.  */
++     *name != '.' && *name != '$'
++     /* -gstabs creates FAKE_LABEL_NAME labels.  */
++     && ! S_IS_LOCAL (sym)
++     /* Check for recursive invocation creating the _$name.  */
++     && strncmp (name, VU_LABEL_PREFIX, sizeof (VU_LABEL_PREFIX) - 1) != 0
++     /* Machine generated labels to mark the start of overlays.  */
++     && strncmp (name, VUOVERLAY_START_PREFIX, sizeof (VUOVERLAY_START_PREFIX) - 1) != 0
++     );
++
++  /* All labels in vu code must be specially marked for the disassembler.
++     The disassembler ignores all previous information at each new label
++     (that has an address higher than the last one).  */
++  if (CUR_ASM_STATE == ASM_MPG
++      || CUR_ASM_STATE == ASM_VU)
++    S_SET_OTHER (sym, STO_DVP_VU);
++
++  if (! user_label_p)
++    return;
++
++  /* If inside an mpg, move vu space labels to their own section and create
++     the corresponding _$ version in normal space.  */
++
++  if (CUR_ASM_STATE == ASM_MPG)
++    {
++      /* Move this symbol to the vu overlay.  */
++      symbolS * cur_mpgloc = compute_mpgloc (mpgloc_sym, vif_data_start,
++					     expr_build_dot ());
++#if 0 /* Don't do this now, leave in ABS and then move to overlay
++	 section before file is written.  */
++      S_SET_SEGMENT (sym, vuoverlay_section);
++#else
++      /* Record the overlay section this symbol is in.  */
++      {
++        ovlysymS *p = (ovlysymS *)xmalloc (sizeof (ovlysymS));
++        p->next = ovlysym_table;
++        p->sec = vuoverlay_section;
++        p->sym = sym;
++        ovlysym_table = p;
++      }
++      S_SET_SEGMENT (sym, expr_section);
++#endif
++      symbol_set_value_expression (sym,
++                                   symbol_get_value_expression (cur_mpgloc));
++      symbol_set_frag (sym, &zero_address_frag);
++
++      /* Save for later automagic alignment.  */
++      last_label_seen2 = sym;
++
++      /* Create the _$ symbol in normal space.
++	 This is the one we store in last_label_seen (and not last_label_seen2)
++	 because when the need for automagic alignment is queried, we want
++	 now_seg == S_GET_GETMENT (last_label_seen).  */
++      last_label_seen = create_colon_label (STO_DVP_VU, VU_LABEL_PREFIX, name);
++    }
++  else
++    {
++      /* Save for later automagic alignment.  */
++      last_label_seen = sym;
++      last_label_seen2 = NULL;
++    }
++}
++
++/* Move vu space symbols into their overlay sections.
++   Called via tc_frob_file.  */
++
++void
++dvp_frob_file (void)
++{
++  ovlysymS *p;
++
++  for (p = ovlysym_table; p; p = p->next)
++    {
++      /* See the comment near tc_frob_file in write.c.
++         We are responsible for updating sym->bsym->value.  */
++      S_SET_SEGMENT (p->sym, p->sec);
++      /* Adjust for the section's vma.  */
++      /* FIXME: bfd doesn't get this right, it adds the section vma
++         back in (in elf.c:swap_out_syms).  As a workaround the
++         section vma is assumed to be zero.  Of course, there might
++         not be a point in setting it to non-zero anyway.  */
++
++      symbol_get_bfdsym(p->sym)->value -= bfd_section_vma (p->sec);
++    }
++}
++
++/* mpg/direct alignment is handled via relaxation */
++
++/* Return an initial guess of the length by which a fragment must grow to
++   hold a branch to reach its destination.
++   Also updates fr_type/fr_subtype as necessary.
++
++   Called just before doing relaxation.
++   Any symbol that is now undefined will not become defined.
++   The guess for fr_var is ACTUALLY the growth beyond fr_fix.
++   Whatever we do to grow fr_fix or fr_var contributes to our returned value.
++   Although it may not be explicit in the frag, pretend fr_var starts with a
++   0 value.  */
++
++int
++md_estimate_size_before_relax (fragS *fragP, segT segment ATTRIBUTE_UNUSED)
++{
++  /* Our initial estimate is always 0.  */
++  /* XXX return 0; */
++  /* XXX Reverse engineered from Sony's ee-dvp-as binary: */
++  return RELAX_DONE_P(fragP->fr_subtype) ? RELAX_GROWTH(fragP->fr_subtype) : 0;
++}
++
++/* Perform the relaxation.
++   STRETCH is the amount the start of the frag has already been shifted by.
++   All we have to do is figure out how many bytes we need to insert to
++   get to the recorded symbol (which is at the required alignment).
++   This function is also called for machine dependent vu insn frags.
++   In this case the growth is always 0.  */
++
++long
++dvp_relax_frag (fragS *fragP, long stretch)
++{
++  /* Address of variable part.  */
++  long address = fragP->fr_address + fragP->fr_fix;
++  /* Symbol marking start of data.  */
++  symbolS * symbolP = fragP->fr_symbol;
++  /* Address of the symbol.  */
++  long target;
++  long growth;
++
++  /* subtype >= 10 means "done" */
++  if (RELAX_DONE_P (fragP->fr_subtype))
++    return 0;
++
++  /* vu insn? */
++  if (fragP->fr_subtype == RELAX_VU)
++    {
++      fragP->fr_subtype = RELAX_ENCODE (RELAX_VU, 0);
++      return 0;
++    }
++
++  /* XXX target = S_GET_VALUE (symbolP) + symbolP->sy_frag->fr_address; */
++  /* XXX The above segfault as symbolP->sy_frag is only a valid pointer when
++   * symbolP is not local. Sony's ee-dvp-as does not add fr_address. */
++  target = S_GET_VALUE (symbolP);
++
++  if (fragP->fr_subtype == RELAX_MPG)
++    {
++      /* The frag the symbol is in hasn't been relaxed yet so any .org
++	 adjustments haven't been applied to it.  We know the symbol
++	 is the address of the next frag so adjust target by stretch.  */
++      target += stretch;
++      growth = target - address;
++      if (growth < 0)
++	as_fatal ("internal error: bad mpg alignment handling");
++      fragP->fr_subtype = RELAX_ENCODE (RELAX_MPG, growth);
++      return growth;
++    }
++
++  if (fragP->fr_subtype == RELAX_DIRECT)
++    {
++      /* The frag the symbol is in hasn't been relaxed yet so any .org
++	 adjustments haven't been applied to it.  We know the symbol
++	 is the address of the next frag so adjust target by stretch.  */
++      target += stretch;
++      growth = target - address;
++      if (growth < 0)
++	as_fatal ("internal error: bad direct alignment handling");
++      fragP->fr_subtype = RELAX_ENCODE (RELAX_DIRECT, growth);
++      return growth;
++    }
++
++  as_fatal ("internal error: unknown fr_subtype");
++}
++
++/* *fragP has been relaxed to its final size, and now needs to have
++   the bytes inside it modified to conform to the new size.
++
++   Called after relaxation is finished.
++   fragP->fr_type == rs_machine_dependent.
++   fragP->fr_subtype is the subtype of what the address relaxed to.  */
++
++void
++md_convert_frag (bfd *abfd ATTRIBUTE_UNUSED, segT sec ATTRIBUTE_UNUSED, fragS *fragP)
++{
++  int growth = RELAX_GROWTH (fragP->fr_subtype);
++
++  fragP->fr_fix += growth;
++
++  if (growth != 0)
++    {
++      /* We had to grow this fragment.  Shift the mpg/direct insn to the end
++	 (so it abuts the following data).  */
++      DVP_INSN insn = bfd_getl32 (fragP->fr_opcode);
++      md_number_to_chars (fragP->fr_opcode, VIFNOP, 4);
++      if (growth > 4)
++	md_number_to_chars (fragP->fr_opcode + 4, VIFNOP, 4);
++      if (growth > 8)
++	md_number_to_chars (fragP->fr_opcode + 8, VIFNOP, 4);
++      md_number_to_chars (fragP->fr_literal + fragP->fr_fix - 4, insn, 4);
++
++      /* Adjust fr_opcode so md_apply_fix3 works with the right bytes.  */
++      fragP->fr_opcode += growth;
++    }
++}
++
++/* Functions concerning relocs.  */
++
++/* Spacing between each cpu type's operand numbers.
++   Should be at least as big as any operand table.  */
++#define RELOC_SPACING 256
++
++/* Given a cpu type and operand number, return a temporary reloc type
++   for use in generating the fixup that encodes the cpu type and operand
++   number.  */
++
++static bfd_reloc_code_real_type
++encode_fixup_reloc_type (dvp_cpu cpu, int opnum)
++{
++  return BFD_RELOC_UNUSED + ((int) cpu * RELOC_SPACING) + opnum;
++}
++
++/* Given a fixup reloc type, decode it into cpu type and operand.  */
++
++static void
++decode_fixup_reloc_type (int fixup_reloc, dvp_cpu *cpuP,
++                         const dvp_operand **operandP)
++{
++  dvp_cpu cpu = (fixup_reloc - (int) BFD_RELOC_UNUSED) / RELOC_SPACING;
++  int opnum = (fixup_reloc - (int) BFD_RELOC_UNUSED) % RELOC_SPACING;
++
++  *cpuP = cpu;
++  switch (cpu)
++    {
++    case DVP_VUUP : *operandP = &vu_operands[opnum]; break;
++    case DVP_VULO : *operandP = &vu_operands[opnum]; break;
++    case DVP_DMA : *operandP = &dma_operands[opnum]; break;
++    case DVP_VIF : *operandP = &vif_operands[opnum]; break;
++    case DVP_GIF : *operandP = &gif_operands[opnum]; break;
++    default : as_fatal ("internal error: bad fixup encoding");
++    }
++}
++
++/* The location from which a PC relative jump should be calculated,
++   given a PC relative reloc.  */
++
++long
++md_pcrel_from_section (fixS *fixP, segT sec)
++{
++  if (fixP->fx_addsy != (symbolS *) NULL
++      && (! S_IS_DEFINED (fixP->fx_addsy)
++	  || S_GET_SEGMENT (fixP->fx_addsy) != sec))
++    {
++      /* If fx_tcbit is set this is for a vif insn and thus should never
++	 happen in correct code.  */
++      /* ??? The error message could be a bit more descriptive.  */
++      if (fixP->fx_tcbit)
++	as_bad ("unable to compute length of vif insn");
++      /* The symbol is undefined (or is defined but not in this section).
++	 Let the linker figure it out.  +8: branch offsets are relative to the
++	 delay slot.  */
++      return 8;
++    }
++
++  /* If fx_tcbit is set, this is a vif end-of-variable-length-insn marker.
++     In this case the offset is relative to the start of data.
++     Otherwise we assume this is a vu branch.  In this case
++     offsets are calculated based on the address of the next insn.  */
++  if (fixP->fx_tcbit)
++    {
++      /* As a further refinement, if fr_opcode is NULL this is `unpack'
++	 which doesn't involve any relaxing.  */
++      if (fixP->fx_frag->fr_opcode == NULL)
++	return fixP->fx_frag->fr_address + fixP->fx_where + 4;
++      else
++	return fixP->fx_frag->fr_address + fixP->fx_frag->fr_fix;
++    }
++  else
++    return ((fixP->fx_frag->fr_address + fixP->fx_where) & -8L) + 8;
++}
++
++/* Apply a fixup to the object code.  This is called for all the
++   fixups we generated by calls to fix_new_exp.  At this point all symbol
++   values should be fully resolved, and we attempt to completely resolve the
++   reloc.  If we can not do that, we determine the correct reloc code and put
++   it back in the fixup.  */
++
++void
++md_apply_fix (fixS *fixP, valueT *valueP, segT seg ATTRIBUTE_UNUSED)
++{
++  char *where = fixP->fx_frag->fr_literal + fixP->fx_where;
++  valueT value;
++
++  /* FIXME FIXME FIXME: The value we are passed in *valueP includes
++     the symbol values.  Since we are using BFD_ASSEMBLER, if we are
++     doing this relocation the code in write.c is going to call
++     bfd_perform_relocation, which is also going to use the symbol
++     value.  That means that if the reloc is fully resolved we want to
++     use *valueP since bfd_perform_relocation is not being used.
++     However, if the reloc is not fully resolved we do not want to use
++     *valueP, and must use fx_offset instead.  However, if the reloc
++     is PC relative, we do want to use *valueP since it includes the
++     result of md_pcrel_from.  This is confusing.  */
++
++  if (fixP->fx_addsy == (symbolS *) NULL)
++    {
++      value = *valueP;
++      fixP->fx_done = 1;
++    }
++  else if (fixP->fx_pcrel)
++    {
++      value = *valueP;
++    }
++  /* If this is for mpgloc and the value is a label in vu space, we
++     know its value.  We don't handle emitting a relocation for this
++     so handle it specially here.
++     The test of fx_tcbit is a quick test to avoid unnecessary cpu.  */
++  else if (fixP->fx_tcbit
++	   && fixP->fx_r_type == encode_fixup_reloc_type (DVP_VIF, vif_operand_mpgloc)
++	   && vuoverlay_section_p (S_GET_SEGMENT (fixP->fx_addsy)))
++    {
++      value = *valueP;
++    }
++  else
++    {
++      value = fixP->fx_offset;
++      if (fixP->fx_subsy != (symbolS *) NULL)
++	{
++	  if (S_GET_SEGMENT (fixP->fx_subsy) == absolute_section)
++	    value -= S_GET_VALUE (fixP->fx_subsy);
++	  else
++	    {
++	      /* We can't actually support subtracting a symbol.  */
++	      as_bad_where (fixP->fx_file, fixP->fx_line,
++			    "expression too complex");
++	    }
++	}
++    }
++
++  /* Check for dvp operands.  These are indicated with a reloc value
++     >= BFD_RELOC_UNUSED.  */
++
++  if ((int) fixP->fx_r_type >= (int) BFD_RELOC_UNUSED)
++    {
++      dvp_cpu cpu;
++      const dvp_operand *operand;
++      DVP_INSN insn;
++      fragS *fragP = fixP->fx_frag;
++
++      /* If this was a relaxable insn, the opcode may have moved.  Find it.  */
++      if (fragP->fr_opcode != NULL)
++	where = fragP->fr_opcode;
++
++      decode_fixup_reloc_type ((int) fixP->fx_r_type,
++			       & cpu, & operand);
++
++      /* For variable length vif insn data lengths, validate the user specified
++	 value or install the computed value in the instruction.  */
++      if (cpu == DVP_VIF
++	  && (operand - vif_operands) == vif_operand_datalen_special)
++	{
++	  int insn_type = vif_insn_type (where[3]);
++	  value = vif_length_value (where[3],
++				    fixP->tc_fix_data.wl, fixP->tc_fix_data.cl,
++				    value);
++	  if (fixP->tc_fix_data.user_value != -1)
++	    {
++	      /* We can't do this for unpack insns with wl > cl.  */
++	      if ((insn_type != VIF_OPCODE_UNPACK
++		   || (fixP->tc_fix_data.wl <= fixP->tc_fix_data.cl))
++		  && fixP->tc_fix_data.user_value != (int)value)
++		as_warn_where (fixP->fx_file, fixP->fx_line,
++			       "specified length value doesn't match computed value");
++	      /* Don't override the user specified value.  */
++	    }
++	  else
++	    {
++	      if (output_vif)
++		{
++		  install_vif_length (where, value);
++		}
++	    }
++	  fixP->fx_done = 1;
++	  return;
++	}
++
++      /* For the gif nloop operand, if it was specified by the user ensure
++	 it matches the value we computed.  */
++      if (cpu == DVP_GIF
++	  && (operand - gif_operands) == gif_operand_nloop)
++	{
++	  value = compute_nloop (fixP->tc_fix_data.type,
++				 fixP->tc_fix_data.nregs,
++				 value);
++	  if (fixP->tc_fix_data.user_value != -1)
++	    {
++	      check_nloop (fixP->tc_fix_data.type,
++			   fixP->tc_fix_data.nregs,
++			   fixP->tc_fix_data.user_value,
++			   value,
++			   fixP->fx_file, fixP->fx_line);
++	      /* Don't override the user specified value.  */
++	      fixP->fx_done = 1;
++	      return;
++	    }
++	}
++
++      /* ??? It might be cleaner to not do this at all here (when ! fx_done)
++	 and leave it to bfd_install_relocation.  */
++      if ((operand->flags & DVP_OPERAND_RELOC_U15_S3) != 0)
++	value >>= 3;
++      else if ((operand->flags & DVP_OPERAND_RELOC_11_S4) != 0)
++	value >>= 4;
++
++      /* Fetch the instruction, insert the fully resolved operand
++	 value, and stuff the instruction back again.  The fixup is recorded
++	 at the appropriate word so pass DVP_MOD_THIS_WORD so any offset
++	 specified in the tables is ignored.  */
++      insn = bfd_getl32 ((unsigned char *) where);
++      insert_operand_final (cpu, operand, DVP_MOD_THIS_WORD, &insn,
++			    (offsetT) value, fixP->fx_file, fixP->fx_line);
++      bfd_putl32 ((bfd_vma) insn, (unsigned char *) where);
++
++      /* If this is mpgloc/unpackloc, we're done.  */
++      if (operand->flags & (DVP_OPERAND_VU_ADDRESS | DVP_OPERAND_UNPACK_ADDRESS))
++	fixP->fx_done = 1;
++
++      if (fixP->fx_done)
++	{
++	  /* Nothing else to do here.  */
++	  return;
++	}
++
++      /* Determine a BFD reloc value based on the operand information.
++	 We are only prepared to turn a few of the operands into relocs.  */
++      if ((operand->flags & DVP_OPERAND_RELATIVE_BRANCH) != 0)
++	{
++	  gas_assert (operand->bits == 11
++		  && operand->shift == 0);
++
++	  /* The fixup isn't recorded as a pc relative branch to some label.
++	     Instead a complicated expression is used to compute the desired
++	     value.  Well, that didn't work and we have to emit a reloc.
++	     Things are tricky because the result we want is the difference
++	     of two addresses in a section potentially different from the one
++	     the reloc is in.  Ugh.
++	     The solution is to emit two relocs, one that adds the target
++	     address and one that subtracts the source address + 8 (the
++	     linker will perform the byte->dword conversion).
++	     This is rather complicated and rather than risk breaking
++	     existing code we fall back on the old way if the file only
++	     contains vu code.  In this case the file is intended to
++	     be fully linked with other vu code and thus we have a normal
++	     situation where the relocation directly corresponds to the
++	     branch insn.  */
++
++	  if (non_vu_insn_seen_p)
++	    {
++	      as_bad_where (fixP->fx_file, fixP->fx_line,
++			    "can't handle mpg loaded vu code with branch relocations");
++	      fixP->fx_done = 1;
++	      return;
++	    }
++	  else
++	    {
++	      fixP->fx_r_type = BFD_RELOC_MIPS_DVP_11_PCREL;
++	    }
++	}
++      else if ((operand->flags & DVP_OPERAND_DMA_ADDR) != 0
++	       || (operand->flags & DVP_OPERAND_DMA_NEXT) != 0)
++	{
++	  gas_assert (operand->bits == 27
++		  && operand->shift == 4);
++	  fixP->fx_r_type = BFD_RELOC_MIPS_DVP_27_S4;
++	}
++      else if ((operand->flags & DVP_OPERAND_RELOC_11_S4) != 0)
++	{
++	  gas_assert (operand->bits == 11
++		  && operand->shift == 0);
++	  fixP->fx_r_type = BFD_RELOC_MIPS_DVP_11_S4;
++	  /* ??? bfd_install_relocation will duplicate what we've done to
++	     install the addend, so tell it not to.  This is an instance
++	     where setting partial_inplace to true has some use.  */
++	  value = 0;
++	}
++      else if ((operand->flags & DVP_OPERAND_RELOC_U15_S3) != 0)
++	{
++	  gas_assert (operand->bits == 15
++		  && operand->shift == 0);
++	  fixP->fx_r_type = BFD_RELOC_MIPS_DVP_U15_S3;
++	  /* ??? bfd_install_relocation will duplicate what we've done to
++	     install the addend, so tell it not to.  This is an instance
++	     where setting partial_inplace to true has some use.  */
++	  value = 0;
++	}
++      else
++	{
++	  as_bad_where (fixP->fx_file, fixP->fx_line,
++			"unresolved expression that must be resolved");
++	  fixP->fx_done = 1;
++	  return;
++	}
++    }
++  else if (fixP->fx_done)
++    {
++      /* We're finished with this fixup.  Install it because
++	 bfd_install_relocation won't be called to do it.  */
++      switch (fixP->fx_r_type)
++	{
++	case BFD_RELOC_8:
++	  md_number_to_chars (where, value, 1);
++	  break;
++	case BFD_RELOC_16:
++	  md_number_to_chars (where, value, 2);
++	  break;
++	case BFD_RELOC_32:
++	  md_number_to_chars (where, value, 4);
++	  break;
++	case BFD_RELOC_64:
++	  md_number_to_chars (where, value, 8);
++	  break;
++	default:
++	  as_fatal ("internal error: unexpected fixup");
++	}
++    }
++  else
++    {
++      /* bfd_install_relocation will be called to finish things up.  */
++    }
++
++  /* Tuck `value' away for use by tc_gen_reloc.
++     See the comment describing fx_addnumber in write.h.  */
++  fixP->fx_addnumber = value;
++
++  return;
++}
++
++/* Translate internal representation of relocation info to BFD target
++   format.  */
++
++arelent *
++tc_gen_reloc (asection *section ATTRIBUTE_UNUSED, fixS *fixP)
++{
++  arelent *reloc;
++
++  reloc = XCNEW (arelent);
++  reloc->sym_ptr_ptr = XNEW (asymbol *);
++  *reloc->sym_ptr_ptr = symbol_get_bfdsym(fixP->fx_addsy);
++  reloc->address = fixP->fx_frag->fr_address + fixP->fx_where;
++  reloc->howto = bfd_reloc_type_lookup (stdoutput, fixP->fx_r_type);
++  if (reloc->howto == (reloc_howto_type *) NULL)
++    {
++      as_bad_where (fixP->fx_file, fixP->fx_line,
++		    "internal error: can't export reloc type %d (`%s')",
++		    fixP->fx_r_type, bfd_get_reloc_code_name (fixP->fx_r_type));
++      return NULL;
++    }
++
++  if (!fixP->fx_pcrel != !reloc->howto->pc_relative)
++    {
++      as_bad_where (fixP->fx_file, fixP->fx_line,
++		    fixP->fx_pcrel
++		    ? "PC-relative reloc not supported here"
++		    : "PC-relative reloc required here");
++      return NULL;
++    }
++
++  reloc->addend = fixP->fx_addnumber;
++
++  return reloc;
++}
++
++/* Write a value out to the object file, using the appropriate endianness.  */
++
++void
++md_number_to_chars (char *buf, valueT val, int n)
++{
++  if (target_big_endian)
++    number_to_chars_bigendian (buf, val, n);
++  else
++    number_to_chars_littleendian (buf, val, n);
++}
++
++/* Turn a string in input_line_pointer into a floating point constant of type
++   type, and store the appropriate bytes in *litP.  The number of LITTLENUMS
++   emitted is stored in *sizeP .  An error message is returned, or NULL on OK.
++*/
++
++/* Equal to MAX_PRECISION in atof-ieee.c */
++#define MAX_LITTLENUMS 6
++
++const char *
++md_atof (int type, char *litP, int *sizeP)
++{
++  int i,prec;
++  LITTLENUM_TYPE words[MAX_LITTLENUMS];
++  char *t;
++
++  switch (type)
++    {
++    case 'f':
++    case 'F':
++    case 's':
++    case 'S':
++      prec = 2;
++      break;
++
++    case 'd':
++    case 'D':
++    case 'r':
++    case 'R':
++      prec = 4;
++      break;
++
++   /* FIXME: Some targets allow other format chars for bigger sizes here.  */
++
++    default:
++      *sizeP = 0;
++      return "Bad call to md_atof()";
++    }
++
++  t = atof_ieee (input_line_pointer, type, words);
++  if (t)
++    input_line_pointer = t;
++  *sizeP = prec * sizeof (LITTLENUM_TYPE);
++
++  if (target_big_endian)
++    {
++      for (i = 0; i < prec; i++)
++	{
++	  md_number_to_chars (litP, (valueT) words[i], sizeof (LITTLENUM_TYPE));
++	  litP += sizeof (LITTLENUM_TYPE);
++	}
++    }
++  else
++    {
++      for (i = prec - 1; i >= 0; i--)
++	{
++	  md_number_to_chars (litP, (valueT) words[i], sizeof (LITTLENUM_TYPE));
++	  litP += sizeof (LITTLENUM_TYPE);
++	}
++    }
++
++  return 0;
++}
++
++/* Miscellaneous utilities.  */
++
++/* Parse a 32 bit floating point number.
++   The result is those 32 bits as an integer.  */
++
++static long
++parse_float (char **pstr, const char **errmsg ATTRIBUTE_UNUSED)
++{
++  if ((*pstr)[0] == '0'
++      && ((*pstr)[1] == 'x' || (*pstr)[1] == 'X'))
++    {
++      long value;
++      (*pstr) += 2;
++      value = strtoul (*pstr, pstr, 16);
++      return value;
++    }
++  else
++    {
++      LITTLENUM_TYPE words[MAX_LITTLENUMS];
++      if ((*pstr)[0] == '0'
++	  && ISALPHA ((*pstr)[1]))
++	(*pstr) += 2;
++      *pstr = atof_ieee (*pstr, 'f', words);
++      return (words[0] << 16) | words[1];
++    }
++}
++
++/* Scan a symbol and return a pointer to one past the end.  */
++
++#define ISSYMCHAR(ch) (ISALNUM(ch) || ch == '_')
++static char *
++scan_symbol (char *sym)
++{
++  while (*sym && ISSYMCHAR (*sym))
++    ++sym;
++  return sym;
++}
++
++/* Evaluate an expression for an operand.
++   The result is the value of the expression if it can be evaluated,
++   or 0 if it cannot (say because some symbols haven't been defined yet)
++   in which case a fixup is queued.
++
++   If OPINDEX is 0, don't queue any fixups, just return 0.  */
++
++static long
++eval_expr (dvp_cpu cpu, int opindex, int offset, const char *fmt, ...)
++{
++  long value;
++  va_list ap;
++  char *str,*save_input;
++  expressionS exp;
++
++  va_start (ap, fmt);
++  vasprintf (&str, fmt, ap);
++  va_end (ap);
++
++  save_input = input_line_pointer;
++  input_line_pointer = str;
++  expression (&exp);
++  input_line_pointer = save_input;
++  free (str);
++  if (exp.X_op == O_constant)
++    value = exp.X_add_number;
++  else
++    {
++      if (opindex != 0)
++	{
++	  fixups[fixup_count].cpu = cpu;
++	  fixups[fixup_count].exp = exp;
++	  fixups[fixup_count].opindex = opindex;
++	  fixups[fixup_count].offset = offset;
++	  fixups[fixup_count].user_value = -1;
++	  fixups[fixup_count].wl = -1;
++	  fixups[fixup_count].cl = -1;
++	  ++fixup_count;
++	}
++      value = 0;
++    }
++  return value;
++}
++
++/* Create a label named by concatenating PREFIX to NAME.  */
++
++static symbolS *
++create_label (const char *prefix, const char *name)
++{
++  int namelen = strlen (name);
++  int prefixlen = strlen (prefix);
++  char *fullname;
++  symbolS *result;
++
++  fullname = xmalloc (prefixlen + namelen + 1);
++  strcpy (fullname, prefix);
++  strcat (fullname, name);
++  result = symbol_find_or_make (fullname);
++  free (fullname);
++  return result;
++}
++
++/* Create a label named by concatenating PREFIX to NAME,
++   and define it as `.'.
++   STO, if non-zero, is the st_other value to assign to this label.
++   If STO is zero `cur_cpu', call force_mach_label to force record_mach to
++   emit a cpu label.  Otherwise the disassembler gets confused.  */
++
++static symbolS *
++create_colon_label (int sto, const char *prefix, const char *name)
++{
++  int namelen = strlen (name);
++  int prefixlen = strlen (prefix);
++  char *fullname;
++  symbolS *result;
++
++  fullname = xmalloc (prefixlen + namelen + 1);
++  strcpy (fullname, prefix);
++  strcat (fullname, name);
++  result = colon (fullname);
++  if (sto)
++    S_SET_OTHER (result, sto);
++  else
++    force_mach_label ();
++  free (fullname);
++  return result;
++}
++
++/* Return a malloc'd string useful in creating unique labels.
++   PREFIX is the prefix to use or NULL if we're to pick one.  */
++
++static char *
++unique_name (const char *prefix)
++{
++  static int counter;
++  char *result;
++
++  if (prefix == NULL)
++    prefix = UNIQUE_LABEL_PREFIX;
++  asprintf (&result, "%s%d", prefix, counter);
++  ++counter;
++  return result;
++}
++
++/* VU support.  */
++
++/* Return a boolean indicating if SEG is a vu overlay section.  */
++
++static int
++vuoverlay_section_p (segT seg)
++{
++  return (strncmp (segment_name (seg), SHNAME_DVP_OVERLAY_PREFIX,
++		   sizeof (SHNAME_DVP_OVERLAY_PREFIX) - 1)
++	  == 0);
++}
++
++/* Return the name of the overlay section.
++   It must be unique among all overlays in the executable.  */
++
++static char *
++vuoverlay_section_name (symbolS *addr)
++{
++  char *section_name;
++  const char *file;
++  unsigned int lineno;
++  unsigned int fileno;
++  /* One mpg may actually result in several, counter keeps track of this.  */
++  static int counter;
++
++  file = as_where (&lineno);
++  for (fileno = 0; *file; ++file)
++    fileno = (fileno << 1) + *file;
++  if (symbol_get_value_expression(addr)->X_op == O_constant)
++    asprintf (&section_name, "%s.0x%x.%u.%u.%d", SHNAME_DVP_OVERLAY_PREFIX,
++	      (int) S_GET_VALUE (addr), fileno, lineno, counter);
++  else
++    asprintf (&section_name, "%s.unknvma.%u.%u.%d", SHNAME_DVP_OVERLAY_PREFIX,
++	      fileno, lineno, counter);
++  ++counter;
++  return section_name;
++}
++
++/* Create a shadow section for VU code that starts at ADDR in vu space.
++   START_LABEL and END_LABEL, if non-NULL, are symbols marking the start and
++   end of the section.  If NULL, no overlay tracking information is output.  */
++
++static void
++create_vuoverlay_section (const char *section_name,
++                          /* Remember, expressions are recorded as symbols.  */
++                          symbolS *addr, symbolS *start_label,
++                          symbolS *end_label)
++{
++  /* Must preserve the current seg/subseg.  */
++  segT orig_seg = now_seg;
++  subsegT orig_subseg = now_subseg;
++
++  /* Create and get handle of a vu overlay section.  All vu symbols go here.
++     The section name must be unique in the entire executable.
++     We achieve this by encoding the source file name and file number.  Ick.
++     ??? A cleaner way would be if mpg took a new argument that named the
++     overlay.  */
++  vuoverlay_section = subseg_new (section_name, 0);
++  bfd_set_section_flags (vuoverlay_section, SEC_CODE);
++  /* There's no point in setting the section vma as we can't get the linker
++     to preserve it.  But what the heck ...  It might be useful to the
++     objdump user.  */
++#if 0  /* FIXME: bfd's elf.c:swap_out_syms always emits symbol values with
++	  the section vma added in so we can't do this.  */
++  if (addr->sy_value.X_op == O_constant)
++    bfd_set_section_vma (stdoutput, vuoverlay_section, S_GET_VALUE (addr));
++#endif
++
++#if 1
++  /* Create a symbol marking the start of the section.
++     This is different than START_LABEL as this one is for gdb.
++     It needs a symbol to start a section so we give it one.
++     This one could be combined with START_LABEL, but I haven't since
++     they serve different purposes.  */
++  {
++    symbolS *gdb_start_sym;
++    gdb_start_sym = create_colon_label (STO_DVP_VU, VUOVERLAY_START_PREFIX,
++                                        section_name);
++    symbol_set_value_expression (gdb_start_sym,
++                                 symbol_get_value_expression (addr));
++  }
++#endif
++
++  /* The size of the section won't be known until we see the .endmpg,
++     but we can compute it from the start and end labels.  */
++  /* FIXME: This causes the section to occupy space in the file.  */
++  if (start_label)
++    frag_var (rs_space, 1, 1, (relax_substateT) 0,
++	      expr_build_binary (O_subtract, end_label, start_label),
++	      (offsetT) 0, (char *) 0);
++
++#if 0 /* already done */
++  /* Initialize $.mpgloc.  */
++  mpgloc_sym = expr_build_uconstant (addr);
++  S_SET_OTHER (mpgloc_sym, STO_DVP_VU);
++#endif
++
++#if 0 /* $.mpgloc is kept in the ABS section.  */
++  S_SET_SEGMENT (mpgloc_sym, vuoverlay_section);
++#endif
++
++  /* Add an entry to the vu overlay table.  */
++  if (start_label)
++    {
++      expressionS exp;
++      const char *p;
++      symbolS * name_label;
++
++      /* Put the section name in the overlay string table.  */
++
++      subseg_set (vuoverlay_string_section, 0);
++      name_label = create_colon_label (0, DVP_LOCAL_LABEL_PREFIX,
++				       unique_name ("secstr"));
++      /* FIXME: should be a utility to do this.  */
++      for (p = section_name; *p; ++p)
++	FRAG_APPEND_1_CHAR (*p);
++      FRAG_APPEND_1_CHAR (0);
++
++      subseg_set (vuoverlay_table_section, 0);
++
++      /* FIXME: should be a utility to do these.  */
++      /* Offset into string table.  */
++      exp.X_op = O_symbol;
++      exp.X_add_symbol = name_label;
++      exp.X_add_number = 0;
++      emit_expr (&exp, 4);
++
++      /* The section's lma.  */
++      exp.X_op = O_symbol;
++      exp.X_add_symbol = start_label;
++      exp.X_add_number = 0;
++      emit_expr (&exp, 4);
++
++      /* The section's vma.  */
++      exp.X_op = O_symbol;
++      exp.X_add_symbol = addr;
++      exp.X_add_number = 0;
++      emit_expr (&exp, 4);
++    }
++
++  /* Restore the original seg/subseg.  */
++  subseg_set (orig_seg, orig_subseg);
++}
++
++/* Compute a value for $.mpgloc given a symbol at the start of a chunk
++   of code, the $.mpgloc value for the start, and a symbol at the end
++   of the chunk of code.  */
++
++static symbolS *
++compute_mpgloc (symbolS *startloc, symbolS *startsym, symbolS *endsym)
++{
++  symbolS *s;
++
++  s = expr_build_binary (O_subtract, endsym, startsym);
++  s = expr_build_binary (O_add, startloc, s);
++  return s;
++}
++
++/* Compute a value for nloop.  */
++
++static int
++compute_nloop (gif_type type, int nregs, int bytes)
++{
++  int computed_nloop;
++
++  switch (type)
++    {
++    case GIF_PACKED :
++      /* We can't compute a value if no regs were specified and there is a
++	 non-zero amount of data.  Just set to something useful, a warning
++	 will be issued later.  */
++      if (nregs == 0)
++	nregs = 1;
++      computed_nloop = (bytes >> 4) / nregs;
++      break;
++    case GIF_REGLIST :
++      if (nregs == 0)
++	nregs = 1;
++      computed_nloop = (bytes >> 3) / nregs;
++      break;
++    case GIF_IMAGE :
++      computed_nloop = bytes >> 4;
++      break;
++    }
++
++  return computed_nloop;
++}
++
++/* Issue a warning if the user specified nloop value doesn't match the
++   computed value.  */
++
++static void
++check_nloop (gif_type type ATTRIBUTE_UNUSED, int nregs ATTRIBUTE_UNUSED,
++             int user_nloop, int computed_nloop, const char *file,
++             unsigned int line)
++{
++  if (user_nloop != computed_nloop)
++    as_warn_where (file, line, "nloop value does not match amount of data");
++}
++
++/* Compute the auto-count value for a DMA tag.
++   INLINE_P is non-zero if the dma data is inline.  */
++
++static void
++setup_dma_autocount (const char *name, DVP_INSN *insn_buf, int inline_p)
++{
++  long count;
++
++  if (inline_p)
++    {
++      /* -1: The count is the number of following quadwords, so skip the one
++	 containing the dma tag.  */
++      count = eval_expr (DVP_DMA, dma_operand_count, 0,
++			 "((%s%s - %s) >> 4) - 1", END_LABEL_PREFIX, name, name);
++    }
++  else
++    {
++      /* We don't want to subtract 1 here as the begin and end labels
++	 properly surround the data we want to compute the length of.  */
++      count = eval_expr (DVP_DMA, dma_operand_count, 0,
++			 "(%s%s - %s) >> 4", END_LABEL_PREFIX, name, name);
++    }
++
++  /* Store the count field. */
++  insn_buf[0] &= 0xffff0000;
++  insn_buf[0] |= count & 0x0000ffff;
++}
++
++/* Record that inline data follows.  */
++
++static void
++inline_dma_data (int autocount_p, DVP_INSN *insn_buf)
++{
++  if (dma_data_state != 0 )
++    {
++      as_bad ("DmaData blocks cannot be nested.");
++      return;
++    }
++
++  dma_data_state = 1;
++
++  if (autocount_p)
++    {
++      dma_data_name = S_GET_NAME (create_colon_label (0, "", unique_name (NULL)));
++      setup_dma_autocount (dma_data_name, insn_buf, 1);
++    }
++  else
++    dma_data_name = 0;
++}
++
++/* Compute the auto-count value for a DMA tag with out-of-line data.  */
++
++static long
++parse_dma_addr_autocount (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                          const dvp_operand *operand ATTRIBUTE_UNUSED,
++                          int mods ATTRIBUTE_UNUSED, DVP_INSN *insn_buf,
++                          char **pstr, const char **errmsg)
++{
++  char *start = *pstr;
++  char *end = start;
++  long retval;
++  /* Data reference must be a .DmaData label.  */
++  symbolS *label ATTRIBUTE_UNUSED, *label2, *endlabel ATTRIBUTE_UNUSED;
++  char *name;
++  char c;
++
++  label = label2 = 0;
++  if (! is_name_beginner (*start))
++    {
++      *errmsg = "invalid .DmaData label";
++      return 0;
++    }
++
++  name = start;
++  end = scan_symbol (name);
++  c = *end;
++  *end = 0;
++  label = symbol_find_or_make (name);
++  *end = c;
++
++  /* Use the same prefix as vu labels here.  */
++  label2 = create_label (VU_LABEL_PREFIX, name);
++  endlabel = create_label (END_LABEL_PREFIX, name);
++
++  retval = eval_expr (DVP_DMA, dma_operand_addr, 4, name);
++
++  setup_dma_autocount (name, insn_buf, 0);
++
++  *pstr = end;
++  return retval;
++}
++
++/* Compute the type of vif insn of IBYTE.
++   IBYTE is the msb of the insn.
++   This is only used for mpg,direct,unpack insns.
++   The result is one of VIF_OPCODE_{DIRECT,DIRECTHL,MPG,UNPACK}.  */
++
++static int
++vif_insn_type (char ibyte)
++{
++  switch (ibyte & 0x70)
++    {
++    case 0x50 :
++      return (ibyte & 1) ? VIF_OPCODE_DIRECTHL : VIF_OPCODE_DIRECT;
++    case 0x40 :
++      return VIF_OPCODE_MPG;
++    case 0x60 :
++    case 0x70 :
++      return VIF_OPCODE_UNPACK;
++    default :
++      as_fatal ("internal error: bad call to vif_insn_type");
++    }
++}
++
++/* Return the length value to insert in a VIF instruction whose upper
++   byte is IBYTE and whose data length is BYTES.
++   WL,CL are used for unpack insns and are the stcycl values in effect.
++   This does not do the max -> 0 conversion.  */
++
++static int
++vif_length_value (char ibyte, int wl, int cl, int bytes)
++{
++  switch (ibyte & 0x70)
++    {
++    case 0x50 : /* direct */
++      /* ??? Worry about data /= 16 cuts off?  */
++      return bytes / 16;
++    case 0x40 : /* mpg */
++      /* ??? Worry about data /= 8 cuts off?  */
++      return bytes / 8;
++    case 0x60 : /* unpack */
++    case 0x70 :
++      return vif_unpack_len_value (ibyte & 15, wl, cl, bytes);
++    default :
++      as_fatal ("internal error: bad call to vif_length_value");
++    }
++}
++
++/* Install length LEN in the vif insn at BUF.
++   LEN is the actual value to store, except that the max->0 conversion
++   hasn't been done (we do it).
++   The bytes in BUF are in target order.  */
++
++static void
++install_vif_length (char *buf, int len)
++{
++  unsigned char ibyte = buf[3];
++
++  if ((ibyte & 0x70) == 0x40)
++    {
++      /* mpg */
++      if (len > 256)
++	as_bad ("`mpg' data length must be between 1 and 256");
++      buf[2] = len == 256 ? 0 : len;
++    }
++  else if ((ibyte & 0x70) == 0x50)
++    {
++      /* direct/directhl */
++      if (len > 65536)
++	as_bad ("`direct' data length must be between 1 and 65536");
++      len = len == 65536 ? 0 : len;
++      buf[0] = len;
++      buf[1] = len >> 8;
++    }
++  else if ((ibyte & 0x60) == 0x60)
++    {
++      /* unpack */
++      /* len == -1 means wl,cl are unknown and thus we can't compute
++	 a useful value */
++      if (len == -1)
++	{
++	  as_bad ("missing `stcycle', can't compute length of `unpack' insn");
++	  len = 1;
++	}
++      if (len < 0 || len > 256)
++	as_bad ("`unpack' data length must be between 0 and 256");
++      /* 256 is recorded as 0 in the insn */
++      len = len == 256 ? 0 : len;
++      buf[2] = len;
++    }
++  else
++    as_fatal ("internal error: bad call to install_vif_length");
++}
++
++/* Finish off the current set of mpg insns, and start a new set.
++   The IGNORE arg exists because insert_unpack_marker uses it and both
++   of these functions are passed to insert_file.  */
++
++static void
++insert_mpg_marker (unsigned long ignore ATTRIBUTE_UNUSED)
++{
++  char tmp[32];
++
++  s_endmpg (ENDMPG_MIDDLE);
++  /* FIXME stupid */
++  strcpy(tmp, "mpg *,*");
++  /* mpgloc is updated by s_endmpg.  */
++  md_assemble (tmp);
++  /* Record the cpu type in case we're in the middle of reading binary
++     data.  */
++  record_mach (DVP_VUUP, 0);
++  /* We need a stabs line number entry at the start of the vu code.
++     This has already been called, but too early and we can't stop that.
++     So just emit another.  */
++  generate_lineno_debug ();
++}
++
++/* Finish off the current unpack insn and start a new one.
++   INSN0 is the first word of the insn and is used to figure out what
++   kind of unpack insn it is.  */
++
++ATTRIBUTE_UNUSED static void
++insert_unpack_marker (unsigned long insn0 ATTRIBUTE_UNUSED)
++{
++}
++
++/* Insert a file into the output.
++   The -I arg passed to GAS is used to specify where to find the file.
++   INSERT_MARKER if non-NULL is called every SIZE bytes with an argument of
++   INSERT_MARKER_ARG.  This is used by the mpg insn to insert mpg's every 256
++   insns and by the unpack insn.
++   The result is the number of bytes inserted.
++   If an error occurs an error message is printed and zero is returned.  */
++
++static int
++insert_file (const char *file, void (*insert_marker) (unsigned long),
++             unsigned long insert_marker_arg, int size)
++{
++  FILE *f;
++  char buf[256];
++  size_t i;
++  int n, total, left_before_marker;
++  char *path;
++
++  path = xmalloc (strlen (file) + include_dir_maxlen + 5 /*slop*/);
++  f = NULL;
++  for (i = 0; i < include_dir_count; i++)
++    {
++      strcpy (path, include_dirs[i]);
++      strcat (path, "/");
++      strcat (path, file);
++      if ((f = fopen (path, FOPEN_RB)) != NULL)
++	break;
++    }
++  free (path);
++  if (f == NULL)
++    f = fopen (file, FOPEN_RB);
++  if (f == NULL)
++    {
++      as_bad ("unable to read file `%s'", file);
++      return 0;
++    }
++
++  total = 0;
++  left_before_marker = 0;
++  do {
++    int bytes;
++    if (insert_marker)
++      bytes = MIN (size - left_before_marker, (int)sizeof (buf));
++    else
++      bytes = sizeof (buf);
++    n = fread (buf, 1, bytes, f);
++    if (n > 0)
++      {
++	char *fr = frag_more (n);
++	memcpy (fr, buf, n);
++	total += n;
++	if (insert_marker)
++	  {
++	    left_before_marker += n;
++	    if (left_before_marker > size)
++	      as_fatal ("internal error: file insertion sanity checky failed");
++	    if (left_before_marker == size)
++	      {
++		(*insert_marker) (insert_marker_arg);
++		left_before_marker = 0;
++	      }
++	  }
++      }
++  } while (n > 0);
++
++  fclose (f);
++  /* We assume the file is smaller than 2^31 bytes.
++     Ok, we shouldn't make any assumptions.  */
++  return total;
++}
++
++/* Insert an operand value into an instruction.  */
++
++static void
++insert_operand (dvp_cpu cpu ATTRIBUTE_UNUSED, const dvp_opcode *opcode,
++                const dvp_operand *operand, int mods, DVP_INSN *insn_buf,
++                offsetT val, const char **errmsg)
++{
++  if (operand->insert)
++    {
++      (*operand->insert) (opcode, operand, mods, insn_buf, (long) val, errmsg);
++    }
++  else
++    {
++      /* We currently assume a field does not cross a word boundary.  */
++      int shift = ((mods & DVP_MOD_THIS_WORD)
++		   ? (operand->shift & 31)
++		   : operand->shift);
++      /* FIXME: revisit */
++      if (operand->word == 0)
++	{
++	  int word = (mods & DVP_MOD_THIS_WORD) ? 0 : (shift / 32);
++	  if (operand->bits == 32)
++	    insn_buf[word] = val;
++	  else
++	    {
++	      shift = shift % 32;
++	      insn_buf[word] |= ((long) val & ((1 << operand->bits) - 1)) << shift;
++	    }
++	}
++      else
++	{
++	  int word = (mods & DVP_MOD_THIS_WORD) ? 0 : operand->word;
++	  if (operand->bits == 32)
++	    insn_buf[word] = val;
++	  else
++	    {
++	      long temp = (long) val & ((1 << operand->bits) - 1);
++	      insn_buf[word] |= temp << operand->shift;
++	    }
++	}
++    }
++}
++
++/* Insert an operand's final value into an instruction.
++   Here we can give warning messages about operand values if we want to.  */
++
++static void
++insert_operand_final (dvp_cpu cpu, const dvp_operand *operand, int mods,
++                      DVP_INSN *insn_buf, offsetT val, const char *file,
++                      unsigned int line)
++{
++  if (operand->bits != 32)
++    {
++      offsetT min, max, test;
++
++      /* ??? This test belongs more properly in the insert handler.  */
++      if ((operand->flags & DVP_OPERAND_RELATIVE_BRANCH) != 0)
++	{
++	  if ((val & 7) != 0)
++	    {
++	      if (file == (char *) NULL)
++		as_warn ("branch to misaligned address");
++	      else
++		as_warn_where (file, line, "branch to misaligned address");
++	    }
++	  val >>= 3;
++	}
++      /* ??? This test belongs more properly in the insert handler.  */
++      else if ((operand->flags & DVP_OPERAND_VU_ADDRESS) != 0)
++	{
++	  if ((val & 7) != 0)
++	    {
++	      if (file == (char *) NULL)
++		as_warn ("misaligned vu address");
++	      else
++		as_warn_where (file, line, "misaligned vu address");
++	    }
++	  val >>= 3;
++	}
++
++      if ((operand->flags & DVP_OPERAND_SIGNED) != 0)
++	{
++	  if ((operand->flags & DVP_OPERAND_SIGNOPT) != 0)
++	    max = (1 << operand->bits) - 1;
++	  else
++	    max = (1 << (operand->bits - 1)) - 1;
++	  min = - (1 << (operand->bits - 1));
++	}
++      else
++	{
++	  max = (1 << operand->bits) - 1;
++	  min = 0;
++	}
++
++      if ((operand->flags & DVP_OPERAND_NEGATIVE) != 0)
++	test = - val;
++      else
++	test = val;
++
++      if (test < (offsetT) min || test > (offsetT) max)
++	{
++	  const char *err =
++	    "operand out of range (%s not between %ld and %ld)";
++	  char buf[100];
++
++      sprintf(buf, "%ld", test);
++	  if (file == (char *) NULL)
++	    as_warn (err, buf, min, max);
++	  else
++	    as_warn_where (file, line, err, buf, min, max);
++	}
++    }
++
++  {
++    const char *errmsg = NULL;
++    insert_operand (cpu, NULL, operand, mods, insn_buf, val, &errmsg);
++    if (errmsg != NULL)
++      as_warn_where (file, line, errmsg);
++  }
++}
++
++/* DVP pseudo ops.  */
++
++static void
++s_dmadata (int ignore ATTRIBUTE_UNUSED)
++{
++  char *name, c;
++
++  dma_data_name = 0;
++
++  if (dma_data_state != 0)
++    {
++      as_bad ("DmaData blocks cannot be nested.");
++      ignore_rest_of_line ();
++      return;
++    }
++  dma_data_state = 1;
++
++  SKIP_WHITESPACE ();		/* Leading whitespace is part of operand. */
++  c = get_symbol_name (&name);
++
++  if (!is_name_beginner (*name))
++    {
++      as_bad ("invalid identifier for \".DmaData\"");
++      ignore_rest_of_line ();
++      return;
++    }
++
++  /* Do an implicit alignment to a 16 byte boundary. */
++  frag_align (4, 0, 0);
++  record_alignment (now_seg, 4);
++
++  line_label = colon (name);	/* user-defined label */
++  dma_data_name = S_GET_NAME (line_label);
++  *input_line_pointer = c;
++
++  /* Force emission of a machine type label for the next insn.  */
++  force_mach_label ();
++
++  demand_empty_rest_of_line ();
++}
++
++static void
++s_enddmadata (int ignore ATTRIBUTE_UNUSED)
++{
++  if (dma_data_state != 1)
++    {
++      as_warn (".EndDmaData encountered outside a DmaData block -- ignored.");
++      ignore_rest_of_line ();
++      dma_data_name = 0;
++    }
++  dma_data_state = 0;
++  demand_empty_rest_of_line ();
++
++  /* If count provided, verify it is correct.  */
++  /* ... */
++
++  /* Fill the data out to a multiple of 16 bytes.  */
++  /* FIXME: Are the fill contents right?  */
++  frag_align (4, 0, 0);
++
++  /* "label" points to beginning of block.
++     Create a name for the final label like _$<name>.  */
++  if (dma_data_name)
++    create_colon_label (0, END_LABEL_PREFIX, dma_data_name);
++}
++
++static void
++s_dmapackvif (int ignore ATTRIBUTE_UNUSED)
++{
++  /* Syntax: .dmapackvif 0|1 */
++
++  /* Leading whitespace is part of operand. */
++  SKIP_WHITESPACE ();
++  switch (*input_line_pointer++)
++    {
++    case '0':
++      dma_pack_vif_p = 0;
++      break;
++    case '1':
++      dma_pack_vif_p = 1;
++      break;
++    default:
++      as_bad ("illegal argument to `.dmapackvif'");
++    }
++  demand_empty_rest_of_line ();
++}
++
++/* INTERNAL_P is non-zero if invoked internally by this file rather than
++   by the user.  In this case we don't touch the input stream.  */
++
++static void
++s_enddirect (int internal_p)
++{
++  if (CUR_ASM_STATE != ASM_DIRECT)
++    {
++      as_bad ("`.enddirect' has no matching `direct' instruction");
++      return;
++    }
++
++    if (!output_vif)
++    {
++        pop_asm_state (1);
++        demand_empty_rest_of_line ();
++      return;
++    }
++  /* Record in the end data symbol the current location.  */
++  if (now_seg != S_GET_SEGMENT (vif_data_end))
++    as_bad (".enddirect in different section");
++
++  symbol_set_value_now(vif_data_end);
++
++  pop_asm_state (1);
++
++  /* Needn't be reset, but to catch bugs it is.  */
++  vif_data_end = NULL;
++
++  if (! internal_p)
++    demand_empty_rest_of_line ();
++}
++
++/* CALLER denotes who's calling us.
++   If ENDMPG_USER then .endmpg was found in the input stream.
++   If ENDMPG_INTERNAL then we've been invoked to finish off file insertion.
++   If ENDMPG_MIDDLE then we've been invoked in the middle of a long stretch
++   of vu code.  */
++
++static void
++s_endmpg (int caller)
++{
++  if (CUR_ASM_STATE != ASM_MPG)
++    {
++      as_bad ("`.endmpg' has no matching `mpg' instruction");
++      return;
++    }
++
++  if (!output_vif)
++    {
++      pop_asm_state (1);
++      /* Reset the vu insn counter.  */
++      if (caller != ENDMPG_MIDDLE)
++        vu_count = -1;
++      if (caller == ENDMPG_USER)
++        demand_empty_rest_of_line ();
++      return;
++    }
++  /* Record in the end data symbol the current location.  */
++  if (now_seg != S_GET_SEGMENT (vif_data_end))
++    as_bad (".endmpg in different section");
++
++  symbol_set_value_now(vif_data_end);
++
++  /* Update $.mpgloc.
++     We have to leave the old value alone as it may be used in fixups
++     already recorded.  Since compute_mpgloc allocates a new symbol for the
++     result we're ok.  The new value is the old value plus the number of
++     double words in this chunk.  */
++  mpgloc_sym = compute_mpgloc (mpgloc_sym, vif_data_start, vif_data_end);
++  S_SET_OTHER (mpgloc_sym, STO_DVP_VU);
++
++  pop_asm_state (1);
++
++  /* Needn't be reset, but to catch bugs it is.  */
++  vif_data_end = NULL;
++
++  /* Reset the vu insn counter.  */
++  if (caller != ENDMPG_MIDDLE)
++    vu_count = -1;
++
++  if (caller == ENDMPG_USER)
++    demand_empty_rest_of_line ();
++}
++
++/* INTERNAL_P is non-zero if invoked internally by this file rather than
++   by the user.  In this case we don't touch the input stream.  */
++
++static void
++s_endunpack (int internal_p)
++{
++  if (CUR_ASM_STATE != ASM_UNPACK)
++    {
++      as_bad ("`.endunpack' has no matching `unpack' instruction");
++      return;
++    }
++
++    if (!output_vif)
++    {
++        pop_asm_state (1);
++        demand_empty_rest_of_line ();
++      return;
++    }
++
++
++  /* Record in the end data symbol the current location.  */
++  /* ??? $.unpackloc is gone.  Is this also used for data length
++     verification?  */
++  if (now_seg != S_GET_SEGMENT (vif_data_end))
++    as_bad (".endunpack in different section");
++
++  symbol_set_value_now(vif_data_end);
++
++  /* Round up to next word boundary.  */
++  frag_align (2, 0, 0);
++
++  pop_asm_state (1);
++
++  /* Needn't be reset, but to catch bugs it is.  */
++  vif_data_end = NULL;
++
++  if (! internal_p)
++    demand_empty_rest_of_line ();
++}
++
++static void
++s_endgif (int ignore ATTRIBUTE_UNUSED)
++{
++  int bytes;
++  int specified_nloop = gif_nloop ();
++  int computed_nloop;
++  int nregs = gif_nregs ();
++  const char *file;
++  unsigned int line;
++
++  file = as_where (&line);
++
++  if (CUR_ASM_STATE != ASM_GIF)
++    {
++      as_bad (".endgif doesn't follow a gif tag");
++      return;
++    }
++  pop_asm_state (1);
++
++  /* Fill out to proper boundary.
++     ??? This may cause eval_expr to always queue a fixup.  So be it.  */
++  switch (gif_insn_type)
++    {
++    case GIF_PACKED :  frag_align (4, 0, 0); break;
++    case GIF_REGLIST : frag_align (3, 0, 0); break;
++    case GIF_IMAGE :   frag_align (4, 0, 0); break;
++    }
++
++  /* The -16 is because the `gif_data_name' label is emitted at the
++     start of the gif tag.  If we're in a different frag from the one we
++     started with, this can't be computed until much later.  To cope we queue
++     a fixup and deal with it then.
++     ??? The other way to handle this is by having expr() compute "syma - symb"
++     when they're in different fragments but the difference is constant.
++     Not sure how much of a slowdown that will introduce though.  */
++  fixup_count = 0;
++  bytes = eval_expr (DVP_GIF, gif_operand_nloop, 0, ". - %s - 16", gif_data_name);
++
++  /* Compute a value for nloop if we can.  */
++
++  if (fixup_count == 0)
++    {
++      computed_nloop = compute_nloop (gif_insn_type, nregs, bytes);
++
++      /* If the user specified nloop, verify it.  */
++      if (specified_nloop != -1)
++	check_nloop (gif_insn_type, nregs,
++		     specified_nloop, computed_nloop,
++		     file, line);
++    }
++
++  /* If computation of nloop can't be done yet, queue a fixup and do it later.
++     Otherwise validate nloop if specified or write the computed value into
++     the insn.  */
++
++  if (fixup_count != 0)
++    {
++      /* FIXME: It might eventually be possible to combine all the various
++	 copies of this bit of code.  */
++      int op_type, reloc_type, offset;
++      const dvp_operand *operand ATTRIBUTE_UNUSED;
++      fixS *fix;
++
++      op_type = fixups[0].opindex;
++      offset = fixups[0].offset;
++      reloc_type = encode_fixup_reloc_type (DVP_GIF, op_type);
++      operand = &gif_operands[op_type];
++      fix = fix_new_exp (gif_insn_frag,
++			 (gif_insn_frag_loc + offset
++			  - gif_insn_frag->fr_literal),
++			 4, &fixups[0].exp, 0,
++			 (bfd_reloc_code_real_type) reloc_type);
++      /* Record user specified value so we can test it when we compute the
++	 actual value.  */
++      fix->tc_fix_data.type = gif_insn_type;
++      fix->tc_fix_data.nregs = nregs;
++      fix->tc_fix_data.user_value = specified_nloop;
++    }
++  else if (specified_nloop != -1)
++    ; /* nothing to do */
++  else
++    {
++      DVP_INSN insn = bfd_getl32 (gif_insn_frag_loc);
++      insert_operand_final (DVP_GIF, &gif_operands[gif_operand_nloop],
++			    DVP_MOD_THIS_WORD, &insn,
++			    (offsetT) computed_nloop, file, line);
++      bfd_putl32 ((bfd_vma) insn, gif_insn_frag_loc);
++    }
++
++  /* These needn't be reset, but to catch bugs they are.  */
++  gif_data_name = NULL;
++  gif_insn_frag = NULL;
++  gif_insn_frag_loc = NULL;
++
++  demand_empty_rest_of_line ();
++}
++
++static void
++s_vu (int ignore ATTRIBUTE_UNUSED)
++{
++  /* If in MPG state and the user requests to change to VU state,
++     leave the state as MPG.  This happens when we see an mpg followed
++     by a .include that has .vu.  Note that no attempt is made to support
++     an include depth > 1 for this case.  */
++  if (CUR_ASM_STATE == ASM_MPG)
++    return;
++
++  /* We need to set up things for $.mpgloc calculations.  */
++  /* FIXME: May need to check that we're not clobbering currently
++     in use versions of these.  Also need to worry about which section
++     the .vu is issued in.  On the other hand, ".vu" isn't intended
++     to be supported everywhere.  */
++  vif_data_start = expr_build_dot ();
++  mpgloc_sym = expr_build_uconstant (0);
++  S_SET_OTHER (mpgloc_sym, STO_DVP_VU);
++#if 0 /* ??? wip */
++  create_vuoverlay_section (vuoverlay_section_name (NULL), mpgloc_sym,
++			    NULL, NULL);
++#endif
++
++  set_asm_state (ASM_VU, ".vu");
++
++  demand_empty_rest_of_line ();
++}
++
++/* Same as read.c:s_func except prepend VU_LABEL_PREFIX by default.  */
++
++static void
++s_dvp_func (int end_p)
++{
++  do_s_func (end_p, VU_LABEL_PREFIX);
++}
+diff -x .DS_Store -ruN binutils-2.46.1/gas/config/tc-dvp.h binutils-2.46.1-kos/gas/config/tc-dvp.h
+--- binutils-2.46.1/gas/config/tc-dvp.h	1969-12-31 16:00:00
++++ binutils-2.46.1-kos/gas/config/tc-dvp.h	2026-07-06 18:45:40
+@@ -0,0 +1,101 @@
++/* tc-dvp.h -- Header file for tc-dvp.c.
++   Copyright (C) 1997, 1998 Free Software Foundation, Inc.
++
++   This file is part of GAS, the GNU Assembler.
++
++   GAS is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 2, or (at your option)
++   any later version.
++
++   GAS is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with GAS; see the file COPYING.  If not, write to
++   the Free Software Foundation, 59 Temple Place - Suite 330,
++   Boston, MA 02111-1307, USA. */
++
++#define TC_DVP
++
++#define LISTING_HEADER "DVP GAS "
++
++/* The target BFD architecture.  */
++#define TARGET_ARCH bfd_arch_mips
++
++#define TARGET_FORMAT "elf32-littlemips"
++
++#define TARGET_BYTES_BIG_ENDIAN 0
++
++/* Handle +- specially so the scrubber doesn't remove the space after loi
++  in "nop loi +1.0" and "nop loi -1.0".  */
++#define tc_symbol_chars "+-"
++
++/* call md_pcrel_from_section, not md_pcrel_from */
++#define MD_PCREL_FROM_SECTION(FIXP, SEC) md_pcrel_from_section(FIXP, SEC)
++extern long md_pcrel_from_section (struct fix *, segT);
++
++/* Permit temporary numeric labels.  */
++#define LOCAL_LABELS_FB 1
++/* .-foo gets turned into PC relative relocs */
++#define DIFF_EXPR_OK 1
++/* We don't need to handle .word strangely.  */
++#define WORKING_DOT_WORD 1
++
++/* Handle mpg/direct alignment requirements with relaxation.  */
++extern long dvp_relax_frag (fragS *, long);
++#define md_relax_frag(segment, fragP,stretch) dvp_relax_frag ((fragP), (stretch))
++
++#define MD_APPLY_FIX3
++
++/* Ensure insns at labels have their mach type properly recorded.  */
++int force_mach_label (void);
++#define TC_START_LABEL(STR, NUL_CHAR, NEXT_CHAR)	\
++  (NEXT_CHAR == ':' && force_mach_label ())
++
++#define TC_HANDLES_FX_DONE
++
++/* Record user specified val, for cases where we can't compute the actual
++   value until the end of assembly.  */
++#define TC_FIX_TYPE \
++struct { \
++  int type; /* gif_type, or vif type */ \
++  int nregs; /* for gif insns only */ \
++  short wl; short cl; /* for unpack only */ \
++  int user_value; \
++}
++/* Code to initialize it.  */
++#define TC_INIT_FIX_DATA(fixP) \
++do { memset (&fixP->tc_fix_data, 0, sizeof (fixP->tc_fix_data)); } while (0)
++
++/* Called before parsing each line.  */
++extern void dvp_start_line_hook (void);
++#define md_start_line_hook() dvp_start_line_hook ()
++
++/* Called after parsing a file.  */
++extern void dvp_after_pass_hook (void);
++#define md_after_pass_hook() dvp_after_pass_hook ()
++
++/* Called after parsing all files.  */
++extern void dvp_end (void);
++#define md_end() dvp_end ()
++
++/* Called for each label.  */
++extern void dvp_frob_label (struct symbol *);
++#define tc_frob_label(sym) dvp_frob_label (sym)
++
++/* Called just before writing the file out.  */
++extern void dvp_frob_file (void);
++#define tc_frob_file() dvp_frob_file ()
++
++/* Default section names. */
++#define TEXT_SECTION_NAME	".vutext"
++#define DATA_SECTION_NAME	".vudata"
++#define BSS_SECTION_NAME	".vubss"
++
++#define ELF_TC_SPECIAL_SECTIONS \
++  { ".vubss",	SHT_NOBITS,	SHF_ALLOC + SHF_WRITE		}, \
++  { ".vudata",	SHT_PROGBITS,	SHF_ALLOC + SHF_WRITE		}, \
++  { ".vutext",	SHT_PROGBITS,	SHF_ALLOC + SHF_EXECINSTR	},
+diff -x .DS_Store -ruN binutils-2.46.1/gas/configure.tgt binutils-2.46.1-kos/gas/configure.tgt
+--- binutils-2.46.1/gas/configure.tgt	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/gas/configure.tgt	2026-07-06 18:45:40
+@@ -201,6 +201,8 @@
+ 
+   ft32-*-*)				fmt=elf ;;
+ 
++  dvp-*-*)				fmt=elf bfd_gas=yes ;;
++
+   hppa-*-linux*)
+     case ${cpu} in
+       hppa*64*)				fmt=elf em=hppalinux64 ;;
+diff -x .DS_Store -ruN binutils-2.46.1/gas/read.c binutils-2.46.1-kos/gas/read.c
+--- binutils-2.46.1/gas/read.c	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/gas/read.c	2026-07-06 18:45:40
+@@ -233,7 +233,7 @@
+ static unsigned int bundle_lock_depth;
+ #endif
+ 
+-static void do_s_func (int end_p, const char *default_prefix);
++void do_s_func (int end_p, const char *default_prefix);
+ static void s_altmacro (int);
+ static void s_bad_end (int);
+ static void s_errwarn_if (int);
+@@ -6665,7 +6665,7 @@
+ /* Subroutine of s_func so targets can choose a different default prefix.
+    If DEFAULT_PREFIX is NULL, use the target's "leading char".  */
+ 
+-static void
++void
+ do_s_func (int end_p, const char *default_prefix)
+ {
+   if (end_p)
+diff -x .DS_Store -ruN binutils-2.46.1/include/dis-asm.h binutils-2.46.1-kos/include/dis-asm.h
+--- binutils-2.46.1/include/dis-asm.h	2026-07-06 18:45:01
++++ binutils-2.46.1-kos/include/dis-asm.h	2026-07-06 18:45:40
+@@ -379,6 +379,7 @@
+ extern int print_insn_rl78_g10		(bfd_vma, disassemble_info *);
+ extern int print_insn_rl78_g13		(bfd_vma, disassemble_info *);
+ extern int print_insn_rl78_g14		(bfd_vma, disassemble_info *);
++extern int print_insn_dvp		(bfd_vma, disassemble_info *);
+ 
+ extern disassembler_ftype arc_get_disassembler (bfd *);
+ extern disassembler_ftype cris_get_disassembler (bfd *);
+diff -x .DS_Store -ruN binutils-2.46.1/include/elf/mips.h binutils-2.46.1-kos/include/elf/mips.h
+--- binutils-2.46.1/include/elf/mips.h	2026-07-06 18:45:01
++++ binutils-2.46.1-kos/include/elf/mips.h	2026-07-06 18:45:40
+@@ -124,6 +124,12 @@
+   FAKE_RELOC (R_MICROMIPS_min, 130)
+   RELOC_NUMBER (R_MICROMIPS_26_S1, 133)
+   RELOC_NUMBER (R_MICROMIPS_HI16, 134)
++
++  /* These relocs are for the dvp.  */
++  RELOC_NUMBER (R_MIPS_DVP_11_PCREL, 120)
++  RELOC_NUMBER (R_MIPS_DVP_27_S4, 121)
++  RELOC_NUMBER (R_MIPS_DVP_11_S4, 122)
++  RELOC_NUMBER (R_MIPS_DVP_U15_S3, 123)
+   RELOC_NUMBER (R_MICROMIPS_LO16, 135)
+   RELOC_NUMBER (R_MICROMIPS_GPREL16, 136)	/* In Elf 64:
+ 						   alias R_MICROMIPS_GPREL */
+@@ -504,6 +510,15 @@
+ /* GNU style symbol hash table with xlat.  */
+ #define SHT_MIPS_XHASH		(SHT_LOPROC + 0x2b)
+ 
++/* The VU overlay table.  */
++#define SHT_DVP_OVERLAY_TABLE           0x7ffff420
++#define SHNAME_DVP_OVERLAY_TABLE        ".DVP.ovlytab"
++#define SHNAME_DVP_OVERLAY_STRTAB       ".DVP.ovlystrtab"
++/* A VU overlay.  */
++#define SHT_DVP_OVERLAY                 0x7ffff421
++/* Prefix of VU overlay sections.  */
++#define SHNAME_DVP_OVERLAY_PREFIX       ".DVP.overlay."
++
+ /* A section of type SHT_MIPS_LIBLIST contains an array of the
+    following structure.  The sh_link field is the section index of the
+    string table.  The sh_info field is the number of entries in the
+@@ -875,6 +890,16 @@
+ #define STO_HIDDEN		STV_HIDDEN
+ #define STO_PROTECTED		STV_PROTECTED
+ 
++/* These values are used for the dvp.  */
++#define STO_DVP_DMA             0xe8
++#define STO_DVP_VIF             0xe9
++#define STO_DVP_GIF             0xea
++#define STO_DVP_VU              0xeb
++/* Reserve a couple in case we need them.  */
++#define STO_DVP_RES1            0xec
++#define STO_DVP_RES2            0xed
++#define STO_DVP_P(sto) ((sto) >= STO_DVP_DMA && (sto) <= STO_DVP_RES2)
++
+ /* Two topmost bits denote the MIPS ISA for .text symbols:
+    + 00 -- standard MIPS code,
+    + 10 -- microMIPS code,
+@@ -1223,6 +1248,23 @@
+   (bfd *, const Elf64_External_RegInfo *, Elf64_Internal_RegInfo *);
+ extern void bfd_mips_elf64_swap_reginfo_out
+   (bfd *, const Elf64_Internal_RegInfo *, Elf64_External_RegInfo *);
++
++/* The vu overlay table is an array of this.  */
++
++typedef struct
++{
++  /* `name' is offset into overlay string table section.  */
++  char name[4];
++  char lma[4];
++  char vma[4];
++} Elf32_Dvp_External_Overlay;
++
++typedef struct
++{
++  bfd_vma name;
++  bfd_vma lma;
++  bfd_vma vma;
++} Elf32_Dvp_Internal_Overlay;
+ 
+ /* MIPS ELF flags swapping routines.  */
+ extern void bfd_mips_elf_swap_abiflags_v0_in
+diff -x .DS_Store -ruN binutils-2.46.1/include/opcode/dvp.h binutils-2.46.1-kos/include/opcode/dvp.h
+--- binutils-2.46.1/include/opcode/dvp.h	1969-12-31 16:00:00
++++ binutils-2.46.1-kos/include/opcode/dvp.h	2026-07-06 18:45:40
+@@ -0,0 +1,412 @@
++/* Opcode table for the DVP.
++   Copyright 1998 Free Software Foundation, Inc.
++
++This file is part of GAS, the GNU Assembler, GDB, the GNU debugger, and
++the GNU Binutils.
++
++GAS/GDB is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2, or (at your option)
++any later version.
++
++GAS/GDB is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GAS or GDB; see the file COPYING.	If not, write to
++the Free Software Foundation, 59 Temple Place - Suite 330,
++Boston, MA 02111-1307, USA.  */
++
++/* Enum describing each processing component.
++   In the case where one wants to specify DVP_VU, use DVP_VUUP.  */
++typedef enum {
++  DVP_UNKNOWN, DVP_DMA, DVP_VIF, DVP_GIF, DVP_VUUP, DVP_VULO
++} dvp_cpu;
++
++/* Type to denote a DVP instruction (at least a 32 bit unsigned int).  */
++typedef unsigned int DVP_INSN;
++
++/* Maximum number of operands and syntax chars an instruction can have.  */
++#define DVP_MAX_OPERANDS 16
++
++typedef struct dvp_opcode {
++  char *mnemonic;
++  /* The value stored is 128 + operand number.
++     This allows ASCII chars to go here as well.  */
++  unsigned char syntax[DVP_MAX_OPERANDS];
++  DVP_INSN mask, value;	/* recognize insn if (op&mask)==value */
++  unsigned opcode_word;	/* opcode word to contain contain "value"; usually 0 */
++		      	/* (definition of a word is target specific) */
++  int flags;		/* various flag bits */
++
++/* Values for `flags'.  */
++
++/* This insn is a conditional branch.  */
++#define DVP_OPCODE_COND_BRANCH 1
++/* Ignore this insn during disassembly.  */
++#define DVP_OPCODE_IGNORE_DIS 2
++/* CPU specific values begin at 0x10.  */
++} dvp_opcode;
++
++/* The operand table.  */
++
++typedef struct dvp_operand {
++  /* The number of bits in the operand (may be unused for a modifier).  */
++  unsigned char bits;
++
++  /* How far the operand is left shifted in the instruction, or
++     the modifier's flag bit (may be unused for a modifier).  */
++  unsigned char shift;
++
++  /* An index to the instruction word which will contain the operand value.
++     Usually 0.  */
++  unsigned char word;
++
++  /* Various flag bits.  */
++  int flags;
++
++/* Values for `flags'.  */
++
++/* This operand is a suffix to the opcode.  */
++#define DVP_OPERAND_SUFFIX 1
++
++/* This operand is a relative branch displacement.  The disassembler
++   prints these symbolically if possible.  */
++#define DVP_OPERAND_RELATIVE_BRANCH 2
++
++/* This operand is an absolute branch address.  The disassembler
++   prints these symbolically if possible.  */
++#define DVP_OPERAND_ABSOLUTE_BRANCH 4
++
++/* This operand is a mips address.  The disassembler
++   prints these symbolically if possible.  */
++#define DVP_OPERAND_MIPS_ADDRESS 8
++
++/* This operand is a vu address.  The disassembler
++   prints these symbolically if possible.  */
++#define DVP_OPERAND_VU_ADDRESS 0x10
++
++/* This operand takes signed values (default is unsigned).
++   The default was chosen to be unsigned as most fields are unsigned
++   (e.g. registers).  */
++#define DVP_OPERAND_SIGNED 0x20
++
++/* This operand takes signed values, but also accepts a full positive
++   range of values.  That is, if bits is 16, it takes any value from
++   -0x8000 to 0xffff.  */
++#define DVP_OPERAND_SIGNOPT 0x40
++
++/* This operand should be regarded as a negative number for the
++   purposes of overflow checking (i.e., the normal most negative
++   number is disallowed and one more than the normal most positive
++   number is allowed).  This flag will only be set for a signed
++   operand.  */
++#define DVP_OPERAND_NEGATIVE 0x80
++
++/* This operand doesn't really exist.  The program uses these operands
++   in special ways by creating insertion or extraction functions to have
++   arbitrary processing performed during assembly/disassemble.
++   Parse and print routines are ignored for FAKE operands.  */
++#define DVP_OPERAND_FAKE 0x100
++
++/* This operand is the address of the `unpack' insn.  */
++#define DVP_OPERAND_UNPACK_ADDRESS 0x200
++
++/* Inline data.  */
++#define DVP_OPERAND_DMA_INLINE 0x10000
++
++/* Pointer to the data.  */
++#define DVP_OPERAND_DMA_ADDR 0x20000
++
++/* Pointer to the data.  */
++#define DVP_OPERAND_DMA_NEXT 0x40000
++
++/* The actual count operand.  */
++#define DVP_OPERAND_DMA_COUNT 0x80000
++
++/* A 32 bit floating point immediate.  */
++#define DVP_OPERAND_FLOAT 0x100000
++
++/* An 11-bit immediate operand.  May be a label.  */
++#define DVP_OPERAND_RELOC_11_S4 0x200000
++
++/* An 15-bit unsigned immediate operand.  May be a label.  */
++#define DVP_OPERAND_RELOC_U15_S3 0x400000
++
++/* Modifier values.  */
++
++/* A dot is required before a suffix.  e.g. .le  */
++/* ??? Not currently used.  */
++#define DVP_MOD_DOT 0x1000000
++
++/* The count operand was an asterisk.  */
++#define DVP_OPERAND_AUTOCOUNT 0x2000000
++
++/* Ignore the word part of any shift and operate on the "first" word
++   of the instruction.  */
++#define DVP_MOD_THIS_WORD 0x4000000
++
++/* Sum of all DVP_MOD_XXX bits.  */
++#define DVP_MOD_BITS 0xff000000
++
++/* Non-zero if the operand type is really a modifier.  */
++#define DVP_MOD_P(X) ((X) & DVP_MOD_BITS)
++
++  /* Parse function.  This is used by the assembler.
++     MODS is a list of modifiers preceding the operand in the syntax string.
++     If the operand cannot be parsed an error message is stored in ERRMSG,
++     otherwise ERRMSG is unchanged.  */
++  long (*parse) (const struct dvp_opcode *opcode,
++			 const struct dvp_operand *operand,
++			 int mods, char **str, const char **errmsg);
++
++  /* Insertion function.  This is used by the assembler.  To insert an
++     operand value into an instruction, check this field.
++
++     If it is NULL, execute
++         i |= (p & ((1 << o->bits) - 1)) << o->shift;
++     (I is the instruction which we are filling in, O is a pointer to
++     this structure, and OP is the opcode value; this assumes twos
++     complement arithmetic).
++
++     If this field is not NULL, then simply call it with the
++     instruction and the operand value.  It will overwrite the appropriate
++     bits of the instruction with the operand's value.
++     MODS is a list of modifiers preceding the operand in the syntax string.
++     If the ERRMSG argument is not NULL, then if the operand value is illegal,
++     *ERRMSG will be set to a warning string (the operand will be inserted in
++     any case).  If the operand value is legal, *ERRMSG will be unchanged.
++     OPCODE may be NULL, in which case the value isn't known.  This happens
++     when applying fixups.  */
++
++  void (*insert) (const struct dvp_opcode *opcode,
++			  const struct dvp_operand *operand,
++			  int mods, DVP_INSN *insn,
++			  long value, const char **errmsg);
++
++  /* Extraction function.  This is used by the disassembler.  To
++     extract this operand type from an instruction, check this field.
++
++     If it is NULL, compute
++         op = ((i) >> o->shift) & ((1 << o->bits) - 1);
++	 if ((o->flags & DVP_OPERAND_SIGNED) != 0
++	     && (op & (1 << (o->bits - 1))) != 0)
++	   op -= 1 << o->bits;
++     (I is the instruction, O is a pointer to this structure, and OP
++     is the result; this assumes twos complement arithmetic).
++
++     If this field is not NULL, then simply call it with the
++     instruction value.  It will return the value of the operand.  If
++     the INVALID argument is not NULL, *INVALID will be set to
++     non-zero if this operand type can not actually be extracted from
++     this operand (i.e., the instruction does not match).  If the
++     operand is valid, *INVALID will not be changed.
++     MODS is a list of modifiers preceding the operand in the syntax string.
++
++     INSN is a pointer to one or two `DVP_INSN's.  The first element is
++     the insn, the second is an immediate constant if present.
++     FIXME: just thrown in here for now.
++     */
++
++  long (*extract) (const struct dvp_opcode *opcode,
++			   const struct dvp_operand *operand,
++			   int mods, DVP_INSN *insn, int *pinvalid);
++
++  /* Print function.  This is used by the disassembler.  */
++  void (*print) (const struct dvp_opcode *opcode,
++			 const struct dvp_operand *operand,
++			 int mods, DVP_INSN *insn,
++			 disassemble_info *info, long value);
++} dvp_operand;
++
++/* Given an operand entry, return the table index.  */
++#define DVP_OPERAND_INDEX(op) ((op) - 128)
++
++/* Macro support.  */
++
++typedef struct dvp_macro {
++  const char *template;
++  const char *result;
++} dvp_macro;
++
++/* Expand an instruction if it is a macro, else NULL.  */
++extern char * dvp_expand_macro (const dvp_macro *, int, char *);
++
++/* VU support.  */
++
++/* Flag values.
++   The actual value stored in the insn is left shifted by 27.  */
++#define VU_FLAG_I 16
++#define VU_FLAG_E 8
++#define VU_FLAG_M 4
++#define VU_FLAG_D 2
++#define VU_FLAG_T 1
++
++/* Positions, masks, and values of various fields used in multiple places
++   (the opcode table, the disassembler, GAS).  */
++#define VU_SHIFT_DEST 21
++#define VU_SHIFT_TREG 16
++#define VU_SHIFT_SREG 11
++#define VU_SHIFT_DREG 6
++#define VU_MASK_REG 31
++/* Bits for multiple dest choices.  */
++#define VU_DEST_X 8
++#define VU_DEST_Y 4
++#define VU_DEST_Z 2
++#define VU_DEST_W 1
++/* Values for a single dest choice.  */
++#define VU_SDEST_X 0
++#define VU_SDEST_Y 1
++#define VU_SDEST_Z 2
++#define VU_SDEST_W 3
++
++extern const dvp_operand vu_operands[];
++extern const dvp_opcode vu_upper_opcodes[];
++extern const dvp_opcode vu_lower_opcodes[];
++
++/* VIF support.  */
++
++/* VIF opcode flags.
++   The usage here is a bit wasteful of bits, but there's enough bits
++   and we can always make better usage later.
++   We begin at 0x10 because the lower 4 bits are reserved for
++   general opcode flags.  */
++
++/* 2 word instruction */
++#define VIF_OPCODE_LEN2 0x10
++/* 5 word instruction */
++#define VIF_OPCODE_LEN5 0x20
++/* variable length instruction */
++#define VIF_OPCODE_LENVAR 0x40
++/* the mpg instruction */
++#define VIF_OPCODE_MPG 0x80
++/* the direct instruction */
++#define VIF_OPCODE_DIRECT 0x100
++/* the directhl instruction */
++#define VIF_OPCODE_DIRECTHL 0x200
++/* the unpack instruction */
++#define VIF_OPCODE_UNPACK 0x400
++
++/* Instruction flag bits.  M,R,U are only applicable to `unpack'.
++   These aren't the actual bit numbers.  They're for internal use.
++   The insert/extract handlers do the appropriate conversions.  */
++#define VIF_FLAG_I 1
++#define VIF_FLAG_M 2
++#define VIF_FLAG_R 4
++#define VIF_FLAG_U 8
++
++/* The "mode" operand of the "stmod" insn.  */
++#define VIF_MODE_DIRECT 0
++#define VIF_MODE_ADD 1
++#define VIF_MODE_ADDROW 2
++
++/* Unpack types.  */
++typedef enum {
++  VIF_UNPACK_S_32 = 0,
++  VIF_UNPACK_S_16 = 1,
++  VIF_UNPACK_S_8 = 2,
++  VIF_UNPACK_UNUSED3 = 3,
++  VIF_UNPACK_V2_32 = 4,
++  VIF_UNPACK_V2_16 = 5,
++  VIF_UNPACK_V2_8 = 6,
++  VIF_UNPACK_UNUSED7 = 7,
++  VIF_UNPACK_V3_32 = 8,
++  VIF_UNPACK_V3_16 = 9,
++  VIF_UNPACK_V3_8 = 10,
++  VIF_UNPACK_UNUSED11 = 11,
++  VIF_UNPACK_V4_32 = 12,
++  VIF_UNPACK_V4_16 = 13,
++  VIF_UNPACK_V4_8 = 14,
++  VIF_UNPACK_V4_5 = 15
++} unpack_type;
++
++extern const dvp_operand vif_operands[];
++extern const dvp_opcode vif_opcodes[];
++extern const dvp_macro vif_macros[];
++extern const int vif_macro_count;
++const dvp_opcode *vif_opcode_lookup_asm (const char *);
++const dvp_opcode *vif_opcode_lookup_dis (unsigned int);
++
++/* Return length, in 32 bit words, of just parsed vif insn,
++   or 0 if unknown.  */
++int vif_len (void);
++
++/* Given the first word of a VIF insn, return its length.  */
++int vif_insn_len (DVP_INSN, dvp_cpu *);
++
++/* Return the length value to use for an unpack instruction.  */
++int vif_unpack_len_value (unpack_type, int, int, int);
++
++/* Return the length, in words, of an unpack insn.  */
++int vif_unpack_len (unpack_type, int);
++
++int vif_get_mpgloc (void);
++
++/* Fetch user data for variable length insns.  */
++void vif_get_var_data (const char **, int *);
++
++/* Fetch the current values of wl,cl.  */
++void vif_get_wl_cl (int *, int *);
++
++/* Various operand numbers.  */
++extern const int vif_operand_mpgloc;
++extern const int vif_operand_datalen_special;
++
++/* DMA support.  */
++
++/* DMA instruction flags.  */
++#define DMA_FLAG_PCE0 1
++#define DMA_FLAG_PCE1 2
++#define DMA_FLAG_INT 4
++#define DMA_FLAG_SPR 8
++
++extern const dvp_operand dma_operands[];
++extern const dvp_opcode dma_opcodes[];
++
++/* Various operand numbers.  */
++extern const int dma_operand_count;
++extern const int dma_operand_addr;
++
++/* GIF support.  */
++
++/* Maximum value for nloop.  */
++#define GIF_MAX_NLOOP 32767
++
++/* The PRE bit in the appropriate word in a tag.  */
++#define GIF_PRE (1 << 14)
++
++/* The values here correspond to the values in the instruction.  */
++typedef enum { GIF_PACKED = 0, GIF_REGLIST = 1, GIF_IMAGE = 2 } gif_type;
++
++typedef enum {
++  GIF_REG_PRIM = 0,
++  GIF_REG_RGBAQ = 1,
++  GIF_REG_ST = 2,
++  GIF_REG_UV = 3,
++  GIF_REG_XYZF2 = 4,
++  GIF_REG_XYZ2 = 5,
++  GIF_REG_TEX0_1 = 6,
++  GIF_REG_TEX0_2 = 7,
++  GIF_REG_CLAMP_1 = 8,
++  GIF_REG_CLAMP_2 = 9,
++  GIF_REG_XYZF = 10,
++  GIF_REG_UNUSED11 = 11, /* 11 is unused */
++  GIF_REG_XYZF3 = 12,
++  GIF_REG_XYZ3 = 13,
++  GIF_REG_A_D = 14,
++  GIF_REG_NOP = 15
++} gif_reg;
++
++extern const dvp_operand gif_operands[];
++extern const dvp_opcode gif_opcodes[];
++extern int gif_nloop (void);
++extern int gif_nregs (void);
++
++/* Various operand numbers.  */
++extern const int gif_operand_nloop;
++
++/* Utility fns in dvp-opc.c.  */
++void dvp_opcode_init_parse (void);
++void dvp_opcode_init_print (void);
+diff -x .DS_Store -ruN binutils-2.46.1/ld/emulparams/elf32lr5900.sh binutils-2.46.1-kos/ld/emulparams/elf32lr5900.sh
+--- binutils-2.46.1/ld/emulparams/elf32lr5900.sh	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/ld/emulparams/elf32lr5900.sh	2026-07-06 18:45:40
+@@ -13,5 +13,3 @@
+ 
+ unset DATA_ADDR
+ SHLIB_TEXT_START_ADDR=0
+-unset GENERATE_SHLIB_SCRIPT
+-
+diff -x .DS_Store -ruN binutils-2.46.1/ld/emulparams/elf32lr5900n32.sh binutils-2.46.1-kos/ld/emulparams/elf32lr5900n32.sh
+--- binutils-2.46.1/ld/emulparams/elf32lr5900n32.sh	2026-07-06 18:44:58
++++ binutils-2.46.1-kos/ld/emulparams/elf32lr5900n32.sh	2026-07-06 18:45:40
+@@ -19,5 +19,3 @@
+ 
+ unset DATA_ADDR
+ SHLIB_TEXT_START_ADDR=0
+-unset GENERATE_SHLIB_SCRIPT
+-
+diff -x .DS_Store -ruN binutils-2.46.1/opcodes/configure binutils-2.46.1-kos/opcodes/configure
+--- binutils-2.46.1/opcodes/configure	2026-07-06 18:45:01
++++ binutils-2.46.1-kos/opcodes/configure	2026-07-06 18:45:40
+@@ -14394,6 +14394,7 @@
+ 	bfd_tic54x_arch)	ta="$ta tic54x-dis.lo tic54x-opc.lo" ;;
+ 	bfd_tic6x_arch)		ta="$ta tic6x-dis.lo" ;;
+ 	bfd_tilegx_arch)	ta="$ta tilegx-dis.lo tilegx-opc.lo" ;;
++	bfd_dvp_arch)		ta="$ta mips-dis.lo mips-opc.lo mips16-opc.lo dvp-dis.lo dvp-opc.lo" ;;
+ 	bfd_tilepro_arch)	ta="$ta tilepro-dis.lo tilepro-opc.lo" ;;
+ 	bfd_v850_arch)		ta="$ta v850-opc.lo v850-dis.lo" ;;
+ 	bfd_v850e_arch)		ta="$ta v850-opc.lo v850-dis.lo" ;;
+diff -x .DS_Store -ruN binutils-2.46.1/opcodes/configure.ac binutils-2.46.1-kos/opcodes/configure.ac
+--- binutils-2.46.1/opcodes/configure.ac	2026-07-06 18:45:01
++++ binutils-2.46.1-kos/opcodes/configure.ac	2026-07-06 18:45:40
+@@ -332,6 +332,7 @@
+ 	bfd_tic4x_arch)		ta="$ta tic4x-dis.lo" ;;
+ 	bfd_tic54x_arch)	ta="$ta tic54x-dis.lo tic54x-opc.lo" ;;
+ 	bfd_tic6x_arch)		ta="$ta tic6x-dis.lo" ;;
++	bfd_dvp_arch)		ta="$ta mips-dis.lo mips-opc.lo mips16-opc.lo dvp-dis.lo dvp-opc.lo" ;;
+ 	bfd_tilegx_arch)	ta="$ta tilegx-dis.lo tilegx-opc.lo" ;;
+ 	bfd_tilepro_arch)	ta="$ta tilepro-dis.lo tilepro-opc.lo" ;;
+ 	bfd_v850_arch)		ta="$ta v850-opc.lo v850-dis.lo" ;;
+diff -x .DS_Store -ruN binutils-2.46.1/opcodes/disassemble.c binutils-2.46.1-kos/opcodes/disassemble.c
+--- binutils-2.46.1/opcodes/disassemble.c	2026-07-06 18:45:01
++++ binutils-2.46.1-kos/opcodes/disassemble.c	2026-07-06 18:45:40
+@@ -324,12 +324,16 @@
+       disassemble = print_insn_metag;
+       break;
+ #endif
+-#ifdef ARCH_mips
++#if defined(ARCH_mips) || defined(ARCH_dvp)
+     case bfd_arch_mips:
++#ifdef ARCH_mips
+       if (big)
+ 	disassemble = print_insn_big_mips;
+       else
+ 	disassemble = print_insn_little_mips;
++#else
++  disassemble = print_insn_dvp;
++#endif
+       break;
+ #endif
+ #ifdef ARCH_mmix
+diff -x .DS_Store -ruN binutils-2.46.1/opcodes/dvp-dis.c binutils-2.46.1-kos/opcodes/dvp-dis.c
+--- binutils-2.46.1/opcodes/dvp-dis.c	1969-12-31 16:00:00
++++ binutils-2.46.1-kos/opcodes/dvp-dis.c	2026-07-06 18:45:40
+@@ -0,0 +1,406 @@
++/* Instruction printing code for the DVP
++   Copyright (C) 1998 Free Software Foundation, Inc.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 2 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with this program; if not, write to the Free Software Foundation, Inc.,
++   59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
++
++#include "sysdep.h"
++#include "dis-asm.h"
++#include "opcode/dvp.h"
++#include "elf-bfd.h"
++#include "elf/mips.h"
++#include "opintl.h"
++
++static int print_dma (bfd_vma, disassemble_info *);
++static int print_vif (bfd_vma, disassemble_info *);
++static int print_gif (bfd_vma, disassemble_info *);
++static int print_vu (bfd_vma, disassemble_info *);
++static void print_insn (dvp_cpu, const dvp_opcode *, const dvp_operand *,
++                        bfd_vma, disassemble_info *, DVP_INSN *);
++
++static int read_word (bfd_vma, disassemble_info *, DVP_INSN *);
++
++/* Return the dvp mach number to use or 0 if not at a dvp insn.
++   The different machs are distinguished by marking the start of a group
++   of related insns by a specially marked label.  */
++
++static int
++dvp_info_mach_type (struct disassemble_info *info)
++{
++  if (info->flavour == bfd_target_elf_flavour
++      && info->symbols != NULL)
++    {
++      asymbol **sym,**symend;
++
++      for (sym = info->symbols, symend = sym + info->num_symbols;
++	   sym < symend; ++sym)
++	{
++	  int sto = (*(elf_symbol_type **) sym)->internal_elf_sym.st_other;
++	  switch (sto)
++	    {
++	    case STO_DVP_DMA : return bfd_mach_dvp_dma;
++	    case STO_DVP_VIF : return bfd_mach_dvp_vif;
++	    case STO_DVP_GIF : return bfd_mach_dvp_gif;
++	    case STO_DVP_VU : return bfd_mach_dvp_vu;
++	    default : break;
++	    }
++	}
++    }
++
++  return 0;
++}
++
++/* Print one instruction from PC on INFO->STREAM.
++   Return the size of the instruction.  */
++
++int
++print_insn_dvp (bfd_vma memaddr, disassemble_info *info)
++{
++  int mach;
++
++  mach = dvp_info_mach_type (info);
++  if (mach == bfd_mach_dvp_dma
++      || info->mach == bfd_mach_dvp_dma)
++    return print_dma (memaddr, info);
++  if (mach == bfd_mach_dvp_vif
++      || info->mach == bfd_mach_dvp_vif)
++    return print_vif (memaddr, info);
++  if (mach == bfd_mach_dvp_gif
++      || info->mach == bfd_mach_dvp_gif)
++    return print_gif (memaddr, info);
++  if (mach == bfd_mach_dvp_vu
++      || info->mach == bfd_mach_dvp_vu)
++    return print_vu (memaddr, info);
++
++  (*info->fprintf_func) (info->stream, _("*unknown*"));
++  return 4;
++}
++
++/* Print one DMA instruction from PC on INFO->STREAM.
++   Return the size of the instruction.  */
++
++static int
++print_dma (bfd_vma memaddr, disassemble_info *info)
++{
++  bfd_byte buffer[8];
++  int i, status, len;
++  DVP_INSN insn_buf[2];
++
++  /* The length of a dma tag is 16, however the upper two words are
++     vif insns.  */
++
++  len = 8;
++  status = (*info->read_memory_func) (memaddr, buffer, len, info);
++  if (status != 0)
++    {
++      (*info->memory_error_func) (status, memaddr, info);
++      return -1;
++    }
++
++  for (i = 0; i < 2; ++i)
++    insn_buf[i] = bfd_getl32 (buffer + i * 4);
++
++  print_insn (DVP_DMA, dma_opcodes, dma_operands, memaddr, info, insn_buf);
++  return len;
++}
++
++/* Print one VIF instruction from PC on INFO->STREAM.
++   Return the size of the instruction.  */
++
++static int
++print_vif (bfd_vma memaddr, disassemble_info *info)
++{
++  int len;
++  /* Non-zero if vu code follows (i.e. this is mpg).  */
++  dvp_cpu cpu;
++  DVP_INSN insn_buf[5];
++
++  if (read_word (memaddr, info, insn_buf) != 0)
++    return -1;
++
++  len = vif_insn_len (insn_buf[0], &cpu);
++  switch (len)
++    {
++    case 5 :
++      if (read_word (memaddr + 16, info, insn_buf + 4) != 0)
++	return -1;
++      if (read_word (memaddr + 12, info, insn_buf + 3) != 0)
++	return -1;
++      if (read_word (memaddr + 8, info, insn_buf + 2) != 0)
++	return -1;
++      /* fall through */
++    case 2 :
++      if (read_word (memaddr + 4, info, insn_buf + 1) != 0)
++	return -1;
++      /* fall through */
++    case 1 :
++    case 0 :
++      break;
++    }
++
++  print_insn (DVP_VIF, vif_opcodes, vif_operands, memaddr, info, insn_buf);
++
++  /* If symbols are present and this is an mpg or direct insn, assume there
++     are symbols to distinguish the mach type so that we can properly
++     disassemble the vu code and gif tags.  */
++  if (info->symbols
++      && (cpu == DVP_VUUP || cpu == DVP_GIF))
++    return 4;
++  return len * 4;
++}
++
++/* Print one GIF instruction from PC on INFO->STREAM.
++   Return the size of the instruction.  */
++
++static int
++print_gif (bfd_vma memaddr, disassemble_info *info)
++{
++  bfd_byte buffer[16];
++  int i, status, len, type, nloop, nregs;
++  DVP_INSN insn_buf[4];
++
++  status = (*info->read_memory_func) (memaddr, buffer, 16, info);
++  if (status != 0)
++    {
++      (*info->memory_error_func) (status, memaddr, info);
++      return -1;
++    }
++  len = 16;
++
++  for (i = 0; i < 4; ++i)
++    insn_buf[i] = bfd_getl32 (buffer + i * 4);
++
++  print_insn (DVP_GIF, gif_opcodes, gif_operands, memaddr, info, insn_buf);
++
++  type = (insn_buf[1] >> 26) & 3;
++  nloop = insn_buf[0] & 0x7fff;
++  nregs = (insn_buf[1] >> 28) & 15;
++  switch (type)
++    {
++    case GIF_PACKED :
++      return len + nloop * nregs * 16;
++    case GIF_REGLIST :
++      return len + ((nloop * nregs + 1) & ~1) * 8;
++    case GIF_IMAGE :
++      return len + nloop * 16;
++    }
++
++  return len;
++}
++
++/* Print one VU instruction from PC on INFO->STREAM.
++   Return the size of the instruction.  */
++
++static int
++print_vu (bfd_vma memaddr, disassemble_info *info)
++{
++  bfd_byte buffer[8];
++  void *stream = info->stream;
++  fprintf_ftype func = info->fprintf_func;
++  int status;
++  /* First element is upper, second is lower.  */
++  DVP_INSN upper,lower;
++
++  status = (*info->read_memory_func) (memaddr, buffer, 8, info);
++  if (status != 0)
++    {
++      (*info->memory_error_func) (status, memaddr, info);
++      return -1;
++    }
++  /* The lower instruction has the lower address.  */
++  upper = bfd_getl32 (buffer + 4);
++  lower = bfd_getl32 (buffer);
++
++  /* FIXME: This will need revisiting.  */
++  print_insn (DVP_VUUP, vu_upper_opcodes, vu_operands, memaddr, info, &upper);
++#ifdef VERTICAL_BAR_SEPARATOR
++  (*func) (stream, " | ");
++#else
++  /* Not sure how much whitespace to print here.
++     At least two spaces, not more than 9, and having columns line up somewhat
++     seems reasonable.  */
++  (*func) (stream, " \t");
++#endif
++  /* If the 'i' bit is set then the lower word is not an insn but a 32 bit
++     floating point immediate value.  */
++  if (upper & 0x80000000)
++    {
++      /* FIXME: assumes float/int are same size/endian.  */
++      union { float f; int i; } x;
++      x.i = lower;
++      (*func) (stream, "loi %g", x.f);
++    }
++  else
++    print_insn (DVP_VULO, vu_lower_opcodes, vu_operands, memaddr, info,
++                &lower);
++
++  return 8;
++}
++
++/* Print one instruction.
++   OPCODE is a pointer to the head of the hash list.  */
++
++static void
++print_insn (dvp_cpu cpu ATTRIBUTE_UNUSED, const dvp_opcode *opcode,
++            const dvp_operand *operand_table, bfd_vma memaddr,
++            disassemble_info *info, DVP_INSN *insn)
++{
++  void *stream = info->stream;
++  fprintf_ftype func = info->fprintf_func;
++
++  for ( ; opcode && opcode->mnemonic; opcode++)
++    {
++      const unsigned char *syn;
++      int mods,invalid,num_operands;
++      long value;
++      const dvp_operand *operand;
++
++      /* Ignore insns that have a mask value of 0.
++	 Such insns are not intended to be disassembled by us.  */
++      if (opcode->mask == 0)
++	continue;
++      if (opcode->flags & DVP_OPCODE_IGNORE_DIS)
++	continue;
++      /* Basic bit mask must be correct.  */
++      if ((insn[opcode->opcode_word] & opcode->mask) != opcode->value)
++	continue;
++
++      /* Make two passes over the operands.  First see if any of them
++	 have extraction functions, and, if they do, make sure the
++	 instruction is valid.  */
++
++      dvp_opcode_init_print ();
++      invalid = 0;
++
++      for (syn = opcode->syntax; *syn; ++syn)
++	{
++	  int index;
++
++	  if (*syn < 128)
++	    continue;
++
++	  mods = 0;
++	  index = DVP_OPERAND_INDEX (*syn);
++	  while (DVP_MOD_P (operand_table[index].flags))
++	    {
++	      mods |= operand_table[index].flags & DVP_MOD_BITS;
++	      ++syn;
++	      index = DVP_OPERAND_INDEX (*syn);
++	    }
++	  operand = operand_table + index;
++	  if (operand->extract)
++	    (*operand->extract) (opcode, operand, mods, insn, &invalid);
++	}
++      if (invalid)
++	continue;
++
++      /* The instruction is valid.  */
++
++      (*func) (stream, "%s", opcode->mnemonic);
++      num_operands = 0;
++      for (syn = opcode->syntax; *syn; ++syn)
++	{
++	  int index;
++
++	  if (*syn < 128)
++	    {
++	      (*func) (stream, "%c", *syn);
++	      continue;
++	    }
++
++	  /* We have an operand.  Fetch any special modifiers.  */
++	  mods = 0;
++	  index = DVP_OPERAND_INDEX (*syn);
++	  while (DVP_MOD_P (operand_table[index].flags))
++	    {
++	      mods |= operand_table[index].flags & DVP_MOD_BITS;
++	      ++syn;
++	      index = DVP_OPERAND_INDEX (*syn);
++	    }
++	  operand = operand_table + index;
++
++	  /* Extract the value from the instruction.  */
++	  if (operand->extract)
++	    {
++	      value = (*operand->extract) (opcode, operand, mods,
++					   insn, (int *) NULL);
++	    }
++	  else
++	    {
++	      /* We currently assume a field does not cross a word boundary.  */
++	      int shift = ((mods & DVP_MOD_THIS_WORD)
++			   ? (operand->shift & 31)
++			   : operand->shift);
++	      /* FIXME: There are currently two ways to specify which word:
++		 the `word' member and shift / 32.  */
++	      int word = operand->word ? operand->word : shift / 32;
++	      DVP_INSN mask = (operand->bits == 32
++			       ? 0xffffffff : (unsigned)((1 << operand->bits) - 1));
++	      shift = shift % 32;
++	      value = (insn[word] >> shift) & mask;
++	      if ((operand->flags & DVP_OPERAND_SIGNED) != 0
++		  && (value & (1 << (operand->bits - 1)))
++		  && operand->bits < 8 * sizeof (long))
++		value -= 1L << operand->bits;
++	    }
++
++	  /* Print the operand as directed by the flags.  */
++	  if (operand->print)
++	    (*operand->print) (opcode, operand, mods, insn, info, value);
++	  else if (operand->flags & DVP_OPERAND_FAKE)
++	    ; /* nothing to do (??? at least not yet) */
++	  else if (operand->flags & DVP_OPERAND_RELATIVE_BRANCH)
++	    (*info->print_address_func) (memaddr + 8 + (value << 3), info);
++	  /* ??? Not all cases of this are currently caught.  */
++	  else if (operand->flags & DVP_OPERAND_ABSOLUTE_BRANCH)
++	    (*info->print_address_func) ((bfd_vma) value & 0xffffffff, info);
++	  else if (operand->flags & DVP_OPERAND_MIPS_ADDRESS)
++	    (*info->print_address_func) ((bfd_vma) value & 0xffffffff, info);
++	  else if (operand->flags & (DVP_OPERAND_VU_ADDRESS | DVP_OPERAND_UNPACK_ADDRESS))
++	    (*func) (stream, "0x%lx", value & 0xffffffff);
++          else if ((operand->flags & (DVP_OPERAND_SIGNED | DVP_OPERAND_RELOC_11_S4)) != 0
++		   || (value >= -1 && value < 16))
++	    (*func) (stream, "%ld", value);
++	  else
++	    (*func) (stream, "0x%lx", value);
++
++	  if (! (operand->flags & DVP_OPERAND_SUFFIX))
++	    ++num_operands;
++	}
++
++      /* We have found and printed an instruction; return.  */
++      return;
++    }
++
++  (*func) (stream, _("*unknown*"));
++}
++
++/* Utility to read one word.
++   The result is 0 for success, -1 for failure.  */
++
++static int
++read_word (bfd_vma memaddr, disassemble_info *info, DVP_INSN *insn_buf)
++{
++  int status;
++  bfd_byte buffer[4];
++
++  status = (*info->read_memory_func) (memaddr, buffer, 4, info);
++  if (status != 0)
++    {
++      (*info->memory_error_func) (status, memaddr, info);
++      return -1;
++    }
++  *insn_buf = bfd_getl32 (buffer);
++  return 0;
++}
+diff -x .DS_Store -ruN binutils-2.46.1/opcodes/dvp-opc.c binutils-2.46.1-kos/opcodes/dvp-opc.c
+--- binutils-2.46.1/opcodes/dvp-opc.c	1969-12-31 16:00:00
++++ binutils-2.46.1-kos/opcodes/dvp-opc.c	2026-07-06 18:45:40
+@@ -0,0 +1,3009 @@
++/* Opcode table for the DVP
++   Copyright (c) 1998 Free Software Foundation, Inc.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 2, or (at your option)
++   any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with this program; if not, write to the Free Software Foundation, Inc.,
++   59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
++
++#include "sysdep.h"
++#include "ansidecl.h"
++#include "libiberty.h"
++#include "dis-asm.h"
++#include "opcode/dvp.h"
++#include "opintl.h"
++
++#include <ctype.h>
++
++#ifndef NULL
++#define NULL 0
++#endif
++
++#define MIN(a,b) ((a) < (b) ? (a) : (b))
++
++typedef struct {
++  int value;
++  const char *name;
++} keyword;
++
++static int lookup_keyword_value (const keyword *, const char *, int);
++static const char *lookup_keyword_name (const keyword *table, int);
++
++static char *scan_symbol (char *);
++
++/* Return non-zero if CH is a character that may appear in a symbol.  */
++/* FIXME: This will need revisiting.  */
++#define issymchar(ch) (isalnum ((unsigned char) ch) || ch == '_')
++
++#define SKIP_BLANKS(var) while (isspace ((unsigned char) *(var))) ++(var)
++
++/* ??? One can argue it's preferable to have the PARSE_FN support in tc-dvp.c
++   and the PRINT_FN support in dvp-dis.c.  For this project I like having
++   them all in one place.  */
++
++#define PARSE_FN(fn) \
++static long CONCAT2 (parse_,fn) \
++     (const dvp_opcode *, const dvp_operand *, int, char **, \
++	      const char **);
++#define INSERT_FN(fn) \
++static void CONCAT2 (insert_,fn) \
++     (const dvp_opcode *, const dvp_operand *, int, DVP_INSN *, \
++	      long, const char **)
++#define EXTRACT_FN(fn) \
++static long CONCAT2 (extract_,fn) \
++     (const dvp_opcode *, const dvp_operand *, int, DVP_INSN *, \
++	      int *);
++#define PRINT_FN(fn) \
++static void CONCAT2 (print_,fn) \
++     (const dvp_opcode *, const dvp_operand *, int, DVP_INSN *, \
++	      disassemble_info *, long);
++
++PARSE_FN (dotdest);
++INSERT_FN (dotdest);
++EXTRACT_FN (dotdest);
++PRINT_FN (dotdest);
++
++PARSE_FN (dotdest1);
++PARSE_FN (dest1);
++PRINT_FN (dest1);
++
++PARSE_FN (uflags);
++PRINT_FN (uflags);
++
++PARSE_FN (bc);
++EXTRACT_FN (bc);
++PRINT_FN (sdest);
++
++PARSE_FN (vfreg);
++PRINT_FN (vfreg);
++
++PARSE_FN (bcftreg);
++PRINT_FN (bcftreg);
++
++PARSE_FN (accdest);
++PRINT_FN (accdest);
++
++INSERT_FN (xyz);
++INSERT_FN (w);
++
++PARSE_FN (ireg);
++PRINT_FN (ireg);
++
++PARSE_FN (freg);
++PRINT_FN (freg);
++
++PARSE_FN (ffstreg);
++INSERT_FN (ffstreg);
++EXTRACT_FN (ffstreg);
++PRINT_FN (ffstreg);
++
++PARSE_FN (vi01);
++PRINT_FN (vi01);
++
++INSERT_FN (luimm12);
++EXTRACT_FN (luimm12);
++
++INSERT_FN (luimm12up6);
++
++INSERT_FN (luimm15);
++EXTRACT_FN (luimm15);
++
++/* Various types of DVP operands, including insn suffixes.
++
++   Fields are:
++
++   BITS SHIFT FLAGS PARSE_FN INSERT_FN EXTRACT_FN PRINT_FN
++
++   Operand values are 128 + table index.  This allows ASCII chars to be
++   included in the syntax spec.  */
++
++const dvp_operand vu_operands[] =
++{
++  /* place holder (??? not sure if needed) */
++#define UNUSED 128
++  { 0 },
++
++  /* Operands that exist in the same place for essentially the same purpose
++     in both upper and lower instructions.  These don't have a U or L prefix.
++     Operands specific to the upper or lower instruction are so prefixed.  */
++
++  /* Destination indicator attached to mnemonic, with leading '.' or '/'.
++     After parsing this, the value is stored in global `state_vu_mnemonic_dest'
++     so that the register parser can verify the same choice of xyzw is
++     used.  */
++#define DOTDEST (UNUSED + 1)
++  { 4, VU_SHIFT_DEST, 0, DVP_OPERAND_SUFFIX,
++      parse_dotdest, insert_dotdest, extract_dotdest, print_dotdest },
++
++  /* ft reg, with vector specification same as DOTDEST */
++#define VFTREG (DOTDEST + 1)
++  { 5, VU_SHIFT_TREG, 0, 0, parse_vfreg, 0, 0, print_vfreg },
++
++  /* fs reg, with vector specification same as DOTDEST */
++#define VFSREG (VFTREG + 1)
++  { 5, VU_SHIFT_SREG, 0, 0, parse_vfreg, 0, 0, print_vfreg },
++
++  /* fd reg, with vector specification same as DOTDEST */
++#define VFDREG (VFSREG + 1)
++  { 5, VU_SHIFT_DREG, 0, 0, parse_vfreg, 0, 0, print_vfreg },
++
++  /* Upper word operands.  */
++
++  /* flag bits */
++#define UFLAGS (VFDREG + 1)
++  { 5, 27, 0, DVP_OPERAND_SUFFIX, parse_uflags, 0, 0, print_uflags },
++
++  /* broadcast */
++#define UBC (UFLAGS + 1)
++  { 2, 0, 0, DVP_OPERAND_SUFFIX, parse_bc, 0, extract_bc, print_sdest },
++
++  /* ftreg in broadcast case */
++#define UBCFTREG (UBC + 1)
++  { 5, VU_SHIFT_TREG, 0, 0, parse_bcftreg, 0, 0, print_bcftreg },
++
++  /* accumulator dest */
++#define UACCDEST (UBCFTREG + 1)
++  { 0, 0, 0, 0, parse_accdest, 0, 0, print_accdest },
++
++  /* The XYZ operand is a fake one that is used to ensure only "xyz" is
++     specified.  It simplifies the opmula and opmsub entries.  */
++#define UXYZ (UACCDEST + 1)
++  { 0, 0, 0, DVP_OPERAND_FAKE, 0, insert_xyz, 0, 0 },
++
++  /* The W operand is a fake one that is used to ensure only "w" is
++     specified.  It simplifies the clipw entry.  */
++#define UW (UXYZ + 1)
++  { 0, 0, 0, DVP_OPERAND_FAKE, 0, insert_w, 0, 0 },
++
++  /* Lower word operands.  */
++
++  /* 5 bit signed immediate.  */
++#define LIMM5 (UW + 1)
++  { 5, 6, 0, DVP_OPERAND_SIGNED, 0, 0, 0, 0 },
++
++  /* 11 bit signed immediate.  */
++#define LIMM11 (LIMM5 + 1)
++  { 11, 0, 0, DVP_OPERAND_SIGNED, 0, 0, 0, 0 },
++  /* WAS: { 11, 0, 0, DVP_OPERAND_RELOC_11_S4, 0, 0, 0, 0 },*/
++
++  /* 15 bit unsigned immediate.  */
++#define LUIMM15 (LIMM11 + 1)
++  { 15, 0, 0, DVP_OPERAND_RELOC_U15_S3, 0, insert_luimm15, extract_luimm15, 0 },
++
++  /* ID register.  */
++#define LIDREG (LUIMM15 + 1)
++  { 5, 6, 0, 0, parse_ireg, 0, 0, print_ireg },
++
++  /* IS register.  */
++#define LISREG (LIDREG + 1)
++  { 5, 11, 0, 0, parse_ireg, 0, 0, print_ireg },
++
++  /* IT register.  */
++#define LITREG (LISREG + 1)
++  { 5, 16, 0, 0, parse_ireg, 0, 0, print_ireg },
++
++  /* FS reg, with FSF field selector.  */
++#define LFSFFSREG (LITREG + 1)
++  { 5, 11, 0, 0, parse_ffstreg, insert_ffstreg, extract_ffstreg, print_ffstreg },
++
++  /* FS reg, no selector (choice of x,y,z,w is provided by opcode).  */
++#define LFSREG (LFSFFSREG + 1)
++  { 5, 11, 0, 0, parse_freg, 0, 0, print_freg },
++
++  /* FT reg, with FTF field selector.  */
++#define LFTFFTREG (LFSREG + 1)
++  { 5, 16, 0, 0, parse_ffstreg, insert_ffstreg, extract_ffstreg, print_ffstreg },
++
++  /* VI01 register.  */
++#define LVI01 (LFTFFTREG + 1)
++  { 0, 0, 0, 0, parse_vi01, 0, 0, print_vi01 },
++
++  /* 24 bit unsigned immediate.  */
++#define LUIMM24 (LVI01 + 1)
++  { 24, 0, 0, 0, 0, 0, 0, 0 },
++
++  /* 12 bit unsigned immediate, split into 1 and 11 bit pieces.  */
++#define LUIMM12 (LUIMM24 + 1)
++  { 12, 0, 0, 0, 0, insert_luimm12, extract_luimm12, 0 },
++
++  /* upper 6 bits of 12 bit unsigned immediate */
++#define LUIMM12UP6 (LUIMM12 + 1)
++  { 12, 0, 0, 0, 0, insert_luimm12up6, extract_luimm12, 0 },
++
++  /* 11 bit pc-relative signed immediate.  */
++#define LPCREL11 (LUIMM12UP6 + 1)
++  { 11, 0, 0, DVP_OPERAND_SIGNED + DVP_OPERAND_RELATIVE_BRANCH, 0, 0, 0, 0 },
++
++  /* Destination indicator, single letter only, with leading '.' or '/'.  */
++#define LDOTDEST1 (LPCREL11 + 1)
++  { 4, VU_SHIFT_DEST, 0, DVP_OPERAND_SUFFIX,
++      /* Note that we borrow the insert/extract/print functions from the
++	 vector case.  */
++      parse_dotdest1, insert_dotdest, extract_dotdest, print_dotdest },
++
++  /* Destination indicator, single letter only, no leading '.'.  */
++  /* ??? Making this FAKE is a workaround to a limitation in the parser.
++     It can't handle operands with a legitimate value of "".  */
++#define LDEST1 (LDOTDEST1 + 1)
++  { 0, 0, 0, DVP_OPERAND_FAKE, parse_dest1, 0, 0, print_dest1 },
++
++  /* 32 bit floating point immediate.  */
++#define LFIMM32 (LDEST1 + 1)
++  { 32, 0, 0, DVP_OPERAND_FLOAT, 0, 0, 0, 0 },
++/* end of list place holder */
++  { 0 }
++};
++
++/* Macros to put a field's value into the right place.  */
++/* ??? If assembler needs these, move to opcode/dvp.h.  */
++
++/* value X, B bits, shift S */
++#define V(x,b,s) (((x) & ((1 << (b)) - 1)) << (s))
++
++/* Field value macros for both upper and lower instructions.
++   These shift a value into the right place in the instruction.  */
++
++/* [FI] T reg field (remember it's V for value, not vector, here).  */
++#define VT(x) V ((x), 5, VU_SHIFT_TREG)
++/* [FI] S reg field.  */
++#define VS(x) V ((x), 5, VU_SHIFT_SREG)
++/* [FI] D reg field.  */
++#define VD(x) V ((x), 5, VU_SHIFT_DREG)
++/* DEST field.  */
++#define VDEST(x) V ((x), 4, 21)
++
++/* Masks for fields in both upper and lower instructions.
++   These mask out all bits but the ones for the field in the instruction.  */
++
++#define MT VT (~0)
++#define MS VS (~0)
++#define MD VD (~0)
++#define MDEST VDEST (~0)
++
++/* Upper instruction Value macros.  */
++
++/* Upper Flag bits.  */
++#define VUF(x) V ((x), 5, 27)
++/* Upper REServed two bits next to flag bits.  */
++#define VURES(x) V ((x), 2, 25)
++/* 4 bit opcode field.  */
++#define VUOP4(x) V ((x), 4, 2)
++/* 6 bit opcode field.  */
++#define VUOP6(x) V ((x), 6, 0)
++/* 9 bit opcode field.  */
++#define VUOP9(x) V ((x), 9, 2)
++/* 11 bit opcode field.  */
++#define VUOP11(x) V ((x), 11, 0)
++/* BroadCast field.  */
++#define VUBC(x) V ((x), 2, 0)
++
++/* Upper instruction field masks.  */
++#define MURES VURES (~0)
++#define MUOP4 VUOP4 (~0)
++#define MUOP6 VUOP6 (~0)
++#define MUOP9 VUOP9 (~0)
++#define MUOP11 VUOP11 (~0)
++
++/* A space, separates instruction name (mnemonic + mnemonic operands) from
++   operands.  */
++#define SP ' '
++/* Commas separate operands.  */
++#define C ','
++/* Special I,P,Q,R operands.  */
++#define I 'i'
++#define P 'p'
++#define Q 'q'
++#define R 'r'
++
++/* VU instructions.
++   [??? some of these comments are left over from the ARC port from which
++   this code is borrowed, delete in time]
++
++   Longer versions of insns must appear before shorter ones (if gas sees
++   "lsr r2,r3,1" when it's parsing "lsr %a,%b" it will think the ",1" is
++   junk).  This isn't necessary for `ld' because of the trailing ']'.
++
++   Instructions that are really macros based on other insns must appear
++   before the real insn so they're chosen when disassembling.  Eg: The `mov'
++   insn is really the `and' insn.
++
++   This table is best viewed on a wide screen (161 columns).  I'd prefer to
++   keep it this way.  The rest of the file, however, should be viewable on an
++   80 column terminal.  */
++
++/* ??? This table also includes macros: asl, lsl, and mov.  The ppc port has
++   a more general facility for dealing with macros which could be used if
++   we need to.  */
++
++/* These tables can't be `const' because members `next_asm' and `next_dis' are
++   computed at run-time.  We could split this into two, as that would put the
++   constant stuff into a readonly section.  */
++
++const struct dvp_opcode vu_upper_opcodes[] =
++{
++  /* Macros appear first, so the disassembler will try them first.  */
++  /* ??? Any aliases?  */
++
++  /* The rest of these needn't be sorted, but it helps to find them if they are.  */
++  { "abs",    { UFLAGS, DOTDEST, SP, VFTREG, C, VFSREG },                   MURES + MUOP11,      VUOP11 (0x1fd), 0, 0 },
++  { "add",    { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, VFTREG },        MURES + MUOP6,       VUOP6 (0x28), 0, 0 },
++  { "addi",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, I },             MURES + MT + MUOP6,  VUOP6 (0x22), 0, 0 },
++  { "addq",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, Q },             MURES + MT + MUOP6,  VUOP6 (0x20), 0, 0 },
++  { "add",    { UBC, UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, UBCFTREG }, MURES + VUOP4 (~0),  VUOP4 (0), 0, 0  },
++  { "adda",   { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, VFTREG },      MURES + MUOP11,      VUOP11 (0x2bc), 0, 0 },
++  { "addai",  { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, I },           MURES + MT + MUOP11, VUOP11 (0x23e), 0, 0 },
++  { "addaq",  { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, Q },           MURES + MT + MUOP11, VUOP11 (0x23c), 0, 0 },
++  { "adda",   { UBC, UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, UBCFTREG }, MURES + MUOP9,     VUOP9 (0xf), 0, 0  },
++  { "clip",   { UBC, UFLAGS, DOTDEST, SP, VFSREG, C, UBCFTREG, UW },        MURES + MDEST + MUOP11, VDEST (0xe) + VUOP11 (0x1ff), 0, 0 },
++  { "ftoi0",  { UFLAGS, DOTDEST, SP, VFTREG, C, VFSREG },                   MURES + MUOP11,      VUOP11 (0x17c), 0, 0 },
++  { "ftoi4",  { UFLAGS, DOTDEST, SP, VFTREG, C, VFSREG },                   MURES + MUOP11,      VUOP11 (0x17d), 0, 0 },
++  { "ftoi12", { UFLAGS, DOTDEST, SP, VFTREG, C, VFSREG },                   MURES + MUOP11,      VUOP11 (0x17e), 0, 0 },
++  { "ftoi15", { UFLAGS, DOTDEST, SP, VFTREG, C, VFSREG },                   MURES + MUOP11,      VUOP11 (0x17f), 0, 0 },
++  { "itof0",  { UFLAGS, DOTDEST, SP, VFTREG, C, VFSREG },                   MURES + MUOP11,      VUOP11 (0x13c), 0, 0 },
++  { "itof4",  { UFLAGS, DOTDEST, SP, VFTREG, C, VFSREG },                   MURES + MUOP11,      VUOP11 (0x13d), 0, 0 },
++  { "itof12", { UFLAGS, DOTDEST, SP, VFTREG, C, VFSREG },                   MURES + MUOP11,      VUOP11 (0x13e), 0, 0 },
++  { "itof15", { UFLAGS, DOTDEST, SP, VFTREG, C, VFSREG },                   MURES + MUOP11,      VUOP11 (0x13f), 0, 0 },
++  { "madd",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, VFTREG },        MURES + MUOP6,       VUOP6 (0x29), 0, 0 },
++  { "maddi",  { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, I },             MURES + MT + MUOP6,  VUOP6 (0x23), 0, 0 },
++  { "maddq",  { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, Q },             MURES + MT + MUOP6,  VUOP6 (0x21), 0, 0 },
++  { "madd",   { UBC, UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, UBCFTREG }, MURES + MUOP4,       VUOP4 (0x2), 0, 0 },
++  { "madda",  { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, VFTREG },      MURES + MUOP11,      VUOP11 (0x2bd), 0, 0 },
++  { "maddai", { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, I },           MURES + MT + MUOP11, VUOP11 (0x23f), 0, 0 },
++  { "maddaq", { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, Q },           MURES + MT + MUOP11, VUOP11 (0x23d), 0, 0 },
++  { "madda",  { UBC, UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, UBCFTREG }, MURES + MUOP9,     VUOP9 (0x2f), 0, 0 },
++  { "max",    { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, VFTREG },        MURES + MUOP6,       VUOP6 (0x2b), 0, 0 },
++  { "maxi",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, I },             MURES + MT + MUOP6,  VUOP6 (0x1d), 0, 0 },
++  { "max",    { UBC, UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, UBCFTREG }, MURES + MUOP4,       VUOP4 (0x4), 0, 0 },
++  { "mini",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, VFTREG },        MURES + MUOP6,       VUOP6 (0x2f), 0, 0 },
++  { "minii",  { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, I },             MURES + MT + MUOP6,  VUOP6 (0x1f), 0, 0 },
++  { "mini",   { UBC, UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, UBCFTREG }, MURES + MUOP4,       VUOP4 (0x5), 0, 0 },
++  { "msub",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, VFTREG },        MURES + MUOP6,       VUOP6 (0x2d), 0, 0 },
++  { "msubi",  { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, I },             MURES + MT + MUOP6,  VUOP6 (0x27), 0, 0 },
++  { "msubq",  { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, Q },             MURES + MT + MUOP6,  VUOP6 (0x25), 0, 0 },
++  { "msub",   { UBC, UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, UBCFTREG }, MURES + MUOP4,       VUOP4 (0x3), 0, 0 },
++  { "msuba",  { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, VFTREG },      MURES + MUOP11,      VUOP11 (0x2fd), 0, 0 },
++  { "msubai", { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, I },           MURES + MT + MUOP11, VUOP11 (0x27f), 0, 0 },
++  { "msubaq", { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, Q },           MURES + MT + MUOP11, VUOP11 (0x27d), 0, 0 },
++  { "msuba",  { UBC, UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, UBCFTREG }, MURES + MUOP9,     VUOP9 (0x3f), 0, 0 },
++  { "mul",    { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, VFTREG },        MURES + MUOP6,       VUOP6 (0x2a), 0, 0 },
++  { "muli",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, I },             MURES + MT + MUOP6,  VUOP6 (0x1e), 0, 0 },
++  { "mulq",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, Q },             MURES + MT + MUOP6,  VUOP6 (0x1c), 0, 0 },
++  { "mul",    { UBC, UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, UBCFTREG }, MURES + VUOP4 (~0),  VUOP4 (6), 0, 0 },
++  { "mula",   { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, VFTREG },      MURES + MUOP11,      VUOP11 (0x2be), 0, 0 },
++  { "mulai",  { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, I },           MURES + MT + MUOP11, VUOP11 (0x1fe), 0, 0 },
++  { "mulaq",  { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, Q },           MURES + MT + MUOP11, VUOP11 (0x1fc), 0, 0 },
++  { "mula",   { UBC, UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, UBCFTREG }, MURES + MUOP9,     VUOP9 (0x6f), 0, 0 },
++  { "nop",    { UFLAGS },                                                   MURES + MDEST + MT + MS + MUOP11, VUOP11 (0x2ff), 0, 0 },
++  { "opmula", { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, VFTREG, UXYZ }, MURES + MUOP11,     VUOP11 (0x2fe), 0, 0 },
++  { "opmsub", { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, VFTREG, UXYZ },  MURES + MUOP6,       VUOP6 (0x2e), 0, 0 },
++  { "sub",    { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, VFTREG },        MURES + MUOP6,       VUOP6 (0x2c), 0, 0 },
++  { "subi",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, I },             MURES + MT + MUOP6,  VUOP6 (0x26), 0, 0 },
++  { "subq",   { UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, Q },             MURES + MT + MUOP6,  VUOP6 (0x24), 0, 0 },
++  { "sub",    { UBC, UFLAGS, DOTDEST, SP, VFDREG, C, VFSREG, C, UBCFTREG }, MURES + VUOP4 (~0),  VUOP4 (1), 0, 0 },
++  { "suba",   { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, VFTREG },      MURES + MUOP11,      VUOP11 (0x2fc), 0, 0 },
++  { "subai",  { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, I },           MURES + MT + MUOP11, VUOP11 (0x27e), 0, 0 },
++  { "subaq",  { UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, Q },           MURES + MT + MUOP11, VUOP11 (0x27c), 0, 0 },
++  { "suba",   { UBC, UFLAGS, DOTDEST, SP, UACCDEST, C, VFSREG, C, UBCFTREG }, MURES + MUOP9,     VUOP9 (0x1f), 0, 0 },
++  { 0, { 0 }, 0, 0, 0, 0  },
++};
++
++/* Lower instruction Value macros.  */
++
++/* 6 bit opcode.  */
++#define VLOP6(x) V ((x), 6, 0)
++/* 7 bit opcode.  */
++#define VLOP7(x) V ((x), 7, 25)
++/* 11 bit opcode.  */
++#define VLOP11(x) V ((x), 11, 0)
++/* 11 bit immediate.  */
++#define VLIMM11(x) V ((x), 11, 0)
++/* FTF field.  */
++#define VLFTF(x) V ((x), 2, 23)
++/* FSF field.  */
++#define VLFSF(x) V ((x), 2, 21)
++/* Upper bit of 12 bit unsigned immediate.  */
++#define VLUIMM12TOP(x) V ((x), 1, 21)
++/* Upper 4 bits of 15 bit unsigned immediate.  */
++#define VLUIMM15TOP(x) VDEST (x)
++
++/* Lower instruction field masks.  */
++#define MLOP6 VLOP6 (~0)
++#define MLOP7 VLOP7 (~0)
++#define MLOP11 VLOP11 (~0)
++#define MLIMM11 VLIMM11 (~0)
++#define MLB24 V (1, 1, 24)
++#define MLUIMM12TOP VLUIMM12TOP (~0)
++/* 12 bit unsigned immediates are split into two parts, 1 bit and 11 bits.
++   The upper 1 bit is part of the `dest' field.  This mask is for the
++   other 3 bits of the dest field.  */
++#define MLUIMM12UNUSED V (7, 3, 22)
++#define MLUIMM15TOP MDEST
++
++const struct dvp_opcode vu_lower_opcodes[] =
++{
++  /* Macros appear first, so the disassembler will try them first.  */
++
++  /* There isn't an explicit nop.  Apparently it's "move vf0,vf0".  */
++  { "nop", { 0 }, 0xffffffff, VLOP7 (0x40) + VLIMM11 (0x33c) , 0, 0 },
++
++  /* The rest of these needn't be sorted, but it helps to find them if they are.  */
++  { "b",       { SP, LPCREL11 },                      MLOP7 + MDEST + MT + MS,          VLOP7 (0x20), 0, 0 },
++  { "bal",     { SP, LITREG, C, LPCREL11 },           MLOP7 + MDEST + MS,               VLOP7 (0x21), 0, 0 },
++  { "div",     { SP, Q, C, LFSFFSREG, C, LFTFFTREG }, MLOP7 + MLOP11,                   VLOP7 (0x40) + VLOP11 (0x3bc), 0, 0 },
++  { "eatan",   { SP, P, C, LFSFFSREG },               MLOP7 + VLFTF (~0) + MT + MLOP11, VLOP7 (0x40) + VLOP11 (0x7fd), 0, 0 },
++  { "eatanxy", { SP, P, C, LFSREG },                  MLOP7 + MDEST + MT + MLOP11,      VLOP7 (0x40) + VDEST (0xc) + VLOP11 (0x77c), 0, 0 },
++  { "eatanxz", { SP, P, C, LFSREG },                  MLOP7 + MDEST + MT + MLOP11,      VLOP7 (0x40) + VDEST (0xa) + VLOP11 (0x77d), 0, 0 },
++  { "eexp",    { SP, P, C, LFSFFSREG },               MLOP7 + VLFTF (~0) + MT + MLOP11, VLOP7 (0x40) + VLOP11 (0x7fe), 0, 0 },
++  { "eleng",   { SP, P, C, LFSREG },                  MLOP7 + MDEST + MT + MLOP11,      VLOP7 (0x40) + VDEST (0xe) + VLOP11 (0x73e), 0, 0 },
++  { "ercpr",   { SP, P, C, LFSFFSREG },               MLOP7 + VLFTF (~0) + MT + MLOP11, VLOP7 (0x40) + VLOP11 (0x7be), 0, 0 },
++  { "erleng",  { SP, P, C, LFSREG },                  MLOP7 + MDEST + MT + MLOP11,      VLOP7 (0x40) + VDEST (0xe) + VLOP11 (0x73f), 0, 0 },
++  { "ersadd",  { SP, P, C, LFSREG },                  MLOP7 + MDEST + MT + MLOP11,      VLOP7 (0x40) + VDEST (0xe) + VLOP11 (0x73d), 0, 0 },
++  { "ersqrt",  { SP, P, C, LFSFFSREG },               MLOP7 + VLFTF (~0) + MT + MLOP11, VLOP7 (0x40) + VLOP11 (0x7bd), 0, 0 },
++  { "esadd",   { SP, P, C, LFSREG },                  MLOP7 + MDEST + MT + MLOP11,      VLOP7 (0x40) + VDEST (0xe) + VLOP11 (0x73c), 0, 0 },
++  { "esin",    { SP, P, C, LFSFFSREG },               MLOP7 + VLFTF (~0) + MT + MLOP11, VLOP7 (0x40) + VLOP11 (0x7fc), 0, 0 },
++  { "esqrt",   { SP, P, C, LFSFFSREG },               MLOP7 + VLFTF (~0) + MT + MLOP11, VLOP7 (0x40) + VLOP11 (0x7bc), 0, 0 },
++  { "esum",    { SP, P, C, LFSREG },                  MLOP7 + MDEST + MT + MLOP11,      VLOP7 (0x40) + VDEST (0xf) + VLOP11 (0x77e), 0, 0 },
++  { "fcand",   { SP, LVI01, C, LUIMM24 },             MLOP7 + MLB24,                    VLOP7 (0x12), 0, 0 },
++  { "fceq",    { SP, LVI01, C, LUIMM24 },             MLOP7 + MLB24,                    VLOP7 (0x10), 0, 0 },
++  { "fcget",   { SP, LITREG },                        MLOP7 + MDEST + MS + MLIMM11,     VLOP7 (0x1c), 0, 0 },
++  { "fcor",    { SP, LVI01, C, LUIMM24 },             MLOP7 + MLB24,                    VLOP7 (0x13), 0, 0 },
++  { "fcset",   { SP, LUIMM24 },                       MLOP7 + MLB24,                    VLOP7 (0x11), 0, 0 },
++  { "fmand",   { SP, LITREG, C, LISREG },             MLOP7 + MDEST + MLIMM11,          VLOP7 (0x1a), 0, 0 },
++  { "fmeq",    { SP, LITREG, C, LISREG },             MLOP7 + MDEST + MLIMM11,          VLOP7 (0x18), 0, 0 },
++  { "fmor",    { SP, LITREG, C, LISREG },             MLOP7 + MDEST + MLIMM11,          VLOP7 (0x1b), 0, 0 },
++  { "fsand",   { SP, LITREG, C, LUIMM12 },            MLOP7 + MLUIMM12UNUSED + MS,      VLOP7 (0x16), 0, 0 },
++  { "fseq",    { SP, LITREG, C, LUIMM12 },            MLOP7 + MLUIMM12UNUSED + MS,      VLOP7 (0x14), 0, 0 },
++  { "fsor",    { SP, LITREG, C, LUIMM12 },            MLOP7 + MLUIMM12UNUSED + MS,      VLOP7 (0x17), 0, 0 },
++  { "fsset",   { SP, LUIMM12UP6 },                    MLOP7 + MLUIMM12UNUSED + V (~0, 6, 0) + MS + MT, VLOP7 (0x15), 0, 0 },
++  { "iadd",    { SP, LIDREG, C, LISREG, C, LITREG },  MLOP7 + MDEST + MLOP6,            VLOP7 (0x40) + VLOP6 (0x30), 0, 0 },
++  { "iaddi",   { SP, LITREG, C, LISREG, C, LIMM5 },   MLOP7 + MDEST + MLOP6,            VLOP7 (0x40) + VLOP6 (0x32), 0, 0 },
++  { "iaddiu",  { SP, LITREG, C, LISREG, C, LUIMM15 }, MLOP7,                            VLOP7 (0x08), 0, 0 },
++  { "iand",    { SP, LIDREG, C, LISREG, C, LITREG },  MLOP7 + MDEST + MLOP6,            VLOP7 (0x40) + VLOP6 (0x34), 0, 0 },
++  { "ibeq",    { SP, LITREG, C, LISREG, C, LPCREL11 }, MLOP7 + MDEST,                   VLOP7 (0x28), 0, 0 },
++  { "ibgez",   { SP, LISREG, C, LPCREL11 },           MLOP7 + MDEST + MT,               VLOP7 (0x2f), 0, 0 },
++  { "ibgtz",   { SP, LISREG, C, LPCREL11 },           MLOP7 + MDEST + MT,               VLOP7 (0x2d), 0, 0 },
++  { "iblez",   { SP, LISREG, C, LPCREL11 },           MLOP7 + MDEST + MT,               VLOP7 (0x2e), 0, 0 },
++  { "ibltz",   { SP, LISREG, C, LPCREL11 },           MLOP7 + MDEST + MT,               VLOP7 (0x2c), 0, 0 },
++  { "ibne",    { SP, LITREG, C, LISREG, C, LPCREL11 }, MLOP7 + MDEST,                   VLOP7 (0x29), 0, 0 },
++  { "ilw",     { LDOTDEST1, SP, LITREG, C, LIMM11, '(', LISREG, ')', LDEST1 }, MLOP7,   VLOP7 (0x04), 0, 0 },
++  { "ilwr",    { LDOTDEST1, SP, LITREG, C, '(', LISREG, ')', LDEST1 }, MLOP7 + MLIMM11, VLOP7 (0x40) + VLIMM11 (0x3fe), 0, 0 },
++  { "ior",     { SP, LIDREG, C, LISREG, C, LITREG },  MLOP7 + MDEST + MLOP6,            VLOP7 (0x40) + VLOP6 (0x35), 0, 0 },
++  { "isub",    { SP, LIDREG, C, LISREG, C, LITREG },  MLOP7 + MDEST + MLOP6,            VLOP7 (0x40) + VLOP6 (0x31), 0, 0 },
++  { "isubiu",  { SP, LITREG, C, LISREG, C, LUIMM15 }, MLOP7,                            VLOP7 (0x09), 0, 0 },
++  { "isw",     { DOTDEST, SP, LITREG, C, LIMM11, '(', LISREG, ')', LDEST1 }, MLOP7,     VLOP7 (0x05), 0, 0 },
++  { "iswr",    { DOTDEST, SP, LITREG, C, '(', LISREG, ')', LDEST1 }, MLOP7 + MLIMM11,   VLOP7 (0x40) + VLIMM11 (0x3ff), 0, 0 },
++  { "jalr",    { SP, LITREG, C, LISREG },             MLOP7 + MDEST + MLIMM11,          VLOP7 (0x25), 0, 0 },
++  { "jr",      { SP, LISREG },                        MLOP7 + MDEST + MT + MLIMM11,     VLOP7 (0x24), 0, 0 },
++  { "loi",     { SP, LFIMM32 },                       0,                                0 , 0, 0},
++  { "lq",      { DOTDEST, SP, VFTREG, C, LIMM11, '(', LISREG, ')' }, MLOP7,             VLOP7 (0x00), 0, 0 },
++  { "lqd",     { DOTDEST, SP, VFTREG, C, '(', '-', '-', LISREG, ')' }, MLOP7 + MLIMM11, VLOP7 (0x40) + VLIMM11 (0x37e), 0, 0 },
++  { "lqi",     { DOTDEST, SP, VFTREG, C, '(', LISREG, '+', '+', ')' }, MLOP7 + MLIMM11, VLOP7 (0x40) + VLIMM11 (0x37c), 0, 0 },
++  /* Only a single VF reg is allowed here.  We can use VFTREG because LDOTDEST1
++     handles verifying only a single choice of xyzw is present.  */
++  { "mfir",    { DOTDEST, SP, VFTREG, C, LISREG },    MLOP7 + MLIMM11,                  VLOP7 (0x40) + VLIMM11 (0x3fd), 0, 0 },
++  { "mfp",     { DOTDEST, SP, VFTREG, C, P },         MLOP7 + MS + MLIMM11,             VLOP7 (0x40) + VLIMM11 (0x67c), 0, 0 },
++  { "move",    { DOTDEST, SP, VFTREG, C, VFSREG },    MLOP7 + MLIMM11,                  VLOP7 (0x40) + VLIMM11 (0x33c), 0, 0 },
++  { "mr32",    { DOTDEST, SP, VFTREG, C, VFSREG },    MLOP7 + MLIMM11,                  VLOP7 (0x40) + VLIMM11 (0x33d), 0, 0 },
++  { "mtir",    { SP, LITREG, C, LFSFFSREG },          MLOP7 + VLFTF (~0) + MLOP11,      VLOP7 (0x40) + VLOP11 (0x3fc), 0, 0 },
++  { "rget",    { DOTDEST, SP, VFTREG, C, R },         MLOP7 + MS + MLIMM11,             VLOP7 (0x40) + VLIMM11 (0x43d), 0, 0 },
++  { "rinit",   { SP, R, C, LFSFFSREG },               MLOP7 + VLFTF (~0) + MT + MLIMM11, VLOP7 (0x40) + VLIMM11 (0x43e), 0, 0 },
++  { "rnext",   { DOTDEST, SP, VFTREG, C, R },         MLOP7 + MS + MLIMM11,             VLOP7 (0x40) + VLIMM11 (0x43c), 0, 0 },
++  { "rsqrt",   { SP, Q, C, LFSFFSREG, C, LFTFFTREG }, MLOP7 + MLIMM11,                  VLOP7 (0x40) + VLIMM11 (0x3be), 0, 0 },
++  { "rxor",    { SP, R, C, LFSFFSREG },               MLOP7 + VLFTF (~0) + MT + MLIMM11, VLOP7 (0x40) + VLIMM11 (0x43f), 0, 0 },
++  { "sq",      { DOTDEST, SP, VFSREG, C, LIMM11, '(', LITREG, ')' }, MLOP7,             VLOP7 (0x01), 0, 0 },
++  { "sqd",     { DOTDEST, SP, VFSREG, C, '(', '-', '-', LITREG, ')' }, MLOP7 + MLIMM11, VLOP7 (0x40) + VLIMM11 (0x37f), 0, 0 },
++  { "sqi",     { DOTDEST, SP, VFSREG, C, '(', LITREG, '+', '+', ')' }, MLOP7 + MLIMM11, VLOP7 (0x40) + VLIMM11 (0x37d), 0, 0 },
++  { "sqrt",    { SP, Q, C, LFTFFTREG },               MLOP7 + VLFSF (~0) + MS + MLIMM11, VLOP7 (0x40) + VLIMM11 (0x3bd), 0, 0 },
++  { "waitp",   { 0 },                                 0xffffffff,                       VLOP7 (0x40) + VLIMM11 (0x7bf), 0, 0 },
++  { "waitq",   { 0 },                                 0xffffffff,                       VLOP7 (0x40) + VLIMM11 (0x3bf), 0, 0 },
++  { "xgkick",  { SP, LISREG },                        MLOP7 + MDEST + MT + MLIMM11,     VLOP7 (0x40) + VLIMM11 (0x6fc), 0, 0 },
++  { "xitop",   { SP, LITREG },                        MLOP7 + MDEST + MS + MLIMM11,     VLOP7 (0x40) + VLIMM11 (0x6bd), 0, 0 },
++  { "xtop",    { SP, LITREG },                        MLOP7 + MDEST + MS + MLIMM11,     VLOP7 (0x40) + VLIMM11 (0x6bc), 0, 0 },
++  { 0, { 0 }, 0, 0, 0, 0  },
++};
++
++/* Value of DEST in use.
++   Each of the registers must specify the same value as the opcode.  */
++static int state_vu_mnemonic_dest;
++
++/* Value of BC to use.
++   The register specified for the ftreg must match the broadcast register
++   specified in the opcode.  */
++static int state_vu_mnemonic_bc;
++
++#define INVALID_DEST 		_("invalid `dest'")
++#define MISSING_DEST 		_("missing `dest'")
++#define MISSING_DOT  		_("missing `.'")
++#define UNKNOWN_REGISTER 	_("unknown register")
++#define INVALID_REGISTER_NUMBER _("invalid register number")
++
++/* Multiple destination choice support.
++   The "dest" string selects any combination of x,y,z,w.
++   [The letters are ordered that way to follow the manual's style.]  */
++
++/* Utility to parse a `dest' spec.
++   Return the found value or zero if not present.
++   *PSTR is set to the character that terminated the parsing.
++   It is up to the caller to do any error checking.  */
++
++static long
++u_parse_dest (char **pstr)
++{
++  long dest = 0;
++
++  while (**pstr)
++    {
++      switch (**pstr)
++	{
++	case 'x' : case 'X' : dest |= VU_DEST_X; break;
++	case 'y' : case 'Y' : dest |= VU_DEST_Y; break;
++	case 'z' : case 'Z' : dest |= VU_DEST_Z; break;
++	case 'w' : case 'W' : dest |= VU_DEST_W; break;
++	default : return dest;
++	}
++      ++*pstr;
++    }
++
++  return dest;
++}
++
++static long
++parse_dotdest (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++               const dvp_operand *operand ATTRIBUTE_UNUSED,
++               int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  long dest;
++
++  /* If we're at a space, the dest isn't present so use the default: xyzw.  */
++  if (**pstr == ' ')
++    return VU_DEST_X | VU_DEST_Y | VU_DEST_Z | VU_DEST_W;
++
++  if (**pstr != '.' && **pstr != '/')
++    {
++      *errmsg = MISSING_DOT;
++      return 0;
++    }
++
++  ++*pstr;
++  dest = u_parse_dest (pstr);
++  if (dest == 0 || isalnum ((unsigned char) **pstr))
++    {
++      *errmsg = INVALID_DEST;
++      return 0;
++    }
++
++  return dest;
++}
++
++/* Parse a `dest' spec where only a single letter is allowed,
++   but the encoding handles all four.  */
++
++static long
++parse_dotdest1 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char c;
++  long dest;
++
++  if (**pstr != '.' && **pstr != '/')
++    {
++      *errmsg = MISSING_DOT;
++      return 0;
++    }
++
++  ++*pstr;
++  switch (**pstr)
++    {
++    case 'x' : case 'X' : dest = VU_DEST_X; break;
++    case 'y' : case 'Y' : dest = VU_DEST_Y; break;
++    case 'z' : case 'Z' : dest = VU_DEST_Z; break;
++    case 'w' : case 'W' : dest = VU_DEST_W; break;
++    default : *errmsg = INVALID_DEST; return 0;
++    }
++  ++*pstr;
++  c = tolower (**pstr);
++  if (c == 'x' || c == 'y' || c == 'z' || c == 'w')
++    {
++      *errmsg = _("only one of x,y,z,w can be specified");
++      return 0;
++    }
++  if (isalnum ((unsigned char) **pstr))
++    {
++      *errmsg = INVALID_DEST;
++      return 0;
++    }
++
++  return dest;
++}
++
++/* Parse a `dest' spec with no leading '.', where only a single letter is
++   allowed, but the encoding handles all four.  The value, if specified,
++   must match that recorded in `dest'.  */
++
++static long
++parse_dest1 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++             const dvp_operand *operand ATTRIBUTE_UNUSED,
++             int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  long dest;
++
++  dest = u_parse_dest (pstr);
++  if (dest == 0)
++    ; /* not specified, nothing to do */
++  else if (dest != VU_DEST_X
++      && dest != VU_DEST_Y
++      && dest != VU_DEST_Z
++      && dest != VU_DEST_W)
++    {
++      *errmsg = _("expecting one of x,y,z,w");
++      return 0;
++    }
++  else if (dest != state_vu_mnemonic_dest)
++    {
++      *errmsg = _("`dest' suffix does not match instruction `dest'");
++      return 0;
++    }
++
++  return dest;
++}
++
++static void
++insert_dotdest (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                DVP_INSN *insn, long value,
++                const char **errmsg ATTRIBUTE_UNUSED)
++{
++  /* Record the DEST value in use so the register parser can use it.  */
++  state_vu_mnemonic_dest = value;
++  *insn |= value << operand->shift;
++}
++
++static long
++extract_dotdest (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                 DVP_INSN *insn, int *pinvalid ATTRIBUTE_UNUSED)
++{
++  /* Record the DEST value in use so the register printer can use it.  */
++  state_vu_mnemonic_dest = (*insn >> operand->shift) & ((1 << operand->bits) - 1);
++  return state_vu_mnemonic_dest;
++}
++
++/* Utility to print a multiple dest spec.  */
++
++static void
++u_print_dest (disassemble_info *info, DVP_INSN *insn ATTRIBUTE_UNUSED,
++              long value)
++{
++  if (value & VU_DEST_X)
++    (*info->fprintf_func) (info->stream, "x");
++  if (value & VU_DEST_Y)
++    (*info->fprintf_func) (info->stream, "y");
++  if (value & VU_DEST_Z)
++    (*info->fprintf_func) (info->stream, "z");
++  if (value & VU_DEST_W)
++    (*info->fprintf_func) (info->stream, "w");
++}
++
++static void
++print_dotdest (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++               const dvp_operand *operand ATTRIBUTE_UNUSED,
++               int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++               disassemble_info *info, long value)
++{
++  (*info->fprintf_func) (info->stream, ".");
++  u_print_dest (info, insn, value);
++}
++
++static void
++print_dest1 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++             const dvp_operand *operand ATTRIBUTE_UNUSED,
++             int mods ATTRIBUTE_UNUSED, DVP_INSN *insn, disassemble_info *info,
++             long value ATTRIBUTE_UNUSED)
++{
++  u_print_dest (info, insn, state_vu_mnemonic_dest);
++}
++
++/* Utilities for single destination choice handling.  */
++
++/* Parse a single dest spec.
++   Return one of VU_SDEST_[XYZW] or -1 if not present.  */
++
++static long
++u_parse_sdest (char **pstr, const char **errmsg)
++{
++  char c;
++  long dest = 0;
++
++  switch (**pstr)
++    {
++    case 'x' : case 'X' : dest = VU_SDEST_X; break;
++    case 'y' : case 'Y' : dest = VU_SDEST_Y; break;
++    case 'z' : case 'Z' : dest = VU_SDEST_Z; break;
++    case 'w' : case 'W' : dest = VU_SDEST_W; break;
++    default : return -1;
++    }
++  ++*pstr;
++  c = tolower (**pstr);
++  if (c == 'x' || c == 'y' || c == 'z' || c == 'w')
++    {
++      *errmsg = _("only one of x,y,z,w can be specified");
++      return 0;
++    }
++  if (isalnum ((unsigned char) **pstr))
++    {
++      *errmsg = INVALID_DEST;
++      return 0;
++    }
++
++  return dest;
++}
++
++static void
++print_sdest (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++             const dvp_operand *operand ATTRIBUTE_UNUSED,
++             int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++             disassemble_info *info, long value)
++{
++  char c;
++
++  switch (value)
++    {
++    case VU_SDEST_X : c = 'x'; break;
++    case VU_SDEST_Y : c = 'y'; break;
++    case VU_SDEST_Z : c = 'z'; break;
++    case VU_SDEST_W : c = 'w'; break;
++    default: abort (); return;
++    }
++
++  (*info->fprintf_func) (info->stream, "%c", c);
++}
++
++/* The upper word flags bits.  */
++
++static long
++parse_uflags (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++              const dvp_operand *operand ATTRIBUTE_UNUSED,
++              int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  long value = 0;
++  char *str = *pstr;
++
++  if (*str != '[')
++    return 0;
++  ++str;
++  while (*str && *str != ']')
++    {
++      switch (tolower (*str))
++	{
++	case 'i' : value |= VU_FLAG_I; break;
++	case 'e' : value |= VU_FLAG_E; break;
++	case 'm' : value |= VU_FLAG_M; break;
++	case 'd' : value |= VU_FLAG_D; break;
++	case 't' : value |= VU_FLAG_T; break;
++	default : *errmsg = _("invalid flag character present"); return 0;
++	}
++      ++str;
++    }
++  if (*str != ']')
++    {
++      *errmsg = _("syntax error in flag spec");
++      return 0;
++    }
++  *pstr = str + 1;
++  return value;
++}
++
++static void
++print_uflags (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++              const dvp_operand *operand ATTRIBUTE_UNUSED,
++              int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++              disassemble_info *info, long value)
++{
++  if (value)
++    {
++      (*info->fprintf_func) (info->stream, "[");
++      if (value & VU_FLAG_I)
++	(*info->fprintf_func) (info->stream, "i");
++      if (value & VU_FLAG_E)
++	(*info->fprintf_func) (info->stream, "e");
++      if (value & VU_FLAG_M)
++	(*info->fprintf_func) (info->stream, "m");
++      if (value & VU_FLAG_D)
++	(*info->fprintf_func) (info->stream, "d");
++      if (value & VU_FLAG_T)
++	(*info->fprintf_func) (info->stream, "t");
++      (*info->fprintf_func) (info->stream, "]");
++    }
++}
++
++/* Broadcase field.  */
++
++static long
++parse_bc (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++          const dvp_operand *operand ATTRIBUTE_UNUSED,
++          int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  long value = u_parse_sdest (pstr, errmsg);
++
++  if (*errmsg)
++    return 0;
++  if (value == -1)
++    {
++      *errmsg = MISSING_DEST;
++      return 0;
++    }
++  if (isalnum ((unsigned char) **pstr))
++    {
++      *errmsg = INVALID_DEST;
++      return 0;
++    }
++  /* Save value for later verification in register parsing.  */
++  state_vu_mnemonic_bc = value;
++  return value;
++}
++
++/* During the extraction process, save the bc field for use in
++   printing the bc register.  */
++
++static long
++extract_bc (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++            const dvp_operand *operand ATTRIBUTE_UNUSED,
++            int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++            int *pinvalid ATTRIBUTE_UNUSED)
++{
++  state_vu_mnemonic_bc = *insn & 3;
++  return state_vu_mnemonic_bc;
++}
++
++static long
++parse_vfreg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++             const dvp_operand *operand ATTRIBUTE_UNUSED,
++             int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  long reg;
++  int reg_dest;
++
++  if (tolower (str[0]) != 'v'
++      || tolower (str[1]) != 'f')
++    {
++      *errmsg = UNKNOWN_REGISTER;
++      return 0;
++    }
++
++  start = str = str + 2;
++  reg = strtol (start, &str, 10);
++  if (reg < 0 || reg > 31)
++    {
++      *errmsg = INVALID_REGISTER_NUMBER;
++      return 0;
++    }
++  reg_dest = u_parse_dest (&str);
++  if (isalnum ((unsigned char) *str))
++    {
++      *errmsg = INVALID_DEST;
++      return 0;
++    }
++  if (reg_dest == 0)
++    ; /* not specified, nothing to do */
++  else if (reg_dest != state_vu_mnemonic_dest)
++    {
++      *errmsg = _("register `dest' does not match instruction `dest'");
++      return 0;
++    }
++  *pstr = str;
++  return reg;
++}
++
++static void
++print_vfreg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++             const dvp_operand *operand ATTRIBUTE_UNUSED,
++             int mods ATTRIBUTE_UNUSED, DVP_INSN *insn, disassemble_info *info,
++             long value)
++{
++  (*info->fprintf_func) (info->stream, "vf%02ld", value);
++  u_print_dest (info, insn, state_vu_mnemonic_dest);
++}
++
++/* FT register in broadcast case.  */
++
++static long
++parse_bcftreg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++               const dvp_operand *operand ATTRIBUTE_UNUSED,
++               int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  long reg;
++  int reg_bc;
++
++  if (tolower (str[0]) != 'v'
++      || tolower (str[1]) != 'f')
++    {
++      *errmsg = UNKNOWN_REGISTER;
++      return 0;
++    }
++
++  start = str = str + 2;
++  reg = strtol (start, &str, 10);
++  if (reg < 0 || reg > 31)
++    {
++      *errmsg = _("invalid register number");
++      return 0;
++    }
++  reg_bc = u_parse_sdest (&str, errmsg);
++  if (*errmsg)
++    return 0;
++  if (reg_bc == -1)
++    ; /* not specified, nothing to do */
++  else if (reg_bc != state_vu_mnemonic_bc)
++    {
++      *errmsg = _("register `bc' does not match instruction `bc'");
++      return 0;
++    }
++  *pstr = str;
++  return reg;
++}
++
++static void
++print_bcftreg (const dvp_opcode *opcode, const dvp_operand *operand, int mods,
++               DVP_INSN *insn, disassemble_info *info, long value)
++{
++  (*info->fprintf_func) (info->stream, "vf%02ld", value);
++  /* The assembler syntax has been modified to not require the dest spec
++     on the register.  Unlike the normal dest spec, for bc we print the
++     letter because it makes the output more readable without having to
++     remember which register is the bc one.  */
++  print_sdest (opcode, operand, mods, insn, info, state_vu_mnemonic_bc);
++}
++
++/* ACC handling.  */
++
++static long
++parse_accdest (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++               const dvp_operand *operand ATTRIBUTE_UNUSED,
++               int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  long acc_dest = 0;
++
++  if (strncasecmp (str, "acc", 3) != 0)
++    {
++      *errmsg = _("expecting `acc'");
++      return 0;
++    }
++  str += 3;
++  acc_dest = u_parse_dest (&str);
++  if (isalnum ((unsigned char) *str))
++    {
++      *errmsg = INVALID_DEST;
++      return 0;
++    }
++  if (acc_dest == 0)
++    ; /* not specified, nothing to do */
++  else if (acc_dest != state_vu_mnemonic_dest)
++    {
++      *errmsg = _("acc `dest' does not match instruction `dest'");
++      return 0;
++    }
++  *pstr = str;
++  /* Value isn't used, but we must return something.  */
++  return 0;
++}
++
++static void
++print_accdest (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++               const dvp_operand *operand ATTRIBUTE_UNUSED,
++               int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++               disassemble_info *info, long value ATTRIBUTE_UNUSED)
++{
++  (*info->fprintf_func) (info->stream, "acc");
++  u_print_dest (info, insn, state_vu_mnemonic_dest);
++}
++
++/* XYZ operand handling.
++   This simplifies the opmula,opmsub entries by keeping them equivalent to
++   the others.  */
++
++static void
++insert_xyz (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++            const dvp_operand *operand ATTRIBUTE_UNUSED,
++            int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++            long value ATTRIBUTE_UNUSED, const char **errmsg)
++{
++  if (state_vu_mnemonic_dest != (VU_DEST_X | VU_DEST_Y | VU_DEST_Z))
++    *errmsg = _ ("expecting `xyz' for `dest' value");
++}
++
++/* W operand handling.
++   This simplifies the clip entry. */
++
++static void
++insert_w (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++          const dvp_operand *operand ATTRIBUTE_UNUSED,
++          int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++          long value ATTRIBUTE_UNUSED, const char **errmsg)
++{
++  if (state_vu_mnemonic_bc != VU_SDEST_W)
++    *errmsg = _ ("expecting `w' for `bc' value");
++}
++
++/* F[ST] register using selector in F[ST]F field.
++   Internally, the value is encoded in 7 bits: the 2 bit xyzw indicator
++   followed by the 5 bit register number.  */
++
++static long
++parse_ffstreg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++               const dvp_operand *operand ATTRIBUTE_UNUSED,
++               int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  int reg, xyzw;
++
++  if (tolower (str[0]) != 'v'
++      || tolower (str[1]) != 'f')
++    {
++      *errmsg = UNKNOWN_REGISTER;
++      return 0;
++    }
++
++  start = str = str + 2;
++  reg = strtol (start, &str, 10);
++  if (reg < 0 || reg > 31)
++    {
++      *errmsg = _("invalid register number");
++      return 0;
++    }
++  xyzw = u_parse_sdest (&str, errmsg);
++  if (*errmsg)
++    return 0;
++  if (xyzw == -1)
++    {
++      *errmsg = MISSING_DEST;
++      return 0;
++    }
++  if (isalnum ((unsigned char) *str))
++    {
++      *errmsg = INVALID_DEST;
++      return 0;
++    }
++  *pstr = str;
++  return reg | (xyzw << 5);
++}
++
++static void
++print_ffstreg (const dvp_opcode *opcode, const dvp_operand *operand, int mods,
++               DVP_INSN *insn, disassemble_info *info, long value)
++{
++  (*info->fprintf_func) (info->stream, "vf%02ld", value & VU_MASK_REG);
++  print_sdest (opcode, operand, mods, insn, info, (value >> 5) & 3);
++}
++
++static void
++insert_ffstreg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                DVP_INSN *insn, long value,
++                const char **errmsg ATTRIBUTE_UNUSED)
++{
++  if (operand->shift == VU_SHIFT_SREG)
++    *insn |= VLFSF (value >> 5) | VS (value);
++  else
++    *insn |= VLFTF (value >> 5) | VT (value);
++}
++
++static long
++extract_ffstreg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                 DVP_INSN *insn, int *pinvalid ATTRIBUTE_UNUSED)
++{
++  if (operand->shift == VU_SHIFT_SREG)
++    return (((*insn & VLFSF (~0)) >> 21) << 5) | (((*insn) & MS) >> VU_SHIFT_SREG);
++  else
++    return (((*insn & VLFTF (~0)) >> 23) << 5) | (((*insn) & MT) >> VU_SHIFT_TREG);
++}
++
++/* F register.  */
++
++static long
++parse_freg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++            const dvp_operand *operand ATTRIBUTE_UNUSED,
++            int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  long reg;
++
++  if (tolower (str[0]) != 'v'
++      || tolower (str[1]) != 'f')
++    {
++      *errmsg = UNKNOWN_REGISTER;
++      return 0;
++    }
++
++  start = str = str + 2;
++  reg = strtol (start, &str, 10);
++  if (reg < 0 || reg > 31)
++    {
++      *errmsg = INVALID_REGISTER_NUMBER;
++      return 0;
++    }
++  *pstr = str;
++  return reg;
++}
++
++static void
++print_freg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++            const dvp_operand *operand ATTRIBUTE_UNUSED,
++            int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++            disassemble_info *info, long value)
++{
++  (*info->fprintf_func) (info->stream, "vf%02ld", value);
++}
++
++/* I register.  */
++
++static long
++parse_ireg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++            const dvp_operand *operand ATTRIBUTE_UNUSED,
++            int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  long reg;
++
++  if (tolower (str[0]) != 'v'
++      || tolower (str[1]) != 'i')
++    {
++      *errmsg = UNKNOWN_REGISTER;
++      return 0;
++    }
++
++  start = str = str + 2;
++  reg = strtol (start, &str, 10);
++  if (reg < 0 || reg > 31)
++    {
++      *errmsg = INVALID_REGISTER_NUMBER;
++      return 0;
++    }
++  *pstr = str;
++  return reg;
++}
++
++static void
++print_ireg (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++            const dvp_operand *operand ATTRIBUTE_UNUSED,
++            int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++            disassemble_info *info, long value)
++{
++  (*info->fprintf_func) (info->stream, "vi%02ld", value);
++}
++
++/* VI01 register.  */
++
++static long
++parse_vi01 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++            const dvp_operand *operand ATTRIBUTE_UNUSED,
++            int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  long reg;
++
++  if (tolower (str[0]) != 'v'
++      || tolower (str[1]) != 'i')
++    {
++      *errmsg = UNKNOWN_REGISTER;
++      return 0;
++    }
++
++  start = str = str + 2;
++  reg = strtol (start, &str, 10);
++  if (reg != 1)
++    {
++      *errmsg = _("vi01 required here");
++      return 0;
++    }
++  *pstr = str;
++  return reg;
++}
++
++static void
++print_vi01 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++            const dvp_operand *operand ATTRIBUTE_UNUSED,
++            int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++            disassemble_info *info, long value ATTRIBUTE_UNUSED)
++{
++  (*info->fprintf_func) (info->stream, "vi01");
++}
++
++/* Lower instruction 12 bit unsigned immediate.  */
++
++static void
++insert_luimm12 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, DVP_INSN *insn, long value,
++                const char **errmsg ATTRIBUTE_UNUSED)
++{
++  *insn |= VLUIMM12TOP ((value & (1 << 11)) != 0) | VLIMM11 (value);
++}
++
++static long
++extract_luimm12 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand ATTRIBUTE_UNUSED,
++                 int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++                 int *pinvalid ATTRIBUTE_UNUSED)
++{
++  return (((*insn & MLUIMM12TOP) != 0) << 11) | VLIMM11 (*insn);
++}
++
++/* Lower instruction 12 bit unsigned immediate, upper 6 bits.  */
++
++static void
++insert_luimm12up6 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                   const dvp_operand *operand ATTRIBUTE_UNUSED,
++                   int mods ATTRIBUTE_UNUSED, DVP_INSN *insn, long value,
++                   const char **errmsg ATTRIBUTE_UNUSED)
++{
++  *insn |= VLUIMM12TOP ((value & (1 << 11)) != 0) | (value & 0x7c0);
++}
++
++/* Lower instruction 15 bit unsigned immediate.  */
++
++static void
++insert_luimm15 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, DVP_INSN *insn, long value,
++                const char **errmsg ATTRIBUTE_UNUSED)
++{
++  *insn |= VLUIMM15TOP (value >> 11) | VLIMM11 (value);
++}
++
++static long
++extract_luimm15 (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand ATTRIBUTE_UNUSED,
++                 int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++                 int *pinvalid ATTRIBUTE_UNUSED)
++{
++  return (((*insn & MLUIMM15TOP) >> 21) << 11) | VLIMM11 (*insn);
++}
++
++/* VIF support.  */
++
++PARSE_FN (vif_ibit);
++PRINT_FN (vif_ibit);
++
++INSERT_FN (vif_wlcl);
++EXTRACT_FN (vif_wlcl);
++
++PARSE_FN (vif_mode);
++PRINT_FN (vif_mode);
++
++PARSE_FN (vif_ability);
++PRINT_FN (vif_ability);
++
++PARSE_FN (vif_mpgloc);
++INSERT_FN (vif_mpgloc);
++
++PARSE_FN (vif_datalen_special);
++INSERT_FN (vif_datalen);
++EXTRACT_FN (vif_datalen);
++
++PARSE_FN (vif_imrubits);
++INSERT_FN (vif_imrubits);
++EXTRACT_FN (vif_imrubits);
++PRINT_FN (vif_imrubits);
++
++PARSE_FN (vif_unpacktype);
++PRINT_FN (vif_unpacktype);
++
++const dvp_operand vif_operands[] =
++{
++  /* place holder (??? not sure if needed) */
++#define VIF_UNUSED 128
++  { 0 },
++
++  /* The I bit.  */
++#define VIF_IBIT (VIF_UNUSED + 1)
++  { 1, 31, 0, DVP_OPERAND_SUFFIX, parse_vif_ibit, 0, 0, print_vif_ibit },
++
++  /* WL value, an 8 bit unsigned immediate, stored in upper 8 bits of
++     immed field.  */
++#define VIF_WL (VIF_IBIT + 1)
++  { 8, 8, 0, 0, 0, insert_vif_wlcl, extract_vif_wlcl, 0 },
++
++  /* CL value, an 8 bit unsigned immediate, stored in lower 8 bits of
++     immed field.  */
++#define VIF_CL (VIF_WL + 1)
++  { 8, 0, 0, 0, 0, insert_vif_wlcl, extract_vif_wlcl, 0 },
++
++  /* An 16 bit unsigned immediate, stored in lower 8 bits of immed field.  */
++#define VIF_UIMM16 (VIF_CL + 1)
++  { 16, 0, 0, 0, 0, 0, 0, 0 },
++
++  /* The mode operand of `stmod'.  */
++#define VIF_MODE (VIF_UIMM16 + 1)
++  { 2, 0, 0, 0, parse_vif_mode, 0, 0, print_vif_mode },
++
++  /* The ability operand of `mskpath3'.  */
++#define VIF_ABILITY (VIF_MODE + 1)
++  { 1, 15, 0, 0, parse_vif_ability, 0, 0, print_vif_ability },
++
++  /* A VU address.  */
++#define VIF_VUADDR (VIF_ABILITY + 1)
++  { 16, 0, 0, 0, 0, 0, 0, 0 },
++
++  /* A 32 bit immediate, appearing in 2nd word.  */
++#define VIF_UIMM32_2 (VIF_VUADDR + 1)
++  { 32, 0, 1, 0, 0, 0, 0, 0 },
++
++  /* A 32 bit immediate, appearing in 3rd word.  */
++#define VIF_UIMM32_3 (VIF_UIMM32_2 + 1)
++  { 32, 0, 2, 0, 0, 0, 0, 0 },
++
++  /* A 32 bit immediate, appearing in 4th word.  */
++#define VIF_UIMM32_4 (VIF_UIMM32_3 + 1)
++  { 32, 0, 3, 0, 0, 0, 0, 0 },
++
++  /* A 32 bit immediate, appearing in 5th word.  */
++#define VIF_UIMM32_5 (VIF_UIMM32_4 + 1)
++  { 32, 0, 4, 0, 0, 0, 0, 0 },
++
++  /* VU address used by mpg insn.  */
++#define VIF_MPGLOC (VIF_UIMM32_5 + 1)
++  { 16, 0, 0, DVP_OPERAND_VU_ADDRESS, parse_vif_mpgloc, insert_vif_mpgloc, 0, 0 },
++
++  /* A variable length data specifier as an expression.  */
++#define VIF_DATALEN (VIF_MPGLOC + 1)
++  { 0, 0, 0, 0, 0, insert_vif_datalen, extract_vif_datalen, 0 },
++
++  /* A variable length data specifier as a file name or '*'.
++     The operand is marked as pc-relative as the length is calculated by
++     emitting a label at the end of the data.  */
++#define VIF_DATALEN_SPECIAL (VIF_DATALEN + 1)
++  { 0, 0, 0, DVP_OPERAND_RELATIVE_BRANCH, parse_vif_datalen_special, insert_vif_datalen, 0, 0 },
++
++  /* The IMRU bits of the unpack insn.  */
++#define VIF_IMRUBITS (VIF_DATALEN_SPECIAL + 1)
++  { 0, 0, 0, DVP_OPERAND_SUFFIX,
++    parse_vif_imrubits, insert_vif_imrubits, extract_vif_imrubits, print_vif_imrubits },
++
++  /* The type of the unpack insn.  */
++#define VIF_UNPACKTYPE (VIF_IMRUBITS + 1)
++  { 4, 24, 0, 0, parse_vif_unpacktype, 0, 0, print_vif_unpacktype },
++
++  /* VU address used by unpack insn.  */
++#define VIF_UNPACKLOC (VIF_UNPACKTYPE + 1)
++  { 10, 0, 0, DVP_OPERAND_UNPACK_ADDRESS, 0, 0, 0, 0 },
++
++/* end of list place holder */
++  { 0 }
++};
++
++/* Some useful operand numbers.  */
++const int vif_operand_mpgloc = DVP_OPERAND_INDEX (VIF_MPGLOC);
++const int vif_operand_datalen_special = DVP_OPERAND_INDEX (VIF_DATALEN_SPECIAL);
++
++/* Field mask values.  */
++#define MVIFCMD 0x7f000000
++#define MVIFUNPACK 0x60000000
++
++/* Field values.  */
++#define VVIFCMD(x) V ((x), 7, 24)
++#define VVIFUNPACK V (0x60, 8, 24)
++
++const struct dvp_opcode vif_opcodes[] =
++{
++  { "vifnop",   { VIF_IBIT },                                  0x7fffffff, 0, 0, 0 },
++  { "stcycle",  { VIF_IBIT, SP, VIF_WL, C, VIF_CL },           MVIFCMD, VVIFCMD (1), 0, DVP_OPCODE_IGNORE_DIS },
++  { "stcycl",   { VIF_IBIT, SP, VIF_WL, C, VIF_CL },           MVIFCMD, VVIFCMD (1), 0, 0 },
++  { "offset",   { VIF_IBIT, SP, VIF_UIMM16 },                  MVIFCMD, VVIFCMD (2), 0, 0 },
++  { "base",     { VIF_IBIT, SP, VIF_UIMM16 },                  MVIFCMD, VVIFCMD (3), 0, 0 },
++  { "itop",     { VIF_IBIT, SP, VIF_UIMM16 },                  MVIFCMD, VVIFCMD (4), 0, 0 },
++  { "stmod",    { VIF_IBIT, SP, VIF_MODE },                    MVIFCMD + V (~0, 14, 2), VVIFCMD (5), 0, 0 },
++  { "mskpath3", { VIF_IBIT, SP, VIF_ABILITY },                 MVIFCMD + V (~0, 15, 0), VVIFCMD (6), 0, 0 },
++  { "mark",     { VIF_IBIT, SP, VIF_UIMM16 },                  MVIFCMD, VVIFCMD (7), 0, 0 },
++  { "flushe",   { VIF_IBIT },                                  MVIFCMD, VVIFCMD (16), 0, 0 },
++  { "flusha",   { VIF_IBIT },                                  MVIFCMD, VVIFCMD (19), 0, 0 },
++  /* "flush" must appear after the previous two, longer ones first remember */
++  { "flush",    { VIF_IBIT },                                  MVIFCMD, VVIFCMD (17), 0, 0 },
++  { "mscalf",   { VIF_IBIT, SP, VIF_VUADDR },                  MVIFCMD, VVIFCMD (21), 0, 0 },
++  { "mscal",    { VIF_IBIT, SP, VIF_VUADDR },                  MVIFCMD, VVIFCMD (20), 0, 0 },
++  /* "mscal" must appear after the previous one. */
++  { "mscnt",    { VIF_IBIT },                                  MVIFCMD, VVIFCMD (23), 0, 0 },
++
++  /* 2 word instructions */
++  { "stmask",   { VIF_IBIT, SP, VIF_UIMM32_2 },                MVIFCMD, VVIFCMD (32), 0, VIF_OPCODE_LEN2},
++
++  /* 5 word instructions */
++  { "strow",    { VIF_IBIT, SP, VIF_UIMM32_2, C, VIF_UIMM32_3, C, VIF_UIMM32_4, C, VIF_UIMM32_5 }, MVIFCMD, VVIFCMD (48), 0, VIF_OPCODE_LEN5 },
++  { "stcol",    { VIF_IBIT, SP, VIF_UIMM32_2, C, VIF_UIMM32_3, C, VIF_UIMM32_4, C, VIF_UIMM32_5 }, MVIFCMD, VVIFCMD (49), 0, VIF_OPCODE_LEN5 },
++
++  /* variable length instructions */
++  { "mpg",      { VIF_IBIT, SP, VIF_MPGLOC, C, VIF_DATALEN_SPECIAL }, MVIFCMD, VVIFCMD (0x4a), 0, VIF_OPCODE_LENVAR + VIF_OPCODE_MPG + DVP_OPCODE_IGNORE_DIS },
++  { "mpg",      { VIF_IBIT, SP, VIF_MPGLOC, C, VIF_DATALEN },         MVIFCMD, VVIFCMD (0x4a), 0, VIF_OPCODE_LENVAR + VIF_OPCODE_MPG },
++
++  /* `directhl' must appear before `direct', longer ones first */
++  { "directhl", { VIF_IBIT, SP, VIF_DATALEN_SPECIAL },  MVIFCMD, VVIFCMD (0x51), 0, VIF_OPCODE_LENVAR + VIF_OPCODE_DIRECT + DVP_OPCODE_IGNORE_DIS },
++  { "directhl", { VIF_IBIT, SP, VIF_DATALEN },          MVIFCMD, VVIFCMD (0x51), 0, VIF_OPCODE_LENVAR + VIF_OPCODE_DIRECT },
++
++  { "direct",   { VIF_IBIT, SP, VIF_DATALEN_SPECIAL },  MVIFCMD, VVIFCMD (0x50), 0, VIF_OPCODE_LENVAR + VIF_OPCODE_DIRECT + DVP_OPCODE_IGNORE_DIS },
++  { "direct",   { VIF_IBIT, SP, VIF_DATALEN },          MVIFCMD, VVIFCMD (0x50), 0, VIF_OPCODE_LENVAR + VIF_OPCODE_DIRECT },
++
++  { "unpack",   { VIF_IMRUBITS, SP, VIF_UNPACKTYPE, C, VIF_UNPACKLOC, C, VIF_DATALEN_SPECIAL }, MVIFUNPACK, VVIFUNPACK, 0, VIF_OPCODE_LENVAR + VIF_OPCODE_UNPACK + DVP_OPCODE_IGNORE_DIS },
++  { "unpack",   { VIF_IMRUBITS, SP, VIF_UNPACKTYPE, C, VIF_UNPACKLOC, C, VIF_DATALEN },         MVIFUNPACK, VVIFUNPACK, 0, VIF_OPCODE_LENVAR + VIF_OPCODE_UNPACK },
++  { 0, { 0 }, 0, 0, 0, 0  },
++};
++
++/* unpack/stcycl macro */
++
++const struct dvp_macro vif_macros[] = {
++  { "unpack${imrubits} ${wl},${cl},${unpacktype},${unpackloc},${datalen}", "stcycl %1,%2\nunpack%0 %3,%4,%5" }
++};
++const int vif_macro_count = sizeof (vif_macros) / sizeof (vif_macros[0]);
++
++/* Length of parsed insn, in 32 bit words, or 0 if unknown.  */
++static int state_vif_len;
++
++/* The value for mpgloc seen.  */
++static int state_vif_mpgloc;
++/* Non-zero if '*' was seen for mpgloc.  */
++static int state_vif_mpgloc_star_p;
++
++/* The most recent WL,CL args to stcycl.
++   HACK WARNING: This is a real kludge because when processing an `unpack'
++   we don't necessarily know what stcycl insn goes with it.
++   For now we punt and assume the last one we assembled.
++   Note that this requires that there be at least one stcycl in the
++   file before any unpack (if not we assume wl <= cl).  */
++static int state_vif_wl = -1, state_vif_cl = -1;
++
++/* The file argument to mpg,direct,directhl,unpack is stored here
++   (in a malloc'd buffer).  */
++static char *state_vif_data_file;
++/* A numeric length for mpg,direct,directhl,unpack is stored here.  */
++static int state_vif_data_len;
++
++/* VIF parse,insert,extract,print helper fns.  */
++
++static long
++parse_vif_ibit (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  int flags = 0;
++
++  if (*str != '[')
++    return 0;
++
++  for (str = str + 1; *str != ']'; ++str)
++    {
++      switch (tolower (*str))
++	{
++	case 'i' : flags = 1; break;
++	default : *errmsg = _("unknown flag"); return 0;
++	}
++    }
++
++  *pstr = str + 1;
++  return flags;
++}
++
++static void
++print_vif_ibit (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                disassemble_info *info, long value)
++{
++  if (value)
++    (*info->fprintf_func) (info->stream, "[i]");
++}
++
++/* Insert the wl,cl value into the insn.
++   This is used to record the wl,cl values for subsequent use by an unpack
++   insn.  */
++
++static void
++insert_vif_wlcl (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                 DVP_INSN *insn, long value,
++                 const char **errmsg ATTRIBUTE_UNUSED)
++{
++  *insn |= (value & ((1 << operand->bits) - 1)) << operand->shift;
++  if (operand->shift == 8)
++    state_vif_wl = value;
++  else
++    state_vif_cl = value;
++}
++
++/* Extract the wl,cl value from the insn.
++   This is used to record the wl,cl values for subsequent use by an unpack
++   insn.  */
++
++static long
++extract_vif_wlcl (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                  const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                  DVP_INSN *insn, int *pinvalid ATTRIBUTE_UNUSED)
++{
++  long value = (*insn >> operand->shift) & ((1 << operand->bits) - 1);
++  if (operand->shift == 8)
++    state_vif_wl = value;
++  else
++    state_vif_cl = value;
++  return value;
++}
++
++static const keyword stmod_modes[] = {
++  { VIF_MODE_DIRECT, "direct" },
++  { VIF_MODE_ADD,    "add" },
++  { VIF_MODE_ADDROW, "addrow" },
++  { 0, 0 }
++};
++
++static long
++parse_vif_mode (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  int mode;
++  char *str = *pstr;
++  char *start;
++  char c;
++
++  start = str;
++  if (isdigit ((unsigned char) *str))
++    {
++      mode = strtol (start, &str, 0);
++    }
++  else
++    {
++      str = scan_symbol (str);
++      c = *str;
++      *str = 0;
++      mode = lookup_keyword_value (stmod_modes, start, 0);
++      *str = c;
++    }
++  if (mode >= 0 && mode <= 2)
++    {
++      *pstr = str;
++      return mode;
++    }
++  *errmsg = _("invalid mode");
++  return 0;
++}
++
++static void
++print_vif_mode (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                disassemble_info *info, long value)
++{
++  const char *name = lookup_keyword_name (stmod_modes, value);
++
++  if (name)
++    (*info->fprintf_func) (info->stream, name);
++  else
++    (*info->fprintf_func) (info->stream, "???");
++}
++
++static long
++parse_vif_ability (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                   const dvp_operand *operand ATTRIBUTE_UNUSED,
++                   int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++
++  if (strncasecmp (str, "disable", 7) == 0)
++    {
++      *pstr += 7;
++      return 1;
++    }
++  else if (strncasecmp (str, "enable", 6) == 0)
++    {
++      *pstr += 6;
++      return 0;
++    }
++  *errmsg = _("invalid ability");
++  return 1;
++}
++
++static void
++print_vif_ability (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                   const dvp_operand *operand ATTRIBUTE_UNUSED,
++                   int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                   disassemble_info *info, long value)
++{
++  if (!value)
++    (*info->fprintf_func) (info->stream, "enable");
++  else
++    (*info->fprintf_func) (info->stream, "disable");
++}
++
++/* Parse the mpgloc field.
++   This doesn't do any actual parsing.
++   It exists to record the fact that '*' was seen.  */
++
++static long
++parse_vif_mpgloc (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                  const dvp_operand *operand ATTRIBUTE_UNUSED,
++                  int mods ATTRIBUTE_UNUSED, char **pstr,
++                  const char **errmsg ATTRIBUTE_UNUSED)
++{
++  if (**pstr == '*')
++    state_vif_mpgloc_star_p = 1;
++  /* Since we don't advance *pstr, the normal expression parser will
++     be called.  */
++  return 0;
++}
++
++static void
++insert_vif_mpgloc (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                   const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                   DVP_INSN *insn, long value,
++                   const char **errmsg ATTRIBUTE_UNUSED)
++{
++  *insn |= (value & ((1 << operand->bits) - 1)) << operand->shift;
++  /* If we saw a '*', don't record VALUE - it's meaningless.  */
++  if (! state_vif_mpgloc_star_p)
++    state_vif_mpgloc = value;
++}
++
++/* Parse a file name or '*'.
++   If a file name, the name is stored in state_vif_data_file and result is 0.
++   If a *, result is -1.  */
++
++static long
++parse_vif_datalen_special (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                           const dvp_operand *operand ATTRIBUTE_UNUSED,
++                           int mods ATTRIBUTE_UNUSED, char **pstr,
++                           const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  int len;
++
++  if (*str == '*')
++    {
++      ++*pstr;
++      return -1;
++    }
++
++  if (*str == '"')
++    {
++      start = ++str;
++      ++str;
++      while (*str && *str != '"')
++	{
++	  /* FIXME: \ parsing? */
++	  ++str;
++	}
++      if (*str == 0)
++	{
++	  *errmsg = _("file name missing terminating `\"'");
++	  return 0;
++	}
++      len = str - start;
++      state_vif_data_file = xmalloc (len + 1);
++      memcpy (state_vif_data_file, start, len);
++      state_vif_data_file[len] = 0;
++      *pstr = str + 1;
++      return 0;
++    }
++
++  *errmsg = _("invalid data length");
++  return 0;
++}
++
++/* This routine is used for both the mpg and unpack insns which store
++   their length value in the `num' field and the direct/directhl insns
++   which store their length value in the `immediate' field.  */
++
++static void
++insert_vif_datalen (const dvp_opcode *opcode,
++                    const dvp_operand *operand ATTRIBUTE_UNUSED,
++                    int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                    long value, const char **errmsg ATTRIBUTE_UNUSED)
++{
++  /* FIXME: The actual insertion of the value in the insn is currently done
++     in tc-dvp.c.  We just record the value.  */
++  /* Perform the max+1 -> 0 conversion.  */
++  if ((opcode->flags & VIF_OPCODE_MPG) != 0
++      && value == 256)
++    value = 0;
++  else if ((opcode->flags & VIF_OPCODE_DIRECT) != 0
++	   && value == 65536)
++    value = 0;
++  else if ((opcode->flags & VIF_OPCODE_UNPACK) != 0
++	   && value == 256)
++    value = 0;
++  state_vif_data_len = value;
++}
++
++/* This routine is used for both the mpg and unpack insns which store
++   their length value in the `num' field and the direct/directhl insns
++   which store their length value in the `immediate' field.  */
++
++static long
++extract_vif_datalen (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                     const dvp_operand *operand ATTRIBUTE_UNUSED,
++                     int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++                     int *pinvalid ATTRIBUTE_UNUSED)
++{
++  int len;
++
++  switch ((*insn >> 24) & 0x70)
++    {
++    case 0x40 : /* mpg */
++      len = (*insn >> 16) & 0xff;
++      return len ? len : 256;
++    case 0x50 : /* direct,directhl */
++      len = *insn & 0xffff;
++      return len ? len : 65536;
++    case 0x60 : /* unpack */
++    case 0x70 :
++      len = (*insn >> 16) & 0xff;
++      return len ? len : 256;
++    default :
++      return 0;
++    }
++}
++
++static long
++parse_vif_imrubits (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                    const dvp_operand *operand ATTRIBUTE_UNUSED,
++                    int mods ATTRIBUTE_UNUSED, char **pstr,
++                    const char **errmsg)
++{
++  char *str = *pstr;
++  int flags = 0;
++
++  if (*str != '[')
++    return 0;
++
++  for (str = str + 1; *str != ']'; ++str)
++    {
++      switch (tolower (*str))
++	{
++	case 'i' : flags |= VIF_FLAG_I; break;
++	case 'm' : flags |= VIF_FLAG_M; break;
++	case 'r' : flags |= VIF_FLAG_R; break;
++	case 'u' : flags |= VIF_FLAG_U; break;
++	default : *errmsg = _("unknown vif flag"); return 0;
++	}
++    }
++
++  *pstr = str + 1;
++  return flags;
++}
++
++static void
++insert_vif_imrubits (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                     const dvp_operand *operand ATTRIBUTE_UNUSED,
++                     int mods ATTRIBUTE_UNUSED, DVP_INSN *insn, long value,
++                     const char **errmsg ATTRIBUTE_UNUSED)
++{
++  if (value & VIF_FLAG_I)
++    *insn |= 0x80000000;
++  if (value & VIF_FLAG_M)
++    *insn |= 0x10000000;
++  if (value & VIF_FLAG_R)
++    *insn |= 0x8000;
++  if (value & VIF_FLAG_U)
++    *insn |= 0x4000;
++}
++
++static long
++extract_vif_imrubits (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                      const dvp_operand *operand ATTRIBUTE_UNUSED,
++                      int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++                      int *pinvalid ATTRIBUTE_UNUSED)
++{
++  long value = 0;
++  if (*insn & 0x80000000)
++    value |= VIF_FLAG_I;
++  if (*insn & 0x10000000)
++    value |= VIF_FLAG_M;
++  if (*insn & 0x8000)
++    value |= VIF_FLAG_R;
++  if (*insn & 0x4000)
++    value |= VIF_FLAG_U;
++  return value;
++}
++
++static void
++print_vif_imrubits (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                    const dvp_operand *operand ATTRIBUTE_UNUSED,
++                    int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                    disassemble_info *info, long value)
++{
++  if (value)
++    {
++      (*info->fprintf_func) (info->stream, "[");
++      if (value & VIF_FLAG_I)
++	(*info->fprintf_func) (info->stream, "i");
++      if (value & VIF_FLAG_M)
++	(*info->fprintf_func) (info->stream, "m");
++      if (value & VIF_FLAG_R)
++	(*info->fprintf_func) (info->stream, "r");
++      if (value & VIF_FLAG_U)
++	(*info->fprintf_func) (info->stream, "u");
++      (*info->fprintf_func) (info->stream, "]");
++    }
++}
++
++static const keyword unpack_types[] = {
++  { VIF_UNPACK_S_32, "s_32" },
++  { VIF_UNPACK_S_16, "s_16" },
++  { VIF_UNPACK_S_8, "s_8" },
++  { VIF_UNPACK_V2_32, "v2_32" },
++  { VIF_UNPACK_V2_16, "v2_16" },
++  { VIF_UNPACK_V2_8, "v2_8" },
++  { VIF_UNPACK_V3_32, "v3_32" },
++  { VIF_UNPACK_V3_16, "v3_16" },
++  { VIF_UNPACK_V3_8, "v3_8" },
++  { VIF_UNPACK_V4_32, "v4_32" },
++  { VIF_UNPACK_V4_16, "v4_16" },
++  { VIF_UNPACK_V4_8, "v4_8" },
++  { VIF_UNPACK_V4_5, "v4_5" },
++  { 0, 0 }
++};
++
++static long
++parse_vif_unpacktype (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                      const dvp_operand *operand ATTRIBUTE_UNUSED,
++                      int mods ATTRIBUTE_UNUSED, char **pstr,
++                      const char **errmsg)
++{
++  int type;
++  char *str = *pstr;
++  char *start;
++  char c;
++
++  start = str;
++  str = scan_symbol (str);
++  c = *str;
++  *str = 0;
++  type = lookup_keyword_value (unpack_types, start, 0);
++  *str = c;
++  if (type != -1)
++    {
++      *pstr = str;
++      return type;
++    }
++  *errmsg = _("invalid unpack type");
++  return 0;
++}
++
++static void
++print_vif_unpacktype (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                      const dvp_operand *operand ATTRIBUTE_UNUSED,
++                      int mods ATTRIBUTE_UNUSED,
++                      DVP_INSN *insn ATTRIBUTE_UNUSED, disassemble_info *info,
++                      long value)
++{
++  const char *name = lookup_keyword_name (unpack_types, value);
++
++  if (name)
++    (*info->fprintf_func) (info->stream, name);
++  else
++    (*info->fprintf_func) (info->stream, "???");
++}
++
++/* External VIF supporting routines.  */
++
++/* Return length, in 32 bit words, of just parsed vif insn,
++   or 0 if unknown.  */
++
++int
++vif_len ()
++{
++  /* This shouldn't be called unless a vif insn was parsed.
++     Also, we want to catch errors in parsing that don't set this.  */
++  if (state_vif_len == -1)
++    abort ();
++
++  return state_vif_len;
++}
++
++/* Return the length value to use for an unpack instruction, type TYPE,
++   whose data length in bytes is LEN.
++   We do not perform the max + 1 -> 0 transformation.  That's up to the caller.
++   WL,CL are the values to use for those registers.  A value of -1 means to
++   use the internally recorded values.  If the values are still -1, we
++   assume wl <= cl.
++   This means that it is assumed that unpack always requires a preceeding
++   stcycl sufficiently recently that the value we have recorded is correct.
++   FIXME: We assume len % 4 == 0.  */
++
++int
++vif_unpack_len_value (unpack_type type, int wl, int cl, int len)
++{
++  int vn = (type >> 2) & 3;
++  int vl = type & 3;
++  int n, num;
++
++  if (wl < 0)
++    wl = state_vif_wl;
++  if (cl < 0)
++    cl = state_vif_cl;
++  if (wl == -1 || cl == -1)
++    wl = cl = 1;
++
++  if (wl <= cl)
++    {
++      /* data length (in words) len = ((((32 >> vl) * (vn + 1)) * num) / 32)
++	 Thus num = (len / 4) * 32 / ((32 >> vl) * (vn + 1)) */
++      num = (len * 32 / 4) / ((32 >> vl) * (vn + 1));
++    }
++  else /* wl > cl */
++    {
++      /* data length (in words) len = ((((32 >> vl) * (vn + 1)) * n) / 32)
++	 n = CL * (num / WL) + min (num % WL, CL)
++	 Thus n = (len / 4) * 32 / ((32 >> vl) * (vn + 1))
++	 num = (n - delta) * wl / cl;
++	 where `delta' is defined to be "just right".
++	 I'm too bloody tired to do this more cleverly.  */
++      n = (len * 32 / 4) / ((32 >> vl) * (vn + 1));
++      /* Avoid divide by zero.  */
++      if (cl == 0)
++	return 0;
++      /* Note that wl cannot be zero here.
++	 We know that cl > 0 and thus if wl == 0 we would have taken
++	 the `then' part of this if().  */
++      num = n * wl / cl;
++      while (num > 0
++	     && n != (cl * num / wl) + MIN (num % wl, cl))
++	--num;
++      if (num == 0)
++	{
++	  fprintf (stderr, _("internal error in unpack length calculation"));
++	  abort ();
++	}
++    }
++  return num;
++}
++
++/* Return the data length, in bytes, of an unpack insn of type TYPE,
++   whose `num' field in NUM.
++   If WL,CL are unknown, we assume wl <= cl.  */
++
++int
++vif_unpack_len (unpack_type type, int num)
++{
++  int vn = (type >> 2) & 3;
++  int vl = type & 3;
++  int wl = state_vif_wl;
++  int cl = state_vif_cl;
++  int n, len;
++
++  if (wl == -1 || cl == -1)
++    wl = cl = 1;
++
++  /* Perform 0 -> max+1 conversion.  */
++  if (num == 0)
++    num = 256;
++  if (wl == 0)
++    wl = 256;
++
++  if (wl <= cl)
++    {
++      /* data length (in words) len = ((((32 >> vl) * (vn + 1)) * num) / 32) */
++      n = num;
++    }
++  else /* wl > cl */
++    {
++      /* data length (in words) len = ((((32 >> vl) * (vn + 1)) * n) / 32)
++	 n = CL * (num / WL) + min (num % WL, CL) */
++      n = cl * num / wl + MIN (num % wl, cl);
++    }
++  /* +31: round up to next word boundary */
++  len = ((((32 >> vl) * (vn + 1)) * n) + 31) / 32;
++  return len * 4;
++}
++
++/* Return the length, in 32 bit words, of a VIF insn.
++   INSN is the first word.
++   The cpu type of the following data is stored in PCPU.  */
++
++int
++vif_insn_len (DVP_INSN insn, dvp_cpu *pcpu)
++{
++  unsigned char cmd;
++
++  *pcpu = DVP_VIF;
++
++  /* strip off `i' bit */
++  insn &= 0x7fffffff;
++
++  /* get top byte */
++  cmd = insn >> 24;
++
++  /* see page 11 of cpu2 spec 2.1 for further info */
++  if ((cmd & 0x60) == 0)
++    return 1;
++  if ((cmd & 0x70) == 0x20)
++    return 2;
++  if ((cmd & 0x70) == 0x30)
++    return 5;
++  if ((cmd & 0x70) == 0x40)
++    {
++      /* mpg */
++      int len = (insn >> 16) & 0xff;
++      *pcpu = DVP_VUUP;
++      return 1 + (len == 0 ? 256 : len) * 2;
++    }
++  if ((cmd & 0x70) == 0x50)
++    {
++      /* direct,directhl */
++      int len = insn & 0xffff;
++      *pcpu = DVP_GIF;
++      return 1 + (len == 0 ? 65536 : len) * 4;
++    }
++  if ((cmd & 0x60) == 0x60)
++    {
++      /* unpack */
++      int len = vif_unpack_len (cmd & 15, (insn >> 16) & 0xff);
++      if (len == -1)
++	len = 4; /* FIXME: revisit */
++      return 1 + len / 4;
++    }
++
++  /* unknown insn */
++  return 1;
++}
++
++/* Get the value of mpgloc seen.  */
++
++int
++vif_get_mpgloc (void)
++{
++  return state_vif_mpgloc;
++}
++
++/* Return recorded variable data length indicator.
++   This is either a file name or a numeric length.
++   A length of -1 means the caller must compute it.  */
++
++void
++vif_get_var_data (const char **file, int *len)
++{
++  *file = state_vif_data_file;
++  *len = state_vif_data_len;
++}
++
++/* Return the specified values for wl,cl.  */
++
++void
++vif_get_wl_cl (int *wlp, int *clp)
++{
++  *wlp = state_vif_wl;
++  *clp = state_vif_cl;
++}
++
++/* DMA support.  */
++
++PARSE_FN (dma_flags);
++INSERT_FN (dma_flags);
++EXTRACT_FN (dma_flags);
++PRINT_FN (dma_flags);
++
++INSERT_FN (dma_count);
++EXTRACT_FN (dma_count);
++PRINT_FN (dma_count);
++
++PARSE_FN (dma_addr);
++INSERT_FN (dma_addr);
++EXTRACT_FN (dma_addr);
++PRINT_FN (dma_addr);
++
++const dvp_operand dma_operands[] =
++{
++    /* place holder (??? not sure if needed) */
++#define DMA_UNUSED 128
++    { 0 },
++
++    /* dma tag flag bits */
++#define DMA_FLAGS (DMA_UNUSED + 1)
++    { 0, 0, 0, DVP_OPERAND_SUFFIX,
++      parse_dma_flags, insert_dma_flags, extract_dma_flags, print_dma_flags },
++
++    /* dma data spec */
++#define DMA_COUNT (DMA_FLAGS + 1)
++    { 16, 0, 0, DVP_OPERAND_DMA_COUNT,
++      0, 0 /*insert_dma_count*/,
++      0 /*extract_dma_count*/, 0 /*print_dma_count*/ },
++
++    /* dma autocount modifier */
++#define DMA_AUTOCOUNT (DMA_COUNT + 1)
++    { 0, 0, 0, DVP_OPERAND_AUTOCOUNT, 0, 0, 0, 0 },
++
++    /* dma in-line-data */
++#define DMA_INLINE (DMA_AUTOCOUNT + 1)
++    { 0, 0, 0, DVP_OPERAND_FAKE + DVP_OPERAND_DMA_INLINE, 0, 0, 0, 0 },
++
++    /* dma ref data address */
++#define DMA_ADDR (DMA_INLINE + 1)
++    { 27, 4, 1, DVP_OPERAND_DMA_ADDR + DVP_OPERAND_MIPS_ADDRESS,
++      0 /*parse_dma_addr*/, insert_dma_addr,
++      extract_dma_addr, 0 /*print_dma_addr*/ },
++
++    /* dma next tag spec */
++#define DMA_NEXT (DMA_ADDR + 1)
++    { 27, 4, 1, DVP_OPERAND_DMA_NEXT + DVP_OPERAND_MIPS_ADDRESS,
++      0, insert_dma_addr, extract_dma_addr, 0 /*print_dma_addr*/ },
++
++/* end of list place holder */
++  { 0 }
++};
++
++/* Some useful operand numbers.  */
++const int dma_operand_count = DVP_OPERAND_INDEX (DMA_COUNT);
++const int dma_operand_addr = DVP_OPERAND_INDEX (DMA_ADDR);
++
++const struct dvp_opcode dma_opcodes[] =
++{
++  { "dmarefe", { DMA_FLAGS, SP, '*',       C, DMA_AUTOCOUNT, DMA_ADDR },             0x70000000, 0x00000000, 0, DVP_OPCODE_IGNORE_DIS },
++  { "dmarefe", { DMA_FLAGS, SP, DMA_COUNT, C, DMA_ADDR },                            0x70000000, 0x00000000, 0, 0 },
++  { "dmacnt",  { DMA_FLAGS, SP, '*',       DMA_AUTOCOUNT, DMA_INLINE },              0x70000000, 0x10000000, 0, DVP_OPCODE_IGNORE_DIS },
++  { "dmacnt",  { DMA_FLAGS, SP, DMA_COUNT, DMA_INLINE },                             0x70000000, 0x10000000, 0, 0 },
++  { "dmanext", { DMA_FLAGS, SP, '*',       C, DMA_AUTOCOUNT, DMA_INLINE, DMA_NEXT }, 0x70000000, 0x20000000, 0, DVP_OPCODE_IGNORE_DIS },
++  { "dmanext", { DMA_FLAGS, SP, DMA_COUNT, C, DMA_INLINE, DMA_NEXT },                0x70000000, 0x20000000, 0, 0 },
++  { "dmaref",  { DMA_FLAGS, SP, '*',       C, DMA_AUTOCOUNT, DMA_ADDR },             0x70000000, 0x30000000, 0, DVP_OPCODE_IGNORE_DIS },
++  { "dmaref",  { DMA_FLAGS, SP, DMA_COUNT, C, DMA_ADDR },                            0x70000000, 0x30000000, 0, 0 },
++  { "dmarefs", { DMA_FLAGS, SP, '*',       C, DMA_AUTOCOUNT, DMA_ADDR },             0x70000000, 0x40000000, 0, DVP_OPCODE_IGNORE_DIS },
++  { "dmarefs", { DMA_FLAGS, SP, DMA_COUNT, C, DMA_ADDR },                            0x70000000, 0x40000000, 0, 0 },
++  { "dmacall", { DMA_FLAGS, SP, '*',       C, DMA_AUTOCOUNT, DMA_INLINE, DMA_NEXT }, 0x70000000, 0x50000000, 0, DVP_OPCODE_IGNORE_DIS },
++  { "dmacall", { DMA_FLAGS, SP, DMA_COUNT, C, DMA_INLINE, DMA_NEXT },                0x70000000, 0x50000000, 0, 0 },
++  { "dmaret",  { DMA_FLAGS, SP, '*',       DMA_AUTOCOUNT, DMA_INLINE},               0x70000000, 0x60000000, 0, DVP_OPCODE_IGNORE_DIS },
++  { "dmaret",  { DMA_FLAGS, SP, DMA_COUNT, DMA_INLINE },                             0x70000000, 0x60000000, 0, 0 },
++  { "dmaend",  { DMA_FLAGS, SP, '*',       DMA_AUTOCOUNT, DMA_INLINE },              0x70000000, 0x70000000, 0, DVP_OPCODE_IGNORE_DIS },
++  { "dmaend",  { DMA_FLAGS, SP, DMA_COUNT, DMA_INLINE },                             0x70000000, 0x70000000, 0, 0 },
++  { "dmaend",  { DMA_FLAGS },                                                        0x70000000, 0x70000000, 0, 0 },
++  { 0, { 0 }, 0, 0, 0, 0  },
++};
++
++/* DMA parse,insert,extract,print helper fns.  */
++
++static long
++parse_dma_flags (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand ATTRIBUTE_UNUSED,
++                 int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  int flags = 0;
++
++  if (*str != '[')
++    return 0;
++
++  for (str = str + 1; *str != ']'; ++str)
++    {
++      switch (tolower (*str))
++	{
++	case '0' : flags |= DMA_FLAG_PCE0; break;
++	case '1' : flags |= DMA_FLAG_PCE1; break;
++	case 'i' : flags |= DMA_FLAG_INT; break;
++	case 's' : flags |= DMA_FLAG_SPR; break;
++	default : *errmsg = _("unknown dma flag"); return 0;
++	}
++    }
++
++  *pstr = str + 1;
++  return flags;
++}
++
++static void
++insert_dma_flags (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                  const dvp_operand *operand ATTRIBUTE_UNUSED,
++                  int mods ATTRIBUTE_UNUSED, DVP_INSN *insn, long value,
++                  const char **errmsg ATTRIBUTE_UNUSED)
++{
++  if (value & DMA_FLAG_PCE0)
++    insn[0] |= 2 << 26;
++  else if (value & DMA_FLAG_PCE0)
++    insn[0] |= 3 << 26;
++  if (value & DMA_FLAG_INT)
++    insn[0] |= (1 << 31);
++  if (value & DMA_FLAG_SPR)
++    insn[1] |= (1 << 31);
++}
++
++static long
++extract_dma_flags (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                   const dvp_operand *operand ATTRIBUTE_UNUSED,
++                   int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++                   int *pinvalid ATTRIBUTE_UNUSED)
++{
++  long value = 0;
++  if (((insn[0] >> 26) & 3) == 2)
++    value |= DMA_FLAG_PCE0;
++  if (((insn[0] >> 26) & 3) == 3)
++     value |= DMA_FLAG_PCE0;
++  if (((insn[0] >> 31) & 1) == 1)
++     value |= DMA_FLAG_INT;
++  if (((insn[1] >> 31) & 1) == 1)
++     value |= DMA_FLAG_SPR;
++  return value;
++}
++
++static void
++print_dma_flags (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand ATTRIBUTE_UNUSED,
++                 int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                 disassemble_info *info, long value)
++{
++  if (value)
++    {
++      (*info->fprintf_func) (info->stream, "[");
++      if (value & DMA_FLAG_PCE0)
++	(*info->fprintf_func) (info->stream, "0");
++      if (value & DMA_FLAG_PCE1)
++	(*info->fprintf_func) (info->stream, "1");
++      if (value & DMA_FLAG_INT)
++	(*info->fprintf_func) (info->stream, "i");
++      if (value & DMA_FLAG_SPR)
++	(*info->fprintf_func) (info->stream, "s");
++      (*info->fprintf_func) (info->stream, "]");
++    }
++}
++
++ATTRIBUTE_UNUSED static void
++insert_dma_count (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                  const dvp_operand *operand ATTRIBUTE_UNUSED,
++                  int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                  long value ATTRIBUTE_UNUSED,
++                  const char **errmsg ATTRIBUTE_UNUSED)
++{
++}
++
++ATTRIBUTE_UNUSED static long
++extract_dma_count (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                   const dvp_operand *operand ATTRIBUTE_UNUSED,
++                   int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                   int *pinvalid ATTRIBUTE_UNUSED)
++{
++  return 0;
++}
++
++ATTRIBUTE_UNUSED static void
++print_dma_count (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand ATTRIBUTE_UNUSED,
++                 int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                 disassemble_info *info, long value ATTRIBUTE_UNUSED)
++{
++  (*info->fprintf_func) (info->stream, "???");
++}
++
++ATTRIBUTE_UNUSED static long
++parse_dma_addr (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, char **pstr ATTRIBUTE_UNUSED,
++                const char **errmsg ATTRIBUTE_UNUSED)
++{
++  return 0;
++}
++
++static void
++insert_dma_addr (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand, int mods, DVP_INSN *insn,
++                 long value, const char **errmsg ATTRIBUTE_UNUSED)
++{
++  int word;
++
++  if (mods & DVP_MOD_THIS_WORD)
++    word = 0;
++  else if (operand->word)
++    word = operand->word;
++  else
++    word = operand->shift / 32;
++
++  /* The lower 4 bits are cut off and the value begins at bit 4.  */
++  insn[word] |= value & 0x7ffffff0;
++}
++
++static long
++extract_dma_addr (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                  const dvp_operand *operand, int mods, DVP_INSN *insn,
++                  int *pinvalid ATTRIBUTE_UNUSED)
++{
++  int word;
++
++  if (mods & DVP_MOD_THIS_WORD)
++    word = 0;
++  else if (operand->word)
++    word = operand->word;
++  else
++    word = operand->shift / 32;
++
++  return insn[word] & 0x7ffffff0;
++}
++
++ATTRIBUTE_UNUSED static void
++print_dma_addr (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                disassemble_info *info, long value ATTRIBUTE_UNUSED)
++{
++  (*info->fprintf_func) (info->stream, "???");
++}
++
++/* GIF support.  */
++
++PARSE_FN (gif_prim);
++INSERT_FN (gif_prim);
++EXTRACT_FN (gif_prim);
++PRINT_FN (gif_prim);
++
++PARSE_FN (gif_regs);
++INSERT_FN (gif_regs);
++EXTRACT_FN (gif_regs);
++PRINT_FN (gif_regs);
++
++PARSE_FN (gif_nloop);
++INSERT_FN (gif_nloop);
++EXTRACT_FN (gif_nloop);
++PRINT_FN (gif_nloop);
++
++PARSE_FN (gif_eop);
++EXTRACT_FN (gif_eop);
++PRINT_FN (gif_eop);
++
++/* Bit numbering:
++
++    insn[0]    insn[1]     insn[2]     insn[3]
++   31 ... 0 | 63 ... 32 | 95 ... 64 | 127 ... 96  */
++
++const dvp_operand gif_operands[] =
++{
++  /* place holder (??? not sure if needed) */
++#define GIF_UNUSED 128
++  { 0 },
++
++  /* PRIM=foo operand */
++#define GIF_PRIM (GIF_UNUSED + 1)
++  { 11, 47, 0, 0, parse_gif_prim, insert_gif_prim, extract_gif_prim, print_gif_prim },
++
++  /* REGS=foo operand */
++#define GIF_REGS (GIF_PRIM + 1)
++  { 64, 0, 0, 0, parse_gif_regs, insert_gif_regs, extract_gif_regs, print_gif_regs },
++
++  /* NLOOP=foo operand */
++#define GIF_NLOOP (GIF_REGS + 1)
++  { 15, 0, 0, 0, parse_gif_nloop, insert_gif_nloop, extract_gif_nloop, print_gif_nloop },
++
++  /* EOP operand */
++#define GIF_EOP (GIF_NLOOP + 1)
++  { 1, 15, 0, 0, parse_gif_eop, 0, extract_gif_eop, print_gif_eop },
++
++/* end of list place holder */
++  { 0 }
++};
++
++/* Some useful operand numbers.  */
++const int gif_operand_nloop = DVP_OPERAND_INDEX (GIF_NLOOP);
++
++/* GIF opcode values.  */
++#define VGIFOP(x) (((x) & 3) << 26)
++#define VGIFNREGS(x) (((x) & 15) << 28)
++
++/* GIF opcode masks.  */
++#define MGIFOP VGIFOP (~0)
++#define MGIFNREGS VGIFNREGS (~0)
++
++const struct dvp_opcode gif_opcodes[] =
++{
++  /* Some of these may take optional arguments.
++     The way this is handled is to have multiple table entries, those with and
++     those without the optional arguments.
++     !!! The order here is important.  The code that scans this table assumes
++     that if it reaches the end of a syntax string there is nothing more to
++     parse.  This means that longer versions of instructions must appear before
++     shorter ones.  Otherwise the text at the "end" of a longer one may be
++     interpreted as junk when the parser is using a shorter version of the
++     syntax string.  */
++
++  { "gifpacked", { SP, GIF_PRIM, C, GIF_REGS, C, GIF_NLOOP, C, GIF_EOP }, MGIFOP, VGIFOP (0), 1, 0 },
++  { "gifpacked", { SP, GIF_REGS, C, GIF_NLOOP, C, GIF_EOP },              MGIFOP, VGIFOP (0), 1, 0 },
++  { "gifpacked", { SP, GIF_PRIM, C, GIF_REGS, C, GIF_EOP },               MGIFOP, VGIFOP (0), 1, 0 },
++  { "gifpacked", { SP, GIF_PRIM, C, GIF_REGS, C, GIF_NLOOP },             MGIFOP, VGIFOP (0), 1, 0 },
++  { "gifpacked", { SP, GIF_REGS, C, GIF_EOP },                            MGIFOP, VGIFOP (0), 1, 0 },
++  { "gifpacked", { SP, GIF_REGS, C, GIF_NLOOP },                          MGIFOP, VGIFOP (0), 1, 0 },
++  { "gifpacked", { SP, GIF_PRIM, C, GIF_REGS },                           MGIFOP, VGIFOP (0), 1, 0 },
++  { "gifpacked", { SP, GIF_REGS },                                        MGIFOP, VGIFOP (0), 1, 0 },
++
++  { "gifreglist", { SP, GIF_REGS, C, GIF_NLOOP, C, GIF_EOP }, MGIFOP, VGIFOP (1), 1, 0 },
++  { "gifreglist", { SP, GIF_REGS, C, GIF_EOP },               MGIFOP, VGIFOP (1), 1, 0 },
++  { "gifreglist", { SP, GIF_REGS, C, GIF_NLOOP },             MGIFOP, VGIFOP (1), 1, 0 },
++  { "gifreglist", { SP, GIF_REGS },                           MGIFOP, VGIFOP (1), 1, 0 },
++
++  { "gifimage", { SP, GIF_NLOOP, C, GIF_EOP }, MGIFOP, VGIFOP (2), 1, 0 },
++  { "gifimage", { SP, GIF_EOP },               MGIFOP, VGIFOP (2), 1, 0 },
++  { "gifimage", { SP, GIF_NLOOP },             MGIFOP, VGIFOP (2), 1, 0 },
++  { "gifimage", { 0 },                         MGIFOP, VGIFOP (2), 1, 0 },
++  { 0, { 0 }, 0, 0, 0, 0  },
++};
++
++/* GIF parsing/printing state.  */
++
++static int state_gif_nregs;
++static int state_gif_regs[16];
++static int state_gif_nloop;
++
++/* GIF parse,insert,extract,print helper fns.  */
++
++static long
++parse_gif_prim (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  long prim;
++
++  if (strncasecmp (str, "prim=", 5) != 0)
++    {
++      *errmsg = _("missing PRIM spec");
++      return 0;
++    }
++  str += 5;
++  start = str;
++  prim = strtol (start, &str, 0);
++  if (str == start)
++    {
++      *errmsg = _("missing PRIM spec");
++      return 0;
++    }
++  *pstr = str;
++  return prim;
++}
++
++static void
++insert_gif_prim (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                 DVP_INSN *insn, long value,
++                 const char **errmsg ATTRIBUTE_UNUSED)
++{
++  int word = operand->shift / 32;
++  /* Chop off unwanted bits.  */
++  insn[word] |= (value & ((1 << operand->bits) - 1)) << operand->shift % 32;
++  /* Set the PRE bit.  */
++  insn[word] |= GIF_PRE;
++}
++
++static long
++extract_gif_prim (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                  const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                  DVP_INSN *insn, int *pinvalid)
++{
++  int word = operand->shift / 32;
++  if (! (insn[word] & GIF_PRE))
++    {
++      /* The prim register isn't used.  Mark as invalid so this choice is
++	 skipped as a possibility for disassembly.  */
++      *pinvalid = 1;
++      return -1;
++    }
++  return (insn[word] >> operand->shift % 32) & ((1 << operand->bits) - 1);
++}
++
++static void
++print_gif_prim (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                disassemble_info *info, long value)
++{
++  if (value != -1)
++    (*info->fprintf_func) (info->stream, "prim=0x%lx", value);
++}
++
++static const keyword gif_regs[] = {
++  { GIF_REG_PRIM,    "prim" },
++  { GIF_REG_RGBAQ,   "rgbaq" },
++  { GIF_REG_ST,      "st" },
++  { GIF_REG_UV,      "uv" },
++  { GIF_REG_XYZF2,   "xyzf2" },
++  { GIF_REG_XYZ2,    "xyz2" },
++  { GIF_REG_TEX0_1,  "tex0_1" },
++  { GIF_REG_TEX0_2,  "tex0_2" },
++  { GIF_REG_CLAMP_1, "clamp_1" },
++  { GIF_REG_CLAMP_2, "clamp_2" },
++  { GIF_REG_XYZF,    "xyzf" },
++  /* 11 is unused.  Should it ever appear we want to disassemble it somehow
++     so we give it a name anyway.  */
++  { GIF_REG_UNUSED11, "unused11" },
++  { GIF_REG_XYZF3,   "xyzf3" },
++  { GIF_REG_XYZ3,    "xyz3" },
++  { GIF_REG_A_D,     "a_d" },
++  { GIF_REG_NOP,     "nop" },
++  { 0, 0 }
++};
++
++/* Parse a REGS= spec.
++   The result is the number of registers parsed.
++   The selected registers are recorded internally in a static
++   variable for use later by the insert routine.  */
++
++static long
++parse_gif_regs (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  char c;
++  int reg,nregs;
++
++  if (strncasecmp (str, "regs=", 5) != 0)
++    {
++      *errmsg = _("missing REGS spec");
++      return 0;
++    }
++  str += 5;
++  SKIP_BLANKS (str);
++  if (*str != '{')
++    {
++      *errmsg = _("missing '{' in REGS spec");
++      return 0;
++    }
++  ++str;
++
++  nregs = 0;
++  while (*str && *str != '}')
++    {
++      if (nregs == 16)
++	{
++	  *errmsg = _("too many registers");
++	  return 0;
++	}
++
++      /* Pick out the register name.  */
++      SKIP_BLANKS (str);
++      start = str;
++      str = scan_symbol (str);
++      if (str == start)
++	{
++	  *errmsg = _("invalid REG");
++	  return 0;
++	}
++
++      /* Look it up in the table.  */
++      c = *str;
++      *str = 0;
++      reg = lookup_keyword_value (gif_regs, start, 0);
++      *str = c;
++      if (reg == -1)
++	{
++	  *errmsg = _("invalid REG");
++	  return 0;
++	}
++
++      /* Tuck the register number away for later use.  */
++      state_gif_regs[nregs++] = reg;
++
++      /* Prepare for the next one.  */
++      SKIP_BLANKS (str);
++      if (*str == ',')
++	++str;
++      else if (*str != '}')
++	break;
++    }
++  if (*str != '}')
++    {
++      *errmsg = _("missing '}' in REGS spec");
++      return 0;
++    }
++
++  *pstr = str + 1;
++  return nregs;
++}
++
++static void
++insert_gif_regs (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand ATTRIBUTE_UNUSED,
++                 int mods ATTRIBUTE_UNUSED, DVP_INSN *insn, long value,
++                 const char **errmsg ATTRIBUTE_UNUSED)
++{
++  int i;
++  DVP_INSN *p;
++
++  state_gif_nregs = value;
++
++  /* Registers are stored in word 2,3 (0-origin) in memory.
++     Each word is processed from the lower bit numbers upwards,
++     and the words are stored little endian.  We must record each word
++     in host-endian form as the word will be swapped to target endianness
++     when written out.  */
++
++  p = insn + 2;
++  for (i = 0; i < state_gif_nregs; ++i)
++    {
++      /* Move to next word?  */
++      if (i == 8)
++	++p;
++
++      *p |= state_gif_regs[i] << (i * 4);
++    }
++
++  insn[1] |= VGIFNREGS (state_gif_nregs);
++}
++
++static long
++extract_gif_regs (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                  const dvp_operand *operand ATTRIBUTE_UNUSED,
++                  int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++                  int *pinvalid ATTRIBUTE_UNUSED)
++{
++  state_gif_nregs = (insn[1] & MGIFNREGS) >> 28;
++  return state_gif_nregs;
++}
++
++static void
++print_gif_regs (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                const dvp_operand *operand ATTRIBUTE_UNUSED,
++                int mods ATTRIBUTE_UNUSED, DVP_INSN *insn,
++                disassemble_info *info, long value)
++{
++  /* VALUE is the number of registers [returned by the extract handler].  */
++  int i;
++  DVP_INSN *p;
++
++  /* See insert_gif_regs for an explanation of how the regs are stored.  */
++
++  (*info->fprintf_func) (info->stream, "regs={");
++
++  p = insn + 2;
++  for (i = 0; i < value; ++i)
++    {
++      int reg;
++
++      /* Move to next word?  */
++      if (i == 8)
++	++p;
++
++      reg = (*p >> (i * 4)) & 15;
++
++      (*info->fprintf_func) (info->stream, "%s",
++			     lookup_keyword_name (gif_regs, reg));
++      if (i + 1 != value)
++	(*info->fprintf_func) (info->stream, ",");
++    }
++
++  (*info->fprintf_func) (info->stream, "}");
++}
++
++static long
++parse_gif_nloop (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand ATTRIBUTE_UNUSED,
++                 int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  char *str = *pstr;
++  char *start;
++  int nloop;
++
++  if (strncasecmp (str, "nloop=", 6) != 0)
++    {
++      *errmsg = _("missing NLOOP spec");
++      return 0;
++    }
++  str += 6;
++  SKIP_BLANKS (str);
++  start = str;
++  nloop = strtol (start, &str, 10);
++  if (str == start)
++    {
++      *errmsg = _("invalid NLOOP spec");
++      return 0;
++    }
++  *pstr = str;
++  return nloop;
++}
++
++static void
++insert_gif_nloop (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                  const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                  DVP_INSN *insn, long value,
++                  const char **errmsg ATTRIBUTE_UNUSED)
++{
++  int word = operand->shift / 32;
++  insn[word] |= (value & ((1 << operand->bits) - 1)) << operand->shift % 32;
++  /* Tuck the value away for later use.  */
++  state_gif_nloop = value;
++}
++
++static long
++extract_gif_nloop (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                   const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                   DVP_INSN *insn, int *pinvalid ATTRIBUTE_UNUSED)
++{
++  long value;
++  int word = operand->shift / 32;
++  value = (insn[word] >> operand->shift % 32) & ((1 << operand->bits) - 1);
++  /* Tuck the value away for later use.  */
++  state_gif_nloop = value;
++  return value;
++}
++
++static void
++print_gif_nloop (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand ATTRIBUTE_UNUSED,
++                 int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++                 disassemble_info *info, long value)
++{
++  (*info->fprintf_func) (info->stream, "nloop=%ld", value);
++}
++
++static long
++parse_gif_eop (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++               const dvp_operand *operand ATTRIBUTE_UNUSED,
++               int mods ATTRIBUTE_UNUSED, char **pstr, const char **errmsg)
++{
++  if (strncasecmp (*pstr, "eop", 3) == 0)
++    {
++      *pstr += 3;
++      return 1;
++    }
++  *errmsg = _("missing `EOP'");
++  return 0;
++}
++
++static long
++extract_gif_eop (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++                 const dvp_operand *operand, int mods ATTRIBUTE_UNUSED,
++                 DVP_INSN *insn, int *pinvalid)
++{
++  long value;
++  int word = operand->shift / 32;
++  value = (insn[word] >> operand->shift % 32) & ((1 << operand->bits) - 1);
++  /* If EOP=0, mark this choice as invalid so it's not used for
++     disassembly.  */
++  if (! value)
++    *pinvalid = 1;
++  return value;
++}
++
++static void
++print_gif_eop (const dvp_opcode *opcode ATTRIBUTE_UNUSED,
++               const dvp_operand *operand ATTRIBUTE_UNUSED,
++               int mods ATTRIBUTE_UNUSED, DVP_INSN *insn ATTRIBUTE_UNUSED,
++               disassemble_info *info, long value)
++{
++  if (value)
++    (*info->fprintf_func) (info->stream, "eop");
++}
++
++/* External GIF support routines.  */
++
++int
++gif_nloop ()
++{
++  return state_gif_nloop;
++}
++
++int
++gif_nregs ()
++{
++  return state_gif_nregs;
++}
++
++/* Init fns.
++   These are called before doing each of the respective activities.  */
++
++/* Called by the assembler before parsing an instruction.  */
++
++void
++dvp_opcode_init_parse ()
++{
++  state_vu_mnemonic_dest = -1;
++  state_vu_mnemonic_bc = -1;
++  state_vif_mpgloc = -1;
++  state_vif_mpgloc_star_p = 0;
++  state_vif_len = -1;
++  state_vif_data_file = NULL;
++  state_vif_data_len = 0;
++  state_gif_nregs = -1;
++  state_gif_nloop = -1;
++}
++
++/* Called by the disassembler before printing an instruction.  */
++
++void
++dvp_opcode_init_print ()
++{
++  state_vu_mnemonic_dest = -1;
++  state_vu_mnemonic_bc = -1;
++  state_vif_len = -1;
++  state_gif_nregs = -1;
++  state_gif_nloop = -1;
++}
++
++
++/* Misc. utilities.  */
++
++/* Scan a symbol and return a pointer to one past the end.  */
++
++static char *
++scan_symbol (char *sym)
++{
++  while (*sym && issymchar (*sym))
++    ++sym;
++  return sym;
++}
++
++/* Given a keyword, look up its value, or -1 if not found.  */
++
++static int
++lookup_keyword_value (const keyword *table, const char *name,
++                      int case_sensitive_p)
++{
++  const keyword *p;
++
++  if (case_sensitive_p)
++    {
++      for (p = table; p->name; ++p)
++	if (strcmp (name, p->name) == 0)
++	  return p->value;
++    }
++  else
++    {
++      for (p = table; p->name; ++p)
++	if (strcasecmp (name, p->name) == 0)
++	  return p->value;
++    }
++
++  return -1;
++}
++
++/* Given a keyword's value, look up its name, or NULL if not found.  */
++
++static const char *
++lookup_keyword_name (const keyword *table, int value)
++{
++  const keyword *p;
++
++  for (p = table; p->name; ++p)
++    if (value == p->value)
++      return p->name;
++
++  return NULL;
++}
++
++/* Macro insn support.  */
++
++/* Given a string, see if it's a macro insn and return the expanded form.
++   If not a macro insn, return NULL.
++   The expansion is done in malloc'd space.
++   It is up to the caller to free it.  */
++
++char *
++dvp_expand_macro (const dvp_macro * mactable, int tabsize, char *insn)
++{
++  const dvp_macro * m, *mend;
++  char * operands[10];
++  int oplens[10];
++  int noperands = 0;
++
++  for (m = mactable, mend = mactable + tabsize; m < mend; ++m)
++    {
++      const char * p = m->template;
++      char * ip = insn;
++
++      for (;;)
++	{
++	  while (*p && *p == *ip)
++	    ++p, ++ip;
++
++	  /* Did we find a complete match?  */
++	  if (*p == 0 && *ip == 0)
++	    {
++	      int total_len = strlen (m->result);
++	      int i;
++	      char * result;
++
++	      for (i = 0; i < noperands; ++i)
++		total_len += strlen (operands[i]);
++	      total_len += 1 + 10  /* slop */;
++	      result = xmalloc (total_len);
++	      for (ip = result, p = m->result; *p; )
++		{
++		  if (*p == '%')
++		    {
++		      /* Ok, we shouldn't assume max 10 operands.  */
++		      int opnum = *++p - '0';
++		      memcpy (ip, operands[opnum], oplens[opnum]);
++		      ++p;
++		      ip += oplens[opnum];
++		    }
++		  else
++		    {
++		      *ip++ = *p++;
++		    }
++		}
++	      if (ip - result >= total_len)
++		abort ();
++	      *ip = 0;
++	      return result;
++	    }
++
++	  /* Is this an operand?  */
++	  if (*p == '$' && p[1] == '{')
++	    {
++	      if (strncmp (p + 2, "imrubits}", 9) == 0)
++		{
++		  if (*ip == '[')
++		    {
++		      char *q = ip;
++		      while (*q && *q != ']')
++			++q;
++		      if (! *q)
++			return NULL;
++		      ++q;
++		      operands[noperands] = ip;
++		      oplens[noperands++] = q - ip;
++		      ip = q;
++		    }
++		  else
++		    {
++		      operands[noperands] = "";
++		      oplens[noperands++] = 0;
++		    }
++		}
++	      else if (strncmp (p + 2, "wl}", 3) == 0
++		       || strncmp (p + 2, "cl}", 3) == 0
++		       || strncmp (p + 2, "unpacktype}", 11) == 0
++		       || strncmp (p + 2, "unpackloc}", 10) == 0
++		       || strncmp (p + 2, "datalen}", 8) == 0)
++		{
++		  char *q = ip;
++		  while (*q && *q != ',')
++		    ++q;
++		  operands[noperands] = ip;
++		  oplens[noperands++] = q - ip;
++		  ip = q;
++		}
++	      else
++		abort ();
++
++	      /* Skip to end of operand in template.  */
++	      p = strchr (p, '}');
++	      if (! p)
++		abort ();
++	      ++p;
++	    }
++	  else
++	    break;
++	}
++    }
++
++  return NULL;
++}
+diff -x .DS_Store -ruN binutils-2.46.1/opcodes/mips-opc.c binutils-2.46.1-kos/opcodes/mips-opc.c
+--- binutils-2.46.1/opcodes/mips-opc.c	2026-07-06 18:45:01
++++ binutils-2.46.1-kos/opcodes/mips-opc.c	2026-07-06 18:45:40
+@@ -1950,6 +1950,7 @@
+ {"sqc2",		"+7,o(b)",	0xf8000000, 0xfc000000,	RD_3|RD_C2|SM,		0,		EE,		0,	0 },
+ {"sqc2",		"+7,A(b)",	0,    (int) M_SQC2_AB,	INSN_MACRO,		0,		EE,		0,	0 },
+ {"sqrt.d",		"D,S",		0x46200004, 0xffff003f, WR_1|RD_2|FP_D,		0,		I2,		0,	SF },
++{"sqrt.s",		"D,T",      0x46000004, 0xffe0f83f, WR_1|RD_2|FP_S,		0,		EE,		0,	0 },
+ {"sqrt.s",		"D,S",		0x46000004, 0xffff003f, WR_1|RD_2|FP_S,		0,		I2,		0,	0 },
+ {"sqrt.ps",		"D,S",		0x46c00004, 0xffff003f, WR_1|RD_2|FP_D,		0,		SB1,		0,	0 },
+ {"srav",		"d,t,s",	0x00000007, 0xfc0007ff,	WR_1|RD_2|RD_3,		0,		I1,		0,	0 },

--- a/utils/kos-chain/patches/targets/binutils-2.47-kos.diff
+++ b/utils/kos-chain/patches/targets/binutils-2.47-kos.diff
@@ -1,9 +1,12 @@
-Emotion Engine (EE, mips64r5900el-ps2-elf) tweaks for binutils 2.47.
+PlayStation 2 binutils 2.47 support: Emotion Engine tweaks and the DVP
+(VIF/VU) assembler target.
+
+== Emotion Engine (EE, mips64r5900el-ps2-elf) ==
 
 Upstream 2.47 already provides the R5900 core (gas -march=r5900, the MMI and
 VU0 macro-mode opcodes, the elf32lr5900 linker emulations, the mips*-ps2-elf*
-target, and all MIPS relocations incl. TLS). This patch adds only three small
-EE-specific fixes on top:
+target, and all MIPS relocations incl. TLS). Three small EE-specific fixes are
+added on top:
 
   * opcodes/mips-opc.c: an EE-form "sqrt.s D,T" whose source operand is read
     from the ft field (the generic "sqrt.s D,S" encodes it wrong for R5900).
@@ -11,6 +14,27 @@ EE-specific fixes on top:
     the R5900 linker emulations can still generate shared-library link scripts.
   * configure{,.ac}: an empty mips64r5900el-ps2-elf case ahead of the mips*
     catch-all so gprof is NOT disabled for the EE target.
+
+== DVP (VIF/VU) ==
+
+Adds a `dvp-elf' target: a GAS backend for the VU microinstruction set and the
+VIF/DMA/GIF container directives, the opcode tables behind it, and the BFD
+architecture and ELF32 backend its objects need.  This is the clean-room
+"dvp-as" assembler; it contains no ps2sdk- or Cygnus/ps2dev-derived code.
+
+Most of the DVP change is new files.  The registration edits that reach shared
+files add the architecture to `bfd/archures.c' and `bfd/targets.c' inside their
+not-SELECT_ARCHITECTURES and not-SELECT_VECS branches, so a target that does
+not select dvp-elf unpacks the sources but compiles none of them.  The
+`gas/read.c' and `gas/depend.c' hooks are `#ifdef'-guarded on md_* macros and
+are inert for every other target.
+
+Licence: GPLv3-or-later, matching the Binutils tree it patches.
+
+NOTE: `config.sub' is patched here so that `configure --target=dvp-elf' is
+accepted.  Under kos-chain the patched copy is kept rather than replaced by
+kos-chain's own: scripts/patch.mk skips the replacement for a file an applied
+patch touches.
 
 diff -ruN pristine/configure ee/configure
 --- pristine/configure	2026-06-07 16:00:00
@@ -65,3 +89,12820 @@ diff -ruN pristine/opcodes/mips-opc.c ee/opcodes/mips-opc.c
  {"sqrt.s",		"D,S",		0x46000004, 0xffff003f, WR_1|RD_2|FP_S,		0,		I2,		0,	0 },
  {"sqrt.ps",		"D,S",		0x46c00004, 0xffff003f, WR_1|RD_2|FP_D,		0,		SB1,		0,	0 },
  {"srav",		"d,t,s",	0x00000007, 0xfc0007ff,	WR_1|RD_2|RD_3,		0,		I1,		0,	0 },
+--- a/bfd/Makefile.am
++++ b/bfd/Makefile.am
+@@ -139,6 +139,7 @@
+ 	cpu-microblaze.lo \
+ 	cpu-mips.lo \
+ 	cpu-mmix.lo \
++	cpu-dvp.lo \
+ 	cpu-moxie.lo \
+ 	cpu-msp430.lo \
+ 	cpu-mt.lo \
+@@ -222,6 +223,7 @@
+ 	cpu-microblaze.c \
+ 	cpu-mips.c \
+ 	cpu-mmix.c \
++	cpu-dvp.c \
+ 	cpu-moxie.c \
+ 	cpu-msp430.c \
+ 	cpu-mt.c \
+@@ -327,6 +329,7 @@
+ 	elf32-mep.lo \
+ 	elf32-metag.lo \
+ 	elf32-microblaze.lo \
++	elf32-dvp.lo \
+ 	elf32-moxie.lo \
+ 	elf32-msp430.lo \
+ 	elf32-mt.lo \
+@@ -461,6 +464,7 @@
+ 	elf32-mep.c \
+ 	elf32-metag.c \
+ 	elf32-microblaze.c \
++	elf32-dvp.c \
+ 	elf32-moxie.c \
+ 	elf32-msp430.c \
+ 	elf32-mt.c \
+--- a/bfd/Makefile.in
++++ b/bfd/Makefile.in
+@@ -607,6 +607,7 @@
+ 	cpu-microblaze.lo \
+ 	cpu-mips.lo \
+ 	cpu-mmix.lo \
++	cpu-dvp.lo \
+ 	cpu-moxie.lo \
+ 	cpu-msp430.lo \
+ 	cpu-mt.lo \
+@@ -690,6 +691,7 @@
+ 	cpu-microblaze.c \
+ 	cpu-mips.c \
+ 	cpu-mmix.c \
++	cpu-dvp.c \
+ 	cpu-moxie.c \
+ 	cpu-msp430.c \
+ 	cpu-mt.c \
+@@ -796,6 +798,7 @@
+ 	elf32-mep.lo \
+ 	elf32-metag.lo \
+ 	elf32-microblaze.lo \
++	elf32-dvp.lo \
+ 	elf32-moxie.lo \
+ 	elf32-msp430.lo \
+ 	elf32-mt.lo \
+@@ -930,6 +933,7 @@
+ 	elf32-mep.c \
+ 	elf32-metag.c \
+ 	elf32-microblaze.c \
++	elf32-dvp.c \
+ 	elf32-moxie.c \
+ 	elf32-msp430.c \
+ 	elf32-mt.c \
+--- a/bfd/archures.c
++++ b/bfd/archures.c
+@@ -384,6 +384,8 @@
+ .#define bfd_mach_frvtomcat	499	{* fr500 prototype.  *}
+ .#define bfd_mach_fr500		500
+ .#define bfd_mach_fr550		550
++.  bfd_arch_dvp,       {* PlayStation 2 DVP (VIF/VU).  *}
++.#define bfd_mach_dvp		1
+ .  bfd_arch_moxie,     {* The moxie processor.  *}
+ .#define bfd_mach_moxie		1
+ .  bfd_arch_ft32,      {* The ft32 processor.  *}
+@@ -671,6 +673,7 @@
+ extern const bfd_arch_info_type bfd_mmix_arch;
+ extern const bfd_arch_info_type bfd_mn10200_arch;
+ extern const bfd_arch_info_type bfd_mn10300_arch;
++extern const bfd_arch_info_type bfd_dvp_arch;
+ extern const bfd_arch_info_type bfd_moxie_arch;
+ extern const bfd_arch_info_type bfd_ft32_arch;
+ extern const bfd_arch_info_type bfd_msp430_arch;
+@@ -759,6 +762,7 @@
+     &bfd_mmix_arch,
+     &bfd_mn10200_arch,
+     &bfd_mn10300_arch,
++    &bfd_dvp_arch,
+     &bfd_moxie_arch,
+     &bfd_ft32_arch,
+     &bfd_msp430_arch,
+--- a/bfd/bfd-in2.h
++++ b/bfd/bfd-in2.h
+@@ -1613,6 +1613,8 @@
+ #define bfd_mach_frvtomcat     499     /* fr500 prototype.  */
+ #define bfd_mach_fr500         500
+ #define bfd_mach_fr550         550
++  bfd_arch_dvp,       /* PlayStation 2 DVP (VIF/VU).  */
++#define bfd_mach_dvp           1
+   bfd_arch_moxie,     /* The moxie processor.  */
+ #define bfd_mach_moxie         1
+   bfd_arch_ft32,      /* The ft32 processor.  */
+@@ -3725,6 +3727,9 @@
+   BFD_RELOC_MIPS_EH,
+ 
+   /* Moxie ELF relocations.  */
++  BFD_RELOC_DVP_11_PCREL,
++  BFD_RELOC_DVP_15,
++  BFD_RELOC_DVP_DMA_ADDR,
+   BFD_RELOC_MOXIE_10_PCREL,
+ 
+   /* FT32 ELF relocations.  */
+--- a/bfd/config.bfd
++++ b/bfd/config.bfd
+@@ -533,6 +533,10 @@
+     targ_selvecs=frv_elf32_vec
+     ;;
+ 
++  dvp-*-elf | dvp-*-*)
++    targ_defvec=dvp_elf32_vec
++    ;;
++
+   moxie-*-elf | moxie-*-rtems* | moxie-*-uclinux)
+     targ_defvec=moxie_elf32_be_vec
+     targ_selvecs=moxie_elf32_le_vec
+--- a/bfd/configure
++++ b/bfd/configure
+@@ -15992,6 +15992,7 @@
+     mmix_mmo_vec)			 tb="$tb mmo.lo" target_size=64 ;;
+     mn10200_elf32_vec)		 tb="$tb elf-m10200.lo elf32.lo $elf" ;;
+     mn10300_elf32_vec)		 tb="$tb elf-m10300.lo elf32.lo $elf" ;;
++    dvp_elf32_vec)		 tb="$tb elf32-dvp.lo elf32.lo $elf" ;;
+     moxie_elf32_be_vec)		 tb="$tb elf32-moxie.lo elf32.lo $elf" ;;
+     moxie_elf32_le_vec)		 tb="$tb elf32-moxie.lo elf32.lo $elf" ;;
+     msp430_elf32_vec)		 tb="$tb elf32-msp430.lo elf32.lo $elf" ;;
+--- a/bfd/configure.ac
++++ b/bfd/configure.ac
+@@ -533,6 +533,7 @@
+     mmix_mmo_vec)			 tb="$tb mmo.lo" target_size=64 ;;
+     mn10200_elf32_vec)		 tb="$tb elf-m10200.lo elf32.lo $elf" ;;
+     mn10300_elf32_vec)		 tb="$tb elf-m10300.lo elf32.lo $elf" ;;
++    dvp_elf32_vec)		 tb="$tb elf32-dvp.lo elf32.lo $elf" ;;
+     moxie_elf32_be_vec)		 tb="$tb elf32-moxie.lo elf32.lo $elf" ;;
+     moxie_elf32_le_vec)		 tb="$tb elf32-moxie.lo elf32.lo $elf" ;;
+     msp430_elf32_vec)		 tb="$tb elf32-msp430.lo elf32.lo $elf" ;;
+--- /dev/null
++++ b/bfd/cpu-dvp.c
+@@ -0,0 +1,43 @@
++/* BFD architecture support for the PlayStation 2 DVP (VIF/VU) target.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of BFD, the Binary File Descriptor library.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++#include "sysdep.h"
++#include "bfd.h"
++#include "libbfd.h"
++
++const bfd_arch_info_type bfd_dvp_arch =
++{
++  32,				/* bits per word */
++  32,				/* bits per address */
++  8,				/* bits per byte */
++  bfd_arch_dvp,
++  bfd_mach_dvp,
++  "dvp",
++  "dvp",
++  3,				/* section alignment power: a VU
++				   microinstruction is eight bytes wide */
++  true,				/* the default machine for this architecture */
++  bfd_default_compatible,
++  bfd_default_scan,
++  bfd_arch_default_fill,
++  NULL,
++  0
++};
+--- /dev/null
++++ b/bfd/elf32-dvp.c
+@@ -0,0 +1,1240 @@
++/* DVP-specific support for 32-bit ELF.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of BFD, the Binary File Descriptor library.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++/* This target exists so an assembler can write DVP objects, and so that a
++   linker can combine them and resolve the DVP relocations.  Relocation
++   processing goes through BFD's generic machinery (bfd_perform_relocation),
++   with a per-relocation function where the field is not a single contiguous
++   run of bits or where a silently truncating result would be wrong.  */
++
++#include "sysdep.h"
++#include "bfd.h"
++#include "libbfd.h"
++#include "elf-bfd.h"
++#include "elf/dvp.h"
++/* The MIPS relocation numbers, for the names `.reloc' accepts.
++   This target is EM_MIPS and shares their numbering; nothing else about the
++   MIPS back end is used.  */
++#include "elf/mips.h"
++
++/* --- the split 15-bit immediate ------------------------------------------ */
++
++/* The `iaddiu'/`isubiu' immediate is not a contiguous field: value bits 10..0
++   sit in word bits 10..0 and value bits 14..11 sit in word bits 24..21.  BFD's
++   generic insertion cannot express that, so the two helpers below are the only
++   place the layout is applied.  Masks and shifts only; no bitfields.  */
++
++static bfd_vma
++dvp_imm15_extract (bfd_vma word)
++{
++  return ((word & DVP_IMM15_LO_MASK)
++	  | (((word & DVP_IMM15_HI_MASK) >> DVP_IMM15_HI_SHIFT)
++	     << DVP_IMM15_LO_WIDTH));
++}
++
++static bfd_vma
++dvp_imm15_insert (bfd_vma word, bfd_vma value)
++{
++  word &= ~(bfd_vma) DVP_IMM15_MASK;
++  word |= value & DVP_IMM15_LO_MASK;
++  word |= (((value >> DVP_IMM15_LO_WIDTH) << DVP_IMM15_HI_SHIFT)
++	   & DVP_IMM15_HI_MASK);
++  return word;
++}
++
++/* --- relocation functions ----------------------------------------------- */
++
++/* Shared preamble.  Returns true when the caller should carry on and modify
++   the section contents, and false when *STATUS is the whole answer.  The early
++   exit for relocatable output is the rule stock BFD applies in
++   bfd_elf_generic_reloc.  */
++
++static bool
++dvp_reloc_prologue (bfd *abfd, arelent *reloc_entry, asymbol *symbol,
++		    asection *input_section, bfd *output_bfd,
++		    bfd_size_type *octets, bfd_vma *relocation,
++		    bfd_reloc_status_type *status)
++{
++  reloc_howto_type *howto = reloc_entry->howto;
++
++  if (output_bfd != NULL
++      && (symbol->flags & BSF_SECTION_SYM) == 0
++      && (!howto->partial_inplace || reloc_entry->addend == 0))
++    {
++      reloc_entry->address += input_section->output_offset;
++      *status = bfd_reloc_ok;
++      return false;
++    }
++
++  if (bfd_is_und_section (symbol->section)
++      && (symbol->flags & BSF_WEAK) == 0
++      && output_bfd == NULL)
++    {
++      *status = bfd_reloc_undefined;
++      return false;
++    }
++
++  *octets = reloc_entry->address * bfd_octets_per_byte (abfd, input_section);
++  if (!bfd_reloc_offset_in_range (howto, abfd, input_section, *octets))
++    {
++      *status = bfd_reloc_outofrange;
++      return false;
++    }
++
++  *relocation = symbol->value;
++  if (symbol->section->output_section != NULL)
++    *relocation += (symbol->section->output_section->vma
++		    + symbol->section->output_offset);
++  *relocation += reloc_entry->addend;
++  return true;
++}
++
++/* --- R_DVP_11_PCREL -------------------------------------------------------
++
++   The field is a signed count of microinstructions, biased by the eight bytes
++   between the branch and the instruction it counts from.  What the assembler
++   put there depends on whether *that assembly* could see the target:
++
++     it could:     field = (S + A - P - 8) / 8, with S and P both offsets in
++		   their own input sections;
++     it could not: field = (A - 8) / 8, because neither position was known.
++
++   A final link adds the *change* in the two positions rather than the
++   displacement, so it must know which form the field is in -- and that cannot
++   be decided by who owns the symbol's section now, because after `ld -r' a name
++   the original assembly left to the link is indistinguishable by ownership from
++   one it defined.  Instead `ld -r' re-expresses an unknown target it has
++   resolved in the merged object's own coordinates, so both routes produce the
++   same field.
++
++   A target that is not a whole number of microinstructions away is reported
++   rather than shifted away, and one too far to express overflows.  */
++
++/* Did the object being relocated already account for this symbol's position?
++   That is exactly "the section defining it belongs to the same object as the
++   section being relocated".  A name resolved from another object, one defined
++   with `--defsym', an absolute symbol and a common one were all left to the
++   link, however definite they look by now.  */
++
++static bool
++dvp_branch_target_was_known (asymbol *symbol, asection *input_section)
++{
++  return (symbol->section != NULL
++	  && symbol->section->owner != NULL
++	  && symbol->section->owner == input_section->owner
++	  && !bfd_is_und_section (symbol->section)
++	  && !bfd_is_com_section (symbol->section)
++	  && !bfd_is_abs_section (symbol->section));
++}
++
++/* And will the *output* of this relocatable link account for it?  It will if
++   the symbol is defined and its section lands in that output -- which is the
++   same question the test above will ask of the merged object, asked one link
++   earlier.  */
++
++static bool
++dvp_branch_target_will_be_known (asymbol *symbol)
++{
++  return (symbol->section != NULL
++	  && !bfd_is_und_section (symbol->section)
++	  && !bfd_is_com_section (symbol->section)
++	  && !bfd_is_abs_section (symbol->section)
++	  && symbol->section->output_section != NULL);
++}
++
++/* Add DELTA bytes to the displacement in the field at OCTETS, checking that it
++   is a whole number of microinstructions and that the result still fits.  */
++
++static bfd_reloc_status_type
++dvp_branch_add_bytes (bfd *abfd, void *data, bfd_size_type octets,
++		      bfd_signed_vma delta, char **error_message)
++{
++  bfd_vma word;
++  bfd_signed_vma disp;
++
++  if (delta % DVP_MICROINSN_BYTES != 0)
++    {
++      *error_message = (char *)
++	_("branch target is not a whole number of VU microinstructions away");
++      return bfd_reloc_dangerous;
++    }
++
++  word = bfd_get_32 (abfd, (bfd_byte *) data + octets);
++
++  disp = (bfd_signed_vma) (word & DVP_DISP11_MASK);
++  if (disp & ((bfd_signed_vma) 1 << (DVP_DISP11_WIDTH - 1)))
++    disp -= (bfd_signed_vma) 1 << DVP_DISP11_WIDTH;
++  disp += delta / DVP_MICROINSN_BYTES;
++
++  if (disp < -((bfd_signed_vma) 1 << (DVP_DISP11_WIDTH - 1))
++      || disp >= ((bfd_signed_vma) 1 << (DVP_DISP11_WIDTH - 1)))
++    return bfd_reloc_overflow;
++
++  word &= ~(bfd_vma) DVP_DISP11_MASK;
++  word |= (bfd_vma) disp & DVP_DISP11_MASK;
++  bfd_put_32 (abfd, word, (bfd_byte *) data + octets);
++  return bfd_reloc_ok;
++}
++
++static bfd_reloc_status_type
++dvp_elf_branch_reloc (bfd *abfd, arelent *reloc_entry, asymbol *symbol,
++		      void *data, asection *input_section, bfd *output_bfd,
++		      char **error_message)
++{
++  reloc_howto_type *howto = reloc_entry->howto;
++  bfd_reloc_status_type status;
++  bfd_size_type octets;
++  bfd_vma relocation;
++  bfd_signed_vma before, after;
++
++  if (output_bfd != NULL)
++    {
++      /* A relocatable link.  The relocation stays; what changes is which
++	 coordinates the field is expressed in.  Nothing is resolved here -- the
++	 symbol's own address is still the next link's business -- so only the
++	 positions the merge itself moves are taken account of.  */
++      octets = reloc_entry->address * bfd_octets_per_byte (abfd, input_section);
++      if (!bfd_reloc_offset_in_range (howto, abfd, input_section, octets))
++	return bfd_reloc_outofrange;
++
++      before = 0;
++      if (dvp_branch_target_was_known (symbol, input_section))
++	before = ((bfd_signed_vma) symbol->value
++		  - (bfd_signed_vma) reloc_entry->address);
++
++      after = 0;
++      if (dvp_branch_target_will_be_known (symbol))
++	after = ((bfd_signed_vma) (symbol->value
++				   + symbol->section->output_offset)
++		 - (bfd_signed_vma) (reloc_entry->address
++				     + input_section->output_offset));
++
++      status = dvp_branch_add_bytes (abfd, data, octets, after - before,
++				     error_message);
++      if (status != bfd_reloc_ok)
++	return status;
++      reloc_entry->address += input_section->output_offset;
++      return bfd_reloc_ok;
++    }
++
++  if (!dvp_reloc_prologue (abfd, reloc_entry, symbol, input_section,
++			   output_bfd, &octets, &relocation, &status))
++    return status;
++
++  relocation -= (input_section->output_section->vma
++		 + input_section->output_offset + reloc_entry->address);
++
++  /* Take back out what the assembler had already accounted for.  */
++  if (dvp_branch_target_was_known (symbol, input_section))
++    relocation -= ((bfd_signed_vma) symbol->value
++		   - (bfd_signed_vma) reloc_entry->address);
++
++  return dvp_branch_add_bytes (abfd, data, octets, (bfd_signed_vma) relocation,
++			       error_message);
++}
++
++/* R_DVP_15.  Unsigned, split across two runs of bits, and scaled: the field
++   holds eight-byte units, so the in-field addend is multiplied back up before
++   the symbol's address is added and the sum is divided again.  A sum that is not
++   a whole number of those units is reported rather than rounded down.  */
++
++static bfd_reloc_status_type
++dvp_elf_imm15_reloc (bfd *abfd, arelent *reloc_entry, asymbol *symbol,
++		     void *data, asection *input_section, bfd *output_bfd,
++		     char **error_message)
++{
++  bfd_reloc_status_type status;
++  bfd_size_type octets;
++  bfd_vma relocation, word, value;
++
++  if (!dvp_reloc_prologue (abfd, reloc_entry, symbol, input_section,
++			   output_bfd, &octets, &relocation, &status))
++    return status;
++
++  word = bfd_get_32 (abfd, (bfd_byte *) data + octets);
++  value = relocation + (dvp_imm15_extract (word) << DVP_IMM15_RELOC_SHIFT);
++  if ((value & (DVP_IMM15_RELOC_SCALE - 1)) != 0)
++    {
++      *error_message = (char *)
++	_("relocated immediate is not a multiple of eight bytes");
++      return bfd_reloc_dangerous;
++    }
++  value >>= DVP_IMM15_RELOC_SHIFT;
++  if (value > DVP_IMM15_MAX)
++    return bfd_reloc_overflow;
++
++  bfd_put_32 (abfd, dvp_imm15_insert (word, value),
++	      (bfd_byte *) data + octets);
++
++  if (output_bfd != NULL)
++    reloc_entry->address += input_section->output_offset;
++  return bfd_reloc_ok;
++}
++
++/* R_DVP_DMA_ADDR.  A DMA tag addresses quadwords, so the field does not encode
++   the low DVP_DMAADDR_LSB bits of the value.  An address that does not fit is
++   reported instead of being rounded down to the previous quadword.  */
++
++static bfd_reloc_status_type
++dvp_elf_dmaaddr_reloc (bfd *abfd, arelent *reloc_entry, asymbol *symbol,
++		       void *data, asection *input_section, bfd *output_bfd,
++		       char **error_message)
++{
++  bfd_reloc_status_type status;
++  bfd_size_type octets;
++  bfd_vma relocation, word, value;
++
++  if (!dvp_reloc_prologue (abfd, reloc_entry, symbol, input_section,
++			   output_bfd, &octets, &relocation, &status))
++    return status;
++
++  word = bfd_get_32 (abfd, (bfd_byte *) data + octets);
++  value = relocation + (word & DVP_DMAADDR_MASK);
++
++  if ((value & (((bfd_vma) 1 << DVP_DMAADDR_LSB) - 1)) != 0)
++    {
++      *error_message = (char *)
++	_("DMA tag address is not quadword aligned");
++      return bfd_reloc_dangerous;
++    }
++  if ((value & ~(bfd_vma) DVP_DMAADDR_MASK) != 0)
++    return bfd_reloc_overflow;
++
++  word &= ~(bfd_vma) DVP_DMAADDR_MASK;
++  word |= value & DVP_DMAADDR_MASK;
++  bfd_put_32 (abfd, word, (bfd_byte *) data + octets);
++
++  if (output_bfd != NULL)
++    reloc_entry->address += input_section->output_offset;
++  return bfd_reloc_ok;
++}
++
++/* The relocations a DVP object can carry.  All are REL form: the addend lives
++   in the instruction or data word, not in the relocation entry, which is why
++   every entry is partial_inplace with src_mask equal to dst_mask.  Field
++   layouts are defined once, in include/elf/dvp.h.  */
++
++static reloc_howto_type dvp_elf_howto_table[] =
++{
++  HOWTO (R_DVP_NONE, 0, 0, 0, false, 0, complain_overflow_dont,
++	 bfd_elf_generic_reloc, "R_DVP_NONE", false, 0, 0, false),
++
++  HOWTO (R_DVP_32,
++	 0,			/* rightshift */
++	 4,			/* size */
++	 32,			/* bitsize */
++	 false,			/* pc_relative */
++	 0,			/* bitpos */
++	 complain_overflow_dont, /* a 32-bit word holds any 32-bit value */
++	 bfd_elf_generic_reloc,
++	 "R_DVP_32",
++	 true,			/* partial_inplace: addend is in the word */
++	 0xffffffff,		/* src_mask */
++	 0xffffffff,		/* dst_mask */
++	 false),		/* pcrel_offset */
++
++  HOWTO (R_DVP_11_PCREL,
++	 3,			/* rightshift: the displacement counts
++				   eight-byte microinstructions */
++	 4,			/* size */
++	 11,			/* bitsize */
++	 true,			/* pc_relative */
++	 0,			/* bitpos */
++	 complain_overflow_signed,
++	 dvp_elf_branch_reloc,
++	 "R_DVP_11_PCREL",
++	 true,			/* partial_inplace */
++	 DVP_DISP11_MASK,	/* src_mask */
++	 DVP_DISP11_MASK,	/* dst_mask */
++	 true),			/* pcrel_offset */
++
++  HOWTO (R_DVP_DMA_ADDR,
++	 0,			/* rightshift: the field sits at its own bit
++				   position, low bits and all */
++	 4,			/* size */
++	 31,			/* bitsize */
++	 false,			/* pc_relative */
++	 0,			/* bitpos */
++	 complain_overflow_dont, /* the function checks alignment and range */
++	 dvp_elf_dmaaddr_reloc,
++	 "R_DVP_DMA_ADDR",
++	 true,			/* partial_inplace */
++	 DVP_DMAADDR_MASK,	/* src_mask */
++	 DVP_DMAADDR_MASK,	/* dst_mask */
++	 false),		/* pcrel_offset */
++
++  HOWTO (R_DVP_15,
++	 DVP_IMM15_RELOC_SHIFT,	/* rightshift: the field holds eight-byte
++				   units, not bytes */
++	 4, 15, false, 0,
++	 complain_overflow_unsigned,
++	 dvp_elf_imm15_reloc,
++	 "R_DVP_15",
++	 true,
++	 DVP_IMM15_MASK,
++	 DVP_IMM15_MASK,
++	 false),
++};
++
++/* --- the addend forms the MIPS-compatible relocations take -----------------
++
++   `.reloc NAME,SYM+A' hands A to the named relocation's own description, and
++   nine of those descriptions do not take it as written.  The forms below are
++   the ones the pristine MIPS back end states -- `mips_elf_high',
++   `mips_elf_higher' and `mips_elf_highest' in elfxx-mips.c, and the narrowing a
++   32-bit object applies to a 64-bit addend.
++
++   Each adjusts the addend and hands the installation back to BFD by returning
++   `bfd_reloc_continue', so the shift, the mask and the overflow check stay the
++   howto's own and are stated in exactly one place.  */
++
++/* A sixteen-bit high half, taken so that adding the matching signed low half
++   back gives the value: R_MIPS_HI16 and the five relocations shaped like it.  */
++
++static bfd_reloc_status_type
++dvp_mips_hi16_addend (bfd *abfd ATTRIBUTE_UNUSED, arelent *reloc_entry,
++		      asymbol *symbol ATTRIBUTE_UNUSED,
++		      void *data ATTRIBUTE_UNUSED,
++		      asection *input_section ATTRIBUTE_UNUSED,
++		      bfd *output_bfd ATTRIBUTE_UNUSED,
++		      char **error_message ATTRIBUTE_UNUSED)
++{
++  reloc_entry->addend += (bfd_vma) 0x8000;
++  return bfd_reloc_continue;
++}
++
++/* The same idea one halfword up: R_MIPS_HIGHER.  */
++
++static bfd_reloc_status_type
++dvp_mips_higher_addend (bfd *abfd ATTRIBUTE_UNUSED, arelent *reloc_entry,
++			asymbol *symbol ATTRIBUTE_UNUSED,
++			void *data ATTRIBUTE_UNUSED,
++			asection *input_section ATTRIBUTE_UNUSED,
++			bfd *output_bfd ATTRIBUTE_UNUSED,
++			char **error_message ATTRIBUTE_UNUSED)
++{
++  reloc_entry->addend += (bfd_vma) 0x80008000;
++  return bfd_reloc_continue;
++}
++
++/* And one more: R_MIPS_HIGHEST.  */
++
++static bfd_reloc_status_type
++dvp_mips_highest_addend (bfd *abfd ATTRIBUTE_UNUSED, arelent *reloc_entry,
++			 asymbol *symbol ATTRIBUTE_UNUSED,
++			 void *data ATTRIBUTE_UNUSED,
++			 asection *input_section ATTRIBUTE_UNUSED,
++			 bfd *output_bfd ATTRIBUTE_UNUSED,
++			 char **error_message ATTRIBUTE_UNUSED)
++{
++  reloc_entry->addend += (bfd_vma) 0x800080008000ULL;
++  return bfd_reloc_continue;
++}
++
++/* R_MIPS_64 stores eight bytes, and the addend that reaches them is a signed
++   32-bit value widened back out: `ext+0x80000000' stores
++   0xffffffff80000000, and `ext+0x100000000' stores nothing at all.  */
++
++static bfd_reloc_status_type
++dvp_mips_sign32_addend (bfd *abfd ATTRIBUTE_UNUSED, arelent *reloc_entry,
++			asymbol *symbol ATTRIBUTE_UNUSED,
++			void *data ATTRIBUTE_UNUSED,
++			asection *input_section ATTRIBUTE_UNUSED,
++			bfd *output_bfd ATTRIBUTE_UNUSED,
++			char **error_message ATTRIBUTE_UNUSED)
++{
++  reloc_entry->addend = (bfd_vma) (bfd_signed_vma)
++			(int32_t) (uint32_t) reloc_entry->addend;
++  return bfd_reloc_continue;
++}
++
++/* --- what a link may do with a MIPS-compatible relocation ----------------
++
++   These entries exist so that `.reloc NAME' produces the object the reference
++   produces.  Handing every one to BFD's generic installer -- symbol plus addend
++   into the field the howto describes -- is the ABI's arithmetic for a plain
++   data word and wrong for most of the rest, in a way that shows up as a program
++   that runs wrong rather than as a failure.  Five classes cannot be resolved by
++   adding a symbol to an addend:
++
++     * A GOT- or GP-relative relocation is measured from a global offset table
++       and a `_gp' that this link does not build at all.
++     * A TLS relocation names a thread-local block that only a dynamic loader
++       can place.
++     * R_MIPS_REL32, COPY, GLOB_DAT and JUMP_SLOT are entries a dynamic linker
++       consumes; a static link has nothing to write.
++     * HI16/LO16 and the relocations shaped like them carry half a value each
++       and are only defined as a pair, so the half a REL field holds does not
++       determine what either should become.
++     * R_MIPS_26, the scaled PC-relative branches, the shift fields and
++       R_MIPS_SCN_DISP each have an ABI form of their own -- a region taken
++       from the program counter, an addend pre-shifted, a field added rather
++       than replaced -- that this target does not implement.
++
++   Each is refused when a *final* link asks for it, by name and with the reason.
++   Nothing the assembler writes changes: `bfd_install_relocation' passes the
++   output BFD where a final link passes NULL, as does a relocatable link, so an
++   object emits the bytes it did and `ld -r' carries the relocation through.  */
++
++enum dvp_mips_link_kind
++{
++  DVP_MIPS_LINK_OK,		/* generic symbol-plus-addend is the ABI form */
++  DVP_MIPS_LINK_SUB,		/* symbol *minus* addend */
++  DVP_MIPS_LINK_REFUSE		/* not resolvable here; say so */
++};
++
++struct dvp_mips_link_rule
++{
++  int kind;
++  /* The addend adjustment this entry's emission depends on, if any.  It runs
++     wherever the old table ran it, so an object's bytes are unchanged.  */
++  bfd_reloc_status_type (*addend) (bfd *, arelent *, asymbol *, void *,
++				   asection *, bfd *, char **);
++  /* Why a final link will not resolve it, for DVP_MIPS_LINK_REFUSE.  */
++  const char *why;
++};
++
++static bfd_reloc_status_type
++dvp_mips_reloc (bfd *, arelent *, asymbol *, void *, asection *, bfd *,
++		char **);
++
++/* --- BEGIN GENERATED: MIPS-compatible relocations -----------------------
++
++   Generated from the pristine Binutils MIPS back end; do not edit by hand.
++
++   The DVP language produces none of these.  They exist because `.reloc NAME'
++   is accepted for every relocation the MIPS ELF back end knows, and a source
++   that writes one has to get the same entry here -- the same number, the same
++   width, the same masks.  Aliasing the names onto DVP howtos would give the
++   right number and the wrong shape, so the descriptions are lifted rather than
++   invented.  The automatic DVP relocations (120, 121 and 123) are a separate
++   table and are unaffected.  */
++static reloc_howto_type dvp_mips_howto_table[] =
++{
++  HOWTO (R_MIPS_NONE, 0, 0, 0, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_NONE", false, 0, 0, false),
++  HOWTO (R_MIPS_16, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_32, 0, 4, 32, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_32", true, 0xffffffff, 0xffffffff, false),
++  HOWTO (R_MIPS_REL32, 0, 4, 32, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_REL32", true, 0xffffffff, 0xffffffff, false),
++  HOWTO (R_MIPS_26, 2, 4, 26, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_26", true, 0x03ffffff, 0x03ffffff, false),
++  HOWTO (R_MIPS_HI16, 16, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_HI16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_LO16, 0, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_LO16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_GPREL16, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_GPREL16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_LITERAL, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_LITERAL", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_GOT16, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_GOT16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_PC16, 2, 4, 16, true, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_PC16", true, 0x0000ffff, 0x0000ffff, true),
++  HOWTO (R_MIPS_CALL16, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_CALL16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_GPREL32, 0, 4, 32, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_GPREL32", true, 0xffffffff, 0xffffffff, false),
++  HOWTO (R_MIPS_SHIFT5, 0, 4, 5, false, 6,
++	 complain_overflow_bitfield, dvp_mips_reloc,
++	 "R_MIPS_SHIFT5", true, 0x000007c0, 0x000007c0, false),
++  HOWTO (R_MIPS_SHIFT6, 0, 4, 6, false, 6,
++	 complain_overflow_bitfield, dvp_mips_reloc,
++	 "R_MIPS_SHIFT6", true, 0x000007c4, 0x000007c4, false),
++  HOWTO (R_MIPS_64, 0, 8, 64, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_64", true, ((bfd_vma) 0 - 1), ((bfd_vma) 0 - 1), false),
++  HOWTO (R_MIPS_GOT_DISP, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_GOT_DISP", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_GOT_PAGE, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_GOT_PAGE", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_GOT_OFST, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_GOT_OFST", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_GOT_HI16, 16, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_GOT_HI16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_GOT_LO16, 0, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_GOT_LO16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_SUB, 0, 8, 64, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_SUB", true, ((bfd_vma) 0 - 1), ((bfd_vma) 0 - 1), false),
++  HOWTO (R_MIPS_HIGHER, 32, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_HIGHER", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_HIGHEST, 48, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_HIGHEST", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_CALL_HI16, 16, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_CALL_HI16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_CALL_LO16, 0, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_CALL_LO16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_SCN_DISP, 0, 4, 32, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_SCN_DISP", true, 0xffffffff, 0xffffffff, false),
++  HOWTO (R_MIPS_JALR, 0, 4, 32, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_JALR", false, 0, 0x00000000, false),
++  HOWTO (R_MIPS_TLS_DTPMOD32, 0, 4, 32, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_TLS_DTPMOD32", true, 0xffffffff, 0xffffffff, false),
++  HOWTO (R_MIPS_TLS_DTPREL32, 0, 4, 32, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_TLS_DTPREL32", true, 0xffffffff, 0xffffffff, false),
++  HOWTO (R_MIPS_TLS_GD, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_TLS_GD", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_TLS_LDM, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_TLS_LDM", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_TLS_DTPREL_HI16, 16, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_TLS_DTPREL_HI16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_TLS_DTPREL_LO16, 0, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_TLS_DTPREL_LO16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_TLS_GOTTPREL, 0, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_TLS_GOTTPREL", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_TLS_TPREL32, 0, 4, 32, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_TLS_TPREL32", true, 0xffffffff, 0xffffffff, false),
++  HOWTO (R_MIPS_TLS_TPREL_HI16, 16, 4, 16, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_TLS_TPREL_HI16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_TLS_TPREL_LO16, 0, 4, 16, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_TLS_TPREL_LO16", true, 0x0000ffff, 0x0000ffff, false),
++  HOWTO (R_MIPS_GLOB_DAT, 0, 4, 32, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_GLOB_DAT", false, 0, 0xffffffff, false),
++  HOWTO (R_MIPS_PC21_S2, 2, 4, 21, true, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_PC21_S2", true, 0x001fffff, 0x001fffff, true),
++  HOWTO (R_MIPS_PC26_S2, 2, 4, 26, true, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_PC26_S2", true, 0x03ffffff, 0x03ffffff, true),
++  HOWTO (R_MIPS_PC18_S3, 3, 4, 18, true, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_PC18_S3", true, 0x0003ffff, 0x0003ffff, true),
++  HOWTO (R_MIPS_PC19_S2, 2, 4, 19, true, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_PC19_S2", true, 0x0007ffff, 0x0007ffff, true),
++  HOWTO (R_MIPS_PCHI16, 16, 4, 16, true, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_PCHI16", true, 0x0000ffff, 0x0000ffff, true),
++  HOWTO (R_MIPS_PCLO16, 0, 4, 16, true, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_PCLO16", true, 0x0000ffff, 0x0000ffff, true),
++  HOWTO (R_MIPS_COPY, 0, 0, 0, false, 0,
++	 complain_overflow_bitfield, dvp_mips_reloc,
++	 "R_MIPS_COPY", false, 0, 0x0, false),
++  HOWTO (R_MIPS_JUMP_SLOT, 0, 4, 32, false, 0,
++	 complain_overflow_bitfield, dvp_mips_reloc,
++	 "R_MIPS_JUMP_SLOT", false, 0, 0x0, false),
++  HOWTO (R_MIPS_PC32, 0, 4, 32, true, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_PC32", true, 0xffffffff, 0xffffffff, true),
++  HOWTO (R_MIPS_EH, 0, 4, 32, false, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_EH", true, 0xffffffff, 0xffffffff, false),
++  HOWTO (R_MIPS_GNU_REL16_S2, 2, 4, 16, true, 0,
++	 complain_overflow_signed, dvp_mips_reloc,
++	 "R_MIPS_GNU_REL16_S2", true, 0xffff, 0xffff, true),
++  HOWTO (R_MIPS_GNU_VTINHERIT, 0, 4, 0, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_GNU_VTINHERIT", false, 0, 0, false),
++  HOWTO (R_MIPS_GNU_VTENTRY, 0, 4, 0, false, 0,
++	 complain_overflow_dont, dvp_mips_reloc,
++	 "R_MIPS_GNU_VTENTRY", false, 0, 0, false),
++};
++
++/* The number each name must carry, measured against the reference
++   rather than taken from a header, and checked at first use.  */
++static const unsigned int dvp_mips_howto_numbers[] =
++{
++  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 23, 24, 28, 29, 30, 31, 32, 37, 38, 39, 42, 43, 44, 45, 46, 47, 49, 50, 51, 60, 61, 62, 63, 64, 65, 126, 127, 248, 249, 250, 253, 254
++};
++
++/* The reasons a final link gives for refusing an entry, named so that
++   the table below can state each of them exactly once.  */
++#define DVP_MIPS_WHY_GOT \
++  N_("this relocation is measured from a global offset table and a _gp " \
++     "symbol, and a DVP link builds neither")
++#define DVP_MIPS_WHY_TLS \
++  N_("this relocation names a thread-local storage block, which only a " \
++     "dynamic loader can place")
++#define DVP_MIPS_WHY_DYNAMIC \
++  N_("this relocation is an entry for a dynamic linker to consume; a static " \
++     "DVP link has nothing to write into it")
++#define DVP_MIPS_WHY_PAIRING \
++  N_("this relocation carries half a value and is only defined together " \
++     "with the relocation it pairs with, which a DVP link does not pair")
++#define DVP_MIPS_WHY_FORM \
++  N_("the addressing form this relocation uses is not implemented by the " \
++     "DVP linker")
++
++/* What a final link may do with each entry, in the same order.  */
++static const struct dvp_mips_link_rule dvp_mips_link_rules[] =
++{
++  { DVP_MIPS_LINK_OK, NULL, NULL },
++  { DVP_MIPS_LINK_OK, NULL, NULL },
++  { DVP_MIPS_LINK_OK, NULL, NULL },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_DYNAMIC },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_REFUSE, dvp_mips_hi16_addend, DVP_MIPS_WHY_PAIRING },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_PAIRING },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_OK, dvp_mips_sign32_addend, NULL },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, dvp_mips_hi16_addend, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_SUB, NULL, NULL },
++  { DVP_MIPS_LINK_REFUSE, dvp_mips_higher_addend, DVP_MIPS_WHY_PAIRING },
++  { DVP_MIPS_LINK_REFUSE, dvp_mips_highest_addend, DVP_MIPS_WHY_PAIRING },
++  { DVP_MIPS_LINK_REFUSE, dvp_mips_hi16_addend, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_OK, NULL, NULL },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, dvp_mips_hi16_addend, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, dvp_mips_hi16_addend, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_TLS },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_DYNAMIC },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_REFUSE, dvp_mips_hi16_addend, DVP_MIPS_WHY_PAIRING },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_PAIRING },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_DYNAMIC },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_DYNAMIC },
++  { DVP_MIPS_LINK_OK, NULL, NULL },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_GOT },
++  { DVP_MIPS_LINK_REFUSE, NULL, DVP_MIPS_WHY_FORM },
++  { DVP_MIPS_LINK_OK, NULL, NULL },
++  { DVP_MIPS_LINK_OK, NULL, NULL },
++};
++/* --- END GENERATED: MIPS-compatible relocations --- */
++
++#define DVP_MIPS_RULE_COUNT \
++  (sizeof (dvp_mips_link_rules) / sizeof (dvp_mips_link_rules[0]))
++
++/* R_MIPS_SUB: the symbol's address *less* the addend.  The addend is in the
++   field, because this target keeps the classic REL form, so the field is read,
++   subtracted rather than added, and written back over the whole doubleword.  */
++
++static bfd_reloc_status_type
++dvp_mips_sub_reloc (bfd *abfd, arelent *reloc_entry, asymbol *symbol,
++		    void *data, asection *input_section, char **error_message)
++{
++  bfd_size_type octets;
++  bfd_vma relocation, addend;
++
++  if (bfd_is_und_section (symbol->section)
++      && (symbol->flags & BSF_WEAK) == 0)
++    return bfd_reloc_undefined;
++
++  octets = reloc_entry->address * bfd_octets_per_byte (abfd, input_section);
++  if (!bfd_reloc_offset_in_range (reloc_entry->howto, abfd, input_section,
++				  octets))
++    return bfd_reloc_outofrange;
++
++  relocation = symbol->value;
++  if (symbol->section->output_section != NULL)
++    relocation += (symbol->section->output_section->vma
++		   + symbol->section->output_offset);
++
++  addend = bfd_get_64 (abfd, (bfd_byte *) data + octets) + reloc_entry->addend;
++  bfd_put_64 (abfd, relocation - addend, (bfd_byte *) data + octets);
++  (void) error_message;
++  return bfd_reloc_ok;
++}
++
++/* The one special function every MIPS-compatible entry carries.  It finds its
++   own rule from the howto it was called through, which is a pointer into the
++   table the rules are generated beside.  */
++
++static bfd_reloc_status_type
++dvp_mips_reloc (bfd *abfd, arelent *reloc_entry, asymbol *symbol,
++		void *data, asection *input_section, bfd *output_bfd,
++		char **error_message)
++{
++  size_t i = (size_t) (reloc_entry->howto - dvp_mips_howto_table);
++  const struct dvp_mips_link_rule *rule;
++
++  if (i >= DVP_MIPS_RULE_COUNT)
++    return bfd_reloc_notsupported;	/* not one of ours after all */
++  rule = &dvp_mips_link_rules[i];
++
++  /* The addend form runs wherever it always ran, and the answer it gives --
++     `bfd_reloc_continue' -- means "carry on", so anything else it returns is
++     the whole answer.  */
++  if (rule->addend != NULL)
++    {
++      bfd_reloc_status_type s
++	= rule->addend (abfd, reloc_entry, symbol, data, input_section,
++			output_bfd, error_message);
++
++      if (s != bfd_reloc_continue)
++	return s;
++    }
++
++  /* Assembling, or a relocatable link.  `bfd_install_relocation' passes the
++     BFD being written and a relocatable link passes the output, so both are
++     told apart from a final link by this one test, and both are handed to the
++     generic entry point.  */
++  if (output_bfd != NULL)
++    return bfd_elf_generic_reloc (abfd, reloc_entry, symbol, data,
++				  input_section, output_bfd, error_message);
++
++  switch (rule->kind)
++    {
++    case DVP_MIPS_LINK_SUB:
++      return dvp_mips_sub_reloc (abfd, reloc_entry, symbol, data,
++				 input_section, error_message);
++
++    case DVP_MIPS_LINK_REFUSE:
++      /* `bfd_reloc_dangerous' rather than `bfd_reloc_notsupported', because it
++	 is the status BFD carries a message with: the linker's callback for it
++	 prints what is written here, where the other prints its own and drops
++	 this one.  */
++      *error_message = (char *) _(rule->why);
++      return bfd_reloc_dangerous;
++
++    default:
++      return bfd_reloc_continue;
++    }
++}
++
++#define DVP_MIPS_HOWTO_COUNT \
++  (sizeof (dvp_mips_howto_table) / sizeof (dvp_mips_howto_table[0]))
++
++struct dvp_reloc_map
++{
++  bfd_reloc_code_real_type bfd_val;
++  unsigned int elf_val;
++};
++
++static const struct dvp_reloc_map dvp_reloc_map[] =
++{
++  { BFD_RELOC_NONE,		R_DVP_NONE },
++  /* A generic 32-bit data reference -- what `.word symbol' asks for -- is the
++     one relocation a DVP object shares with ordinary data directives.  */
++  { BFD_RELOC_32,		R_DVP_32 },
++  { BFD_RELOC_DVP_11_PCREL,	R_DVP_11_PCREL },
++  { BFD_RELOC_DVP_DMA_ADDR,	R_DVP_DMA_ADDR },
++  { BFD_RELOC_DVP_15,		R_DVP_15 },
++};
++
++/* The generic codes that reach the MIPS-compatible table rather than this
++   target's own.  A doubleword data reference -- `.8byte symbol' -- and the two
++   vtable pseudo-operations are ordinary GAS features with no DVP relocation of
++   their own, and each takes the MIPS number.  */
++
++static const struct dvp_reloc_map dvp_mips_reloc_map[] =
++{
++  { BFD_RELOC_64,		R_MIPS_64 },
++  { BFD_RELOC_VTABLE_INHERIT,	R_MIPS_GNU_VTINHERIT },
++  { BFD_RELOC_VTABLE_ENTRY,	R_MIPS_GNU_VTENTRY },
++};
++
++static reloc_howto_type *
++dvp_reloc_type_lookup (bfd *abfd ATTRIBUTE_UNUSED,
++		       bfd_reloc_code_real_type code)
++{
++  unsigned int i, j;
++
++  for (i = 0; i < sizeof (dvp_reloc_map) / sizeof (dvp_reloc_map[0]); i++)
++    if (dvp_reloc_map[i].bfd_val == code)
++      for (j = 0; j < sizeof (dvp_elf_howto_table)
++		    / sizeof (dvp_elf_howto_table[0]); j++)
++	if (dvp_elf_howto_table[j].type == dvp_reloc_map[i].elf_val)
++	  return &dvp_elf_howto_table[j];
++
++  for (i = 0; i < sizeof (dvp_mips_reloc_map)
++		/ sizeof (dvp_mips_reloc_map[0]); i++)
++    if (dvp_mips_reloc_map[i].bfd_val == code)
++      for (j = 0; j < DVP_MIPS_HOWTO_COUNT; j++)
++	if (dvp_mips_howto_table[j].type == dvp_mips_reloc_map[i].elf_val)
++	  return &dvp_mips_howto_table[j];
++  return NULL;
++}
++
++/* The generated table has to carry the numbers that were measured, and a
++   mismatch is a generation fault rather than something to report per object --
++   so it is checked once, the first time a name is looked up.  */
++
++static void
++dvp_check_mips_howto_numbers (void)
++{
++  static int checked = 0;
++  unsigned int i;
++
++  if (checked)
++    return;
++  checked = 1;
++  if (DVP_MIPS_HOWTO_COUNT
++      != sizeof (dvp_mips_howto_numbers) / sizeof (dvp_mips_howto_numbers[0])
++      || DVP_MIPS_HOWTO_COUNT != DVP_MIPS_RULE_COUNT)
++    abort ();
++  for (i = 0; i < DVP_MIPS_HOWTO_COUNT; i++)
++    if (dvp_mips_howto_table[i].type != dvp_mips_howto_numbers[i])
++      abort ();
++}
++
++/* Whether `.reloc' will answer to this target's own relocation names.  They
++   have no spelling in the accepted language, so they are available only when
++   the assembler is asked for its extensions.  Off here, because the linker and
++   anything else opening a BFD directly gets the base language; the assembler
++   turns it on for itself.  */
++bool dvp_elf_private_reloc_names = false;
++
++static reloc_howto_type *
++dvp_reloc_name_lookup (bfd *abfd ATTRIBUTE_UNUSED, const char *r_name)
++{
++  unsigned int i;
++
++  dvp_check_mips_howto_numbers ();
++
++  if (dvp_elf_private_reloc_names)
++    for (i = 0; i < sizeof (dvp_elf_howto_table)
++		  / sizeof (dvp_elf_howto_table[0]); i++)
++      if (dvp_elf_howto_table[i].name != NULL
++	  && strcasecmp (dvp_elf_howto_table[i].name, r_name) == 0)
++	return &dvp_elf_howto_table[i];
++
++  for (i = 0; i < DVP_MIPS_HOWTO_COUNT; i++)
++    if (dvp_mips_howto_table[i].name != NULL
++	&& strcasecmp (dvp_mips_howto_table[i].name, r_name) == 0)
++      return &dvp_mips_howto_table[i];
++  return NULL;
++}
++
++static bool
++dvp_info_to_howto_rel (bfd *abfd, arelent *cache_ptr, Elf_Internal_Rela *dst)
++{
++  unsigned int r_type = ELF32_R_TYPE (dst->r_info);
++  unsigned int i;
++
++  for (i = 0; i < sizeof (dvp_elf_howto_table)
++		/ sizeof (dvp_elf_howto_table[0]); i++)
++    if (dvp_elf_howto_table[i].type == r_type)
++      {
++	cache_ptr->howto = &dvp_elf_howto_table[i];
++	return true;
++      }
++
++  /* An object may carry a relocation that only `.reloc' can have put there.
++     This target generates none of them, but it has to be able to read back what
++     it wrote.  The DVP table is searched first, so where the two agree on a
++     number -- 0 and 2 -- the DVP entry is what a reader sees, which is what it
++     saw before any of this existed.  */
++  for (i = 0; i < DVP_MIPS_HOWTO_COUNT; i++)
++    if (dvp_mips_howto_table[i].type == r_type)
++      {
++	cache_ptr->howto = &dvp_mips_howto_table[i];
++	return true;
++      }
++
++  /* xgettext:c-format */
++  _bfd_error_handler (_("%pB: unsupported relocation type %#x"), abfd, r_type);
++  bfd_set_error (bfd_error_bad_value);
++  return false;
++}
++
++/* The overlay table's entries name their overlay by an offset into the overlay
++   string table, so the table has to say which section that string table is.
++   sh_link cannot be filled in when the section is created, because a section's
++   index is not settled until the object is laid out; this hook runs once it
++   is.  */
++
++static bool
++dvp_elf_section_processing (bfd *abfd, Elf_Internal_Shdr *hdr)
++{
++  if (hdr->sh_type == SHT_DVP_OVERLAY_TABLE && hdr->sh_link == 0)
++    {
++      asection *s = bfd_get_section_by_name (abfd, DVP_OVLYSTRTAB_SECTION);
++
++      if (s != NULL && elf_section_data (s) != NULL)
++	hdr->sh_link = elf_section_data (s)->this_idx;
++    }
++  return true;
++}
++
++/* DVP objects carry a flag word the EE tool flow expects.
++
++   The assembler sets it, because which ABI the word names is a command-line
++   choice and BFD cannot see the command line.  A zero here means
++   nothing set it -- an object this library built without the assembler, and the
++   linker's own output -- and that gets the default, which is what this hook used
++   to write unconditionally.  */
++
++static bool
++dvp_elf_final_write_processing (bfd *abfd)
++{
++  if (elf_elfheader (abfd)->e_flags == 0)
++    elf_elfheader (abfd)->e_flags = EF_DVP_OBJECT;
++  return _bfd_elf_final_write_processing (abfd);
++}
++
++/* --- merging that flag word -----------------------------------------------
++
++   A link starts with an output header whose e_flags is zero, and without a
++   merge hook nothing ever put an input object's word into it: every link, final
++   or relocatable, wrote the default above and threw away whichever ABI the
++   objects had been assembled for.  An object built with `-32' linked to an
++   object built with `-32' came out claiming n32, which is worse than either a
++   correct answer or a refusal, because nothing downstream can tell.
++
++   The word has three independent parts and each merges differently:
++
++     * the architecture and machine (EF_MIPS_ARCH | EF_MIPS_MACH).  Every object
++       this assembler writes carries the same pair, so a difference means an
++       object from somewhere else and the link is refused rather than picking
++       one.
++
++     * the ABI selector (EF_MIPS_ABI | EF_MIPS_ABI2).  Two ABIs do not combine:
++       they decide argument passing and register width, and an object of each in
++       one output is a program that does not run.  Refused, by name, saying what
++       each side asked for.
++
++     * EF_MIPS_CPIC, which `-no-abicalls' clears.  This one is a *property of
++       the code*, not a request: it says every function in the object is safe to
++       call through position-independent code.  A collection is therefore only
++       as CPIC as its least CPIC member, so the merge is a conjunction and one
++       `-no-abicalls' object clears it for the output.  That is a choice this
++       project makes rather than one it measured -- the sanctioned channel is an
++       assembler, and no link is observable through it -- so it is a design
++       decision, pinned by tests on both directions and on the idempotent
++       case.  */
++
++#define EF_DVP_ABI_BITS		(EF_MIPS_ABI | EF_MIPS_ABI2)
++#define EF_DVP_ARCH_BITS	(EF_MIPS_ARCH | EF_MIPS_MACH)
++
++/* The ABI selector's name, for a diagnostic that says which two disagreed.  */
++
++static const char *
++dvp_abi_bits_name (flagword flags)
++{
++  switch (flags & EF_DVP_ABI_BITS)
++    {
++    case EF_MIPS_ABI2:		return "n32";
++    case EF_MIPS_ABI_O32:	return "32";
++    case EF_MIPS_ABI_O64:	return "o64";
++    case EF_MIPS_ABI_EABI32:	return "eabi";
++    case 0:			return "64";
++    default:			return "an unrecognised ABI";
++    }
++}
++
++static bool
++dvp_elf_merge_private_bfd_data (bfd *ibfd, struct bfd_link_info *info)
++{
++  bfd *obfd = info->output_bfd;
++  flagword in_flags, out_flags;
++
++  if (bfd_get_flavour (ibfd) != bfd_target_elf_flavour
++      || bfd_get_flavour (obfd) != bfd_target_elf_flavour)
++    return true;
++
++  in_flags = elf_elfheader (ibfd)->e_flags;
++  out_flags = elf_elfheader (obfd)->e_flags;
++
++  if (!elf_flags_init (obfd))
++    {
++      /* The first object with something to say decides the word.  An object
++	 whose word is zero says nothing -- BFD wrote it, not this assembler --
++	 so it neither decides nor is checked against.  */
++      if (in_flags == 0)
++	return true;
++      elf_flags_init (obfd) = true;
++      elf_elfheader (obfd)->e_flags = in_flags;
++      return true;
++    }
++
++  if (in_flags == 0 || in_flags == out_flags)
++    return true;
++
++  if ((in_flags & EF_DVP_ARCH_BITS) != (out_flags & EF_DVP_ARCH_BITS))
++    {
++      _bfd_error_handler
++	/* xgettext:c-format */
++	(_("%pB: this object is for a different processor than the output "
++	   "(its flag word says %#x where the output says %#x)"),
++	 ibfd, in_flags & EF_DVP_ARCH_BITS, out_flags & EF_DVP_ARCH_BITS);
++      bfd_set_error (bfd_error_bad_value);
++      return false;
++    }
++
++  if ((in_flags & EF_DVP_ABI_BITS) != (out_flags & EF_DVP_ABI_BITS))
++    {
++      _bfd_error_handler
++	/* xgettext:c-format */
++	(_("%pB: this object was assembled for the %s ABI and the output is "
++	   "already the %s ABI; the two cannot be linked together"),
++	 ibfd, dvp_abi_bits_name (in_flags), dvp_abi_bits_name (out_flags));
++      bfd_set_error (bfd_error_bad_value);
++      return false;
++    }
++
++  /* Everything left is the conjunction described above.  */
++  if ((in_flags & EF_MIPS_CPIC) == 0)
++    elf_elfheader (obfd)->e_flags &= ~(flagword) EF_MIPS_CPIC;
++
++  return true;
++}
++
++/* So that `-oformat' and anything else that sets the word by hand takes the
++   same route the merge does, rather than leaving `flags_init' clear and having
++   the first input silently overwrite it.  */
++
++static bool
++dvp_elf_set_private_flags (bfd *abfd, flagword flags)
++{
++  elf_elfheader (abfd)->e_flags = flags;
++  elf_flags_init (abfd) = true;
++  return true;
++}
++
++/* What the word says, in the same words the assembler's options use.  */
++
++static bool
++dvp_elf_print_private_bfd_data (bfd *abfd, void *ptr)
++{
++  FILE *file = (FILE *) ptr;
++  flagword flags = elf_elfheader (abfd)->e_flags;
++
++  _bfd_elf_print_private_bfd_data (abfd, ptr);
++  fprintf (file, _("private flags = %#x: ABI %s%s\n"), flags,
++	   dvp_abi_bits_name (flags),
++	   (flags & EF_MIPS_CPIC) != 0 ? ", CPIC" : ", no-abicalls");
++  return true;
++}
++
++/* Whether a local section symbol carries its section's name.
++
++   The reference gives every one of them a name, in every relocatable object:
++   `.vutext', `.vudata', `.vubss', `.mine', and the generated overlay sections
++   too.  BFD leaves them empty by default, and the difference is visible in the
++   symbol table of every object with a section in it -- so this target answers
++   yes, unconditionally, for a relocatable object.  The MIPS back end asks the
++   same question and answers it the same way for objects it recognises as
++   SGI-compatible; there is no such distinction to make here, because the
++   reference names them always.  */
++
++static bool
++dvp_elf_name_local_section_symbols (bfd *abfd)
++{
++  return elf_elfheader (abfd)->e_type == ET_REL;
++}
++
++static bool
++dvp_elf_object_p (bfd *abfd)
++{
++  bfd_default_set_arch_mach (abfd, bfd_arch_dvp, bfd_mach_dvp);
++  return true;
++}
++
++#define ELF_ARCH		bfd_arch_dvp
++#define ELF_MACHINE_CODE	EM_MIPS
++#define ELF_MAXPAGESIZE		0x1
++
++#define TARGET_LITTLE_SYM	dvp_elf32_vec
++/* The BFD target name.  This is a MIPS object: EM_MIPS in the header, MIPS
++   relocation numbering, MIPS section-symbol naming, and the MIPS flag word --
++   and the reference names it accordingly, so anything that selects a format by
++   name (a linker script's OUTPUT_FORMAT, `--oformat', a build system asking
++   what this assembler produces) gets the same answer from both.  The vector's
++   C symbol keeps its own name; only what the vector is *called* changes.  */
++#define TARGET_LITTLE_NAME	"elf32-littlemips"
++
++#define elf_info_to_howto	NULL
++#define elf_info_to_howto_rel	dvp_info_to_howto_rel
++
++#define elf_backend_may_use_rel_p	1
++#define elf_backend_may_use_rela_p	0
++#define elf_backend_default_use_rela_p	0
++#define elf_backend_rela_normal		0
++#define elf_backend_final_write_processing	dvp_elf_final_write_processing
++#define elf_backend_section_processing		dvp_elf_section_processing
++#define elf_backend_object_p			dvp_elf_object_p
++#define elf_backend_name_local_section_symbols	dvp_elf_name_local_section_symbols
++
++/* A name a DVP object treats as a compiler's own.
++
++   `$' is the local-label prefix here, as it is in a MIPS object: `$a:' is a
++   temporary and does not reach the symbol table unless the source makes it
++   global, while `La:' is an ordinary name that does.  Measured against the
++   reference on both, and on `.La', which the generic ELF rule already covers
++   and which both assemblers drop.  */
++
++static bool
++dvp_elf_is_local_label_name (bfd *abfd, const char *name)
++{
++  if (name[0] == '$')
++    return true;
++  return _bfd_elf_is_local_label_name (abfd, name);
++}
++
++#define bfd_elf32_bfd_reloc_type_lookup	dvp_reloc_type_lookup
++#define bfd_elf32_bfd_reloc_name_lookup	dvp_reloc_name_lookup
++#define bfd_elf32_bfd_is_local_label_name dvp_elf_is_local_label_name
++#define bfd_elf32_bfd_merge_private_bfd_data dvp_elf_merge_private_bfd_data
++#define bfd_elf32_bfd_set_private_flags	dvp_elf_set_private_flags
++#define bfd_elf32_bfd_print_private_bfd_data dvp_elf_print_private_bfd_data
++
++#include "elf32-target.h"
+--- a/bfd/reloc.c
++++ b/bfd/reloc.c
+@@ -2160,6 +2160,22 @@
+   MIPS ELF relocations.
+ 
+ ENUM
++  BFD_RELOC_DVP_11_PCREL
++ENUMDOC
++  PlayStation 2 DVP: 11-bit signed branch displacement, counted in 64-bit
++  VU microinstructions relative to the instruction after the branch.
++ENUM
++  BFD_RELOC_DVP_15
++ENUMDOC
++  PlayStation 2 DVP: 15-bit unsigned immediate, split between bits 10..0
++  and bits 24..21 of the instruction word.
++ENUM
++  BFD_RELOC_DVP_DMA_ADDR
++ENUMDOC
++  PlayStation 2 DVP: address field of a DMA tag.  A tag addresses
++  quadwords, so the field holds value bits 30..4 and encodes neither the
++  low four bits nor bit 31.
++ENUM
+   BFD_RELOC_MOXIE_10_PCREL
+ ENUMDOC
+   Moxie ELF relocations.
+--- a/bfd/targets.c
++++ b/bfd/targets.c
+@@ -825,6 +825,7 @@
+ extern const bfd_target mmix_mmo_vec;
+ extern const bfd_target mn10200_elf32_vec;
+ extern const bfd_target mn10300_elf32_vec;
++extern const bfd_target dvp_elf32_vec;
+ extern const bfd_target moxie_elf32_be_vec;
+ extern const bfd_target moxie_elf32_le_vec;
+ extern const bfd_target msp430_elf32_vec;
+@@ -1198,6 +1199,7 @@
+ 	&mn10200_elf32_vec,
+ 	&mn10300_elf32_vec,
+ 
++	&dvp_elf32_vec,
+ 	&moxie_elf32_be_vec,
+ 	&moxie_elf32_le_vec,
+ 
+--- a/config.sub
++++ b/config.sub
+@@ -1029,6 +1029,9 @@
+ 		vendor=convex
+ 		basic_os=${basic_os:-bsd}
+ 		;;
++	dvp-unknown)
++		vendor=scei
++		;;
+ 	craynv-unknown)
+ 		vendor=cray
+ 		basic_os=${basic_os:-unicosmp}
+@@ -1295,6 +1298,7 @@
+ 			| cydra \
+ 			| d10v \
+ 			| d30v \
++			| dvp \
+ 			| dlx \
+ 			| dsp16xx \
+ 			| e2k \
+--- a/gas/Makefile.am
++++ b/gas/Makefile.am
+@@ -182,6 +182,7 @@
+ 	config/tc-mmix.c \
+ 	config/tc-mn10200.c \
+ 	config/tc-mn10300.c \
++	config/tc-dvp.c \
+ 	config/tc-moxie.c \
+ 	config/tc-msp430.c \
+ 	config/tc-mt.c \
+--- a/gas/Makefile.in
++++ b/gas/Makefile.in
+@@ -684,6 +684,7 @@
+ 	config/tc-mmix.c \
+ 	config/tc-mn10200.c \
+ 	config/tc-mn10300.c \
++	config/tc-dvp.c \
+ 	config/tc-moxie.c \
+ 	config/tc-msp430.c \
+ 	config/tc-mt.c \
+--- /dev/null
++++ b/gas/config/tc-dvp.c
+@@ -0,0 +1,7224 @@
++/* tc-dvp.c -- assembler for the PlayStation 2 DVP (VIF/VU) target.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of GAS, the GNU Assembler.
++
++   GAS is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3, or (at your option)
++   any later version.
++
++   GAS is distributed in the hope that it will be useful, but WITHOUT
++   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++   for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with GAS; see the file COPYING.  If not, write to the Free
++   Software Foundation, 51 Franklin Street - Fifth Floor, Boston, MA
++   02110-1301, USA.  */
++
++/* This is the thin adapter between GAS and the target-independent VU layer in
++   opcodes/dvp-vu.c.  Parsing of registers, destination masks, flag groups and
++   operand syntax, and all encoding, live there; everything to do with GAS state
++   -- expressions, symbols, frags, fixups and diagnostics -- lives here.  */
++
++#include "as.h"
++#include "safe-ctype.h"
++#include <limits.h>
++#include "subsegs.h"
++#include "obstack.h"
++#include "opcode/dvp-vu.h"
++#include "opcode/dvp-vif.h"
++#include "elf/dvp.h"
++#include "elf/internal.h"
++#include "elf-bfd.h"
++
++/* The instruction layer and the object-format layer each state the size of a
++   microinstruction, for their own callers.  They had better agree.  */
++#if DVP_INSN_BYTES != DVP_MICROINSN_BYTES
++# error "microinstruction size disagrees between opcode/ and elf/ headers"
++#endif
++
++/* Comments and statement separation.
++
++   `;' starts a comment to the end of the line, wherever it appears; that is how
++   DVP source is commented.  `#' starts one only at the beginning of a line,
++   which is what gives us stock GAS's `# 123 "file"' line markers; a mid-line
++   `#' is refused, and the stock GAS convention is available under
++   `--cleanroom-extensions'.  That switch is why DVP_COMMENT_CHARS is a
++   variable: do_scrub_begin runs after the options are parsed and reads
++   `tc_comment_chars', and line_comment_chars overrides, which keeps `#' a
++   *line* comment character either way.
++
++   `!' separates statements, so several commands may share one line.  The price
++   is that `!' is no longer GAS's logical-not or `!=' operator; `<>' is the
++   spelling of "not equal" that survives.  */
++
++const char comment_chars[] = ";#";
++const char dvp_comment_chars_default[] = ";";
++const char dvp_comment_chars_extended[] = ";#";
++const char *dvp_comment_chars = dvp_comment_chars_default;
++const char line_comment_chars[] = "#";
++const char line_separator_chars[] = "!";
++const char EXP_CHARS[] = "eE";
++const char FLT_CHARS[] = "fFdD";
++
++/* Target options.
++
++   The first three are extensions: they ask for an *extra* artifact beside the
++   ELF object, and none changes the object itself or is ever enabled by default.
++
++   The rest are the target's official options.  Every one is accepted with one
++   dash and with two, which is what GAS's getopt_long_only gives for free.
++   `-32', `-n32' and `-64' are long options too, for the same reason --
++   md_shortopts is empty, so there is no short option to confuse them with.  */
++
++#define OPTION_RAW		(OPTION_MD_BASE + 0)
++#define OPTION_C_ARRAY		(OPTION_MD_BASE + 1)
++#define OPTION_C_ARRAY_NAME	(OPTION_MD_BASE + 2)
++#define OPTION_NO_DMA		(OPTION_MD_BASE + 3)
++#define OPTION_NO_DMA_VIF	(OPTION_MD_BASE + 4)
++#define OPTION_NO_ABICALLS	(OPTION_MD_BASE + 5)
++#define OPTION_MABI		(OPTION_MD_BASE + 6)
++#define OPTION_ABI_32		(OPTION_MD_BASE + 7)
++#define OPTION_ABI_N32		(OPTION_MD_BASE + 8)
++#define OPTION_ABI_64		(OPTION_MD_BASE + 9)
++#define OPTION_CLEANROOM_EXT	(OPTION_MD_BASE + 10)
++#define OPTION_STRICT_MARKERS	(OPTION_MD_BASE + 11)
++
++const char md_shortopts[] = "";
++const struct option md_longopts[] =
++{
++  { "raw",	    required_argument, NULL, OPTION_RAW },
++  { "c-array",	    required_argument, NULL, OPTION_C_ARRAY },
++  { "c-array-name", required_argument, NULL, OPTION_C_ARRAY_NAME },
++  { "no-dma",	    no_argument,       NULL, OPTION_NO_DMA },
++  { "no-dma-vif",   no_argument,       NULL, OPTION_NO_DMA_VIF },
++  { "no-abicalls",  no_argument,       NULL, OPTION_NO_ABICALLS },
++  { "mabi",	    required_argument, NULL, OPTION_MABI },
++  { "32",	    no_argument,       NULL, OPTION_ABI_32 },
++  { "n32",	    no_argument,       NULL, OPTION_ABI_N32 },
++  { "64",	    no_argument,       NULL, OPTION_ABI_64 },
++  { "cleanroom-extensions", no_argument, NULL, OPTION_CLEANROOM_EXT },
++  { "strict-marker-names",  no_argument, NULL, OPTION_STRICT_MARKERS },
++  { NULL,	    no_argument,       NULL, 0 }
++};
++const size_t md_longopts_size = sizeof (md_longopts);
++
++static const char *dvp_raw_file;
++static const char *dvp_c_array_file;
++static const char *dvp_c_array_name;
++
++/* Whether the syntax this assembler has beyond the reference's is available.  Off by default, so what the assembler accepts is what the
++   reference accepts; `--cleanroom-extensions' turns on the spellings that would
++   otherwise be a source the reference refuses.  The extensions that only ask for
++   an extra artifact -- `--raw' and `--c-array' -- are not gated: they add no
++   syntax and change no object.  */
++int dvp_cleanroom_extensions;
++
++/* Whether a generated name may take over one the source gave with `.set'.  Off by default, which is what the reference does.  */
++static int dvp_strict_marker_names;
++
++/* What the two suppression options remove.  `-no-dma-vif' is
++   `-no-dma' and more, so it sets both.  */
++static int dvp_no_dma;
++static int dvp_no_dma_vif;
++
++/* The object's flag word, as the ABI selectors leave it.  The ABI
++   is one field of it and `-no-abicalls' clears one bit, so the two are kept apart
++   and combined once, where the header is written.  */
++static unsigned int dvp_abi_flags = EF_DVP_ABI_DEFAULT;
++static int dvp_abicalls = 1;
++
++/* The ABI names the selector takes, and the flag bits each one names.  The set is
++   measured: the reference accepts exactly these five and refuses everything else,
++   `o32' included.  */
++static const struct dvp_abi_name
++{
++  const char *name;
++  unsigned int flags;
++}
++dvp_abi_names[] =
++{
++  { "32",   EF_MIPS_ABI_O32 },
++  { "o64",  EF_MIPS_ABI_O64 },
++  { "n32",  EF_MIPS_ABI2 },
++  { "64",   0 },
++  { "eabi", EF_MIPS_ABI_EABI32 }
++};
++
++/* The flag word the object carries, assembled from the ABI the selectors chose
++   and whether the PIC conventions are being claimed.  BFD cannot
++   see the command line, so the assembler writes the word and BFD's
++   final_write_processing only fills in the default when nothing did.  */
++
++static void
++dvp_set_object_flags (void)
++{
++  elf_elfheader (stdoutput)->e_flags =
++    EF_DVP_BASE | dvp_abi_flags | (dvp_abicalls ? EF_MIPS_CPIC : 0);
++}
++
++/* Whether this construct's header words are being left out.
++
++   `-no-dma' removes what a DMA tag emits and nothing else, so a VIF command
++   that would have been packed into the tag's spare half is still written.
++   `-no-dma-vif' removes the VIF command words too, which reaches the `unpack',
++   `mpg' and `direct' headers as well, because each of those *is* a VIF command
++   word.  A GIF tag is neither, and neither option touches one.  */
++
++static int
++dvp_header_suppressed (const struct dvp_ctr_opcode *op)
++{
++  switch (op->kind)
++    {
++    case DVP_CTR_DMA:
++      return dvp_no_dma;
++    case DVP_CTR_VIF:
++    case DVP_CTR_UNPACK:
++    case DVP_CTR_MPG:
++    case DVP_CTR_DIRECT:
++      return dvp_no_dma_vif;
++    default:
++      return 0;
++    }
++}
++
++/* --- state --------------------------------------------------------------- */
++
++static int dvp_in_vu_mode;
++static int dvp_unit_pending;
++static int dvp_unit_counter;
++
++static asection *dvp_ovlytab_section;
++static asection *dvp_ovlystrtab_section;
++
++/* The overlay bookkeeping.  Each `mpg' command describes one overlay: a
++   generated section holding zeroes the size of what it transfers, a name for
++   that section in DVP_OVLYSTRTAB_SECTION, and a twelve-byte entry in
++   DVP_OVLYTAB_SECTION pointing at both.  The counter is the index the generated
++   name ends with, and the cursor is the next free offset in the string table.  */
++static unsigned int dvp_overlay_counter;
++static addressT dvp_ovlystrtab_next;
++
++/* Expressions parsed for the operation currently being assembled.  Both pipes
++   together can never need more than this many.  */
++static expressionS dvp_exprs[2 * DVP_MAX_OPERANDS];
++static int dvp_nexprs;
++
++#define DVP_ERRLEN 320
++
++/* The command the five-operand `unpack' shorthand stands for.  Naming it here
++   rather than inline keeps the shorthand's meaning in one place: it is that
++   command, unchanged, and this file does not know its encoding.  The spellings
++   that set the write cycle come from the generated table, which lists the ones
++   measured to do so; the shorthand is written in the first of them.  */
++static const char *const dvp_cycle_commands[] = DVP_CYCLE_COMMANDS;
++#define DVP_CYCLE_COMMAND dvp_cycle_commands[0]
++
++/* --- helpers ------------------------------------------------------------- */
++
++/* Read a little-endian 32-bit word out of a fragment.  The inverse of
++   md_number_to_chars, kept explicit so byte order lives in one place.  */
++
++static unsigned int
++dvp_read_word (const char *buf)
++{
++  return ((unsigned int) (unsigned char) buf[0])
++	 | ((unsigned int) (unsigned char) buf[1] << 8)
++	 | ((unsigned int) (unsigned char) buf[2] << 16)
++	 | ((unsigned int) (unsigned char) buf[3] << 24);
++}
++
++/* Whitespace after the last operand of a statement.  This is the widest sense
++   the grammar has -- a vertical tab and a form feed are whitespace here and not
++   in the middle of a statement, and a line break can appear here when GAS has
++   repaired an unterminated string -- and it is deliberately the reference's
++   `ISSPACE' set rather than dvp_skip_white's two characters.  */
++
++static char *
++dvp_skip_tail_white (char *p)
++{
++  while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r'
++	 || *p == '\v' || *p == '\f')
++    ++p;
++  return p;
++}
++
++static char *
++dvp_skip_white (char *p)
++{
++  while (*p == ' ' || *p == '\t')
++    ++p;
++  return p;
++}
++
++static void
++dvp_mark_vu_symbol (symbolS *sym)
++{
++  /* Symbols defined inside a .vu block carry a target-specific marker byte in
++     st_other; DVP objects have always carried it, and tools downstream look
++     for it.  */
++  S_SET_OTHER (sym, STO_DVP_VU);
++}
++
++/* Which kind of unit a marker prefix names, for the diagnostic that reports a
++   collision with it.  One place, so the four prefixes and the four words stay
++   together.  */
++
++static const char *
++dvp_marker_kind (const char *prefix)
++{
++  if (strcmp (prefix, DVP_MARK_DMA_PREFIX) == 0)
++    return "DMA tag";
++  if (strcmp (prefix, DVP_MARK_GIF_PREFIX) == 0)
++    return "GIF tag";
++  if (strcmp (prefix, DVP_MARK_VIF_PREFIX) == 0)
++    return "VIF command run";
++  if (strcmp (prefix, DVP_MARK_VU_PREFIX) == 0)
++    return "VU program unit";
++  return "unit";
++}
++
++/* Emit one synthetic unit marker at the current position.  A DVP object marks
++   the start of every DMA tag, VIF command run, GIF tag and VU program unit with
++   a symbol whose name says which kind it is and whose st_other says so again.
++
++   The name is the assembler's, not the source's.  GAS's symbol table replaces a
++   hash entry rather than refusing it and writes both out, so a marker landing
++   on a source-defined name would let a reference bind to whichever went in
++   last.  The name is therefore claimed rather than overwritten:
++
++   - free: create it;
++   - already defined by the source: an error naming the name and marker kind;
++   - present but undefined: define *that* symbol, so the reference resolves to
++     the marker rather than leaving a dangling undefined twin.
++
++   The reverse order needs nothing: a later source definition is an ordinary
++   redefinition and GAS reports it.  `.equ' is a deliberate deviation -- the
++   reference keeps the marker and discards the source's value; this refuses.  */
++
++/* Whether a name the assembler needs for itself is already taken.
++
++   A name the source gave with `.set', `.equ' or `NAME=' is *not* taken: GAS
++   marks such a symbol redefinable, so the marker takes the name over and the
++   source's value is replaced.  A label, a `.comm', and an `.equiv' or `.eqv'
++   are taken, and the collision is reported.  `--strict-marker-names' refuses
++   every one of them; it is off by default.  */
++
++static int
++dvp_name_is_taken (symbolS *sym)
++{
++  if (sym == NULL || !S_IS_DEFINED (sym))
++    return 0;
++  if (dvp_strict_marker_names)
++    return 1;
++  return !S_IS_VOLATILE (sym);
++}
++
++static void
++dvp_emit_marker (const char *prefix, int n, int other)
++{
++  char name[32];
++  symbolS *sym;
++
++  snprintf (name, sizeof (name), "%s%d", prefix, n);
++  sym = symbol_find (name);
++  if (dvp_name_is_taken (sym))
++    {
++      as_bad (_("the source defines \"%s\", which this assembler needs for the "
++		"unit marker on the %s starting here; rename it -- a name of the "
++		"form \"%s<number>\" belongs to the assembler"),
++	      name, dvp_marker_kind (prefix), prefix);
++      return;
++    }
++  if (sym == NULL)
++    {
++      sym = symbol_new (name, now_seg, frag_now, frag_now_fix ());
++      symbol_table_insert (sym);
++    }
++  else
++    {
++      /* A name the source only mentioned.  Defining the symbol that is already
++	 there is what makes the mention resolve to this marker.  */
++      S_SET_SEGMENT (sym, now_seg);
++      symbol_set_frag (sym, frag_now);
++      S_SET_VALUE (sym, frag_now_fix ());
++    }
++  S_SET_OTHER (sym, other);
++}
++
++/* True while microinstructions are being assembled, whether because of `.vu' or
++   because an `mpg' block is open.  Defined below, once the block state is.  */
++static int dvp_assembling_vu (void);
++
++/* Emit the payload a command named by file name, and close the run it opened.
++   Defined below, after the terminator machinery it uses.  */
++static void dvp_emit_named_payload (const struct dvp_ctr_opcode *,
++				    const char *);
++
++/* The overlay machinery, defined below once the block state it works on is:
++   open the overlay an `mpg' command describes, close it once the command's size
++   is known, and move a label defined inside the block into it, leaving an alias
++   behind where the code is.  */
++/* Defined where it is documented, below dvp_frob_label.  */
++static symbolS *dvp_pending_label;
++
++/* And the subsection it was written in.  A label belongs to the run of bytes it
++   was written among; an alignment in a *different* subsection of the same
++   section has nothing to say about where it lands, so the chain is carried
++   beside the symbol rather than the label being matched on its section alone.  */
++static struct frchain *dvp_pending_label_chain;
++
++/* Whether a VIF or container command word has gone into this section yet, and
++   the branch fixups created after one did.
++
++   A VU branch's displacement is counted in microinstructions from the branch.
++   Once command words are interleaved with the microcode, the section offset a
++   linker would work from is no longer the program offset the displacement
++   means, so a branch surviving as a *relocation* cannot be settled by the link.
++   A branch resolved by the assembler stays legal after any number of commands.
++   Whether it resolves is not known where it is parsed, so the fixups are
++   recorded and the refusal happens where the relocation would be emitted.  */
++
++/* Whether any VIF, DMA or GIF command has been processed in this assembly.
++
++   A branch whose target this assembly cannot settle is an error once one has:
++   the displacement the link would work from counts through those command words.
++
++   *Processed*, not *emitted*.  `-no-dma' and `-no-dma-vif' remove a command's
++   bytes from the object; they do not make the source stop saying the command is
++   there.  Keying this on the bytes made the diagnostic depend on an output
++   option, which was a defect.  */
++static int dvp_vif_command_seen;
++
++struct dvp_late_branch
++{
++  struct dvp_late_branch *next;
++  fixS *fix;
++};
++
++static struct dvp_late_branch *dvp_late_branches;
++
++static void
++dvp_note_late_branch (fixS *fix)
++{
++  struct dvp_late_branch *b = XNEW (struct dvp_late_branch);
++
++  b->next = dvp_late_branches;
++  b->fix = fix;
++  dvp_late_branches = b;
++}
++
++static int
++dvp_is_late_branch (const fixS *fix)
++{
++  const struct dvp_late_branch *b;
++
++  for (b = dvp_late_branches; b != NULL; b = b->next)
++    if (b->fix == fix)
++      return 1;
++  return 0;
++}
++static addressT dvp_here (void);
++static int dvp_vif_unit_pending;
++
++static void dvp_forget_pending_label (void);
++static void dvp_overlay_open (void);
++static void dvp_overlay_close (addressT);
++static void dvp_overlay_label (symbolS *);
++
++/* Is NAME one of GAS's temporary labels -- a `1:' or a `4$:'?
++
++   GAS gives both a name the source could not have written, by joining the
++   number to a serial with a control character: '\002' for the fb form and
++   '\001' for the dollar form.  Testing for those two characters separates a
++   temporary from an ordinary name and from a `.L' name.  */
++
++static int
++dvp_label_is_temporary (const char *name)
++{
++  return (name != NULL
++	  && (strchr (name, '\001') != NULL || strchr (name, '\002') != NULL));
++}
++
++void
++dvp_frob_label (symbolS *sym)
++{
++  /* Recorded whether or not the source is in `.vu' mode: a label written just
++     before `.vu' names the first instruction of the block exactly as one
++     written just after it does.  */
++  dvp_pending_label = sym;
++  dvp_pending_label_chain = frchain_now;
++
++  if (!dvp_assembling_vu ())
++    {
++      /* Packet mode.  A label standing in a run of VIF commands starts a new
++	 run there, exactly as one in `.vu' mode starts a new program unit, and
++	 the same temporaries are the exception.  Without this the run is left
++	 unbroken and the marker the disassembler needs is never emitted.
++
++	 Nothing is pending where the run has not started: a label before the
++	 first command coincides with that run's own marker, and one marker is
++	 emitted there, not two.  Two labels together are one break.  */
++      if (!dvp_label_is_temporary (S_GET_NAME (sym)) && dvp_here () != 0)
++	dvp_vif_unit_pending = 1;
++      return;
++    }
++  dvp_mark_vu_symbol (sym);
++  /* The next instruction begins a new VU program unit -- unless the label is a
++     temporary.  A `1:' or `4$:' names an instruction without naming a unit, in
++     a plain `.vu' block or in an `mpg' block, while an ordinary label and a
++     `.L' label both start one.  That is a different line from the overlay
++     promotion test, which declines `.L' too, so the two are asked separately.
++
++     GAS spells both kinds of temporary with a character no source can write.  */
++  if (!dvp_label_is_temporary (S_GET_NAME (sym)))
++    dvp_unit_pending = 1;
++  /* A label inside an `mpg' block belongs to the overlay the block loads, and
++     is measured from the overlay's load address rather than from the section the
++     transfer was assembled into.  */
++  dvp_overlay_label (sym);
++}
++
++/* The label the source defined most recently, if nothing has been emitted
++   since.
++
++   A VU microinstruction is eight bytes and must start on an eight-byte
++   boundary, so data before it is followed by padding.  A label written just
++   before the instruction names the instruction, not the padding, and has to
++   move across it.  One label, not a list, and cleared by anything that emits:
++   two labels on separate lines do not both move, and a label with a data
++   directive after it does not move at all.  */
++
++
++/* Called wherever bytes go down.  What follows the label is no longer the
++   instruction, so the label stays where it is.  */
++
++static void
++dvp_forget_pending_label (void)
++{
++  dvp_pending_label = NULL;
++  dvp_pending_label_chain = NULL;
++}
++
++/* A label waiting to be moved across an instruction's alignment padding, once
++   the finished section says how much padding that is.
++
++   Whether there is any padding is a question about the *final* layout, which
++   the file can still change: bytes given to a lower subsection further down are
++   laid out in front of it, and an `.org' before it moves everything on.  So
++   nothing is decided here; what is kept is the alignment frag whose padding
++   settles it and the frag the instruction starts.  Both belong to the
++   subsection the instruction was assembled into, and the label is recorded only
++   when it was written in that same subsection.
++
++   Deferring also keeps a label that does *not* move where GAS would have put
++   it: pinning one early settles its value ahead of time, and a difference of
++   two labels then folds to a constant and misses the fixup's scaling.  */
++
++struct dvp_pending_label_move
++{
++  struct dvp_pending_label_move *next;
++  symbolS *sym;
++  segT seg;
++  fragS *align;			/* the rs_align frag whose padding decides it */
++  fragS *target;		/* the frag the microinstruction starts */
++  int settled;			/* the settling walk reached that frag */
++  int padded;			/* ... and it inserts padding */
++};
++
++static struct dvp_pending_label_move *dvp_label_moves;
++static struct dvp_pending_label_move **dvp_label_moves_tail = &dvp_label_moves;
++
++/* Set while dvp_settle_layout is walking, so the walk answers the two lookups
++   below and nothing else pays for them.  */
++static int dvp_settling;
++
++static struct dvp_pending_label_move *
++dvp_label_move_for (fragS *f)
++{
++  struct dvp_pending_label_move *m;
++
++  if (!dvp_settling)
++    return NULL;
++  for (m = dvp_label_moves; m != NULL; m = m->next)
++    if (m->align == f)
++      return m;
++  return NULL;
++}
++
++/* Record the pending label against the alignment that will decide it.  The
++   label is consumed either way: what follows it is this instruction, and no
++   later alignment gets a second chance at it.  */
++
++static void
++dvp_defer_pending_label (fragS *align, fragS *target)
++{
++  symbolS *sym = dvp_pending_label;
++  struct frchain *chain = dvp_pending_label_chain;
++  struct dvp_pending_label_move *m;
++
++  dvp_forget_pending_label ();
++  if (sym == NULL || chain != frchain_now || S_GET_SEGMENT (sym) != now_seg)
++    return;
++
++  /* A local label does not move.  The reference decides that by the label's
++     *name*, not by whether the label will reach the object: `.L.foo' stays
++     where the source put it both with and without `-L', while an ordinary
++     label moves in both cases.
++
++     So the test is the target's local-label prefix and not S_IS_LOCAL, which
++     answers the different question of whether the symbol is emitted and
++     therefore flips under `-L'.  The label is still consumed.  */
++  if (bfd_is_local_label_name (stdoutput, S_GET_NAME (sym)))
++    return;
++
++  m = XNEW (struct dvp_pending_label_move);
++  m->next = NULL;
++  m->sym = sym;
++  m->seg = now_seg;
++  m->align = align;
++  m->target = target;
++  m->settled = 0;
++  m->padded = 0;
++  *dvp_label_moves_tail = m;
++  dvp_label_moves_tail = &m->next;
++}
++
++/* GAS calls this before a data directive lays anything down.  */
++
++void
++dvp_cons_align (int nbytes ATTRIBUTE_UNUSED)
++{
++  dvp_forget_pending_label ();
++}
++
++/* The unit marker whose name has been reserved but whose position is not
++   settled yet.  See dvp_reserve_unit_marker.  */
++static symbolS *dvp_reserved_unit_marker;
++
++/* Reserve the name the next program unit's marker will take.
++
++   The name has to enter the symbol table *before* the instruction's operands
++   do: `.vu' / `nop iaddi vi01,vi02,X' / `.set X,3' puts `.vu.0' ahead of `X'.
++   The marker's value is not known this early, so what is reserved is the name,
++   as an undefined symbol, and dvp_emit_marker then defines it.  Nothing is
++   reserved when the source has already used the name -- that is a collision or
++   a take-over, and dvp_emit_marker decides both.  */
++
++static void
++dvp_reserve_unit_marker (void)
++{
++  char name[32];
++
++  if (!dvp_unit_pending || dvp_reserved_unit_marker != NULL)
++    return;
++  snprintf (name, sizeof (name), "%s%d", DVP_MARK_VU_PREFIX, dvp_unit_counter);
++  if (symbol_find (name) != NULL)
++    return;
++  dvp_reserved_unit_marker = symbol_new (name, undefined_section,
++					 &zero_address_frag, 0);
++  symbol_table_insert (dvp_reserved_unit_marker);
++}
++
++/* Emit the synthetic `.vu.<n>' marker for a program unit, if one is due.  */
++
++static void
++dvp_emit_unit_marker (void)
++{
++  dvp_reserved_unit_marker = NULL;
++  if (!dvp_unit_pending)
++    return;
++  dvp_unit_pending = 0;
++  dvp_emit_marker (DVP_MARK_VU_PREFIX, dvp_unit_counter++, DVP_MARK_VU_OTHER);
++}
++
++/* --- container blocks ---------------------------------------------------- */
++
++/* Outside a `.vu' block the assembler is in *container* mode: each line names a
++   VIF command, a DMA tag, a GIF tag, or the opener of a block whose length is
++   worked out from its payload.
++
++   Blocks nest three deep -- `dmacnt *', `direct *', `gifimage' -- which is how
++   a GS packet is written inside a `direct' transfer, so the open blocks are a
++   small stack.  Going past DVP_BLK_DEPTH is reported rather than silently
++   losing the outermost block.  */
++
++struct dvp_block
++{
++  const struct dvp_ctr_opcode *op;	/* NULL only in the sentinel slot */
++  unsigned int cmd_base;		/* command word before any count */
++  unsigned char fmt_elem;		/* unpack: payload bytes per element */
++  unsigned int unit;			/* counted unit in bytes where the
++					   statement decides it rather than the
++					   table: a GIF register list's loop is
++					   as many bytes per register as it names.
++					   Zero means "the table's" */
++  int auto_len;
++  dvp_val explicit_len;
++  fragS *cmd_frag;
++  unsigned long cmd_where;		/* command word's offset in CMD_FRAG */
++  addressT payload;			/* section offset the length is counted
++					   from.  For every block but a DMA
++					   tag's payload that is where the
++					   payload starts; a DMA tag counts
++					   the quadwords past its *own* */
++  dvp_val vu_addr;				/* current MPG run's load address */
++  int addr_is_star;			/* the load address was written `*' */
++  asection *ovly_sec;			/* the generated section describing this
++					   MPG command's overlay, if one is open */
++  symbolS *ovly_code;			/* a symbol on the microcode this command
++					   transfers, so the overlay's entry
++					   can name where that lands rather
++					   than where it was written: a
++					   section's subsegments are run
++					   together afterwards */
++  dvp_val run_insns;			/* instructions parsed in the current run;
++					   only the split point uses it, because the
++					   count itself is measured in bytes */
++  struct dvp_pending_count *pending;	/* count written as an expression that
++					   was not settled at the time */
++  segT seg;				/* subsection the block belongs to */
++  subsegT subseg;
++  int seg_reported;
++  const char *file;
++  unsigned int line;
++};
++
++#define DVP_BLK_DEPTH 4
++
++/* Slot 0 is a sentinel that is never filled in, so `dvp_blk.op == NULL' is the
++   test for "nothing is open" at every depth.  */
++static struct dvp_block dvp_blocks[DVP_BLK_DEPTH + 1];
++static int dvp_blk_depth;
++
++#define dvp_blk (dvp_blocks[dvp_blk_depth])
++
++/* A DMA tag that named its payload with `*' and has to be told, once every
++   symbol is defined, how many quadwords that payload comes to.  */
++struct dvp_pending_extent
++{
++  struct dvp_pending_extent *next;
++  const struct dvp_ctr_opcode *op;
++  struct dvp_ctr_field field;
++  fragS *frag;
++  unsigned long where;
++  const char *name;			/* the payload's symbol */
++  const char *file;
++  unsigned int line;
++};
++
++/* Where the next `mpg *' loads, in microinstructions.  A running `$.mpgloc':
++   it starts at zero, an `mpg' with a written-out address sets it to that
++   address, an `mpg *' takes it as it stands, and closing an `mpg' transfer --
++   including each command an over-long block is split into -- advances it by
++   what that command transferred.  `.vu' resets it.  */
++static dvp_val dvp_mpgloc;
++
++static struct dvp_pending_extent *dvp_pending_extents;
++static struct dvp_pending_extent **dvp_pending_extents_tail = &dvp_pending_extents;
++
++/* A DMA tag whose count the source wrote out as an expression the assembler
++   could not work out yet -- a symbol the file defines further down.  The count
++   still has to be encoded, and it still has to agree with the payload, so both
++   wait until every symbol is defined.  */
++struct dvp_pending_count
++{
++  struct dvp_pending_count *next;
++  const struct dvp_ctr_opcode *op;
++  struct dvp_ctr_field field;
++  fragS *frag;
++  unsigned long where;
++  expressionS ex;
++  dvp_val measured;			/* what the payload came to */
++  int have_measured;			/* zero if the payload never closed */
++  /* Non-zero when the tag opened a payload, so there is something for the count
++     to be checked against and the payload closing is what fills MEASURED in.  A
++     tag that describes a payload living elsewhere -- `dmaref', `dmarefs' and
++     `dmarefe' -- opens nothing, measures nothing, and still has to have its
++     count encoded, which is what this distinguishes.  */
++  int needs_payload;
++  const char *file;
++  unsigned int line;
++};
++
++static struct dvp_pending_count *dvp_pending_counts;
++static struct dvp_pending_count **dvp_pending_counts_tail = &dvp_pending_counts;
++
++/* An operand whose value the source wrote as an expression that was not a value
++   yet -- typically a symbol the file defines further down.  The word is emitted
++   with the field left as the zero it was laid down with, and this records where
++   that field is so the real value can be encoded once every symbol is defined.
++
++   Zero is not merely a placeholder: it is also the value the *rest of the
++   assembly* sees for the operand, so an automatic `unpack' count after a
++   deferred `stcycl' divides by that zero, and an `mpg' with a deferred load
++   address records address zero in its overlay.
++
++   Exactly one of CTR_OP and VU_FIELD is set.  No relocation is emitted for
++   either; both are settled at the end of the assembly.  */
++
++struct dvp_deferred_field
++{
++  struct dvp_deferred_field *next;
++  expressionS ex;
++  fragS *frag;
++  unsigned long where;			/* the command's first word in FRAG */
++  const struct dvp_ctr_opcode *ctr_op;	/* container field, or NULL */
++  struct dvp_ctr_field ctr_field;
++  const struct dvp_vu_field *vu_field;	/* VU operand field, or NULL */
++  const char *what;			/* what to call it in a diagnostic */
++  const char *file;
++  unsigned int line;
++};
++
++/* The eight-byte step an `mpg' load address is taken in when it is settled at
++   the end of the assembly rather than written out.  Measured: a late 8 encodes
++   field value 1, 0x7fff8 encodes 0xffff, and 4 is refused for not being a whole
++   number of steps.  */
++#define DVP_MPG_LATE_ADDR_LSB 3
++
++static struct dvp_deferred_field *dvp_deferred_fields;
++static struct dvp_deferred_field **dvp_deferred_fields_tail = &dvp_deferred_fields;
++
++/* Which container operand classes may be written as a not-yet-known value.  The
++   counts may not -- a count is checked against the payload the command is
++   opening right now, and there is no payload left to check it against by the
++   time a late symbol resolves -- and neither may the enumerated operands, which
++   are spellings rather than values.  Measured class by class against v10.  */
++
++static int
++dvp_class_defers (unsigned char cls)
++{
++  switch (cls)
++    {
++    case DVP_CO_U8:			/* stcycl, stcycle: both operands */
++    case DVP_CO_U16:			/* offset, base, itop, mark, mscal... */
++    case DVP_CO_WORD:			/* stmask, and strow/stcol's four */
++    case DVP_CO_VADDR:			/* unpack's address, and mpg's */
++      return 1;
++    default:
++      return 0;
++    }
++}
++
++static void
++dvp_defer_field (const struct dvp_ctr_opcode *ctr_op,
++		 const struct dvp_ctr_field *ctr_field,
++		 const struct dvp_vu_field *vu_field,
++		 fragS *frag, unsigned long where,
++		 const expressionS *ex, const char *what)
++{
++  struct dvp_deferred_field *d = XNEW (struct dvp_deferred_field);
++
++  d->next = NULL;
++  d->ex = *ex;
++  d->frag = frag;
++  d->where = where;
++  d->ctr_op = ctr_op;
++  if (ctr_field != NULL)
++    d->ctr_field = *ctr_field;
++  else
++    memset (&d->ctr_field, 0, sizeof (d->ctr_field));
++  d->vu_field = vu_field;
++  d->what = what;
++  d->file = as_where (&d->line);
++  *dvp_deferred_fields_tail = d;
++  dvp_deferred_fields_tail = &d->next;
++}
++
++static int dvp_packvif = DVP_PACKVIF_DEFAULT;
++
++/* The write cycle in force, and whether any has been set.  One piece of state
++   for the whole assembly: nothing measured clears it -- not a command, not a
++   block, not a region, not a section change.  */
++static struct
++{
++  int set;
++  dvp_val wl;			/* the setting's first operand */
++  dvp_val cl;			/* its second */
++} dvp_cycle;
++
++/* An automatic `unpack' count that closed before any cycle setting existed, and
++   so has to wait for the one the file ends on.  */
++struct dvp_deferred_count
++{
++  struct dvp_deferred_count *next;
++  const struct dvp_ctr_opcode *op;
++  struct dvp_ctr_field field;
++  fragS *frag;
++  unsigned long where;
++  dvp_val nelem;
++  const char *file;
++  unsigned int line;
++};
++
++static struct dvp_deferred_count *dvp_deferred_counts;
++static struct dvp_deferred_count **dvp_deferred_tail = &dvp_deferred_counts;
++
++/* Whether NAME is one of the spellings measured to set the write cycle.  The
++   list is generated, so a spelling that turned out not to set it is not in
++   it.  */
++
++static int
++dvp_is_cycle_command (const char *name)
++{
++  int i;
++
++  for (i = 0; i < DVP_CYCLE_NCOMMANDS; i++)
++    if (strcmp (name, dvp_cycle_commands[i]) == 0)
++      return 1;
++  return 0;
++}
++
++static void
++dvp_set_cycle (dvp_val wl, dvp_val cl)
++{
++  dvp_cycle.set = 1;
++  dvp_cycle.wl = wl;
++  dvp_cycle.cl = cl;
++}
++
++/* The open `.dmadata' region, if any.  A region is one contiguous run of
++   quadwords under one name, and it is padded out to a whole quadword when it
++   closes, so it needs the same subsection from beginning to end.  */
++static int dvp_dmadata_open;
++static char *dvp_dmadata_name;
++static segT dvp_dmadata_seg;
++static subsegT dvp_dmadata_subseg;
++static int dvp_dmadata_seg_reported;
++static const char *dvp_dmadata_file;
++static unsigned int dvp_dmadata_line;
++
++static int
++dvp_assembling_vu (void)
++{
++  return dvp_in_vu_mode
++	 || (dvp_blk.op != NULL && dvp_blk.op->block == DVP_BLK_VU);
++}
++
++/* Where the section is laid out, not where the subsection is.
++
++   GAS keeps each subsection's frags on a chain of its own and runs the chains
++   together only when it writes the object out, in ascending subsection order;
++   the offsets encoded here are measured in the section that produces.  So the
++   walk below joins the chains the way `chain_frchains_together' will and sizes
++   each frag the way `relax_segment' will, and every offset it returns is a
++   final section offset.  A frag it cannot settle stops the walk.  */
++
++/* How many bytes FRAG holds.
++
++   The last frag on a chain is still being filled: its FR_FIX is not written
++   until the frag is closed, and until then its length lives in the obstack the
++   chain is being filled on.  `frag_now_fix' reads that for the chain being
++   assembled into; a chain the source has switched away from keeps an obstack of
++   its own, and this reads that one the same way.  */
++
++static addressT
++dvp_frag_fix (struct frchain *chain, fragS *frag)
++{
++  if (frag != chain->frch_last)
++    return frag->fr_fix;
++  return (addressT) ((char *) obstack_next_free (&chain->frch_obstack)
++		     - frag->fr_literal);
++}
++
++static int dvp_symbol_offset (symbolS *, segT *, addressT *);
++
++/* How far the section has been laid out, and how far `.org' has moved it.
++
++   OFF is the section offset reached.  SLIP is how much of that came from `.org'
++   rather than from bytes: the sum, over the `.org' frags passed, of the gap each
++   one opened.  A construct that pads its payload to an alignment needs it,
++   because that padding is decided without the gaps in hand (see
++   dvp_settle_one_align).  */
++
++struct dvp_layout
++{
++  addressT off;
++  addressT slip;
++};
++
++/* Padding whose size only the finished section can settle.
++
++   A construct that aligns its payload has to know where it really is, and that
++   depends on what the source can still write: bytes put into a *lower*
++   subsection further down, and an `.org' before it.  So the padding is a frag
++   whose variable part is left open, settled in dvp_md_finish.  */
++
++struct dvp_pending_align
++{
++  struct dvp_pending_align *next;
++  fragS *frag;			/* the frag whose variable part is the padding */
++  segT seg;
++  int align;			/* the boundary the payload has to start on */
++  int lead;			/* bytes between the padding and that boundary:
++				   four for a command word, none for a tail */
++  int check_fit;		/* the command word has to fit before it */
++  int settled;			/* the settling walk reached it */
++  const char *what;
++  const char *file;
++  unsigned int line;
++};
++
++static struct dvp_pending_align *dvp_pending_aligns;
++static struct dvp_pending_align **dvp_pending_aligns_tail = &dvp_pending_aligns;
++
++/* `dvp_settling' is set while dvp_md_finish is settling the padding above, so
++   that the one walk below settles each frag as it reaches it and every offset
++   after it is measured against the settled size.  It is declared beside the
++   pending label moves, which the same walk answers.  */
++
++static struct dvp_pending_align *
++dvp_pending_align_for (fragS *f)
++{
++  struct dvp_pending_align *a;
++
++  if (!dvp_settling)
++    return NULL;
++  for (a = dvp_pending_aligns; a != NULL; a = a->next)
++    if (a->frag == f)
++      return a;
++  return NULL;
++}
++
++/* A `.org' whose target names a symbol is resolved by walking the section to
++   find that symbol -- and the walk may have to pass the very frag being
++   resolved, because the symbol can sit after it.  `relax_segment' meets the
++   same knot and unties it by iterating: it assumes a `.org' is nugatory and
++   grows it on the next pass if the target it computed says so.  These frames
++   carry that assumption inwards, so the walk beneath a `.org' being resolved
++   sees it the way the pass in progress assumes it.  */
++
++#define DVP_ORG_STACK_MAX 8
++
++struct dvp_org_frame
++{
++  fragS *frag;
++  int nugatory;			/* the frag contributes nothing this pass */
++  addressT target;		/* ... or it moves the section here */
++};
++
++static struct dvp_org_frame dvp_org_stack[DVP_ORG_STACK_MAX];
++static int dvp_org_depth;
++
++static struct dvp_org_frame *
++dvp_org_frame_for (fragS *f)
++{
++  int i;
++
++  for (i = 0; i < dvp_org_depth; i++)
++    if (dvp_org_stack[i].frag == f)
++      return &dvp_org_stack[i];
++  return NULL;
++}
++
++/* Where the `.org' frag F moves the section to, in final section coordinates.
++
++   A constant target is the offset itself.  A target written against a symbol --
++   `.org .', `.org .+8', `.org L+32', or `.org K' where K is `.set' further down
++   -- is that symbol's value plus the frag's own offset: an absolute symbol
++   contributes its value, a label where it lands in its section.  A symbol not
++   settled by then leaves the target unknown, and so does one the walk would
++   have to pass this very frag to reach.  */
++
++static int
++dvp_org_resolve (fragS *f, symbolS *sym, int nugatory, addressT assumed,
++		 addressT *out)
++{
++  segT seg;
++  addressT off;
++  int ok;
++
++  dvp_org_stack[dvp_org_depth].frag = f;
++  dvp_org_stack[dvp_org_depth].nugatory = nugatory;
++  dvp_org_stack[dvp_org_depth].target = assumed;
++  ++dvp_org_depth;
++  ok = dvp_symbol_offset (sym, &seg, &off);
++  --dvp_org_depth;
++  if (!ok)
++    return 0;
++  *out = off + (addressT) f->fr_offset;
++  return 1;
++}
++
++static int
++dvp_org_target (fragS *f, addressT *out)
++{
++  symbolS *sym = f->fr_symbol;
++  addressT first, again;
++
++  if (sym == NULL)
++    {
++      *out = (addressT) f->fr_offset;
++      return 1;
++    }
++  if (!S_IS_DEFINED (sym))
++    return 0;
++  if (S_GET_SEGMENT (sym) == absolute_section)
++    {
++      *out = (addressT) S_GET_VALUE (sym) + (addressT) f->fr_offset;
++      return 1;
++    }
++  if (dvp_org_depth >= DVP_ORG_STACK_MAX)
++    return 0;
++  /* One pass with this `.org' assumed nugatory, then one with it grown to what
++     that pass produced.  A target the second pass does not reproduce is one no
++     layout settles on -- `.org F+8' where F is defined after the directive keeps
++     moving F further away -- and is reported rather than answered.  */
++  if (!dvp_org_resolve (f, sym, 1, 0, &first)
++      || !dvp_org_resolve (f, sym, 0, first, &again)
++      || first != again)
++    return 0;
++  *out = first;
++  return 1;
++}
++
++static addressT dvp_settle_one_align (struct dvp_pending_align *,
++				      const struct dvp_layout *);
++
++/* Lay CHAIN out from POS, which is updated to the position just past it.
++
++   When STOP is on the chain, the offset its contents begin at goes into *AT and
++   *FOUND is set.  Returns 0 when a frag is met whose final size this cannot
++   settle; *AT is still good then if STOP came before that frag, and POS is not.  */
++
++static int
++dvp_walk_chain (struct frchain *chain, struct dvp_layout *pos, fragS *stop,
++		addressT *at, int *found)
++{
++  fragS *f;
++
++  for (f = chain->frch_root; f != NULL; f = f->fr_next)
++    {
++      if (stop != NULL && f == stop && !*found)
++	{
++	  *at = pos->off;
++	  *found = 1;
++	}
++      pos->off += dvp_frag_fix (chain, f);
++      /* The chain's last frag is still being filled.  Nothing has closed it, so
++	 it has no variable part yet and its type has not been settled either --
++	 the bytes counted above are all of it, and the chain ends here.  */
++      if (f == chain->frch_last)
++	break;
++      switch (f->fr_type)
++	{
++	case rs_fill:
++	  {
++	    struct dvp_pending_align *a = dvp_pending_align_for (f);
++
++	    if (a != NULL)
++	      {
++		a->settled = 1;
++		f->fr_offset = (offsetT) dvp_settle_one_align (a, pos);
++	      }
++	    pos->off += (addressT) f->fr_offset * f->fr_var;
++	  }
++	  break;
++
++	case rs_align:
++	case rs_align_code:
++	case rs_align_test:
++	  {
++	    addressT mask = ((addressT) 1 << f->fr_offset) - 1;
++	    addressT pad = (addressT) (-(offsetT) pos->off) & mask;
++	    struct dvp_pending_label_move *m;
++
++	    if (f->fr_subtype != 0 && pad > (addressT) f->fr_subtype)
++	      pad = 0;
++	    /* A label waiting on this alignment moves exactly when the alignment
++	       puts something between it and the instruction.  This is the only
++	       place that knows, because the walk is the only thing that sees the
++	       whole section.  */
++	    m = dvp_label_move_for (f);
++	    if (m != NULL)
++	      {
++		m->settled = 1;
++		m->padded = pad != 0;
++	      }
++	    pos->off += pad;
++	  }
++	  break;
++
++	case rs_org:
++	  /* `.org' names a place in the *section*: `relax_segment' grows the
++	     frag until the frag after it starts at the target, so the position
++	     after one is the target itself.  A target already behind the
++	     current position is the backward `.org' GAS refuses, and is left
++	     unsettled rather than guessed at.  */
++	  {
++	    struct dvp_org_frame *frame = dvp_org_frame_for (f);
++	    addressT target;
++
++	    if (frame != NULL)
++	      {
++		if (frame->nugatory)
++		  break;
++		target = frame->target;
++	      }
++	    else if (!dvp_org_target (f, &target))
++	      return 0;
++	    if ((offsetT) target < (offsetT) pos->off)
++	      return 0;
++	    pos->slip += target - pos->off;
++	    pos->off = target;
++	  }
++	  break;
++
++	default:
++	  return 0;
++	}
++    }
++  return 1;
++}
++
++/* The section offset the next byte emitted here would land on, and how much of
++   that offset `.org' opened rather than filled.
++
++   Every subsection laid out *before* the one being assembled into contributes
++   its whole length, so a construct written in a higher subsection is placed
++   where the concatenated section puts it.  One laid out after contributes
++   nothing and is not walked.  */
++
++static int dvp_offset_known;
++static addressT dvp_here_slip;
++
++static addressT
++dvp_here (void)
++{
++  segment_info_type *seginfo = seg_info (now_seg);
++  struct frchain *chain;
++  struct dvp_layout pos;
++
++  dvp_offset_known = 1;
++  dvp_here_slip = 0;
++  pos.off = 0;
++  pos.slip = 0;
++  if (seginfo == NULL)
++    {
++      dvp_offset_known = 0;
++      return 0;
++    }
++  for (chain = seginfo->frchainP; chain != NULL; chain = chain->frch_next)
++    {
++      addressT at = 0;
++      int found = 0;
++
++      if (chain == frchain_now)
++	{
++	  if (!dvp_walk_chain (chain, &pos, frag_now, &at, &found) || !found)
++	    break;
++	  dvp_here_slip = pos.slip;
++	  return at + frag_now_fix ();
++	}
++      if (!dvp_walk_chain (chain, &pos, NULL, NULL, NULL))
++	break;
++    }
++  dvp_offset_known = 0;
++  return 0;
++}
++
++/* Where SYM sits in the section it belongs to, and which section that is.
++
++   Called from dvp_md_finish, which runs before the section is laid out, so
++   every frag address is still zero and a defined label's value is its offset
++   within its own frag.  Adding the offset the frag's chain sits at gives the
++   final section offset.  Two symbols are comparable when they came back from
++   the same *section*, which is why the section is handed back, not the chain.  */
++
++/* How deep `.org'-names-a-symbol nesting may go before the walk gives up.  A
++   source can write a `.org' whose target is only reachable by walking past that
++   same `.org', and the walk would follow it round for ever.  */
++#define DVP_SYMBOL_OFFSET_MAX_DEPTH 8
++
++static int dvp_symbol_offset_depth;
++
++static int
++dvp_symbol_offset_1 (symbolS *sym, segT *segp, addressT *out)
++{
++  segT seg;
++  fragS *frag;
++  segment_info_type *seginfo;
++  struct frchain *chain;
++  struct dvp_layout pos;
++
++  if (sym == NULL || !S_IS_DEFINED (sym))
++    return 0;
++  seg = S_GET_SEGMENT (sym);
++  frag = symbol_get_frag (sym);
++  if (frag == NULL || seg == absolute_section || seg == undefined_section)
++    return 0;
++  seginfo = seg_info (seg);
++  if (seginfo == NULL)
++    return 0;
++  pos.off = 0;
++  pos.slip = 0;
++  for (chain = seginfo->frchainP; chain != NULL; chain = chain->frch_next)
++    {
++      addressT at = 0;
++      int found = 0;
++      int settled = dvp_walk_chain (chain, &pos, frag, &at, &found);
++
++      if (found)
++	{
++	  if (segp != NULL)
++	    *segp = seg;
++	  *out = at + S_GET_VALUE (sym);
++	  return 1;
++	}
++      if (!settled)
++	return 0;
++    }
++  return 0;
++}
++
++static int
++dvp_symbol_offset (symbolS *sym, segT *segp, addressT *out)
++{
++  int ok;
++
++  if (dvp_symbol_offset_depth >= DVP_SYMBOL_OFFSET_MAX_DEPTH)
++    return 0;
++  ++dvp_symbol_offset_depth;
++  ok = dvp_symbol_offset_1 (sym, segp, out);
++  --dvp_symbol_offset_depth;
++  return ok;
++}
++
++/* The value of a deferred operand's expression, now that the file has been read
++   and every symbol it names is defined.  Returns 1 and stores it, or 0 if the
++   expression still is not a value.
++
++   Four shapes resolve:
++
++     * a constant -- the ordinary case, a symbol the file `.set's further down;
++
++     * for a VU memory address only, a label defined anywhere in this assembly.
++       The value is the offset the label sits at in its own subsection: this
++       runs before the sections are laid out, so no section base has been added
++       and that offset *is* the encoded value.  It holds across sections, so
++       this reads the frag chain the label is in rather than the command's.
++       Every other deferred container operand refuses a bare label: `mark L',
++       `stcycl L,1' and `stmask L' are all errors;
++
++     * the difference of two labels laid out in the same *section*, whatever
++       fields they are for and whichever subsections they were written in.  GAS
++       folds such a difference itself when both halves share a frag, and those
++       never reach here; every VU instruction is its own frag, so this is the
++       shape a `.vu' block writes.  Both halves are taken in final section
++       coordinates;
++
++     * a VU memory address naming an undefined symbol, where the symbol
++       contributes nothing and the addend is the whole value.
++
++   Anything else -- an undefined symbol anywhere but a VU memory address, a
++   difference across ELF sections, a difference with an undefined half -- is not
++   a value, and the caller reports it.  */
++
++static int dvp_is_overlay_section (asection *);
++
++/* Raised while an operand whose field scales its value is being read.  */
++static int dvp_own_expr;
++
++/* GAS's md_allow_local_subtract hook.  See the comment in tc-dvp.h.  */
++
++int
++dvp_allow_local_subtract (void *left ATTRIBUTE_UNUSED,
++			  void *right ATTRIBUTE_UNUSED, segT seg)
++{
++  return !(dvp_own_expr > 0 && dvp_is_overlay_section (seg));
++}
++
++/* Preserve the expression behind an equate while pseudo_set reads it.  GAS's
++   general expression parser consults md_allow_local_subtract, but pseudo_set
++   performs another same-frag fold of its own afterwards.  The companion hook
++   below declines that fold for two overlay labels.  Keeping both hooks here
++   makes `.set', bare `=', `.equiv' and `.eqv' follow the same path.  */
++
++void
++dvp_pseudo_set_begin (symbolS *sym ATTRIBUTE_UNUSED)
++{
++  ++dvp_own_expr;
++}
++
++void
++dvp_pseudo_set_end (symbolS *sym ATTRIBUTE_UNUSED,
++		    expressionS *ex ATTRIBUTE_UNUSED)
++{
++  --dvp_own_expr;
++}
++
++int
++dvp_allow_equated_local_subtract (symbolS *sym ATTRIBUTE_UNUSED,
++				   expressionS *ex)
++{
++  return !(ex->X_op == O_subtract
++	   && ex->X_add_symbol != NULL
++	   && ex->X_op_symbol != NULL
++	   && dvp_is_overlay_section (S_GET_SEGMENT (ex->X_add_symbol))
++	   && dvp_is_overlay_section (S_GET_SEGMENT (ex->X_op_symbol)));
++}
++
++
++/* An overlay label's value IS the number a field wants.
++
++   A promoted label is defined on &zero_address_frag in a generated overlay
++   section, valued at its VU byte address (dvp_overlay_label).  That is not a
++   position in any section's frag chain, so dvp_symbol_offset cannot find it --
++   and need not, because the value is already the answer.  What differs between
++   fields is only the encoding applied afterwards.
++
++   Only a local one.  A global or weak label keeps a relocation naming the
++   symbol, so it is declined and the caller falls through.  */
++
++/* Does this label's binding put its value out of the assembly's hands?
++
++   A local promoted label is a number this assembly knows and folds in.  A
++   global or weak one is the link's to place, so the value must not be folded
++   and a relocation naming the symbol has to survive.  Two places need that line
++   -- the settle pass and the overlay arm of md_apply_fix -- and they must agree
++   exactly, or a fixup falls between them and its value is lost.  */
++
++static int
++dvp_overlay_binding_defers (symbolS *sym)
++{
++  return S_IS_EXTERNAL (sym) || S_IS_WEAK (sym);
++}
++
++static int
++dvp_overlay_symbol_value (symbolS *sym, addressT *out)
++{
++  if (sym == NULL || !S_IS_DEFINED (sym))
++    return 0;
++  if (!dvp_is_overlay_section (S_GET_SEGMENT (sym)))
++    return 0;
++  if (dvp_overlay_binding_defers (sym))
++    return 0;
++  *out = (addressT) S_GET_VALUE (sym);
++  return 1;
++}
++
++/* A branch inside an mpg block is fully settled by the assembler: both its PC
++   and a promoted target are fixed VU byte addresses, and no branch relocation
++   survives.  Binding therefore has no bearing on that calculation.  Other
++   fields keep the rule above -- a global or weak symbol stays relocatable where
++   the field has a relocation and is refused where it has none.  */
++
++static int
++dvp_overlay_branch_symbol_value (symbolS *sym, addressT *out)
++{
++  if (sym == NULL || !S_IS_DEFINED (sym)
++      || !dvp_is_overlay_section (S_GET_SEGMENT (sym)))
++    return 0;
++  *out = (addressT) S_GET_VALUE (sym);
++  return 1;
++}
++
++/* Evaluate an expression which contains at least one promoted overlay label.
++
++   GAS correctly refuses most arithmetic on symbols from arbitrary ELF sections:
++   their final values belong to the linker.  A promoted label is different --
++   its section is bookkeeping and its value is already the final VU byte
++   address, so arithmetic over it is ordinary integer arithmetic.  Complex
++   expressions reach fixups through synthetic symbols in expr_section; walking
++   that tree here preserves the VU value.
++
++   USED_OVERLAY stops this helper stealing an ordinary expression from the
++   generic relocation path.  Direct global/weak overlay symbols never enter
++   here, so `.word global_label' keeps its relocation while
++   `.word global_label/8' can be settled.  */
++
++static int dvp_eval_overlay_expression_1 (expressionS, dvp_val *, int *, int);
++
++static int
++dvp_eval_overlay_symbol_1 (symbolS *sym, dvp_val *out, int *used_overlay,
++			   int depth)
++{
++  addressT off;
++  segT seg;
++
++  if (sym == NULL || depth > 64)
++    return 0;
++  seg = S_GET_SEGMENT (sym);
++  if (dvp_is_overlay_section (seg))
++    {
++      if (!S_IS_DEFINED (sym))
++	return 0;
++      *out = (dvp_val) S_GET_VALUE (sym);
++      *used_overlay = 1;
++      return 1;
++    }
++  if (seg == expr_section)
++    return dvp_eval_overlay_expression_1 (*symbol_get_value_expression (sym),
++					  out, used_overlay, depth + 1);
++  if (seg == absolute_section)
++    {
++      *out = (dvp_val) S_GET_VALUE (sym);
++      *used_overlay = 0;
++      return 1;
++    }
++  if (dvp_symbol_offset (sym, &seg, &off))
++    {
++      *out = (dvp_val) off;
++      *used_overlay = 0;
++      return 1;
++    }
++  return 0;
++}
++
++static int
++dvp_eval_overlay_expression_1 (expressionS ex, dvp_val *out,
++			       int *used_overlay, int depth)
++{
++  dvp_val left, right, value;
++  int left_overlay = 0, right_overlay = 0;
++
++  if (depth > 64)
++    return 0;
++  switch (ex.X_op)
++    {
++    case O_constant:
++      *out = (dvp_val) ex.X_add_number;
++      *used_overlay = 0;
++      return 1;
++
++    case O_symbol:
++      if (!dvp_eval_overlay_symbol_1 (ex.X_add_symbol, &left,
++				      &left_overlay, depth + 1))
++	return 0;
++      *out = (dvp_val) ((dvp_uval) left + (dvp_uval) ex.X_add_number);
++      *used_overlay = left_overlay;
++      return 1;
++
++    case O_uminus:
++    case O_bit_not:
++    case O_logical_not:
++      if (!dvp_eval_overlay_symbol_1 (ex.X_add_symbol, &left,
++				      &left_overlay, depth + 1))
++	return 0;
++      if (ex.X_op == O_uminus)
++	value = (dvp_val) -(dvp_uval) left;
++      else if (ex.X_op == O_bit_not)
++	value = (dvp_val) ~(dvp_uval) left;
++      else
++	value = !left;
++      *out = (dvp_val) ((dvp_uval) value + (dvp_uval) ex.X_add_number);
++      *used_overlay = left_overlay;
++      return 1;
++
++    case O_multiply:
++    case O_divide:
++    case O_modulus:
++    case O_left_shift:
++    case O_right_shift:
++    case O_bit_inclusive_or:
++    case O_bit_or_not:
++    case O_bit_exclusive_or:
++    case O_bit_and:
++    case O_add:
++    case O_subtract:
++      if (!dvp_eval_overlay_symbol_1 (ex.X_add_symbol, &left,
++				      &left_overlay, depth + 1)
++	  || !dvp_eval_overlay_symbol_1 (ex.X_op_symbol, &right,
++					&right_overlay, depth + 1))
++	return 0;
++      switch (ex.X_op)
++	{
++	case O_multiply:
++	  value = (dvp_val) ((dvp_uval) left * (dvp_uval) right);
++	  break;
++	case O_divide:
++	  if (right == 0)
++	    return 0;
++	  value = right == -1 ? (dvp_val) -(dvp_uval) left : left / right;
++	  break;
++	case O_modulus:
++	  if (right == 0)
++	    return 0;
++	  value = (right == 1 || right == -1) ? 0 : left % right;
++	  break;
++	case O_left_shift:
++	  if ((dvp_uval) right >= 64)
++	    return 0;
++	  value = (dvp_val) ((dvp_uval) left << (dvp_uval) right);
++	  break;
++	case O_right_shift:
++	  if ((dvp_uval) right >= 64)
++	    return 0;
++	  value = (dvp_val) ((dvp_uval) left >> (dvp_uval) right);
++	  break;
++	case O_bit_inclusive_or: value = left | right; break;
++	case O_bit_or_not:       value = left | ~right; break;
++	case O_bit_exclusive_or: value = left ^ right; break;
++	case O_bit_and:          value = left & right; break;
++	case O_add:
++	  value = (dvp_val) ((dvp_uval) left + (dvp_uval) right);
++	  break;
++	case O_subtract:
++	  value = (dvp_val) ((dvp_uval) left - (dvp_uval) right);
++	  break;
++	default: return 0;
++	}
++      *out = (dvp_val) ((dvp_uval) value + (dvp_uval) ex.X_add_number);
++      *used_overlay = left_overlay || right_overlay;
++      return 1;
++
++    default:
++      return 0;
++    }
++}
++
++static int
++dvp_eval_overlay_expression_symbol (symbolS *sym, dvp_val *out)
++{
++  int used_overlay = 0;
++
++  return (sym != NULL && S_GET_SEGMENT (sym) == expr_section
++	  && dvp_eval_overlay_symbol_1 (sym, out, &used_overlay, 0)
++	  && used_overlay);
++}
++
++static int
++dvp_settle_expression (expressionS ex, int is_vaddr, dvp_val *out)
++{
++  segT lseg, rseg;
++  addressT loff, roff;
++
++  (void) resolve_expression (&ex);
++
++  switch (ex.X_op)
++    {
++    case O_constant:
++      *out = (dvp_val) ex.X_add_number;
++      return 1;
++
++    case O_symbol:
++      /* An overlay label resolves in every field, not only a container's VU
++	 address operand: the reference has no notion of an operand class here,
++	 and the value is the same number whichever field asks for it.  */
++      if (dvp_overlay_symbol_value (ex.X_add_symbol, &loff))
++	{
++	  *out = (dvp_val) ((offsetT) loff + (offsetT) ex.X_add_number);
++	  return 1;
++	}
++      if (!is_vaddr)
++	return 0;
++      /* A VU-address field carries no relocation.  The reference therefore
++	 treats a global or weak symbol exactly like an undefined one here: the
++	 symbol contributes zero and only the addend is encoded.  This includes
++	 labels promoted into an mpg overlay; their binding, not their section,
++	 decides this case.  */
++      if (S_GET_SEGMENT (ex.X_add_symbol) == undefined_section
++	  || dvp_overlay_binding_defers (ex.X_add_symbol))
++	{
++	  *out = (dvp_val) ex.X_add_number;
++	  return 1;
++	}
++      if (!dvp_symbol_offset (ex.X_add_symbol, &lseg, &loff))
++	return 0;
++      *out = (dvp_val) ((offsetT) loff + (offsetT) ex.X_add_number);
++      return 1;
++
++    case O_subtract:
++      {
++	int lovly = dvp_overlay_symbol_value (ex.X_add_symbol, &loff);
++	int rovly = dvp_overlay_symbol_value (ex.X_op_symbol, &roff);
++
++	/* Two overlay labels are two VU byte addresses, so their difference is a
++	   number even when they belong to different overlays -- each `mpg'
++	   command generates a section of its own, and the ELF-section rule below
++	   would refuse the pair for that reason alone.  One of each is two
++	   origins and stays refused.  */
++	if (lovly && rovly)
++	  {
++	    *out = (dvp_val) ((offsetT) loff - (offsetT) roff
++			      + (offsetT) ex.X_add_number);
++	    return 1;
++	  }
++	if (lovly || rovly)
++	  return 0;
++      }
++      if (!dvp_symbol_offset (ex.X_add_symbol, &lseg, &loff)
++	  || !dvp_symbol_offset (ex.X_op_symbol, &rseg, &roff))
++	return 0;
++      /* Two ELF sections lay out independently, so a difference across them is
++	 not a number this assembly knows.  Two subsections of one section do
++	 not: they are concatenated into it, and both offsets above are already
++	 measured in what that concatenation produces.  */
++      if (lseg != rseg)
++	return 0;
++      *out = (dvp_val) ((offsetT) loff - (offsetT) roff
++		     + (offsetT) ex.X_add_number);
++      return 1;
++
++    default:
++      return 0;
++    }
++}
++
++static int
++dvp_deferred_value (const struct dvp_deferred_field *df, dvp_val *out)
++{
++  return dvp_settle_expression (df->ex,
++				df->ctr_op != NULL
++				&& df->ctr_field.cls == DVP_CO_VADDR, out);
++}
++
++static int
++dvp_log2 (int n)
++{
++  int p = 0;
++
++  while ((1 << p) < n)
++    ++p;
++  return p;
++}
++
++static void
++dvp_align_to (int bytes)
++{
++  int p = dvp_log2 (bytes);
++
++  record_alignment (now_seg, p);
++  frag_align (p, 0, 0);
++}
++
++/* dvp_align_to for an alignment a *tag* sits behind.
++
++   A DMA tag and a GIF tag both start on a quadword, so data before one is
++   followed by padding.  A label written just before the tag names the tag and
++   not the padding, exactly as a label before a microinstruction names the
++   instruction, and has to move across it.  That is not only a wrong symbol
++   value: a DMA tag may only address a quadword boundary, so a later tag naming
++   the label is rejected for an address the source never wrote.
++
++   Whether there is padding is a question about the finished section, so the
++   frags are recorded and the answer taken in dvp_settle_layout.
++
++   Deliberately *not* what `.dmadata' and `direct' do: a label before either of
++   those stays where the source put it.  */
++
++static void
++dvp_align_to_tag (int bytes)
++{
++  int p = dvp_log2 (bytes);
++  fragS *alignfrag;
++
++  record_alignment (now_seg, p);
++  alignfrag = frag_now;
++  frag_align (p, 0, 0);
++  dvp_defer_pending_label (alignfrag, frag_now);
++}
++
++/* A section the source names for an overlay is an overlay section.
++
++   The name decides it and nothing else does: SHT_DVP_OVERLAY goes to every
++   section whose name begins with the exact prefix `.DVP.overlay.', with the
++   dot, whether the directive wrote a type or not -- an explicit `@progbits' and
++   an explicit `@nobits' both come back as the overlay type, with the flags the
++   source asked for left alone.
++
++   The comparison is case-sensitive and takes the whole prefix, so `.DVP.overlay'
++   without the dot, `.DVP.overlayfoo', `.dvp.overlay.foo', `.DVP.OVERLAY.foo'
++   and `.DVP.ovlytab.x' stay SHT_PROGBITS.  */
++
++static void
++dvp_type_overlay_section (void)
++{
++  const char *name = bfd_section_name (now_seg);
++
++  if (name != NULL
++      && strncmp (name, DVP_OVERLAY_PREFIX,
++		  strlen (DVP_OVERLAY_PREFIX)) == 0)
++    elf_section_type (now_seg) = SHT_DVP_OVERLAY;
++}
++
++/* Every ELF section-changing directive calls this.
++
++   A block's length is the number of bytes between its command word and its
++   terminator, and an automatic DMA count is the number of quadwords between the
++   tag and whatever ends it, so both need their payload to be one contiguous run
++   in one subsection.  Switching section in the middle of either would leave the
++   count measuring bytes that are not the payload -- silently, because both
++   halves are ordinary data.  So the switch is reported, once per construct.  */
++
++void
++dvp_section_changed (void)
++{
++  dvp_type_overlay_section ();
++
++  int i;
++
++  /* Every open block, not only the innermost.  A nested GIF tag interrupts the
++     block it was written inside without ending it, so a section switch inside the
++     nested tag breaks the outer block's run of bytes just as surely as the inner
++     one's -- and each block is reported once, against its own opener, because
++     each carries its own file, line, subsection and reported flag.  */
++  for (i = 1; i <= dvp_blk_depth; i++)
++    {
++      struct dvp_block *b = &dvp_blocks[i];
++
++      if (b->op == NULL || b->seg_reported
++	  || (now_seg == b->seg && now_subseg == b->subseg))
++	continue;
++      b->seg_reported = 1;
++      as_bad (_("this changes section while the %s block opened at %s:%u is "
++		"still open; that block's length is measured from the bytes "
++		"that follow it, so they have to be one run in one "
++		"subsection -- close it with %s first"),
++	      b->op->name, b->file, b->line, b->op->terminator);
++    }
++  if (dvp_dmadata_open && !dvp_dmadata_seg_reported
++      && (now_seg != dvp_dmadata_seg || now_subseg != dvp_dmadata_subseg))
++    {
++      dvp_dmadata_seg_reported = 1;
++      as_bad (_("this changes section while the .dmadata region \"%s\" opened "
++		"at %s:%u is still open; that region is one contiguous run of "
++		"quadwords and is padded out to one when it closes, so it has "
++		"to stay in one subsection -- close it with .enddmadata "
++		"first"),
++	      dvp_dmadata_name, dvp_dmadata_file, dvp_dmadata_line);
++    }
++}
++
++/* How much padding A needs, given that the section has reached POS, and whether
++   the source can have it at all.
++
++   The padding runs forward to the *next* boundary and no further: a command
++   word takes the LEAD bytes in front of that boundary, so a position already
++   inside those bytes has no room left for it, and the source is reported rather
++   than pushed on to the boundary after next.
++
++   An `.org' is the other way a source loses the boundary.  It moves the section
++   on without putting bytes in it: where an `.org' has shifted the section by an
++   amount the alignment does not divide, the payload lands somewhere other than
++   a boundary and the source is refused.  What decides it is the shift, not the
++   position.  */
++
++static addressT
++dvp_settle_one_align (struct dvp_pending_align *a,
++		      const struct dvp_layout *pos)
++{
++  addressT mask = (addressT) a->align - 1;
++
++  if (a->align <= 1)
++    return 0;
++  /* Only where a command word has to land in front of the boundary.  Padding at
++     the tail of a block has no command to place, and the reference writes it
++     from where the payload really ends however the section got there --
++     measured with an `.org' either side of a one-byte `unpack' payload.  */
++  if (a->check_fit && pos->slip % (addressT) a->align != 0)
++    {
++      as_bad_where (a->file, a->line,
++		    _(".org has moved this section on by %lu bytes, which %d "
++		      "does not divide, and %s aligns its payload to %d -- the "
++		      "padding before it is worked out without that gap, so the "
++		      "payload would not land on a %d-byte boundary; .org to a "
++		      "multiple of %d before it"),
++		    (unsigned long) pos->slip, a->align, a->what, a->align,
++		    a->align, a->align);
++      return 0;
++    }
++  if (a->check_fit
++      && (offsetT) (pos->off & mask) + a->lead > a->align)
++    {
++      as_bad_where (a->file, a->line,
++		    _("%s would start %lu bytes past a %d-byte boundary, which "
++		      "leaves no room for its %d-byte command word before the "
++		      "next one -- its payload has to start on a %d-byte "
++		      "boundary, so pad or align to one before it"),
++		    a->what, (unsigned long) (pos->off & mask), a->align,
++		    a->lead, a->align);
++      return 0;
++    }
++  return (addressT) (-(offsetT) (pos->off + a->lead)) & mask;
++}
++
++/* Settle everything the finished section decides: every piece of padding whose
++   size was left open, and every label waiting to be moved across an
++   instruction's alignment.
++
++   The walk is the one every other offset goes through, so each is settled as
++   the walk reaches it and everything after it is measured against the settled
++   size -- including the next piece.
++
++   A frag whose size this cannot settle stops the walk, and what that costs is
++   exactly what lies *behind* it: a construct in front was already settled, and
++   is placed from the bytes ahead of it.  So the diagnostic is reported only
++   against the constructs the walk never reached.  */
++
++static void
++dvp_settle_layout (void)
++{
++  asection *sec;
++  struct dvp_pending_align *a;
++  struct dvp_pending_label_move *m;
++
++  if (dvp_pending_aligns == NULL && dvp_label_moves == NULL)
++    return;
++  dvp_settling = 1;
++  for (sec = stdoutput->sections; sec != NULL; sec = sec->next)
++    {
++      segment_info_type *seginfo = seg_info (sec);
++      struct frchain *chain;
++      struct dvp_layout pos;
++      int here = 0;
++
++      if (seginfo == NULL)
++	continue;
++      for (a = dvp_pending_aligns; a != NULL; a = a->next)
++	if (a->seg == sec)
++	  here = 1;
++      for (m = dvp_label_moves; m != NULL; m = m->next)
++	if (m->seg == sec)
++	  here = 1;
++      if (!here)
++	continue;
++      pos.off = 0;
++      pos.slip = 0;
++      for (chain = seginfo->frchainP; chain != NULL; chain = chain->frch_next)
++	if (!dvp_walk_chain (chain, &pos, NULL, NULL, NULL))
++	  break;
++    }
++  dvp_settling = 0;
++
++  /* Anything the walk never reached.  Its size really is not settled by
++     anything this assembler can see, so it is reported rather than left
++     silently the wrong length.  */
++  for (a = dvp_pending_aligns; a != NULL; a = a->next)
++    if (!a->settled)
++      as_bad_where (a->file, a->line,
++		    _("cannot tell where %s lands, because something before it "
++		      "in this section has a size that is not settled"),
++		    a->what);
++
++  /* And the labels.  One the walk did not reach keeps the value GAS gave it,
++     which is where it was written; moving it needs to know whether anything was
++     inserted, and that is the thing the walk could not establish.  */
++  for (m = dvp_label_moves; m != NULL; m = m->next)
++    if (m->settled && m->padded && S_GET_SEGMENT (m->sym) == m->seg)
++      {
++	symbol_set_frag (m->sym, m->target);
++	S_SET_VALUE (m->sym, 0);
++      }
++}
++
++/* Leave room for padding whose size dvp_md_finish will settle, and guess at it
++   now so that a length measured while the file is still being read is measured
++   against the same bytes the guess will put there.  LEAD is what goes between
++   the padding and the boundary -- a command word, or nothing at the tail of a
++   block.  */
++
++static void
++dvp_defer_align (const char *what, int align, int lead, int check_fit)
++{
++  struct dvp_pending_align *a;
++  addressT off;
++  addressT guess = 0;
++  fragS *padfrag;
++  char *pad;
++
++  if (align <= 1)
++    return;
++  off = dvp_here ();
++  if (dvp_offset_known)
++    guess = (addressT) (-(offsetT) (off + lead)) & (addressT) (align - 1);
++
++  /* The variable part of the frag being closed, which is where the padding
++     goes: one byte of fill, repeated as many times as the size settles to.
++     frag_var closes the frag that is open now and starts another, so it is this
++     one that holds the padding and this one the settling pass has to find.  */
++  padfrag = frag_now;
++  pad = frag_var (rs_fill, align, 1, (relax_substateT) 0, NULL,
++		  (offsetT) guess, NULL);
++  *pad = 0;
++
++  a = XNEW (struct dvp_pending_align);
++  a->next = NULL;
++  a->frag = padfrag;
++  a->seg = now_seg;
++  a->align = align;
++  a->lead = lead;
++  a->check_fit = check_fit;
++  a->settled = 0;
++  a->what = what;
++  a->file = as_where (&a->line);
++  *dvp_pending_aligns_tail = a;
++  dvp_pending_aligns_tail = &a->next;
++}
++
++/* Leave the padding that puts this construct's payload on an ALIGN boundary,
++   with the command word immediately in front of it.
++
++   The size is not worked out here: where the construct really is depends on
++   bytes a lower subsection can still be given and on an `.org' that can still
++   be written, so it is settled in dvp_md_finish.  */
++
++static void
++dvp_align_payload (const char *what, int align)
++{
++  record_alignment (now_seg, dvp_log2 (align));
++  dvp_defer_align (what, align, DVP_VIFCODE_BYTES, 1);
++}
++
++static void
++dvp_start_vif_unit (void)
++{
++  if (!dvp_vif_unit_pending)
++    return;
++  dvp_vif_unit_pending = 0;
++  dvp_emit_marker (DVP_MARK_VIF_PREFIX, dvp_unit_counter++,
++		   DVP_MARK_VIF_OTHER);
++}
++
++static char *
++dvp_emit_words (const unsigned int *words, int n)
++{
++  char *f;
++  int i;
++
++  /* Whatever label was waiting is not naming this: a container command word is
++     not the microinstruction the label was written for.  */
++  dvp_forget_pending_label ();
++  f = frag_more (n * 4);
++
++  for (i = 0; i < n; i++)
++    md_number_to_chars (f + i * 4, words[i], 4);
++  return f;
++}
++
++/* Put COUNT into a command word that has already been emitted.  */
++
++static void
++dvp_patch_count (const struct dvp_ctr_opcode *op,
++		 const struct dvp_ctr_field *field, dvp_val count,
++		 fragS *frag, unsigned long where)
++{
++  char *buf;
++
++  /* No command word was emitted, because the option that removes this kind of
++     header was given.  There is nothing to write the count into,
++     and nothing that would read it: the count describes a transfer whose command
++     is not in the object.  */
++  if (frag == NULL)
++    return;
++  buf = frag->fr_literal + where;
++  unsigned int words[DVP_CTR_MAX_HEADER];
++  char err[DVP_ERRLEN];
++  const char *e;
++
++  memset (words, 0, sizeof (words));
++  words[0] = dvp_read_word (buf);
++  e = dvp_ctr_place_count (op, field, count, words, err, sizeof (err));
++  if (e != NULL)
++    {
++      as_bad ("%s", e);
++      return;
++    }
++  md_number_to_chars (buf, words[0], 4);
++}
++
++/* Emit N zero bytes at the current position.  Used for the padding a block
++   emits when it closes, which is emitted where the block is so that it counts
++   towards an enclosing block exactly as the payload does.  */
++
++static void
++dvp_emit_zero_bytes (addressT n)
++{
++  while (n-- != 0)
++    {
++      char *p = frag_more (1);
++
++      *p = 0;
++    }
++}
++
++/* --- the write cycle and an unpack's automatic count --------------------- */
++
++/* A cycle setting divides an `unpack' count that the assembler works out for
++   itself.  `stcycl WL, CL' names two operands, named here for their positions.
++
++   While WL is no greater than CL, or WL is no greater than one, the count is
++   the payload's whole element count and nothing here applies.  A CL of zero
++   under a WL of one or more leaves no count at all.  Otherwise, for a payload
++   of N elements,
++
++       NUM = WL * (N / CL) + f(N mod CL)
++
++   with two relations deciding the residual f, both in truncating division:
++
++       E(v) = v + (v * CL) / WL          G(v) = (v * CL) / WL
++
++   f(0) is zero.  For a residue r above zero, f(r) is the v in [1, WL) with
++   E(v) == r if there is one -- E strictly increases, so there is at most one --
++   and otherwise the *largest* v in [1, WL) with either E(v) == r + CL, or
++   G(v) == r together with v >= CL, less WL.  That second answer is negative, so
++   a longer payload can be given a *smaller* count, and a count that would fall
++   to zero or below is refused.  For some settings neither relation is satisfied
++   by any v and there is no count for that residue at any payload length.
++
++   None of that is tidied up here: it is a deliberate bug-for-bug
++   reproduction.  */
++
++static dvp_val
++dvp_cycle_consumed (dvp_val v, dvp_val wl, dvp_val cl)
++{
++  return v + (v * cl) / wl;
++}
++
++static dvp_val
++dvp_cycle_step (dvp_val v, dvp_val wl, dvp_val cl)
++{
++  return (v * cl) / wl;
++}
++
++/* Non-zero when the setting divides an automatic count at all.  */
++
++static int
++dvp_cycle_divides (dvp_val wl, dvp_val cl)
++{
++  return wl > 1 && cl > 0 && cl < wl;
++}
++
++/* f(r).  Returns non-zero and stores the residual, or zero when the reference
++   has no count for that residue.  */
++
++static int
++dvp_cycle_residual (dvp_val wl, dvp_val cl, dvp_val r, dvp_val *out)
++{
++  dvp_val v, best = 0;
++
++  if (r == 0)
++    {
++      *out = 0;
++      return 1;
++    }
++  for (v = 1; v < wl; v++)
++    if (dvp_cycle_consumed (v, wl, cl) == r)
++      {
++	*out = v;
++	return 1;
++      }
++  for (v = 1; v < wl; v++)
++    if (dvp_cycle_consumed (v, wl, cl) == r + cl
++	|| (dvp_cycle_step (v, wl, cl) == r && v >= cl))
++      best = v;
++  if (best == 0)
++    return 0;
++  *out = best - wl;
++  return 1;
++}
++
++/* The count an `unpack' of NELEM elements gets under the setting WL, CL.
++   Returns non-zero and stores it, or zero when there is none -- which is a
++   refusal, not a count of zero, and the caller reports it.  */
++
++static int
++dvp_cycle_count (dvp_val nelem, dvp_val wl, dvp_val cl, dvp_val *out)
++{
++  dvp_val q, r, f;
++
++  if (cl == 0 && wl >= 1)
++    return DVP_CYCLE_ZERO_CL_REFUSES ? 0 : (*out = nelem, 1);
++  if (!dvp_cycle_divides (wl, cl))
++    {
++      *out = nelem;
++      return 1;
++    }
++  q = nelem / cl;
++  r = nelem % cl;
++  if (!dvp_cycle_residual (wl, cl, r, &f))
++    return 0;
++  *out = wl * q + f;
++  return 1;
++}
++
++/* A count the assembler worked out for itself must never be a zero that the
++   field spells as its maximum.
++
++   On `unpack', `mpg', `direct' and `directhl' the largest count is one more
++   than the count field can hold, so it is stored as zero.  A block whose
++   payload measures zero units would therefore be given a command word asking
++   for 256 elements, or 65536 quadwords, while nothing follows it.  There is no
++   bit pattern that says "nothing", so the only correct answer is to report it.
++   Where the source writes the count out itself this does not apply.
++
++   Returns non-zero when the count may be written.  */
++
++static int
++dvp_auto_count_is_expressible (const struct dvp_ctr_opcode *op,
++			       const struct dvp_ctr_field *field, dvp_val count,
++			       const char *file, unsigned int line)
++{
++  if (count != 0 || !dvp_ctr_zero_means_max (op, field))
++    return 1;
++  as_bad_where (file, line,
++		_("this %s works out to a count of zero, and a count of zero is "
++		  "how this field spells %lld, so the count cannot be worked "
++		  "out; write the count out if that is what you mean"),
++		op->name, dvp_ctr_count_max (op));
++  return 0;
++}
++
++/* What a written-out count asks for, which is not always the number written.
++
++   A count field whose largest value is one more than the field can hold stores
++   that largest value as zero.  On such a field a written-out zero is that
++   maximum and not "nothing": `direct 0' asks for 65536 quadwords, `mpg 0, 0'
++   for 256 microinstructions.  Where zero spells nothing but zero -- a GIF tag's
++   nloop, a DMA tag's quadword count -- it is read as written.
++
++   Reading it off the table rather than per command is what makes the rule reach
++   `direct' and `directhl'.  An `unpack' count is not validated against its
++   payload at all, so it never gets here.  */
++
++static dvp_val
++dvp_written_count (const struct dvp_ctr_opcode *op,
++		   const struct dvp_ctr_field *field, dvp_val written)
++{
++  if (written == 0 && dvp_ctr_zero_means_max (op, field))
++    return dvp_ctr_count_max (op);
++  return written;
++}
++
++
++/* Apply the cycle in force to an automatic `unpack' count and patch it in.
++   Reports, rather than emitting a number it did not compute, when the setting
++   leaves no count for this payload.  */
++
++static void
++dvp_patch_unpack_count (const struct dvp_ctr_opcode *op,
++			const struct dvp_ctr_field *field, fragS *frag,
++			unsigned long where, dvp_val nelem, dvp_val wl, dvp_val cl,
++			const char *file, unsigned int line)
++{
++  dvp_val num;
++
++  if (!dvp_cycle_count (nelem, wl, cl, &num))
++    {
++      as_bad_where (file, line,
++		    _("under the cycle setting %lld,%lld an unpack of %lld "
++		      "element%s has no count this field can hold; write the "
++		      "count out, or change the setting"), wl, cl, nelem,
++		    nelem == 1 ? "" : "s");
++      return;
++    }
++  if (num < 0)
++    {
++      as_bad_where (file, line,
++		    _("under the cycle setting %lld,%lld an unpack of %lld "
++		      "element%s works out to a count of %lld, and a count below "
++		      "one cannot be encoded; write the count out, or change "
++		      "the setting"), wl, cl, nelem, nelem == 1 ? "" : "s",
++		    num);
++      return;
++    }
++  if (num > dvp_ctr_count_max (op))
++    {
++      as_bad_where (file, line,
++		    _("under the cycle setting %lld,%lld an unpack of %lld "
++		      "element%s works out to a count of %lld, and the largest "
++		      "count this field holds is %lld"), wl, cl, nelem,
++		    nelem == 1 ? "" : "s", num, dvp_ctr_count_max (op));
++      return;
++    }
++  if (!dvp_auto_count_is_expressible (op, field, num, file, line))
++    return;
++  dvp_patch_count (op, field, num, frag, where);
++}
++
++
++/* The keyword a GIF tag's length is written as.  Found by name rather than by
++   position: a packed tag's keyword list starts with its primitive, so the length
++   is not always the first, and reading it off index zero placed a count in the
++   wrong field.  */
++
++static const struct dvp_ctr_keyword *
++dvp_length_keyword (const struct dvp_ctr_opcode *op)
++{
++  int i;
++
++  for (i = 0; i < op->nkeywords; i++)
++    if (strcmp (op->keywords[i].name, "nloop") == 0)
++      return &op->keywords[i];
++  return NULL;
++}
++
++/* The field a block's automatic length goes into.  For everything with a
++   positional count that is the last operand; a GIF tag spells it as a
++   keyword.  */
++
++static struct dvp_ctr_field
++dvp_length_field (const struct dvp_ctr_opcode *op)
++{
++  struct dvp_ctr_field f;
++
++  if (op->kind == DVP_CTR_DMA)
++    /* A DMA tag's count is its *first* operand, and on `dmanext' and `dmacall'
++       the last one is the address -- so "the last operand" would write the count
++       into the address field.  */
++    return op->fields[0];
++
++  if (op->kind == DVP_CTR_GIF)
++    {
++      const struct dvp_ctr_keyword *k = dvp_length_keyword (op);
++
++      f.cls = DVP_CO_QWCOUNT;
++      f.word = k->word;
++      f.value_lsb = 0;
++      f.shift = k->shift;
++      f.width = k->width;
++      return f;
++    }
++  f = op->fields[op->nfields - 1];
++  return f;
++}
++
++/* --- a payload named by a symbol ---------------------------------------- */
++
++/* The name `.dmadata NAME' defines to mark where the region ends.  A local
++   label, so it stays out of the object's symbol table; the region's extent is
++   the only thing that reads it.  */
++
++static char *
++dvp_end_symbol_name (const char *name)
++{
++  size_t n = strlen (name);
++  char *s = XNEWVEC (char, n + sizeof (DVP_END_PREFIX));
++
++  memcpy (s, DVP_END_PREFIX, sizeof (DVP_END_PREFIX) - 1);
++  memcpy (s + sizeof (DVP_END_PREFIX) - 1, name, n + 1);
++  return s;
++}
++
++/* How many whole quadwords the payload NAME names comes to, from NAME to
++   `.L.end.NAME'.  Returns 0, having reported, if there is no such extent.  */
++
++static int
++dvp_payload_quadwords (const struct dvp_ctr_opcode *op, const char *name,
++		       dvp_val *out, const char *file, unsigned int line)
++{
++  char *endname = dvp_end_symbol_name (name);
++  symbolS *start = symbol_find (name);
++  symbolS *end = symbol_find (endname);
++  segT ss, es;
++  addressT so, eo;
++  offsetT bytes;
++  dvp_val qwc;
++
++  if (start == NULL || !S_IS_DEFINED (start))
++    {
++      as_bad_where (file, line,
++		    _("%s: \"*\" takes its count from the payload \"%s\", and "
++		      "nothing in this input defines \"%s\""),
++		    op->name, name, name);
++      free (endname);
++      return 0;
++    }
++  if (end == NULL || !S_IS_DEFINED (end))
++    {
++      as_bad_where (file, line,
++		    _("%s: \"*\" takes its count from the payload \"%s\", and "
++		      "nothing says where \"%s\" ends; write it as "
++		      "\".dmadata %s\" ... \".enddmadata\", or define \"%s\" "
++		      "yourself"),
++		    op->name, name, name, name, endname);
++      free (endname);
++      return 0;
++    }
++  /* A payload may be described rather than laid out: `.set payload,0' and
++     `.set .L.end.payload,16' say it is one quadword without a byte of it being
++     in this file.  Two absolute symbols have no frag chain to walk, and their
++     difference is simply their values, which is what the reference's expression
++     `(.L.end.NAME - NAME) >> 4' comes to for them.  */
++  if (S_GET_SEGMENT (start) == absolute_section
++      && S_GET_SEGMENT (end) == absolute_section)
++    {
++      so = (addressT) S_GET_VALUE (start);
++      eo = (addressT) S_GET_VALUE (end);
++    }
++  else if (!dvp_symbol_offset (start, &ss, &so)
++	   || !dvp_symbol_offset (end, &es, &eo) || ss != es)
++    {
++      as_bad_where (file, line,
++		    _("%s: the payload \"%s\" and its end are not one run in "
++		      "one section, so its length cannot be measured; give "
++		      "the count instead of \"*\""), op->name, name);
++      free (endname);
++      return 0;
++    }
++  bytes = (offsetT) eo - (offsetT) so;
++  if (bytes < 0)
++    {
++      as_bad_where (file, line,
++		    _("%s: the payload \"%s\" ends %lld bytes before it "
++		      "begins"), op->name, name, (dvp_val) -bytes);
++      free (endname);
++      return 0;
++    }
++  /* Whole quadwords only: a DMA transfer moves quadwords, so a partial one at
++     the end of the payload is not part of the transfer and counts for nothing.  */
++  qwc = (dvp_val) (bytes / DVP_TAG_BYTES);
++  if (qwc > (dvp_val) op->count_max)
++    {
++      as_bad_where (file, line,
++		    _("the payload \"%s\" is %lld bytes, which is %lld "
++		      "quadwords, and this %s's count field holds at most %u"),
++		    name, (dvp_val) bytes, qwc, op->name,
++		    (unsigned) op->count_max);
++      free (endname);
++      return 0;
++    }
++  *out = qwc;
++  free (endname);
++  return 1;
++}
++
++/* Remember a tag that has to be given its count once every symbol is defined:
++   the payload may be written after the tag that refers to it.  */
++
++static void
++dvp_defer_extent (const struct dvp_ctr_opcode *op,
++		  const struct dvp_ctr_field *field, fragS *frag,
++		  unsigned long where, const char *name)
++{
++  struct dvp_pending_extent *d = XNEW (struct dvp_pending_extent);
++
++  d->next = NULL;
++  d->op = op;
++  d->field = *field;
++  d->frag = frag;
++  d->where = where;
++  d->name = xstrdup (name);
++  d->file = as_where (&d->line);
++  *dvp_pending_extents_tail = d;
++  dvp_pending_extents_tail = &d->next;
++}
++
++/* A count the source wrote as an expression that was not a value yet.  The word
++   is already emitted with the count field left at zero; this records where that
++   field is so the value can be encoded once every symbol is defined.
++
++   NEEDS_PAYLOAD says whether the tag opened a payload for the count to be
++   checked against.  It is registered here rather than where a block is pushed
++   because the tags that describe a payload elsewhere push no block.  */
++
++static struct dvp_pending_count *
++dvp_defer_count (const struct dvp_ctr_opcode *op,
++		 const struct dvp_ctr_field *field, fragS *frag,
++		 unsigned long where, const expressionS *ex,
++		 int needs_payload)
++{
++  struct dvp_pending_count *d = XNEW (struct dvp_pending_count);
++
++  d->next = NULL;
++  d->op = op;
++  d->field = *field;
++  d->frag = frag;
++  d->where = where;
++  d->ex = *ex;
++  d->measured = 0;
++  d->have_measured = 0;
++  d->needs_payload = needs_payload;
++  d->file = as_where (&d->line);
++  *dvp_pending_counts_tail = d;
++  dvp_pending_counts_tail = &d->next;
++  return d;
++}
++
++/* --- reading container operands ------------------------------------------ */
++
++/* Copy the identifier at *PP into BUF and advance.  Returns 0 if there is no
++   identifier there, and -1 if there is one too long for BUF -- which is
++   reported rather than truncated, because a truncated name could otherwise be
++   looked up as though it were a different, shorter one.  */
++
++static int
++dvp_read_ident (char **pp, char *buf, size_t buflen)
++{
++  char *p = dvp_skip_white (*pp);
++  size_t n = 0;
++
++  if (!(ISALPHA ((unsigned char) *p) || *p == '_' || *p == '.'))
++    return 0;
++  while (ISALNUM ((unsigned char) *p) || *p == '_' || *p == '.'
++	 || *p == '-' || *p == '$')
++    {
++      if (n + 1 >= buflen)
++	{
++	  as_bad (_("this name is longer than the %lu characters a container "
++		    "command, data format or keyword can have"),
++		  (unsigned long) buflen - 1);
++	  return -1;
++	}
++      buf[n++] = *p;
++      ++p;
++    }
++  buf[n] = 0;
++  *pp = p;
++  return 1;
++}
++
++/* A written-out C integer at *PP, exactly as `strtol (p, &end, 0)' reads one:
++   `0x' or `0X' introduces hexadecimal, a leading `0' octal, anything else
++   decimal, and the scan stops at the first character that does not belong.  No
++   sign, because the digit the caller checked for is the first character.
++   Returns 0 if there are no digits at all; the caller decides what is left
++   over.  */
++
++static int
++dvp_read_c_integer (char **pp, dvp_val *valp)
++{
++  char *p = *pp;
++  dvp_val v = 0;
++  int base = 10;
++  int n = 0;
++
++  if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X') && ISXDIGIT ((unsigned char) p[2]))
++    {
++      base = 16;
++      p += 2;
++    }
++  else if (p[0] == '0')
++    base = 8;
++  for (;; ++p)
++    {
++      int d;
++
++      if (ISDIGIT ((unsigned char) *p))
++	d = *p - '0';
++      else if (base == 16 && ISXDIGIT ((unsigned char) *p))
++	d = (TOLOWER ((unsigned char) *p) - 'a') + 10;
++      else
++	break;
++      if (d >= base)
++	break;
++      v = v * base + d;
++      ++n;
++    }
++  if (n == 0)
++    return 0;
++  *valp = v;
++  *pp = p;
++  return 1;
++}
++
++/* The quoted file name that may stand where a payload count would go.
++
++   It is not a GAS string: the bytes between the quotes are copied verbatim, so
++   `\0', `\x31' and `\.' are those two characters and not an escape.  Decoding
++   them would open a *different file*.
++
++   A name must hold at least one character: the character after the opening
++   quote is stepped over before the closing one is looked for, so `""' is an
++   unterminated name rather than an empty one.
++
++   A NUL inside the name is refused before anything touches the filesystem: the
++   name reaches `open' as a C string, so "f16.bin\0junk" would have opened
++   `f16.bin' while the source said something else.  */
++
++static const char *
++dvp_read_payload_name (char **pp, const struct dvp_ctr_opcode *op)
++{
++  char *p = *pp;
++  char *start, *q;
++  size_t len;
++  char *out;
++
++  start = p + 1;
++  q = start;
++  if (*q != 0)
++    ++q;			/* the first character is always part of it */
++  while (*q != 0 && *q != '"')
++    ++q;
++  if (*q != '"')
++    {
++      as_bad (_("%s: this payload file name has no closing '\"'"), op->name);
++      return NULL;
++    }
++  len = (size_t) (q - start);
++  if (memchr (start, 0, len) != NULL)
++    {
++      as_bad (_("%s: this payload file name contains a NUL, so it does not "
++		"name a file"), op->name);
++      return NULL;
++    }
++  out = XNEWVEC (char, len + 1);
++  memcpy (out, start, len);
++  out[len] = 0;
++  *pp = q + 1;
++  return out;
++}
++
++/* Evaluate an absolute expression at *PP.  Returns 0 and reports if the value
++   is not known at assembly time.  */
++
++static int
++dvp_read_absolute (char **pp, const char *what, offsetT *valp)
++{
++  char *save = input_line_pointer;
++  expressionS ex;
++
++  input_line_pointer = dvp_skip_white (*pp);
++  expression (&ex);
++  *pp = input_line_pointer;
++  input_line_pointer = save;
++
++  if (ex.X_op != O_constant)
++    {
++      as_bad (_("%s must be a value known at assembly time"), what);
++      return 0;
++    }
++  *valp = ex.X_add_number;
++  return 1;
++}
++
++/* Read a GIF tag keyword's value.
++
++   Deliberately not `dvp_read_absolute'.  A keyword's value is a written-out
++   integer, not an expression: `(1)', `1+0' and a symbol are all refused, as is
++   anything left over after the number -- `1a', `0xg' and `1.0' are errors.
++
++   The two value keywords do not read a number the same way, and which form each
++   takes is carried in the generated table:
++
++     DVP_KWNUM_C        a C integer literal -- `0x'/`0X' hexadecimal, a leading
++			zero for octal, otherwise decimal.  `prim=010' is
++			eight, `prim=0x7ff' is 2047, and `prim=08' is not a
++			number at all;
++
++     DVP_KWNUM_DECIMAL  decimal, leading zeros and all.  `nloop=010' is ten and
++			`nloop=08' is eight, and `nloop=0x8' is not a number.
++
++   Both take an optional sign whose digits must follow it directly, so `+1' and
++   `-0' are values and `+ 1' and `- 0' are not.  A negative value is handed on
++   and range-checked with every other, which is why `-0' is accepted and `-1'
++   is not.
++
++   Returns 0 and reports if there is no such integer at *PP.  */
++
++/* One base's digit value for C, or -1.  */
++
++static int
++dvp_digit_value (unsigned char c, int base)
++{
++  int v;
++
++  if (ISDIGIT (c))
++    v = c - '0';
++  else if (c >= 'a' && c <= 'f')
++    v = c - 'a' + 10;
++  else if (c >= 'A' && c <= 'F')
++    v = c - 'A' + 10;
++  else
++    return -1;
++  return v < base ? v : -1;
++}
++
++static int
++dvp_read_gif_number (char **pp, const struct dvp_ctr_keyword *k,
++		     offsetT *valp)
++{
++  char *p = dvp_skip_white (*pp);
++  const char *what = k->name;
++  offsetT v = 0;
++  int digits = 0;
++  int negate = 0;
++  int base = 10;
++
++  if (*p == '+' || *p == '-')
++    negate = (*p++ == '-');
++
++  if (k->numform == DVP_KWNUM_C && *p == '0')
++    {
++      if (p[1] == 'x' || p[1] == 'X')
++	{
++	  base = 16;
++	  p += 2;
++	}
++      else
++	{
++	  /* A bare zero is zero in any base, so the octal reading only has to
++	     take the digits after it; `0' on its own still counts as one.  */
++	  base = 8;
++	  ++p;
++	  ++digits;
++	}
++    }
++
++  while (dvp_digit_value ((unsigned char) *p, base) >= 0)
++    {
++      /* A value far past any field is caught by the range check rather than by
++	 wrapping into it.  */
++      if (v <= (offsetT) 0xfffffff)
++	v = v * base + dvp_digit_value ((unsigned char) *p, base);
++      else
++	v = (offsetT) 0x10000000;
++      ++p;
++      ++digits;
++    }
++
++  if (digits == 0)
++    {
++      as_bad (k->numform == DVP_KWNUM_C
++	      ? _("%s must be written as a number here")
++	      : _("%s must be written as a decimal number here"), what);
++      return 0;
++    }
++  /* Nothing may be left of the word the number was written in.  `018' is one
++     followed by an eight that is not an octal digit, and `1a' and `0xg' are the
++     same shape; each is an error rather than a number with text behind it.  */
++  if (ISALNUM ((unsigned char) *p) || *p == '_' || *p == '.' || *p == '$')
++    {
++      as_bad (_("%s: \"%s\" is not a number this keyword can take"), what, *pp);
++      return 0;
++    }
++  *pp = p;
++  *valp = negate ? -v : v;
++  return 1;
++}
++
++/* The order a tag's keywords are written in, for a diagnostic that has to say
++   what the order is.  Built into a static buffer, which is fine: the caller
++   reports and returns.  */
++
++static const char *
++dvp_gif_keyword_order (const struct dvp_ctr_opcode *op)
++{
++  static char buf[128];
++  size_t at = 0;
++  int i;
++
++  buf[0] = 0;
++  for (i = 0; i < op->nkeywords; i++)
++    {
++      const char *nm = op->keywords[i].name;
++      size_t need = strlen (nm) + (i ? 2 : 0);
++
++      if (at + need + 1 >= sizeof (buf))
++	break;
++      if (i)
++	{
++	  memcpy (buf + at, ", ", 2);
++	  at += 2;
++	}
++      memcpy (buf + at, nm, strlen (nm));
++      at += strlen (nm);
++      buf[at] = 0;
++    }
++  return buf;
++}
++
++/* Read `{R,...}' at *PP into the descriptor's register fields, and hand back how
++   many entries it held.  The braces are required, the list may not be empty and
++   may not have a trailing or leading comma, and a repeated register is
++   deliberately allowed: naming the same register twice in a packed transfer is a
++   meaningful thing to write and the reference accepts it.  */
++
++static int
++dvp_read_register_list (const struct dvp_ctr_opcode *op,
++			const struct dvp_ctr_keyword *k, char **pp,
++			unsigned int *words, unsigned int *countp)
++{
++  char ident[64];
++  char *p = dvp_skip_white (*pp);
++  unsigned int count = 0;
++  struct dvp_ctr_field nf;
++  char err[DVP_ERRLEN];
++  const char *e;
++
++  if (*p != '{')
++    {
++      as_bad (_("%s: a register list is written in braces, as in "
++		"\"%s={PRIM,RGBAQ}\""), op->name, k->name);
++      return 0;
++    }
++  ++p;
++  for (;;)
++    {
++      dvp_val v;
++      int n;
++
++      p = dvp_skip_white (p);
++      n = dvp_read_ident (&p, ident, sizeof (ident));
++      if (n <= 0)
++	{
++	  as_bad (_("%s: expected a register name in \"%s\", found \"%s\""),
++		  op->name, k->name, p);
++	  return 0;
++	}
++      v = dvp_ctr_reg_value (op, ident);
++      if (v < 0)
++	{
++	  as_bad (_("%s: \"%s\" is not one of the registers a %s tag can name"),
++		  op->name, ident, op->name);
++	  return 0;
++	}
++      if (count >= op->nreg_max)
++	{
++	  as_bad (_("%s: a register list holds at most %u registers"),
++		  op->name, op->nreg_max);
++	  return 0;
++	}
++      dvp_ctr_place_reg (op, (int) count, (unsigned int) v, words);
++      ++count;
++      p = dvp_skip_white (p);
++      if (*p == ',')
++	{
++	  ++p;
++	  continue;
++	}
++      if (*p == '}')
++	{
++	  ++p;
++	  break;
++	}
++      as_bad (_("%s: expected \",\" or \"}\" in \"%s\", found \"%s\""),
++	      op->name, k->name, p);
++      return 0;
++    }
++  if (count == 0)
++    {
++      as_bad (_("%s: \"%s\" is empty, and a %s tag transfers at least one "
++		"register"), op->name, k->name, op->name);
++      return 0;
++    }
++  /* NREG spells its maximum as zero, which is what the four-bit field forces;
++     dvp_ctr_place_count is the same encoding rule the counted blocks use.  */
++  nf.cls = DVP_CO_NUM;
++  nf.word = op->nreg_word;
++  nf.value_lsb = 0;
++  nf.shift = op->nreg_shift;
++  nf.width = op->nreg_width;
++  e = dvp_ctr_place_count_max (op->nreg_max, op->nreg_zero_means_max, &nf,
++			       (dvp_val) count, words, err, sizeof (err));
++  if (e != NULL)
++    {
++      as_bad ("%s: %s", op->name, e);
++      return 0;
++    }
++  *countp = count;
++  *pp = p;
++  return 1;
++}
++
++/* Which of `unpack's two shapes a statement is written in.  A data format
++   standing first is the three-operand form; otherwise the five-operand shorthand
++   is the shape whose *third* operand is a format.  Deciding it that way rather
++   than by "the first token is not a format" is what keeps `unpack v9_64, 0, 1'
++   reporting an unknown format instead of a malformed cycle setting, while still
++   letting the cycle operands be symbols, as the reference allows.  A comma inside
++   a quoted string cannot occur this early in either shape, so counting commas is
++   safe here.  */
++
++static int
++dvp_unpack_is_shorthand (char *p)
++{
++  char ident[64];
++  char *q = dvp_skip_white (p);
++  char *r = q;
++  int commas = 0;
++
++  if (dvp_read_ident (&r, ident, sizeof (ident)) > 0
++      && dvp_ctr_format_lookup (ident) != NULL)
++    return 0;
++  while (*q != 0 && !is_end_of_stmt (*q))
++    {
++      if (*q == ',' && ++commas == 2)
++	{
++	  ++q;
++	  q = dvp_skip_white (q);
++	  return (dvp_read_ident (&q, ident, sizeof (ident)) > 0
++		  && dvp_ctr_format_lookup (ident) != NULL);
++	}
++      ++q;
++    }
++  return 0;
++}
++
++/* Read `WL, CL,' at *PP and emit the cycle-setting command it stands for, which
++   is what the five-operand `unpack' shorthand means.  It is not a new encoding:
++   the command emitted is the ordinary one the table already describes, with the
++   two operands the table already places, so the shorthand is byte for byte the
++   two statements written out.  The shorthand's bracketed modifiers are *not*
++   applied here -- they belong to the unpack.  */
++
++static int
++dvp_emit_cycle_prefix (char **pp)
++{
++  const struct dvp_ctr_opcode *cyc = dvp_ctr_lookup (DVP_CYCLE_COMMAND);
++  unsigned int words[DVP_CTR_MAX_HEADER];
++  char err[DVP_ERRLEN];
++  char *p = *pp;
++  const char *e;
++  dvp_val cyc_ops[2];
++  expressionS defer_ex[2];
++  int defer_op[2];
++  int ndefer = 0;
++  int i;
++
++  if (cyc == NULL || cyc->nfields != 2)
++    {
++      as_bad (_("dvp: no two-operand \"%s\" to build this shorthand from"),
++	      DVP_CYCLE_COMMAND);
++      return 0;
++    }
++  memcpy (words, cyc->fixed, sizeof (words));
++  for (i = 0; i < cyc->nfields; i++)
++    {
++      offsetT v;
++
++      expressionS ex;
++      char *save = input_line_pointer;
++
++      p = dvp_skip_white (p);
++      /* The shorthand is the written-out command, so its operands may be
++	 written as an expression that is not a value yet on the same terms.  */
++      input_line_pointer = p;
++      expression (&ex);
++      p = input_line_pointer;
++      input_line_pointer = save;
++      if (ex.X_op == O_absent || ex.X_op == O_illegal || ex.X_op == O_big)
++	{
++	  as_bad (_("%s must be a value known at assembly time"),
++		  i == 0 ? _("the cycle length") : _("the cycle's write count"));
++	  return 0;
++	}
++      if (ex.X_op == O_constant)
++	v = ex.X_add_number;
++      else
++	{
++	  defer_ex[ndefer] = ex;
++	  defer_op[ndefer] = i;
++	  ++ndefer;
++	  v = 0;
++	}
++      e = dvp_ctr_place (cyc, &cyc->fields[i], (dvp_val) v, words,
++			 err, sizeof (err));
++      if (e != NULL)
++	{
++	  as_bad ("%s", e);
++	  return 0;
++	}
++      cyc_ops[i] = (dvp_val) v;
++      p = dvp_skip_white (p);
++      if (*p != ',')
++	{
++	  as_bad (_("%s: expected \",\" after the cycle setting, as in "
++		    "\"unpack 4, 1, v4_32, 0, *\""), DVP_CYCLE_COMMAND);
++	  return 0;
++	}
++      ++p;
++    }
++  /* The shorthand's prefix is that VIF command, so the option that removes VIF
++     command words removes this one too.  */
++  if (!dvp_header_suppressed (cyc))
++    {
++      char *f;
++
++      dvp_start_vif_unit ();
++      f = dvp_emit_words (words, cyc->nheader);
++      for (i = 0; i < ndefer; i++)
++	dvp_defer_field (cyc, &cyc->fields[defer_op[i]], NULL, frag_now,
++			 (unsigned long) (f - frag_now->fr_literal),
++			 &defer_ex[i], cyc->name);
++    }
++  /* The shorthand *is* that command, so it sets the cycle exactly as the
++     written-out statement does, and the unpack it prefixes is divided by it.  */
++  dvp_set_cycle (cyc_ops[DVP_CYCLE_WL_OPERAND], cyc_ops[DVP_CYCLE_CL_OPERAND]);
++  *pp = p;
++  return 1;
++}
++
++/* --- assembling one container command ----------------------------------- */
++
++static void
++dvp_assemble_container (char *str)
++{
++  char err[DVP_ERRLEN];
++  char ident[64];
++  char *p = str;
++  const struct dvp_ctr_opcode *op;
++  const struct dvp_ctr_format *fmt = NULL;
++  unsigned int mods = 0;
++  unsigned int words[DVP_CTR_MAX_HEADER];
++  unsigned int cmd_base;
++  int nheader, i, n;
++  int auto_len = 0;
++  int have_len = 0;
++  dvp_val explicit_len = 0;
++  unsigned int nregs = 0;
++  unsigned int unit_bytes = 0;
++  dvp_val cyc_ops[2];
++  int cycle_stmt = 0;
++  const char *file_name = NULL;
++  const char *e;
++  char *f = NULL;
++  expressionS addr_ex;
++  expressionS count_ex;
++  int count_deferred = 0;
++  int addr_pending = 0;
++  int addr_is_star = 0;
++  int opens_payload = 0;
++  int suppressed;
++  const char *extent_name = NULL;
++  const struct dvp_ctr_field *addr_field = NULL;
++  /* Operands parsed as an expression that was not a value yet.  They cannot be
++     registered where they are parsed: the frag and offset the field will live at
++     are not settled until the words are emitted, which is after the whole
++     statement is read.  DVP_CTR_MAX_HEADER of them is every field a command
++     has.  */
++  struct
++  {
++    expressionS ex;
++    struct dvp_ctr_field field;
++  } defer[DVP_CTR_MAX_HEADER];
++  int ndefer = 0;
++
++  n = dvp_read_ident (&p, ident, sizeof (ident));
++  if (n < 0)
++    return;
++  if (n == 0)
++    {
++      as_bad (_("expected a VIF, DMA or GIF command here, found \"%s\""), str);
++      return;
++    }
++  op = dvp_ctr_lookup (ident);
++  if (op == NULL)
++    {
++      as_bad (_("\"%s\" is not a VIF, DMA or GIF command"), ident);
++      return;
++    }
++  /* The statement names a container command, so from here on a branch this
++     assembly cannot settle is an error -- whether or not the command's bytes
++     survive the target options.  */
++  dvp_vif_command_seen = 1;
++  /* ...and it opens a program unit, so the next microinstruction is named.  A
++     `.vu' directive does not: what starts a unit is the beginning of the
++     assembly, a container command, and a label written in VU mode.  That is why
++     `vifnop' before a `.vu' block gives the block a name and an `.endmpg'
++     immediately before one does not.  */
++  dvp_unit_pending = 1;
++
++  /* Nesting.  Inside a DMA tag's own payload every container command is ordinary
++     payload -- the transfer carries whatever is written there -- so the only
++     thing refused is a second payload, which is checked below once the operands
++     say whether this statement opens one.  Inside any other block the one
++     permitted nesting is still a GIF tag in a data block.  */
++  if (dvp_blk.op != NULL && dvp_blk.op->kind != DVP_CTR_DMA)
++    {
++      if (op->kind != DVP_CTR_GIF || dvp_blk.op->kind == DVP_CTR_GIF)
++	{
++	  as_bad (_("\"%s\" cannot appear inside an open %s block; close it "
++		    "with %s first"), op->name, dvp_blk.op->name,
++		  dvp_blk.op->terminator);
++	  return;
++	}
++    }
++
++  e = dvp_ctr_parse_mods (&p, op, &mods, err, sizeof (err));
++  if (e != NULL)
++    {
++      as_bad ("%s", e);
++      return;
++    }
++
++  /* Whatever follows the mnemonic and its modifier group is separated from them
++     by whitespace, and the separation is required: `base[i]0', `direct*',
++     `dmacnt*', `unpack[i]v4_32,0,1' and `stmod[i]direct' are not this grammar.
++     A command with nothing after it -- `vifnop[i]', a bare `dmaend' -- requires
++     nothing, because there is nothing to separate.
++
++     "Nothing after it" is decided before the separator is taken, not after: a
++     vertical tab or a form feed on its own is the statement's tail and there is
++     no operand, while one *after a space* is where an operand would have gone
++     and is read as one -- which is why `dmaend\v' is a bare `dmaend' and
++     `dmaend \v' is an error about its count.  Both measured.  */
++  {
++    char *after = dvp_skip_white (p);
++
++    if (after == p)
++      {
++	char *tail = dvp_skip_tail_white (p);
++
++	if (*tail == 0 || is_end_of_stmt (*p))
++	  p = tail;			/* nothing follows: no separator needed */
++	else
++	  {
++	    as_bad (_("%s: an operand has to be separated from the command by "
++		      "whitespace"), op->name);
++	    return;
++	  }
++      }
++    else
++      p = after;
++  }
++
++  /* A statement that sets the write cycle carries its two operands away with
++     it, but only once the whole statement has been accepted -- a malformed one
++     must not change the setting.  */
++  cycle_stmt = dvp_is_cycle_command (op->name)
++	       && op->nfields > DVP_CYCLE_WL_OPERAND
++	       && op->nfields > DVP_CYCLE_CL_OPERAND;
++  cyc_ops[0] = cyc_ops[1] = 0;
++
++  memcpy (words, op->fixed, sizeof (words));
++  nheader = op->nheader;
++
++  if (op->kind == DVP_CTR_UNPACK)
++    {
++      /* Five operands rather than three writes the cycle setting into the same
++	 statement: `unpack[MODS] WL, CL, FORMAT, ADDRESS, COUNT' is exactly
++	 `stcycl WL, CL' followed by the three-operand form, with the bracketed
++	 modifiers belonging to the unpack alone.  Which shape this
++	 is follows from what stands first: a data format names one, a number the
++	 other, so nothing has to be counted ahead.  */
++      if (dvp_unpack_is_shorthand (p) && !dvp_emit_cycle_prefix (&p))
++	return;
++
++      n = dvp_read_ident (&p, ident, sizeof (ident));
++      if (n < 0)
++	return;
++      if (n == 0)
++	{
++	  as_bad (_("unpack needs a data format first, as in "
++		    "\"unpack v4_32, 0, *\", or a cycle setting before it, as "
++		    "in \"unpack 4, 1, v4_32, 0, *\""));
++	  return;
++	}
++      fmt = dvp_ctr_format_lookup (ident);
++      if (fmt == NULL)
++	{
++	  as_bad (_("\"%s\" is not an unpack data format"), ident);
++	  return;
++	}
++      words[0] = fmt->fixed;
++      p = dvp_skip_white (p);
++      if (*p != ',')
++	{
++	  as_bad (_("expected \",\" after the unpack data format"));
++	  return;
++	}
++      ++p;
++    }
++
++  /* A modifier letter's bit does not have to sit in the command word: a DMA
++     tag's `s' lands in the tag's second word, so the letters are applied to the
++     header as a whole.  CMD_BASE is still the command word alone, because that
++     is what a split `mpg' block re-emits.  */
++  dvp_ctr_apply_mods (op, mods, words);
++  cmd_base = words[op->cmd_slot];
++
++  /* --- operands ------------------------------------------------------- */
++
++  if (op->kind == DVP_CTR_GIF)
++    {
++      /* Keyword operands, in the one order the table lists them: `prim=N',
++	 `regs={R,...}', `nloop=N', `eop'.  A keyword may be left out, but a
++	 keyword that appears before one already taken is an error, and so is a
++	 repeat -- a repeat would place a second value over the first, so the
++	 last one silently won.  A keyword marked required cannot be left out.  */
++      unsigned int seen = 0;
++      int last_index = -1;
++
++      p = dvp_skip_white (p);
++      auto_len = 1;
++      while (!is_end_of_stmt (*p) && *p != 0)
++	{
++	  const struct dvp_ctr_keyword *k;
++	  struct dvp_ctr_field kf;
++	  unsigned int bit;
++	  int index;
++	  offsetT v;
++
++	  n = dvp_read_ident (&p, ident, sizeof (ident));
++	  if (n < 0)
++	    return;
++	  if (n == 0)
++	    {
++	      as_bad (_("expected a GIF tag keyword, found \"%s\""), p);
++	      return;
++	    }
++	  k = dvp_ctr_keyword_lookup (op, ident);
++	  if (k == NULL)
++	    {
++	      as_bad (_("\"%s\" is not a %s keyword"), ident, op->name);
++	      return;
++	    }
++	  index = (int) (k - op->keywords);
++	  bit = 1u << (unsigned int) index;
++	  if (seen & bit)
++	    {
++	      as_bad (_("%s: the keyword \"%s\" is given twice"), op->name,
++		      k->name);
++	      return;
++	    }
++	  if (index < last_index)
++	    {
++	      as_bad (_("%s: \"%s\" comes before \"%s\", but its keywords are "
++			"written in the order %s"), op->name, k->name,
++		      op->keywords[last_index].name,
++		      dvp_gif_keyword_order (op));
++	      return;
++	    }
++	  seen |= bit;
++	  last_index = index;
++	  kf.cls = DVP_CO_U16;
++	  kf.word = k->word;
++	  kf.value_lsb = 0;
++	  kf.shift = k->shift;
++	  kf.width = k->width;
++	  p = dvp_skip_white (p);
++	  if (k->kind == DVP_KW_REGS)
++	    {
++	      if (*p != '=')
++		{
++		  as_bad (_("%s needs a register list, written "
++			    "\"%s={PRIM,RGBAQ,...}\""), k->name, k->name);
++		  return;
++		}
++	      ++p;
++	      if (!dvp_read_register_list (op, k, &p, words, &nregs))
++		return;
++	    }
++	  else if (k->kind == DVP_KW_VALUE)
++	    {
++	      if (*p != '=')
++		{
++		  as_bad (_("%s needs a value, written \"%s=N\""),
++			  k->name, k->name);
++		  return;
++		}
++	      ++p;
++	      p = dvp_skip_white (p);
++	      if (*p == '*' && dvp_cleanroom_extensions)
++		{
++		  /* A clean-only spelling of "count it yourself", behind
++		     `--cleanroom-extensions'.  Only the length keyword has it
++		     -- it is the only one there is anything to count for.  */
++		  if (k != dvp_length_keyword (op))
++		    {
++		      as_bad (_("%s: \"*\" asks for a length to be counted, and "
++				"\"%s\" is not this tag's length"), op->name,
++			      k->name);
++		      return;
++		    }
++		  ++p;
++		  auto_len = 1;
++		}
++	      else
++		{
++		  if (!dvp_read_gif_number (&p, k, &v))
++		    return;
++		  if (k == dvp_length_keyword (op))
++		    {
++		      auto_len = 0;
++		      have_len = 1;
++		      explicit_len = (dvp_val) v;
++		    }
++		  e = dvp_ctr_place (op, &kf, (dvp_val) v, words,
++				     err, sizeof (err));
++		  if (e != NULL)
++		    {
++		      as_bad ("%s", e);
++		      return;
++		    }
++		}
++	      /* A keyword may carry a companion bit that says it was given at
++		 all, whatever its value: a GIF tag's PRE.  */
++	      if (k->pre_bit >= 0)
++		words[k->pre_word] |= 1u << k->pre_bit;
++	    }
++	  else
++	    {
++	      e = dvp_ctr_place (op, &kf, 1, words, err, sizeof (err));
++	      if (e != NULL)
++		{
++		  as_bad ("%s", e);
++		  return;
++		}
++	    }
++	  p = dvp_skip_white (p);
++	  if (*p == ',')
++	    {
++	      ++p;
++	      p = dvp_skip_white (p);
++	      if (is_end_of_stmt (*p) || *p == 0)
++		{
++		  as_bad (_("%s: this comma has no keyword after it"), op->name);
++		  return;
++		}
++	      continue;
++	    }
++	  break;
++	}
++      for (i = 0; i < op->nkeywords; i++)
++	if (op->keywords[i].required && !(seen & (1u << (unsigned int) i)))
++	  {
++	    as_bad (_("%s needs its \"%s\", written \"%s={PRIM,RGBAQ,...}\""),
++		    op->name, op->keywords[i].name, op->keywords[i].name);
++	    return;
++	  }
++      /* The tag's counted unit: one loop of the transfer.  A register list makes
++	 that depend on the statement rather than on the table, so it is worked
++	 out here from the list's length and the measured bytes each named
++	 register takes.  */
++      if (op->nregs != 0)
++	unit_bytes = (unsigned int) op->loop_bytes_per_reg * nregs;
++    }
++  else
++    for (i = 0; i < op->nfields; i++)
++      {
++	const struct dvp_ctr_field *fl = &op->fields[i];
++	offsetT v;
++
++	p = dvp_skip_white (p);
++	if (i != 0)
++	  {
++	    if (*p != ',')
++	      {
++		if (op->optional_last && i == op->nfields - 1
++		    && (is_end_of_stmt (*p) || *p == 0))
++		  {
++		    /* The count may be left out entirely.  */
++		    break;
++		  }
++		as_bad (_("%s: expected \",\" before operand %d"),
++			op->name, i + 1);
++		return;
++	      }
++	    ++p;
++	    p = dvp_skip_white (p);
++	  }
++	else if (is_end_of_stmt (*p) || *p == 0)
++	  {
++	    if (op->optional_last && op->nfields == 1)
++	      break;
++	    as_bad (_("%s: expected %d operand%s"), op->name,
++		    (int) op->nfields, op->nfields == 1 ? "" : "s");
++	    return;
++	  }
++
++	if (fl->cls == DVP_CO_NUM || fl->cls == DVP_CO_QWCOUNT
++	    || fl->cls == DVP_CO_QWC)
++	  {
++	    if (*p == '*')
++	      {
++		++p;
++		auto_len = 1;
++		continue;
++	      }
++	    if (*p == '"' && op->block != DVP_BLK_NONE)
++	      {
++		/* A quoted file name stands where the count would be: the file's
++		   bytes are the payload and the count is worked out from them,
++		   exactly as `*' would.  Only the four commands
++		   that open a block have this form -- a DMA tag's count is a
++		   DVP_CO_QWC and a GIF tag's is a keyword, so neither reaches
++		   here.  */
++		file_name = dvp_read_payload_name (&p, op);
++		if (file_name == NULL)
++		  return;
++		auto_len = 1;
++		continue;
++	      }
++	    if (fl->cls == DVP_CO_QWC)
++	      {
++		/* A DMA tag's count may name a symbol the file defines further
++		   down.  Nothing about the count is knowable then -- not the
++		   value, and so not whether it agrees with the payload -- so
++		   both wait, and the expression is kept rather than reported.  */
++		char *save = input_line_pointer;
++
++		input_line_pointer = dvp_skip_white (p);
++		expression (&count_ex);
++		p = input_line_pointer;
++		input_line_pointer = save;
++		if (count_ex.X_op == O_absent || count_ex.X_op == O_illegal
++		    || count_ex.X_op == O_big)
++		  {
++		    as_bad (_("%s: this count is not a valid expression"),
++			    op->name);
++		    return;
++		  }
++		have_len = 1;
++		if (count_ex.X_op != O_constant)
++		  {
++		    count_deferred = 1;
++		    continue;
++		  }
++		explicit_len = (dvp_val) count_ex.X_add_number;
++	      }
++	    else
++	      {
++		if (!dvp_read_absolute (&p, "a count", &v))
++		  return;
++		have_len = 1;
++		explicit_len = (dvp_val) v;
++	      }
++	    e = dvp_ctr_place_count (op, fl, explicit_len, words,
++				     err, sizeof (err));
++	    if (e != NULL)
++	      {
++		as_bad ("%s", e);
++		return;
++	      }
++	    continue;
++	  }
++
++	if (fl->cls == DVP_CO_DMAADDR)
++	  {
++	    char *save = input_line_pointer;
++	    char *tokend = NULL;
++	    char tokwas = 0;
++
++	    /* On a tag whose count is `*' and whose payload lives elsewhere,
++	       the address is not read as an expression that happens to be a
++	       symbol: it is read as a *name*, and the name is what the count
++	       is taken from.
++
++	       Reading it as an expression gets both directions wrong.  A name
++	       already bound to an absolute value -- `.set payload,0' -- folds
++	       to a constant before anything can ask what it was called; and
++	       expressions that are not names -- `payload+0', `(payload)',
++	       `0+payload' -- come back as a symbol plus nothing and look like
++	       names.  So the token is taken exactly as far as a name reaches:
++	       a name-beginner and then letters, digits and underscores.  `.'
++	       and `$' are not name characters here, so `payload.bar',
++	       `payload$bar' and a leading `.foo' are refused.
++
++	       The token is then evaluated on its own, terminated in place, so
++	       nothing after it can join in.  */
++	    if (op->kind == DVP_CTR_DMA && !op->inline_payload && auto_len)
++	      {
++		char *tok = dvp_skip_white (p);
++		symbolS *named;
++
++		tokend = tok;
++		if (is_name_beginner ((unsigned char) *tok))
++		  while (ISALNUM ((unsigned char) *tokend) || *tokend == '_')
++		    ++tokend;
++		if (tokend == tok)
++		  {
++		    as_bad (_("%s: \"*\" counts the payload the address names, "
++			      "so the address has to be a symbol on its own"),
++			    op->name);
++		    return;
++		  }
++		tokwas = *tokend;
++		*tokend = 0;
++		/* The reference makes the symbol whether or not anything
++		   defines it, so the name exists from here on.  */
++		named = symbol_find_or_make (tok);
++		extent_name = S_GET_NAME (named);
++		p = tok;
++	      }
++
++	    input_line_pointer = p;
++	    expression (&addr_ex);
++	    p = input_line_pointer;
++	    input_line_pointer = save;
++	    if (tokend != NULL)
++	      {
++		*tokend = tokwas;
++		p = tokend;
++	      }
++	    if (addr_ex.X_op == O_constant)
++	      {
++		e = dvp_ctr_place (op, fl, (dvp_val) addr_ex.X_add_number, words,
++				   err, sizeof (err));
++		if (e != NULL)
++		  {
++		    as_bad ("%s", e);
++		    return;
++		  }
++	      }
++	    else if (addr_ex.X_op == O_absent || addr_ex.X_op == O_illegal
++		     || addr_ex.X_op == O_big)
++	      {
++		as_bad (_("%s: this address is not a valid expression"),
++			op->name);
++		return;
++	      }
++	    else
++	      {
++		addr_pending = 1;
++		addr_field = fl;
++	      }
++	    continue;
++	  }
++
++	if (fl->cls == DVP_CO_MODE)
++	  {
++	    char *q = p;
++
++	    /* A mode written as a number is a written-out C integer, not an
++	       expression: the reference reads it with `strtol' in base zero and
++	       stops where strtol stops, so `0x1' and `01' are a mode and `+1',
++	       `-0', `(1)', `1+1' and `0b10' are not -- the last because base
++	       zero reads `0' and leaves `b10' behind.  */
++	    if (ISDIGIT ((unsigned char) *p))
++	      {
++		dvp_val mv;
++
++		if (!dvp_read_c_integer (&p, &mv))
++		  {
++		    as_bad (_("%s: expected one of its modes here"), op->name);
++		    return;
++		  }
++		e = dvp_ctr_place (op, fl, mv, words, err, sizeof (err));
++		if (e != NULL)
++		  {
++		    as_bad ("%s", e);
++		    return;
++		  }
++		continue;
++	      }
++	    /* Not a number, so it is a name and nothing else: the reference has
++	       no expression fallback here, which is why `stmod +1', `stmod -0'
++	       and `stmod (1)' are refused even though each comes to a mode.  */
++	    {
++	      dvp_val mv;
++
++	      if (dvp_read_ident (&q, ident, sizeof (ident)) <= 0
++		  || (mv = dvp_ctr_mode_value (op, ident)) < 0)
++		{
++		  as_bad (_("%s: \"%s\" is not one of its modes"),
++			  op->name, p);
++		  return;
++		}
++	      p = q;
++	      e = dvp_ctr_place (op, fl, mv, words, err, sizeof (err));
++	      if (e != NULL)
++		{
++		  as_bad ("%s", e);
++		  return;
++		}
++	      continue;
++	    }
++	  }
++
++	if (fl->cls == DVP_CO_NAME)
++	  {
++	    /* Named only: this state has no numeric spelling, so a number here
++	       is an error rather than a value to encode.  Which is which was
++	       measured -- the derivation offers the numeric form and requires
++	       the reference to refuse it before it will call an operand a
++	       name.  */
++	    dvp_val mv;
++
++	    if (dvp_read_ident (&p, ident, sizeof (ident)) <= 0)
++	      {
++		as_bad (_("%s: expected one of its states here, found \"%s\""),
++			op->name, p);
++		return;
++	      }
++	    mv = dvp_ctr_mode_value (op, ident);
++	    if (mv < 0)
++	      {
++		as_bad (_("%s: \"%s\" is not one of its states; it takes a name, "
++			  "not a number"), op->name, ident);
++		return;
++	      }
++	    e = dvp_ctr_place (op, fl, mv, words, err, sizeof (err));
++	    if (e != NULL)
++	      {
++		as_bad ("%s", e);
++		return;
++	      }
++	    continue;
++	  }
++
++	if (fl->cls == DVP_CO_VADDR && op->kind == DVP_CTR_MPG && *p == '*')
++	  {
++	    /* `mpg *' loads where the last transfer left off.  Only `mpg' has
++	       the form -- `unpack *' is not an address, it is an error -- and
++	       only the address operand does; the count's own `*' is read
++	       above.  */
++	    ++p;
++	    e = dvp_ctr_place (op, fl, dvp_mpgloc, words, err, sizeof (err));
++	    if (e != NULL)
++	      {
++		as_bad ("%s", e);
++		return;
++	      }
++	    addr_is_star = 1;
++	    continue;
++	  }
++
++	if (dvp_class_defers (fl->cls))
++	  {
++	    /* The operand may name a symbol the file defines further down.  The
++	       field is left as the zero it was laid down with and the value is
++	       encoded once every symbol is defined; the rest of this statement,
++	       and every piece of assembler state it feeds, sees that zero.  */
++	    expressionS ex;
++	    char *save = input_line_pointer;
++
++	    input_line_pointer = dvp_skip_white (p);
++	    {
++	      /* `mpg' load address only: it is the one container field whose
++		 value is scaled the same way.  */
++	      int scaled = (op->kind == DVP_CTR_MPG && fl->cls == DVP_CO_VADDR);
++
++	      dvp_own_expr += scaled;
++	      expression (&ex);
++	      dvp_own_expr -= scaled;
++	    }
++	    p = input_line_pointer;
++	    input_line_pointer = save;
++	    if (ex.X_op == O_absent || ex.X_op == O_illegal
++		|| ex.X_op == O_big)
++	      {
++		as_bad (_("%s: this operand is not a valid expression"),
++			op->name);
++		return;
++	      }
++	    if (ex.X_op != O_constant)
++	      {
++		defer[ndefer].ex = ex;
++		defer[ndefer].field = *fl;
++		/* An `mpg' load address settled at the end of the assembly is a
++		   *byte* address taken in eight-byte steps, where the same
++		   address written out is the field's own value.  The two
++		   spellings really do mean different things here; measured on
++		   both, across the whole range and either side of it.  */
++		if (op->kind == DVP_CTR_MPG && fl->cls == DVP_CO_VADDR)
++		  defer[ndefer].field.value_lsb = DVP_MPG_LATE_ADDR_LSB;
++		++ndefer;
++		v = 0;
++	      }
++	    else
++	      v = ex.X_add_number;
++	  }
++	else if (!dvp_read_absolute (&p, "this operand", &v))
++	  return;
++	e = dvp_ctr_place (op, fl, (dvp_val) v, words, err, sizeof (err));
++	if (e != NULL)
++	  {
++	    as_bad ("%s", e);
++	    return;
++	  }
++	if (cycle_stmt && (i == DVP_CYCLE_WL_OPERAND
++			   || i == DVP_CYCLE_CL_OPERAND))
++	  cyc_ops[i] = (dvp_val) v;
++      }
++
++  /* The whole of what is left, not just as far as the next line break.  A
++     statement can carry an embedded newline: GAS repairs a string that runs to
++     the end of the file by inserting the missing quote, so `"vifnop' arrives
++     here as the command, a newline, and the inserted quote -- and stopping at
++     that newline would accept the line and emit the command.
++
++     Whitespace is skipped in its widest sense here, a vertical tab and a form
++     feed included: both are taken after the last operand of every VIF, DMA and
++     GIF statement, and nowhere else in the statement.  */
++  p = dvp_skip_tail_white (p);
++  if (*p != 0)
++    {
++      as_bad (_("unexpected text \"%s\" after the %s command"), p, op->name);
++      return;
++    }
++
++  /* A DMA tag's count either opens the payload it counts or describes one that
++     lives elsewhere; which of the two is a property of the tag and was measured.
++     A count left out entirely -- which only `dmaend' allows -- opens nothing.  */
++  if (op->kind == DVP_CTR_DMA && op->inline_payload && (have_len || auto_len))
++    {
++      opens_payload = 1;
++      if (dvp_blk.op != NULL)
++	{
++	  as_bad (_("\"%s\" opens the payload it counts, and there is already "
++		    "an open %s block here; close it with %s first"),
++		  op->name, dvp_blk.op->name, dvp_blk.op->terminator);
++	  return;
++	}
++      if (dvp_dmadata_open)
++	{
++	  as_bad (_("\"%s\" opens the payload it counts, so it cannot appear "
++		    "inside the .dmadata region \"%s\" -- the region's own "
++		    "bytes would be that payload; the tags that refer to a "
++		    "payload elsewhere can appear here"),
++		  op->name, dvp_dmadata_name);
++	  return;
++	}
++    }
++
++  /* The other kind of automatic count: the payload is somewhere else and the tag
++     names it, so the count is the extent of the name the address operand spells.
++     That name was taken as a token where the operand was read, because by the
++     time an expression has been folded the name may be gone; EXTENT_NAME is that
++     token, and reaching here without one means the operand was not an address at
++     all.  */
++  if (op->kind == DVP_CTR_DMA && !opens_payload && auto_len)
++    {
++      if (extent_name == NULL)
++	{
++	  as_bad (_("%s: \"*\" counts the payload the address names, so the "
++		    "address has to be a symbol on its own"), op->name);
++	  return;
++	}
++      {
++	/* The reference puts an undefined global `_$NAME' in the object for
++	   every such tag, whether or not the tag itself is being emitted.
++	   Nothing defines it and no relocation names it, so it is a symbol the
++	   link has to be told to ignore.
++
++	   Where it *sits* in the table is not reproduced.  The reference writes
++	   it between two local symbols while `sh_info' still says the globals
++	   start earlier, so its `.symtab' contradicts itself.  Matching that
++	   would mean writing a symbol table that violates the format, so the
++	   symbol goes in and BFD puts it with the other globals.  */
++	char *alias = concat (DVP_OVERLAY_ALIAS_PREFIX, extent_name, NULL);
++	symbolS *sym = symbol_find (alias);
++
++	if (sym == NULL)
++	  {
++	    sym = symbol_new (alias, undefined_section, &zero_address_frag, 0);
++	    symbol_table_insert (sym);
++	    S_SET_EXTERNAL (sym);
++	  }
++	free (alias);
++      }
++    }
++
++  /* --- emission ------------------------------------------------------- */
++
++  /* Whether this construct's header words are being left out.  The
++     block still opens and its payload is still written; what goes is the header
++     and everything that only exists to describe it -- the count, the relocation
++     on its address field, an `mpg' command's overlay.  */
++  suppressed = dvp_header_suppressed (op);
++
++  /* The alignment the construct records belongs to the construct, and a section
++     whose only constructs were suppressed has nothing to align.  */
++  if (op->sec_align && !suppressed)
++    record_alignment (now_seg, dvp_log2 (op->sec_align));
++
++  switch (op->kind)
++    {
++    case DVP_CTR_VIF:
++      if (!suppressed)
++	{
++	  dvp_start_vif_unit ();
++	  f = dvp_emit_words (words, nheader);
++	  for (n = 0; n < ndefer; n++)
++	    dvp_defer_field (op, &defer[n].field, NULL, frag_now,
++			     (unsigned long) (f - frag_now->fr_literal),
++			     &defer[n].ex, op->name);
++	}
++      /* The write cycle is state and not a byte: `stcycl' still sets it, so an
++	 `unpack' count that survives is still divided by the setting the source
++	 asked for.  An operand that could not be settled contributed its
++	 parse-time zero to CYC_OPS, and that zero is what the cycle gets -- the
++	 value the patch writes into the word later never reaches this state.  */
++      if (cycle_stmt)
++	dvp_set_cycle (cyc_ops[DVP_CYCLE_WL_OPERAND],
++		       cyc_ops[DVP_CYCLE_CL_OPERAND]);
++      return;
++
++    case DVP_CTR_UNPACK:
++      if (!suppressed)
++	{
++	  dvp_start_vif_unit ();
++	  f = dvp_emit_words (words, 1);
++	}
++      break;
++
++    case DVP_CTR_MPG:
++    case DVP_CTR_DIRECT:
++      if (!suppressed)
++	{
++	  dvp_start_vif_unit ();
++	  dvp_align_payload (op->name, op->payload_align);
++	  f = dvp_emit_words (words, 1);
++	}
++      break;
++
++    case DVP_CTR_GIF:
++      dvp_align_to_tag (op->pre_align);
++      /* A GIF tag reserves two unit names and is called after the first.  */
++      dvp_unit_counter += 2;
++      dvp_emit_marker (DVP_MARK_GIF_PREFIX, dvp_unit_counter - 1,
++		       DVP_MARK_GIF_OTHER);
++      f = dvp_emit_words (words, nheader);
++      dvp_vif_unit_pending = 1;
++      break;
++
++    case DVP_CTR_DMA:
++      if (suppressed)
++	{
++	  /* The tag emits nothing at all: not its quadword, not the zeroes that
++	     would have filled its spare half, and not the alignment those would
++	     have needed.  Whatever follows falls where it falls, and a VIF
++	     command that would have been packed into the spare half is written
++	     as the ordinary command it is.
++
++	     One unit name still goes, and only on a tag that opens a payload:
++	     the markers after such a tag are numbered as though it had had one
++	     of its own.  `dmacnt', `dmanext', `dmacall', `dmaret' and `dmaend'
++	     with a count shift the next marker by one; a bare `dmaend',
++	     `dmaref', `dmarefs' and `dmarefe' shift it by nothing.  */
++	  if (opens_payload)
++	    ++dvp_unit_counter;
++	  break;
++	}
++      dvp_align_to_tag (op->pre_align);
++      /* A tag that opens a payload reserves names for it ahead of its own pair,
++	 which is why such a tag is not named from zero even when it is the first
++	 thing in the file.  How many it reserves was measured.  */
++      if (opens_payload)
++	dvp_unit_counter += DVP_DMA_PAYLOAD_UNITS;
++      dvp_emit_marker (DVP_MARK_DMA_PREFIX, dvp_unit_counter++,
++		       DVP_MARK_DMA_OTHER);
++      f = dvp_emit_words (words, 2);
++      /* The tag's second half either carries two VIF command words or is left
++	 empty; either way the VIF run starts there.  */
++      dvp_emit_marker (DVP_MARK_VIF_PREFIX, dvp_unit_counter++,
++		       DVP_MARK_VIF_OTHER);
++      dvp_vif_unit_pending = 0;
++      if (!dvp_packvif)
++	{
++	  unsigned int pad[DVP_PACKVIF_SLOTS];
++
++	  memset (pad, 0, sizeof (pad));
++	  dvp_emit_words (pad, DVP_PACKVIF_SLOTS);
++	}
++      break;
++
++    default:
++      as_fatal (_("dvp: unknown container kind"));
++      return;
++    }
++
++  /* Now that the words are down, the operands that could not be settled have a
++     frag and an offset to be settled *into*.  A suppressed header has no word to
++     patch, and nothing that would read one.  */
++  if (!suppressed)
++    for (n = 0; n < ndefer; n++)
++      dvp_defer_field (op, &defer[n].field, NULL, frag_now,
++		       (unsigned long) (f - frag_now->fr_literal),
++		       &defer[n].ex, op->name);
++
++  /* A relocation names a field inside a header word, so a suppressed header has
++     nowhere to put one and nothing that would read it.  */
++  if (addr_pending && !suppressed)
++    {
++      fixS *fixp = fix_new_exp (frag_now, f - frag_now->fr_literal
++				+ addr_field->word * 4, 4, &addr_ex, 0,
++				BFD_RELOC_DVP_DMA_ADDR);
++      fixp->tc_fix_data.field = NULL;
++    }
++
++  if (op->kind == DVP_CTR_DMA)
++    {
++      if (extent_name != NULL)
++	{
++	  /* The payload may be written after the tag that refers to it, so the
++	     count waits until every symbol is defined.  Nothing waits for a tag
++	     that emitted no count field.  */
++	  if (!suppressed)
++	    dvp_defer_extent (op, &op->fields[0], frag_now,
++			      f - frag_now->fr_literal, extent_name);
++	  return;
++	}
++      if (!opens_payload)
++	{
++	  /* The tag describes a payload that lives elsewhere, so it opens no
++	     block -- but it still carries a count field, and a count written as
++	     a symbol defined further down still has to reach it.  */
++	  if (count_deferred && !suppressed)
++	    dvp_defer_count (op, &op->fields[0], frag_now,
++			     (unsigned long) (f - frag_now->fr_literal),
++			     &count_ex, 0);
++	  return;
++	}
++    }
++
++  /* --- the block is now open ------------------------------------------- */
++
++  if (dvp_blk_depth >= DVP_BLK_DEPTH)
++    {
++      as_bad (_("\"%s\" would be %d blocks deep, and this assembler keeps "
++		"track of %d"), op->name, dvp_blk_depth + 1, DVP_BLK_DEPTH);
++      return;
++    }
++  ++dvp_blk_depth;
++  memset (&dvp_blk, 0, sizeof (dvp_blk));
++
++  dvp_blk.op = op;
++  dvp_blk.fmt_elem = (fmt != NULL) ? fmt->elem_bytes : 0;
++  dvp_blk.unit = unit_bytes;
++  dvp_blk.cmd_base = cmd_base;
++  dvp_blk.auto_len = auto_len;
++  dvp_blk.explicit_len = have_len ? explicit_len : 0;
++  /* A NULL command frag is what says "this construct's header was left out", and
++     everything that would write a count into it checks for exactly that.  */
++  dvp_blk.cmd_frag = suppressed ? NULL : frag_now;
++  dvp_blk.cmd_where = suppressed ? 0 : (unsigned long) (f - frag_now->fr_literal);
++  /* What a DMA tag counts is the quadwords that follow its *own*, so the count is
++     measured from the end of the tag's quadword -- eight bytes past here when the
++     tag's spare half is being packed with VIF commands, and exactly here when it
++     was filled with zeroes.  Whatever the payload writes before that point shares
++     the tag's quadword and is not counted.  */
++  dvp_blk.payload = dvp_here ()
++		    + ((op->kind == DVP_CTR_DMA && dvp_packvif && !suppressed)
++		       ? DVP_TAG_HALF_BYTES : 0);
++  dvp_blk.run_insns = 0;
++  dvp_blk.vu_addr = 0;
++  dvp_blk.seg = now_seg;
++  dvp_blk.subseg = now_subseg;
++  dvp_blk.seg_reported = 0;
++  dvp_blk.file = as_where (&dvp_blk.line);
++  /* A block reserves two unit names.  A GIF tag has already taken its pair, in
++     order to name the tag after the second of them, and so has a DMA tag: the
++     tag itself and the command run that starts in its spare half.  A block whose
++     VIF command word was left out reserves none: there is no command, so there is
++     no run for the names to describe.  */
++  if (op->kind != DVP_CTR_GIF && op->kind != DVP_CTR_DMA && !suppressed)
++    dvp_unit_counter += 2;
++
++  if (count_deferred && !suppressed)
++    {
++      struct dvp_pending_count *d
++	= dvp_defer_count (op, &op->fields[0], dvp_blk.cmd_frag,
++			   dvp_blk.cmd_where, &count_ex, 1);
++
++      d->file = dvp_blk.file;
++      d->line = dvp_blk.line;
++      dvp_blk.pending = d;
++    }
++
++  if (op->kind == DVP_CTR_MPG)
++    {
++      /* The load address operand is the first field; recover it so a split
++	 block's later commands can carry on from it.  */
++      const struct dvp_ctr_field *af = &op->fields[0];
++
++      dvp_blk.vu_addr = (dvp_val) ((words[af->word] >> af->shift)
++				& ((1u << af->width) - 1));
++      dvp_blk.addr_is_star = addr_is_star;
++      /* An address written out sets the running load address; `*' takes it as
++	 it stands, and the field was placed from it, so either way it is what
++	 the field now holds.  */
++      dvp_mpgloc = dvp_blk.vu_addr;
++      dvp_unit_pending = 1;
++      /* The overlay describes where an `mpg' command loads its microcode.  With
++	 the command gone there is no transfer to describe, so no overlay and no
++	 entry naming one.  */
++      if (!suppressed)
++	dvp_overlay_open ();
++    }
++
++  /* A command that named its payload file rather than opening a block has its
++     whole payload here and now, so the run it just opened closes immediately.  */
++  if (file_name != NULL)
++    dvp_emit_named_payload (op, file_name);
++}
++
++/* --- overlays ------------------------------------------------------------ */
++
++/* Define NAME at SEG:FRAG+VALUE, carrying the VU marker byte, and return it --
++   or report, and return NULL, if the source has already defined that name.
++
++   A generated name landing on one the source has used would put two symbols of
++   one spelling into the table: GAS replaces the hash entry silently and writes
++   both out.  A name that merely exists as an undefined reference is welcome --
++   it is defined here, so a source naming the alias before the block gets the
++   code's position rather than a dangling relocation.  */
++
++static symbolS *
++dvp_define_generated (const char *name, segT seg, fragS *frag, valueT value,
++		      const char *what)
++{
++  symbolS *sym = symbol_find (name);
++
++  if (dvp_name_is_taken (sym))
++    {
++      as_bad (_("this %s block needs the name \"%s\" for %s, and the source has "
++		"already defined it"),
++	      dvp_blk.op != NULL ? dvp_blk.op->name : "mpg", name, what);
++      return NULL;
++    }
++  if (sym == NULL)
++    {
++      sym = symbol_new (name, seg, frag, value);
++      symbol_table_insert (sym);
++    }
++  else
++    {
++      S_SET_SEGMENT (sym, seg);
++      symbol_set_frag (sym, frag);
++      S_SET_VALUE (sym, value);
++    }
++  dvp_mark_vu_symbol (sym);
++  return sym;
++}
++
++/* Add S to the overlay string table and return the offset it went to.  */
++
++static addressT
++dvp_ovlystrtab_add (const char *s)
++{
++  asection *save = now_seg;
++  subsegT save_sub = now_subseg;
++  size_t len = strlen (s) + 1;
++  addressT off = dvp_ovlystrtab_next;
++
++  subseg_set (dvp_ovlystrtab_section, 0);
++  memcpy (frag_more (len), s, len);
++  dvp_ovlystrtab_next += len;
++  subseg_set (save, save_sub);
++  return off;
++}
++
++/* The name of the generated section for the overlay the `mpg' command being
++   emitted describes.  Returned in a buffer the section keeps, because BFD
++   stores the pointer it is given rather than a copy.
++
++   The reference's name has one component this one does not: a token derived
++   from the input path.  Leaving it out makes this assembler's output
++   independent of its pathname; a deliberate deviation.  */
++
++static char *
++dvp_overlay_name (void)
++{
++  char buf[160];
++  unsigned int line;
++  unsigned int k;
++  size_t base;
++
++  (void) as_where (&line);
++  snprintf (buf, sizeof (buf), "%s%s.0x%lx.%u.%u", DVP_OVERLAY_PREFIX, "",
++	    (unsigned long) dvp_blk.vu_addr * DVP_MICROINSN_BYTES, line,
++	    dvp_overlay_counter);
++
++  /* Nothing stops a source creating a section with that spelling itself, so a
++     name the source has already used is stepped over rather than joined.  The
++     step is a counted suffix, so it is decided by the sections that exist and
++     not by anything about the run: the same source assembles to the same name
++     every time.
++
++     Two generated overlays cannot collide with each other, because the name
++     carries the overlay's index in the table.  */
++  base = strlen (buf);
++  for (k = 1; bfd_get_section_by_name (stdoutput, buf) != NULL; k++)
++    snprintf (buf + base, sizeof (buf) - base, ".%u", k);
++
++  return notes_strdup (buf);
++}
++
++/* Open the overlay the `mpg' command just emitted describes.  Only its section
++   is created here: what the command transfers is not known until the run ends,
++   and neither is the size the section holds.  */
++
++static void
++dvp_overlay_open (void)
++{
++  asection *save = now_seg;
++  subsegT save_sub = now_subseg;
++  asection *sec = subseg_new (dvp_overlay_name (), 0);
++
++  /* Contents, code, and neither read-only nor allocated: the section carries a
++     placeholder for microcode that a consumer moves into VU memory itself, so
++     nothing maps it.  */
++  bfd_set_section_flags (sec, SEC_CODE | SEC_HAS_CONTENTS);
++  bfd_set_section_alignment (sec, 0);
++  elf_section_type (sec) = SHT_DVP_OVERLAY;
++  /* The symbol a consumer places the overlay by, valued at the load address --
++     the same origin the labels inside the block are measured from.  It is
++     defined here rather than where the overlay closes because that is where the
++     reference defines it: it comes out ahead of the `.vu' marker the block's
++     first microinstruction emits, and behind it if the definition waits.  The load address is settled by now; what is not is how much
++     microcode the command transfers, which is why the rest waits.  */
++  {
++    char *symname = concat (DVP_OVERLAY_START_PREFIX,
++			    bfd_section_name (sec), NULL);
++
++    subseg_set (sec, 0);
++    (void) dvp_define_generated (symname, sec, &zero_address_frag,
++				 (addressT) dvp_blk.vu_addr
++				 * DVP_MICROINSN_BYTES,
++				 "the overlay's start");
++    free (symname);
++  }
++  subseg_set (save, save_sub);
++  dvp_blk.ovly_sec = sec;
++  /* The command word has just been emitted, so this is where its microcode
++     starts.  A symbol rather than an offset, because GAS runs a section's
++     subsegments together only when it lays the section out.  */
++  dvp_blk.ovly_code = symbol_temp_new (now_seg, frag_now, frag_now_fix ());
++}
++
++/* Close it: give the section the zeroes the command transfers, name it in the
++   string table, and add the table entry that points at both.  BYTES is what the
++   command transfers, which is also the size of the program the overlay holds.  */
++
++static void
++dvp_overlay_close (addressT bytes)
++{
++  asection *sec = dvp_blk.ovly_sec;
++  symbolS *code = dvp_blk.ovly_code;
++  addressT vu_bytes = (addressT) dvp_blk.vu_addr * DVP_MICROINSN_BYTES;
++  asection *save = now_seg;
++  subsegT save_sub = now_subseg;
++  addressT name_off;
++  const char *secname;
++  fragS *frag;
++  unsigned long where;
++  char *p;
++
++  if (sec == NULL)
++    return;
++  dvp_blk.ovly_sec = NULL;
++  dvp_blk.ovly_code = NULL;
++  secname = bfd_section_name (sec);
++
++  /* The overlay itself, and the symbol a consumer places it by.  The symbol is
++     valued at the load address, which is the same origin the labels inside the
++     block are measured from.  */
++  subseg_set (sec, 0);
++  if (bytes != 0)
++    memset (frag_more (bytes), 0, bytes);
++
++  name_off = dvp_ovlystrtab_add (secname);
++
++  /* The entry: the name's offset in the string table, the microcode's offset in
++     the section it was assembled into, and the load address in bytes.  The first
++     two are relocated rather than written out, because neither section's final
++     address is this assembler's to know.  */
++  subseg_set (dvp_ovlytab_section, 0);
++  p = frag_more (DVP_OVLYTAB_ENTSIZE);
++  frag = frag_now;
++  where = p - frag_now->fr_literal;
++  memset (p, 0, DVP_OVLYTAB_ENTSIZE);
++  md_number_to_chars (p + DVP_OVLYTAB_ADDR_OFFSET, vu_bytes, 4);
++  /* Against a temporary symbol *in* the string table rather than against the
++     table's section symbol.  The relocation GAS writes is the same either way,
++     but which of them asks for the section symbol decides when that symbol is
++     created, and section symbols come out in the order they were asked for.
++     Asking here would put this table's symbol in front of one belonging to a
++     section the source had not written yet; leaving it to the adjustment does
++     not.  */
++  fix_new (frag, where + DVP_OVLYTAB_NAME_OFFSET, 4,
++	   symbol_temp_new (dvp_ovlystrtab_section, &zero_address_frag,
++			    (valueT) name_off),
++	   0, 0, BFD_RELOC_32);
++  fix_new (frag, where + DVP_OVLYTAB_CODE_OFFSET, 4, code, 0, 0,
++	   BFD_RELOC_32);
++  subseg_set (save, save_sub);
++  ++dvp_overlay_counter;
++}
++
++/* True if SEC is one of the generated overlay sections.  */
++
++static int
++dvp_is_overlay_section (asection *sec)
++{
++  return sec != NULL && sec != absolute_section && sec != undefined_section
++	 && strncmp (bfd_section_name (sec), DVP_OVERLAY_PREFIX,
++		     strlen (DVP_OVERLAY_PREFIX)) == 0;
++}
++
++
++static void dvp_mpg_new_run (void);
++
++/* Does a label of this name get promoted into the block's overlay?
++
++   The choice is made when the label is *defined* and on the name alone: a
++   promoted label is defined in the overlay at its VU byte address with
++   `_$<name>' alongside it in the transfer, and a label this returns zero for is
++   left where GAS put it, with no overlay definition and no alias.  Nothing
++   about the operand that later names it enters into it.
++
++   Promoted are `top', `Ltop', `L.top', `a.b', `_top', `__top', `x_$y', `a$b',
++   `top$' and `q$'; not promoted are `.top', `.Ltop', `.LLtop', `.L1top',
++   `..top', `.x.y', `$top', `$', `_$fake' and `_$', nor the fb (`1:') and dollar
++   (`4$:') temporaries, whose GAS spellings begin with the local-label prefix.
++
++   `_$' is excluded because that spelling is the alias's own.  The answer does
++   not change under `-L', which is why this is not S_IS_LOCAL.  */
++
++static int
++dvp_overlay_promotes_name (const char *name)
++{
++  if (name == NULL || name[0] == '\0')
++    return 0;
++  if (name[0] == '.' || name[0] == '$')
++    return 0;
++  if (name[0] == '_' && name[1] == '$')
++    return 0;
++  return 1;
++}
++
++static void
++dvp_overlay_label (symbolS *sym)
++{
++  addressT here;
++  char *name;
++  symbolS *alias;
++
++  if (dvp_blk.op == NULL || dvp_blk.op->kind != DVP_CTR_MPG)
++    return;
++  if (dvp_blk.ovly_sec == NULL)
++    {
++      /* The command word is gone, so there is no overlay for the label to
++	 belong to and no load address to measure it from -- and the reference
++	 refuses the source rather than leaving the label where the bytes
++	 happen to be.  A block with no label and no reference out of it is
++	 still accepted, because nothing in it needs an origin.  */
++      as_bad (_("\"%s\" is a label inside an %s block, and the option that "
++		"removes VIF command words has removed the command this "
++		"block's labels would be measured from"),
++	      S_GET_NAME (sym), dvp_blk.op->name);
++      return;
++    }
++  /* A label the name test declines stays where GAS put it, in the transfer, with
++     no overlay definition and no alias.  It is not moved into the overlay and
++     given no alias, which is what this used to do: the reference leaves such a
++     label in `.vutext' at the transfer offset, and a reference to it -- from a
++     data word or from an instruction field alike -- resolves to that offset.  */
++  if (!dvp_overlay_promotes_name (S_GET_NAME (sym)))
++    return;
++  here = dvp_here ();
++  if (!dvp_offset_known)
++    {
++      as_bad (_("cannot tell where \"%s\" lands in this %s block, because "
++		"something earlier in this section has a size that is not "
++		"settled yet"), S_GET_NAME (sym), dvp_blk.op->name);
++      return;
++    }
++
++  /* A run holds at most DVP_MPG_SPLIT_AT instructions, and it is the next
++     instruction that would start a fresh command.  A label standing exactly on
++     that boundary belongs to the instruction after it, which lands *past* the
++     new command word -- so the run is started here, before the alias is placed,
++     and the alias names the instruction rather than the command word injected in
++     front of it.
++
++     The overlay value is unaffected: dvp_mpg_new_run advances vu_addr by exactly
++     the units it closes and moves payload to the new run's first byte, so
++     vu_addr * DVP_MICROINSN_BYTES + (here - payload) comes to the same address
++     either way.  */
++  if (dvp_blk.run_insns == DVP_MPG_SPLIT_AT)
++    {
++      dvp_mpg_new_run ();
++      here = dvp_here ();
++    }
++
++  /* Data narrower than a microinstruction can leave the position part way
++     through a slot.  A label written there names the slot the next
++     microinstruction will occupy -- the reference values both the label and its
++     alias at that rounded position -- so the padding the next instruction would
++     insert anyway is emitted here, before either symbol is placed.
++
++     Explicit zero bytes rather than an alignment frag: the amount is known now,
++     and a frag whose size is not settled until layout would put the block's own
++     measurement (dvp_mpg_run_units) out of reach at exactly the point it is
++     needed.  */
++  {
++    addressT rem = (here - dvp_blk.payload) % DVP_INSN_BYTES;
++
++    if (rem != 0)
++      {
++	addressT pad = DVP_INSN_BYTES - rem;
++	char *fill = frag_more ((int) pad);
++
++	memset (fill, 0, (size_t) pad);
++	here = dvp_here ();
++      }
++  }
++
++  /* The alias first, while the label is still where GAS put it.  If the source
++     has already used that spelling the label stays where it is: moving it into the
++     overlay with no alias behind it would leave every reference to it measuring
++     from the wrong origin.  */
++  name = concat (DVP_OVERLAY_ALIAS_PREFIX, S_GET_NAME (sym), NULL);
++  alias = dvp_define_generated (name, now_seg, frag_now, frag_now_fix (),
++				"the label's alias");
++  free (name);
++  if (alias == NULL)
++    return;
++
++  S_SET_SEGMENT (sym, dvp_blk.ovly_sec);
++  symbol_set_frag (sym, &zero_address_frag);
++  S_SET_VALUE (sym, (valueT) dvp_blk.vu_addr * DVP_MICROINSN_BYTES
++		    + (here - dvp_blk.payload));
++}
++
++/* How many microinstructions the current MPG run's payload holds, measured from
++   the bytes that have actually been emitted rather than from the instruction
++   lines that were parsed: a data directive inside an `mpg' block puts bytes into
++   the transfer just as an instruction does, and the eight-byte alignment the next
++   instruction needs puts more.  Returns -1, having reported, if the payload is
++   not a whole number of microinstructions or cannot be measured.  */
++
++static dvp_val
++dvp_mpg_run_units (const struct dvp_ctr_opcode *op)
++{
++  addressT here = dvp_here ();
++  addressT bytes;
++
++  if (!dvp_offset_known)
++    {
++      as_bad_where (dvp_blk.file, dvp_blk.line,
++		    _("cannot measure this %s block, because something in it "
++		      "has a size that is not settled yet"), op->name);
++      return -1;
++    }
++  bytes = here - dvp_blk.payload;
++  if (bytes % DVP_INSN_BYTES != 0)
++    {
++      as_bad_where (dvp_blk.file, dvp_blk.line,
++		    _("this %s block holds %lu bytes, which is not a whole "
++		      "number of %d-byte microinstructions; the leftover would "
++		      "be loaded without being counted"),
++		    op->name, (unsigned long) bytes, DVP_INSN_BYTES);
++      return -1;
++    }
++  return (dvp_val) (bytes / DVP_INSN_BYTES);
++}
++
++/* Start a fresh MPG command because the current one is full.  */
++
++static void
++dvp_mpg_new_run (void)
++{
++  const struct dvp_ctr_opcode *op = dvp_blk.op;
++  const struct dvp_ctr_field *af = &op->fields[0];
++  struct dvp_ctr_field cf = dvp_length_field (op);
++  unsigned int words[DVP_CTR_MAX_HEADER];
++  char err[DVP_ERRLEN];
++  const char *e;
++  char *f;
++  dvp_val units = dvp_mpg_run_units (op);
++  /* The run that has just filled up had no command word, so the run starting
++     here gets none either: what splits is the transfer, and with the commands
++     suppressed there is no transfer to describe.  */
++  int suppressed = dvp_header_suppressed (op);
++
++  if (units < 0)
++    return;
++  if (suppressed)
++    {
++      dvp_blk.vu_addr += units;
++      dvp_mpgloc = dvp_blk.vu_addr;
++      dvp_blk.run_insns = 0;
++      dvp_blk.payload = dvp_here ();
++      return;
++    }
++  if (dvp_blk.auto_len)
++    dvp_patch_count (op, &cf, units, dvp_blk.cmd_frag, dvp_blk.cmd_where);
++  else
++    {
++      /* A block whose count was written out splits too: what fills up is the
++	 command, and a command holds at most DVP_MPG_SPLIT_AT microinstructions
++	 however the count was spelled.  The written count describes the command
++	 it was written on -- the first one -- so it is checked against that
++	 command's payload here and left alone rather than replaced.  Every
++	 command generated after it works its own count out, which is what the
++	 reference does by writing them as `mpg *,*'.  */
++      dvp_val want = dvp_written_count (op, &cf, dvp_blk.explicit_len);
++
++      if (want != units)
++	as_bad_where (dvp_blk.file, dvp_blk.line,
++		      _("this %s block says it holds %lld microinstruction%s "
++			"but its first command holds %lld; write \"*\" to have "
++			"the count worked out"), op->name, want,
++		      want == 1 ? "" : "s", units);
++      dvp_blk.auto_len = 1;
++    }
++  /* The command that has just filled up describes one overlay, and the one
++     starting here describes the next: each is a separate transfer to a separate
++     load address, so each gets its own entry.  */
++  dvp_overlay_close ((addressT) units * DVP_INSN_BYTES);
++  dvp_blk.vu_addr += units;
++  dvp_mpgloc = dvp_blk.vu_addr;
++  dvp_blk.run_insns = 0;
++
++  memset (words, 0, sizeof (words));
++  words[op->cmd_slot] = dvp_blk.cmd_base;
++  e = dvp_ctr_place (op, af, dvp_blk.vu_addr, words, err, sizeof (err));
++  if (e != NULL)
++    {
++      as_bad ("%s", e);
++      return;
++    }
++  /* Each command starts a fresh VIF command run and a fresh program unit, and
++     reserves its own pair of unit names.  */
++  dvp_vif_unit_pending = 1;
++  dvp_start_vif_unit ();
++  dvp_align_payload (op->name, op->payload_align);
++  f = dvp_emit_words (words, 1);
++  dvp_unit_counter += 2;
++  dvp_unit_pending = 1;
++  dvp_blk.cmd_frag = frag_now;
++  dvp_blk.cmd_where = f - frag_now->fr_literal;
++  /* This command's own payload starts here, and is what its count describes.  */
++  dvp_blk.payload = dvp_here ();
++  dvp_overlay_open ();
++}
++
++/* --- block terminators --------------------------------------------------- */
++
++/* Leave the block that has just closed, returning to the one it was written
++   inside if there was one.  */
++
++static void
++dvp_pop_block (void)
++{
++  if (dvp_blk_depth > 0)
++    {
++      memset (&dvp_blk, 0, sizeof (dvp_blk));
++      --dvp_blk_depth;
++    }
++}
++
++static void
++dvp_finish_block (const char *terminator)
++{
++  const struct dvp_ctr_opcode *op = dvp_blk.op;
++  struct dvp_ctr_field cf;
++  addressT here;
++  dvp_val count;
++  /* The construct's header words were left out, so there is no
++     count field: nothing to write a count into, and nothing to check one
++     against.  The payload is still written and still padded, because those are
++     the block's own bytes and not the command's.  */
++  int no_header;
++
++  if (op == NULL)
++    {
++      as_bad (_("%s: there is no open block for it to close"), terminator);
++      return;
++    }
++  if (strcmp (op->terminator, terminator) != 0)
++    {
++      as_bad (_("%s closes an %s block, but the open block was opened by %s "
++		"and ends with %s"), terminator, terminator, op->name,
++	      op->terminator);
++      return;
++    }
++
++  if (now_seg != dvp_blk.seg || now_subseg != dvp_blk.subseg)
++    {
++      /* dvp_section_changed has already said so.  Do not measure, and do not
++	 patch a count that would describe the wrong bytes.  */
++      if (!dvp_blk.seg_reported)
++	as_bad (_("%s closes a block that was opened at %s:%u in another "
++		  "subsection, so its length cannot be measured"),
++		terminator, dvp_blk.file, dvp_blk.line);
++      dvp_pop_block ();
++      return;
++    }
++
++  cf = dvp_length_field (op);
++  no_header = (dvp_blk.cmd_frag == NULL);
++
++  if (op->kind == DVP_CTR_DMA)
++    {
++      /* A DMA transfer moves whole quadwords, so the payload is padded out to
++	 one when it closes.  The padding is a property of where the payload
++	 *ends in the section*, not of how many bytes it holds: a packed tag's
++	 payload starts eight bytes into the tag's own quadword, so a length
++	 measured from there would round to the wrong boundary.  */
++      dvp_val want;
++
++      here = dvp_here ();
++      if (!dvp_offset_known)
++	{
++	  as_bad_where (dvp_blk.file, dvp_blk.line,
++			_("cannot count the quadwords this %s transfers, "
++			  "because something in its payload has a size that is "
++			  "not settled yet"), op->name);
++	  dvp_pop_block ();
++	  return;
++	}
++      if (op->end_align > 1)
++	{
++	  dvp_emit_zero_bytes ((op->end_align - here % op->end_align)
++			       % op->end_align);
++	  here = dvp_here ();
++	}
++      /* A VIF command after the payload starts a fresh command run rather than
++	 continuing the one in the tag's spare half.  Measured, and set here
++	 rather than in the shared tail because every exit from this branch is a
++	 return.  */
++      if (op->closes_vif_unit)
++	dvp_vif_unit_pending = 1;
++      if (no_header)
++	{
++	  dvp_pop_block ();
++	  return;
++	}
++      /* Everything the payload wrote before the end of the tag's own quadword
++	 shares that quadword and is not part of the count.  */
++      count = here <= dvp_blk.payload
++	      ? 0 : (dvp_val) ((here - dvp_blk.payload) / op->unit_bytes);
++      if (count > (dvp_val) op->count_max)
++	{
++	  as_bad_where (dvp_blk.file, dvp_blk.line,
++			_("this %s would have to transfer %lld quadwords, which "
++			  "does not fit its count field (at most %u)"),
++			op->name, count, (unsigned) op->count_max);
++	  dvp_pop_block ();
++	  return;
++	}
++      if (dvp_blk.auto_len)
++	{
++	  if (dvp_auto_count_is_expressible (op, &cf, count, dvp_blk.file,
++					     dvp_blk.line))
++	    dvp_patch_count (op, &cf, count, dvp_blk.cmd_frag,
++			     dvp_blk.cmd_where);
++	  dvp_pop_block ();
++	  return;
++	}
++      if (dvp_blk.pending != NULL)
++	{
++	  /* The written count is not known yet; record what the payload came to
++	     and let dvp_md_finish compare the two.  */
++	  dvp_blk.pending->measured = count;
++	  dvp_blk.pending->have_measured = 1;
++	  dvp_pop_block ();
++	  return;
++	}
++      want = dvp_written_count (op, &cf, dvp_blk.explicit_len);
++      if (op->validate_count && want != count)
++	as_bad_where (dvp_blk.file, dvp_blk.line,
++		      _("this %s says %lld quadword%s follow%s it but %lld do%s; "
++			"write \"*\" to have the count worked out"),
++		      op->name, want, want == 1 ? "" : "s",
++		      want == 1 ? "s" : "", count, count == 1 ? "es" : "");
++      dvp_pop_block ();
++      return;
++    }
++
++  if (op->kind == DVP_CTR_MPG)
++    {
++      /* What the command loads is bytes, so the count comes from the bytes this
++	 run's payload really holds -- not from the instruction lines that were
++	 parsed, which leave out data directives and the alignment they force.  */
++      dvp_val units = dvp_mpg_run_units (op);
++
++      if (units < 0)
++	{
++	  dvp_pop_block ();
++	  return;
++	}
++      if (no_header)
++	count = units;
++      else if (dvp_blk.auto_len)
++	{
++	  if (!dvp_auto_count_is_expressible (op, &cf, units, dvp_blk.file,
++					      dvp_blk.line))
++	    {
++	      dvp_pop_block ();
++	      return;
++	    }
++	  count = units;
++	}
++      else
++	{
++	  dvp_val want = dvp_written_count (op, &cf, dvp_blk.explicit_len);
++
++	  if (units != want)
++	    as_bad_where (dvp_blk.file, dvp_blk.line,
++			  _("this mpg block says it holds %lld "
++			    "microinstruction%s but holds %lld; write \"*\" to "
++			    "have the count worked out"),
++			  want, want == 1 ? "" : "s", units);
++	  count = want;
++	}
++      dvp_patch_count (op, &cf, count, dvp_blk.cmd_frag, dvp_blk.cmd_where);
++      dvp_overlay_close ((addressT) units * DVP_INSN_BYTES);
++    }
++  else
++    {
++      /* An unpack's unit is its data format's element, which is why the table
++	 leaves UNIT_BYTES zero for it; a GIF register list's is one loop of the
++	 transfer, which depends on how many registers the statement named.  Both
++	 are recorded on the open block rather than read off the table.  */
++      unsigned int unit = dvp_blk.unit ? dvp_blk.unit
++			  : (op->kind == DVP_CTR_UNPACK) ? dvp_blk.fmt_elem
++							 : op->unit_bytes;
++
++      if (unit == 0)
++	as_fatal (_("dvp: %s block has no payload unit size"), op->name);
++
++      here = dvp_here ();
++      if (!dvp_offset_known)
++	{
++	  as_bad_where (dvp_blk.file, dvp_blk.line,
++			_("cannot measure this %s block, because something in "
++			  "it has a size that is not settled yet"), op->name);
++	  count = 0;
++	  dvp_blk.auto_len = 0;		/* nothing correct to patch in */
++	}
++      else
++	{
++	  addressT bytes = here - dvp_blk.payload;
++	  int counted = 1;
++
++	  if (op->round_up)
++	    {
++	      /* The count is in whole units, so the block has to hold whole
++		 units: rounding the count up without emitting the bytes that
++		 rounding claims would leave the command describing a longer
++		 transfer than the block actually is.  The padding is emitted
++		 here, where the block is, so it counts towards an enclosing
++		 block exactly as the payload does.  */
++	      addressT pad = (unit - bytes % unit) % unit;
++
++	      dvp_emit_zero_bytes (pad);
++	      bytes += pad;
++	      count = (dvp_val) (bytes / unit);
++	    }
++	  else if (op->kind == DVP_CTR_UNPACK)
++	    /* A payload that stops short of a whole element is not an error
++	       here, and unlike `direct' and `mpg' an `unpack' count is not
++	       validated against its payload at all.  This count is not a
++	       statement about how many bytes were emitted: a write mask makes
++	       the VIF consume a different number of bytes than the element
++	       count implies.  So the rule the other counted blocks are held to
++	       -- an encoded length must equal the bytes emitted -- does not
++	       reach this field, and the count is the number of whole elements
++	       the payload holds.
++
++	       What does reach it is the tail padding below, and the refusal of
++	       a derived count of zero, because a stored zero here spells
++	       256.  */
++	    count = (dvp_val) (bytes / unit);
++	  else
++	    {
++	      if (bytes % unit != 0)
++		{
++		  as_bad_where (dvp_blk.file, dvp_blk.line,
++				_("this %s block holds %lu bytes, which is not "
++				  "a whole number of %u-byte units; the "
++				  "leftover would be transferred without being "
++				  "counted"), op->name, (unsigned long) bytes,
++				unit);
++		  counted = 0;
++		  count = 0;
++		}
++	      else
++		count = (dvp_val) (bytes / unit);
++	    }
++
++	  /* Pad the payload out to the boundary the *next* construct of this
++	     stream starts on.  A VIF command word begins on a four-byte
++	     boundary, so a payload ending part way through a word would put the
++	     following command at an offset that is not a command position.  The
++	     pad is the block's own, so it counts towards an enclosing region as
++	     the payload does, and it does not change the count, which counts
++	     units and not bytes.
++
++	     It is the *command stream's* boundary, so with the VIF command
++	     words suppressed there is no following command to place and nothing
++	     to pad for.
++
++	     Where the payload ends *in the section* decides it, not how many
++	     bytes it holds: an `unpack' whose command word did not itself start
++	     on a four-byte boundary ends a four-byte payload off a boundary,
++	     and it is the boundary the following command word needs.  */
++	  if (op->end_align > 1 && !no_header)
++	    dvp_defer_align (op->name, op->end_align, 0, 0);
++
++	  if (counted && op->validate_count && !dvp_blk.auto_len && !no_header)
++	    {
++	      dvp_val want = dvp_written_count (op, &cf, dvp_blk.explicit_len);
++
++	      if (want != count)
++		as_bad_where (dvp_blk.file, dvp_blk.line,
++			      _("this %s block says it holds %lld unit%s but "
++				"holds %lld; write \"*\" to have the count "
++				"worked out"),
++			      op->name, want, want == 1 ? "" : "s", count);
++	    }
++	  if (!counted)
++	    dvp_blk.auto_len = 0;      /* nothing correct to patch in */
++	}
++      if (no_header)
++	;			/* no count field: nothing to work out */
++      else if (dvp_blk.auto_len && op->kind == DVP_CTR_UNPACK)
++	{
++	  /* An `unpack' count that the assembler works out is divided by the
++	     write cycle in force.  With no setting yet there is
++	     nothing to divide it by *and no answer either*: the reference waits
++	     and uses the setting the file ends on, so this one waits too.  */
++	  if (dvp_cycle.set)
++	    dvp_patch_unpack_count (op, &cf, dvp_blk.cmd_frag,
++				    dvp_blk.cmd_where, count, dvp_cycle.wl,
++				    dvp_cycle.cl, dvp_blk.file, dvp_blk.line);
++	  else
++	    {
++	      struct dvp_deferred_count *d = XNEW (struct dvp_deferred_count);
++
++	      d->next = NULL;
++	      d->op = op;
++	      d->field = cf;
++	      d->frag = dvp_blk.cmd_frag;
++	      d->where = dvp_blk.cmd_where;
++	      d->nelem = count;
++	      d->file = dvp_blk.file;
++	      d->line = dvp_blk.line;
++	      *dvp_deferred_tail = d;
++	      dvp_deferred_tail = &d->next;
++	    }
++	}
++      else if (dvp_blk.auto_len
++	       && dvp_auto_count_is_expressible (op, &cf, count, dvp_blk.file,
++						 dvp_blk.line))
++	dvp_patch_count (op, &cf, count, dvp_blk.cmd_frag, dvp_blk.cmd_where);
++    }
++
++  /* The transfer this command describes is done, so the running load address
++     moves past it and a later `mpg *' carries on from there.  */
++  if (op->kind == DVP_CTR_MPG && !no_header)
++    dvp_mpgloc = dvp_blk.vu_addr + count;
++
++  if (op->closes_vif_unit)
++    dvp_vif_unit_pending = 1;
++
++  dvp_pop_block ();
++}
++
++/* --- a payload named by file --------------------------------------------- */
++
++/* `direct "FILE"', `directhl "FILE"', `unpack FMT, ADDR, "FILE"' and
++   `mpg ADDR, "FILE"' name their payload instead of enclosing it in a block.  The
++   form was established by probe, not assumed: a quoted name in the count's place
++   is accepted by exactly these four commands and by no VIF fixed command, DMA
++   tag or GIF tag, and it opens nothing -- a terminator after it is an error and
++   an ordinary statement may follow immediately.
++
++   Nothing about the counting is new: the file's bytes are emitted where a
++   block's payload would go and the run is closed the ordinary way, so the length
++   arithmetic, the alignment, the whole-unit rule and the splitting of an
++   over-long `mpg' are the same code that a written-out block uses.  */
++
++/* How much of a payload file is read at a time.  It is an I/O buffer size and
++   nothing else: the file is copied into the section a piece at a time, so no
++   ceiling on the file's size follows from it.  The reference streams its payload
++   too, and has no size limit of its own; an assembler-invented one would have
++   refused sources the reference assembles.  */
++#define DVP_PAYLOAD_CHUNK	(64u << 10)
++
++/* Open the payload file and measure it.  Returns the stream, with *LENP set and
++   *PATHP owning the resolved name, or NULL having reported.  */
++
++static FILE *
++dvp_open_payload_file (const char *filename, dvp_val *lenp, char **pathp)
++{
++  FILE *fh;
++  char *path;
++  long len;
++
++  path = XNEWVEC (char, strlen (filename) + include_dir_maxlen + 2);
++  /* search_and_open applies stock GAS's `.incbin' search order: the name as
++     given, then each -I directory.  Using it keeps the two spellings of a
++     file-backed payload finding the same file.  */
++  fh = search_and_open (filename, path);
++  if (fh == NULL)
++    {
++      as_bad (_("cannot open the payload file \"%s\""), filename);
++      free (path);
++      return NULL;
++    }
++  register_dependency (path);
++
++  if (fseek (fh, 0, SEEK_END) != 0
++      || (len = ftell (fh)) < 0
++      || fseek (fh, 0, SEEK_SET) != 0)
++    {
++      as_bad (_("cannot measure the payload file \"%s\""), path);
++      fclose (fh);
++      free (path);
++      return NULL;
++    }
++  /* The one size that has to be refused is one this host cannot address: the
++     bytes go into a section, and a section offset is an addressT.  Every other
++     limit belongs to the command -- how many units its count field holds, and
++     for `mpg' how many commands the transfer is split into -- and is applied
++     where that is decided, not here.  */
++  if ((unsigned long) len > (unsigned long) (addressT) -1
++      || (unsigned long) len > (unsigned long) (size_t) -1)
++    {
++      as_bad (_("the payload file \"%s\" is %lld bytes, which is more than "
++		"this host can place in a section"), path, DVP_VAL_PRINT (len));
++      fclose (fh);
++      free (path);
++      return NULL;
++    }
++  *lenp = (dvp_val) len;
++  *pathp = path;
++  return fh;
++}
++
++/* Copy N bytes of FH into the section.  Returns 0, having reported, on a short
++   read: a payload that stops early is not a payload.  */
++
++static int
++dvp_copy_payload_bytes (FILE *fh, const char *path, dvp_val n)
++{
++  while (n > 0)
++    {
++      size_t want = n > (dvp_val) DVP_PAYLOAD_CHUNK
++		    ? (size_t) DVP_PAYLOAD_CHUNK : (size_t) n;
++      char *f = frag_more (want);
++
++      if (fread (f, 1, want, fh) != want)
++	{
++	  as_bad (_("the payload file \"%s\" ended before the bytes it said "
++		    "it held had been read"), path);
++	  return 0;
++	}
++      n -= (dvp_val) want;
++    }
++  return 1;
++}
++
++static void
++dvp_emit_named_payload (const struct dvp_ctr_opcode *op, const char *filename)
++{
++  dvp_val len = 0, done = 0;
++  char *path = NULL;
++  FILE *fh = dvp_open_payload_file (filename, &len, &path);
++
++  if (fh == NULL)
++    {
++      /* Leave no block open, so that the next statement is judged on its own
++	 merits instead of being reported as a second, dependent error.  */
++      dvp_pop_block ();
++      return;
++    }
++
++  /* The payload is marked, at its first byte, with the same synthetic symbol a
++     written-out block's payload gets -- which for `mpg' is the VU program unit
++     the instructions would have started, and for `direct' and `directhl' is a
++     GIF-kind marker.  Both were measured, in eight surrounding contexts each, so
++     that the unit numbering matches too; an `unpack' payload is marked by
++     nothing, and is not marked here either.  */
++  do
++    {
++      dvp_val chunk = len - done;
++
++      if (op->kind == DVP_CTR_MPG)
++	{
++	  dvp_val room = (dvp_val) DVP_MPG_SPLIT_AT * DVP_INSN_BYTES;
++
++	  if (chunk > room)
++	    chunk = room;
++	  dvp_emit_unit_marker ();
++	}
++      else if (op->kind == DVP_CTR_DIRECT)
++	dvp_emit_marker (DVP_MARK_GIF_PREFIX, dvp_unit_counter++,
++			 DVP_MARK_GIF_OTHER);
++      if (chunk == 0)
++	break;
++      if (!dvp_copy_payload_bytes (fh, path, chunk))
++	{
++	  fclose (fh);
++	  free (path);
++	  dvp_pop_block ();
++	  return;
++	}
++      done += chunk;
++      /* An `mpg' payload longer than one command's count field can express is
++	 loaded by several commands, each carrying on from where the last
++	 ended, as a written-out block does.  */
++      if (done < len)
++	dvp_mpg_new_run ();
++    }
++  while (done < len);
++
++  fclose (fh);
++  free (path);
++  dvp_finish_block (op->terminator);
++}
++
++/* The four terminators, in the order md_pseudo_table lists them.  */
++static const char *const dvp_terminators[] =
++{
++  ".endunpack", ".endmpg", ".enddirect", ".endgif"
++};
++
++static void
++s_dvp_endblock (int which)
++{
++  dvp_finish_block (dvp_terminators[which]);
++  demand_empty_rest_of_line ();
++}
++
++/* Let the open `.dmadata' region go, and release the name copied for it.
++
++   `.dmadata NAME' has to keep NAME: GAS hands the directive a pointer into the
++   line buffer, which the next line overwrites, and the name is wanted again at
++   `.enddmadata' and in every diagnostic about the region.  So it is copied -- and
++   a copy needs one place that releases it, because a region is let go on five
++   different paths: closed by its terminator, abandoned where a positional input
++   ends, reported unclosed at the end of the assembly, and the two error paths
++   that report a region and stop tracking it.  Missing one of them leaked the copy
++   for the whole run, which was measured before this existed.  */
++
++static void
++dvp_dmadata_release (void)
++{
++  free (dvp_dmadata_name);
++  dvp_dmadata_name = NULL;
++  dvp_dmadata_open = 0;
++}
++
++static void
++s_dvp_dmadata (int ignore ATTRIBUTE_UNUSED)
++{
++  char *name;
++  char delim;
++
++  if (dvp_blk.op != NULL)
++    {
++      as_bad (_(".dmadata cannot start inside an open %s block"),
++	      dvp_blk.op->name);
++      ignore_rest_of_line ();
++      return;
++    }
++  if (dvp_dmadata_open)
++    {
++      as_bad (_(".dmadata blocks cannot be nested; \"%s\" is still open"),
++	      dvp_dmadata_name);
++      ignore_rest_of_line ();
++      return;
++    }
++  if (dvp_in_vu_mode)
++    {
++      as_bad (_(".dmadata cannot appear after .vu"));
++      ignore_rest_of_line ();
++      return;
++    }
++
++  SKIP_WHITESPACE ();
++  /* A quoted name is refused.  GAS will read one, but the reference leaves the
++     closing quote where the statement's tail is checked and reports it, so
++     `.dmadata "X"' is an error there and `.dmadata X' is the only spelling.  */
++  if (*input_line_pointer == '"')
++    {
++      as_bad (_(".dmadata takes a plain name, not a quoted string"));
++      ignore_rest_of_line ();
++      return;
++    }
++  delim = get_symbol_name (&name);
++  if (*name == 0)
++    {
++      as_bad (_(".dmadata needs a name for the block it opens"));
++      (void) restore_line_pointer (delim);
++      ignore_rest_of_line ();
++      return;
++    }
++  /* At most one copy is ever live, and this is the only place one is made, so
++     this is where that invariant is kept: anything a path forgot to release goes
++     here rather than staying lost for the rest of the run.  */
++  dvp_dmadata_release ();
++  dvp_dmadata_name = xstrdup (name);
++  (void) restore_line_pointer (delim);
++
++  dvp_align_to (DVP_TAG_BYTES);
++  /* Define the name the way a label is defined, so that a DMA tag which
++     referred to it earlier in the file resolves to this definition instead of
++     staying undefined.  */
++  colon (dvp_dmadata_name);
++  dvp_dmadata_open = 1;
++  dvp_dmadata_seg = now_seg;
++  dvp_dmadata_subseg = now_subseg;
++  dvp_dmadata_seg_reported = 0;
++  dvp_dmadata_file = as_where (&dvp_dmadata_line);
++  dvp_vif_unit_pending = 1;
++  demand_empty_rest_of_line ();
++}
++
++static void
++s_dvp_enddmadata (int ignore ATTRIBUTE_UNUSED)
++{
++  /* One terminator closes two things: a DMA tag's own payload, and a named
++     region.  The innermost open block decides which, so a payload with something
++     still open inside it is reported rather than closed over the child's head.  */
++  if (dvp_blk.op != NULL && dvp_blk.op->kind == DVP_CTR_DMA)
++    {
++      dvp_finish_block (dvp_blk.op->terminator);
++      /* Closing a tag's payload opens a program unit, so a `.vu' block written
++	 straight after it is named even when the payload's own microcode has
++	 already taken the unit the tag opened.  Measured: with an `mpg' block
++	 inside the payload -- which is the only way the unit gets used up before
++	 the payload closes -- the reference names the block after it, and with
++	 the payload holding data it names the same one either way.  */
++      dvp_unit_pending = 1;
++      demand_empty_rest_of_line ();
++      return;
++    }
++  if (dvp_blk.op != NULL)
++    {
++      as_bad (_(".enddmadata cannot close anything while the %s block inside it "
++		"is still open; close that with %s first"),
++	      dvp_blk.op->name, dvp_blk.op->terminator);
++      ignore_rest_of_line ();
++      return;
++    }
++  if (!dvp_dmadata_open)
++    {
++      as_bad (_(".enddmadata has no DMA payload or .dmadata region to close"));
++      ignore_rest_of_line ();
++      return;
++    }
++  if (now_seg != dvp_dmadata_seg || now_subseg != dvp_dmadata_subseg)
++    {
++      /* dvp_section_changed has already said so.  Do not pad, and do not raise
++	 the alignment of, a section that has nothing to do with this region.  */
++      if (!dvp_dmadata_seg_reported)
++	as_bad (_(".enddmadata closes the region \"%s\", which was opened at "
++		  "%s:%u in another subsection, so it cannot be padded out to a "
++		  "whole quadword here"),
++		dvp_dmadata_name, dvp_dmadata_file, dvp_dmadata_line);
++    }
++  else
++    {
++      /* A DMA transfer moves whole quadwords, so a named region is padded out to
++	 one; whatever follows the region starts on the next quadword boundary
++	 rather than sharing the region's last one.  */
++      dvp_align_to (DVP_TAG_BYTES);
++      /* Mark where the region ends, past that padding, so a tag that asks for
++	 the region's length gets a whole number of quadwords.  The name is a
++	 local label and does not reach the object's symbol table.  */
++      {
++	char *endname = dvp_end_symbol_name (dvp_dmadata_name);
++
++	/* colon() copies the name into the symbol table, so this buffer is the
++	   caller's to release.  */
++	colon (endname);
++	free (endname);
++      }
++    }
++  dvp_dmadata_release ();
++  /* The region is a transfer of its own, so a VIF command after it starts a
++     fresh command run rather than continuing the one inside the region.  */
++  dvp_vif_unit_pending = 1;
++  demand_empty_rest_of_line ();
++}
++
++static void
++s_dvp_dmapackvif (int ignore ATTRIBUTE_UNUSED)
++{
++  offsetT v;
++  char *p = dvp_skip_white (input_line_pointer);
++
++  if (is_end_of_stmt (*p) || *p == 0)
++    {
++      as_bad (_(".dmapackvif needs an argument: 1 to pack VIF commands into a "
++		"DMA tag's spare half, 0 to leave it empty"));
++      ignore_rest_of_line ();
++      return;
++    }
++  /* One character, `0' or `1', and not an expression that comes to one: the
++     reference reads the single character and then demands the end of the
++     statement, so `00', `+1', `0x1', `(0)', `1+0' and a symbol worth 0 or 1 are
++     all refused.  */
++  if (*p != '0' && *p != '1')
++    {
++      as_bad (_(".dmapackvif takes 1 to pack VIF commands into a DMA tag's "
++		"spare half, or 0 to leave it empty"));
++      ignore_rest_of_line ();
++      return;
++    }
++  v = *p - '0';
++  ++p;
++  input_line_pointer = p;
++  /* The whole statement has to be accepted before the setting changes.  Under
++     -Z the assembler reports an error and carries on, so a statement that was
++     refused for its trailing junk and changed the setting anyway would silently
++     relayout every DMA tag after it.  */
++  p = dvp_skip_white (input_line_pointer);
++  if (!is_end_of_stmt (*p) && *p != 0)
++    {
++      /* Quote what is left of *this statement*, not the rest of the buffer:
++	 GAS hands the whole remaining input to a directive, so a bare "%s" here
++	 prints the rest of the file.  */
++      char rest[64];
++      size_t n = 0;
++
++      while (n < sizeof (rest) - 1 && p[n] != 0 && !is_end_of_stmt (p[n]))
++	{
++	  rest[n] = p[n];
++	  ++n;
++	}
++      rest[n] = 0;
++      as_bad (_("unexpected text \"%s\" after .dmapackvif; the packing setting "
++		"is left as it was"), rest);
++      ignore_rest_of_line ();
++      return;
++    }
++  dvp_packvif = (int) v;
++  demand_empty_rest_of_line ();
++}
++
++/* Every positional input file ends here, the last one included.
++
++   Ordinary state survives the boundary and is meant to: VU mode, the write
++   cycle, the packing switch, the symbols, the section.  What does not is a
++   construct whose extent is *measured* -- a block, a named `.dmadata' region, a
++   DMA tag's own payload.  Each gets its length from the bytes written after it,
++   and a length reported across a boundary names an opener in one file and the
++   bytes it describes in another.  So the boundary is where they are reported.
++
++   Every open construct is reported, outermost first, which is the order they
++   were written in: reporting only the innermost would name a nested GIF tag and
++   leave the block it was written inside unmentioned.  A named `.dmadata' region
++   cannot start inside a block, so where one is open it comes first.  */
++
++void
++dvp_input_file_end (void)
++{
++  int i;
++
++  if (dvp_dmadata_open)
++    {
++      as_bad_where (dvp_dmadata_file, dvp_dmadata_line,
++		    _("the .dmadata region \"%s\" is still open where the input "
++		      "file ends; its extent is measured from the bytes written "
++		      "after it, so it needs its .enddmadata in the same file"),
++		    dvp_dmadata_name);
++      dvp_dmadata_release ();
++    }
++
++  for (i = 1; i <= dvp_blk_depth; i++)
++    if (dvp_blocks[i].op != NULL)
++      as_bad_where (dvp_blocks[i].file, dvp_blocks[i].line,
++		    _("this %s is still open where the input file ends; its "
++		      "length is measured from the bytes written after it, so "
++		      "it needs its %s in the same file"),
++		    dvp_blocks[i].op->name, dvp_blocks[i].op->terminator);
++  /* Dropped rather than carried on, so the next file does not add to a payload
++     it cannot see and the end of the assembly does not report the same thing
++     again in different words.  */
++  while (dvp_blk_depth > 0)
++    dvp_pop_block ();
++}
++
++/* Point every instruction field that names a label inside an `mpg' block at the
++   alias standing where the code is.
++
++   A label in an overlay is measured from the overlay's load address, so a
++   displacement computed against it would subtract a position in the transfer
++   from an address in VU memory and mix two origins.  The alias is in the
++   transfer, so a branch resolves against it exactly as inside a `.vu' block.
++   This runs here rather than where the operand was parsed because a forward
++   reference names a symbol that is not defined -- and so is not in any overlay
++   -- when the operand is read.
++
++   Only instruction fields are redirected, which is what a non-NULL tc_fix_data
++   identifies.  A data word naming such a label keeps naming the overlay.  */
++
++/* Is R a plain N-byte datum, of the kind `.byte', `.short', `.word' and
++   `.8byte' ask for?  */
++
++static int
++dvp_is_plain_data_reloc (bfd_reloc_code_real_type r, int size)
++{
++  return ((r == BFD_RELOC_8 && size == 1)
++	  || (r == BFD_RELOC_16 && size == 2)
++	  || (r == BFD_RELOC_32 && size == 4)
++	  || (r == BFD_RELOC_64 && size == 8));
++}
++
++/* Settle a data word that names a label inside an `mpg' block, here.
++
++   Such a word holds the label's place in VU memory, and it is a number by the
++   time this runs: the label is defined, and the overlay it belongs to starts at
++   nothing the linker has a say in.  Left to the relocation pass, GAS would
++   reduce the fixup to one against the generated overlay's *section* -- folding
++   it to the same number, and asking for that section's symbol while it did so.
++   Section symbols come out in the order they were asked for, so that one
++   request moved a generated section's symbol ahead of symbols belonging to
++   sections the source wrote earlier.  Settling here writes the same bytes
++   without asking.
++
++   Only a plain four-byte data word: an instruction operand has already been
++   pointed at the code twin.  */
++
++static void
++dvp_settle_overlay_data_words (void)
++{
++  asection *sec;
++
++  for (sec = stdoutput->sections; sec != NULL; sec = sec->next)
++    {
++      segment_info_type *seginfo = seg_info (sec);
++      frchainS *chain;
++
++      if (seginfo == NULL)
++	continue;
++      for (chain = seginfo->frchainP; chain != NULL; chain = chain->frch_next)
++	{
++	  fixS *fixp;
++
++	  for (fixp = chain->fix_root; fixp != NULL; fixp = fixp->fx_next)
++	    {
++	      addressT val;
++	      valueT value;
++
++	      if (fixp->fx_done
++		  || (fixp->fx_addsy == NULL && fixp->fx_subsy == NULL))
++		continue;
++
++	      if (fixp->fx_subsy != NULL)
++		{
++		  addressT lval = 0, rval;
++
++		  /* Two promoted labels are two VU byte addresses, so their
++		     difference is a number whether or not they share an overlay --
++		     each `mpg' run generates a section of its own, and GAS will not
++		     subtract across ELF sections, so left to write.c this is
++		     refused rather than worked out.  Settled here, md_apply_fix
++		     encodes it in the field's own units, which is what gives a
++		     label-derived difference its scaling.
++
++		     Left alone: a pc-relative fixup, where fx_subsy is
++		     fixup_segment's own doing; a binary difference with a global or
++		     weak end, whose relocation is link-visible.  A missing left side
++		     is GAS's unary minus, which does settle.  */
++		  if (fixp->fx_pcrel
++		      || (fixp->fx_addsy == NULL
++			  ? !dvp_overlay_branch_symbol_value (fixp->fx_subsy,
++							     &rval)
++			  : (!dvp_overlay_symbol_value (fixp->fx_addsy, &lval)
++			     || !dvp_overlay_symbol_value (fixp->fx_subsy,
++							&rval))))
++		    continue;
++		  fixp->fx_offset += (offsetT) lval - (offsetT) rval;
++		  fixp->fx_addsy = NULL;
++		  fixp->fx_subsy = NULL;
++		  continue;
++		}
++
++		      /* Arithmetic over a promoted label is an integer expression over
++			 final VU byte addresses, even though GAS represents it by an
++			 expr_section symbol because the labels occupy generated overlay
++			 sections.  Settle that tree before the generic section rules see
++			 it.  This also keeps an equated label difference symbolic until an
++			 imm15 field can apply its eight-byte scaling.  */
++		      if (S_GET_SEGMENT (fixp->fx_addsy) == expr_section)
++			{
++			  dvp_val ev;
++
++			  if (dvp_eval_overlay_expression_symbol (fixp->fx_addsy, &ev))
++			    {
++			      val = (addressT) ev;
++			      goto have_overlay_value;
++			    }
++			}
++
++		      /* A branch target written as an expression -- `a1+(fwd-a1)' -- does
++		 not reach here as a label.  GAS hands it over as an expression
++		 symbol, which lives in expr_section and so is in no overlay, and
++		 the mixed-origin guard below would refuse it.  Resolving first
++		 turns it back into the VU byte address it denotes: the shape
++		 becomes a symbol plus a constant, which dvp_settle_expression
++		 already answers.  */
++	      if (fixp->fx_pcrel && fixp->tc_fix_data.vu_pc_known
++		  && S_GET_SEGMENT (fixp->fx_addsy) == expr_section)
++		{
++		  dvp_val ev;
++
++		  if (dvp_settle_expression (*symbol_get_value_expression
++					     (fixp->fx_addsy), 0, &ev))
++		    {
++		      fixp->fx_offset += (offsetT) ev
++					 - (offsetT) (fixp->tc_fix_data.vu_pc
++						      + DVP_INSN_BYTES);
++		      fixp->fx_addsy = NULL;
++		      fixp->fx_pcrel = 0;
++		      continue;
++		    }
++		}
++
++	      /* A branch inside a block, to a label that is not in an overlay.
++		 The branch counts in VU bytes and the target is a position in
++		 the transfer, so there is no displacement between them that
++		 means anything -- and a label the name test declined is exactly
++		 such a target.  Refused rather than worked out in whichever
++		 origin happened to be reached first.  */
++	      if (fixp->fx_pcrel && fixp->tc_fix_data.vu_pc_known
++		  && S_IS_DEFINED (fixp->fx_addsy)
++		  && !dvp_is_overlay_section (S_GET_SEGMENT (fixp->fx_addsy)))
++		{
++		  as_bad_where (fixp->fx_file, fixp->fx_line,
++				_("this branch is inside an %s block, so its "
++				  "displacement counts in VU memory, but \"%s\" "
++				  "is a label in the transfer -- the two are "
++				  "different origins and there is no "
++				  "displacement between them"),
++				"mpg", S_GET_NAME (fixp->fx_addsy));
++		  fixp->fx_done = 1;
++		  continue;
++		}
++
++		      if (fixp->fx_pcrel && fixp->tc_fix_data.vu_pc_known)
++			{
++			  if (!dvp_overlay_branch_symbol_value (fixp->fx_addsy, &val))
++			    continue;
++			}
++		      else if (!dvp_overlay_symbol_value (fixp->fx_addsy, &val))
++			continue;
++
++		    have_overlay_value:
++
++		      /* A branch to an overlay label.  Both ends are in VU bytes -- the
++		 target because that is what an overlay label's value is, the branch
++		 because dvp_pcrel_from_section answers in VU bytes inside a block --
++		 so the displacement is worked out here and the symbol dropped.  GAS
++		 would not: the target is in the generated overlay section and the
++		 branch is in the transfer.
++
++		 A branch with no VU address of its own is left alone: it is outside
++		 any block, or in one whose command word was suppressed, so the two
++		 ends are in different origins.  */
++	      if (fixp->fx_pcrel)
++		{
++		  if (!fixp->tc_fix_data.vu_pc_known)
++		    continue;
++		  fixp->fx_offset += (offsetT) val
++				     - (offsetT) (fixp->tc_fix_data.vu_pc
++						  + DVP_INSN_BYTES);
++		  fixp->fx_addsy = NULL;
++		  fixp->fx_pcrel = 0;
++		  continue;
++		}
++
++	      /* An instruction field is folded into the fixup and left for
++		 md_apply_fix, which then encodes it in the field's own units --
++		 the imm15 division among them -- exactly as it does for a value
++		 the source wrote as a constant.  Doing it here rather than in
++		 md_apply_fix keeps the section-symbol request described above
++		 from happening: by the time the relocation pass runs there is no
++		 symbol left to reduce.  */
++	      if (fixp->tc_fix_data.field != NULL)
++		{
++		  fixp->fx_offset += (offsetT) val;
++		  fixp->fx_addsy = NULL;
++		  continue;
++		}
++
++	      if (!dvp_is_plain_data_reloc (fixp->fx_r_type, fixp->fx_size))
++		continue;
++	      value = (valueT) val + (valueT) fixp->fx_offset;
++
++	      /* The width rule applies to the number that is stored, not to the
++		 addend the source wrote next to the label.  A promoted label's
++		 value is only known here, so this is the first point at which
++		 the question can be asked at all -- and asking it is what stops
++		 a VU address wider than the datum being cut down to its low
++		 bits without a word.  Sign-extended and zero-extended spellings
++		 of the same bit pattern both fit, as they do for any datum.  */
++	      if (fixp->fx_size < (int) sizeof (valueT))
++		{
++		  valueT lim = (valueT) 1 << (fixp->fx_size * 8);
++		  valueT lo = (valueT) -(offsetT) (lim >> 1);
++
++		  if (value >= lim && value < lo)
++		    {
++		      as_bad_where (fixp->fx_file, fixp->fx_line,
++				    _("\"%s\" is at %lld in VU memory, and this "
++				      "%d-byte datum cannot hold it"),
++				    S_GET_NAME (fixp->fx_addsy),
++				    (dvp_val) value, (int) fixp->fx_size);
++		      fixp->fx_done = 1;
++		      continue;
++		    }
++		}
++
++	      md_number_to_chars (fixp->fx_frag->fr_literal + fixp->fx_where,
++				  value, fixp->fx_size);
++	      fixp->fx_done = 1;
++	    }
++	}
++    }
++}
++
++
++void
++dvp_md_finish (void)
++{
++  struct dvp_deferred_count *d, *next;
++  struct dvp_pending_extent *x, *xnext;
++
++  /* Before anything reads an offset: every piece of padding whose size was left
++     open is settled here, so that a symbol's place in the section and a
++     construct's place in it are both measured against the bytes that will
++     really be written.  */
++  dvp_settle_layout ();
++
++  dvp_settle_overlay_data_words ();
++
++  /* Every block still open, outermost first, which is the order they were
++     written in.  Reporting only the innermost named a nested GIF tag and left
++     the block it was written inside unmentioned, so the source was told about
++     the interruption and not about the thing it interrupted.  */
++  {
++    int i;
++
++    for (i = 1; i <= dvp_blk_depth; i++)
++      if (dvp_blocks[i].op != NULL)
++	as_bad_where (dvp_blocks[i].file, dvp_blocks[i].line,
++		      _("this %s block was never closed; it needs a %s"),
++		      dvp_blocks[i].op->name, dvp_blocks[i].op->terminator);
++  }
++  if (dvp_dmadata_open)
++    {
++      as_bad (_("the .dmadata block \"%s\" was never closed; it needs a "
++		".enddmadata"), dvp_dmadata_name);
++      dvp_dmadata_release ();
++    }
++
++  /* The `unpack' counts that closed before any cycle setting existed.  The
++     setting the file ends on is the one they get; with none at
++     all, the count is the element count, which is what an undivided setting
++     works out to anyway, so there is no separate case for it here.  */
++  for (d = dvp_deferred_counts; d != NULL; d = next)
++    {
++      next = d->next;
++      dvp_patch_unpack_count (d->op, &d->field, d->frag, d->where, d->nelem,
++			      dvp_cycle.wl, dvp_cycle.cl, d->file, d->line);
++      free (d);
++    }
++  dvp_deferred_counts = NULL;
++  dvp_deferred_tail = &dvp_deferred_counts;
++
++  /* The counts the source wrote as an expression that was not settled at the
++     time.  Every symbol is defined by now, so the value is knowable and so is
++     whether it agrees with the payload that was measured when the block closed.  */
++  {
++    struct dvp_pending_count *c, *cnext;
++
++    for (c = dvp_pending_counts; c != NULL; c = cnext)
++      {
++	char err[DVP_ERRLEN];
++	unsigned int words[DVP_CTR_MAX_HEADER];
++	const char *e;
++	dvp_val want;
++
++	cnext = c->next;
++	if (c->needs_payload && !c->have_measured)
++	  {
++	    /* The payload was never closed; that has been reported already.  */
++	    free (c);
++	    continue;
++	  }
++	/* Through the same settling as a deferred operand, so a count written
++	   as a label difference is the number the laid-out section makes it --
++	   including one whose halves are in different subsections of that
++	   section, or on either side of a `.org'.  A count is not a VU memory
++	   address, so a bare label is not a value here and is reported, which
++	   is what the reference does with one.  */
++	if (!dvp_settle_expression (c->ex, 0, &want))
++	  {
++	    as_bad_where (c->file, c->line,
++			  _("%s: this count still is not a value known at "
++			    "assembly time"), c->op->name);
++	    free (c);
++	    continue;
++	  }
++	memset (words, 0, sizeof (words));
++	words[0] = dvp_read_word (c->frag->fr_literal + c->where);
++	e = dvp_ctr_place_count (c->op, &c->field, want, words, err,
++				 sizeof (err));
++	if (e != NULL)
++	  as_bad_where (c->file, c->line, "%s", e);
++	else if (c->op->validate_count && want != c->measured)
++	  as_bad_where (c->file, c->line,
++			_("this %s says %lld quadword%s follow%s it but %lld "
++			  "do%s; write \"*\" to have the count worked out"),
++			c->op->name, want, want == 1 ? "" : "s",
++			want == 1 ? "s" : "", c->measured,
++			c->measured == 1 ? "es" : "");
++	else
++	  md_number_to_chars (c->frag->fr_literal + c->where, words[0], 4);
++	free (c);
++      }
++    dvp_pending_counts = NULL;
++    dvp_pending_counts_tail = &dvp_pending_counts;
++  }
++
++  /* The operands the source wrote as an expression that was not a value yet.
++     Every symbol is defined by now, so each one is encoded into the field it was
++     parsed for, through the same encoder -- and therefore the same range,
++     alignment and bitmap checks -- that a written-out value goes through.  No
++     relocation is emitted: these are settled here, and nothing is left for the
++     linker.  */
++  {
++    struct dvp_deferred_field *df, *dnext;
++
++    for (df = dvp_deferred_fields; df != NULL; df = dnext)
++      {
++	char err[DVP_ERRLEN];
++	unsigned int words[DVP_CTR_MAX_HEADER];
++	const char *e;
++	dvp_val value;
++	unsigned long at;
++
++	dnext = df->next;
++	if (!dvp_deferred_value (df, &value))
++	  {
++	    as_bad_where (df->file, df->line,
++			  _("%s: this operand still is not a value known at "
++			    "assembly time"), df->what);
++	    free (df);
++	    continue;
++	  }
++
++	if (df->ctr_op != NULL)
++	  {
++	    at = df->where + (unsigned long) df->ctr_field.word * 4;
++	    memset (words, 0, sizeof (words));
++	    words[df->ctr_field.word] = dvp_read_word (df->frag->fr_literal + at);
++	    e = dvp_ctr_place (df->ctr_op, &df->ctr_field, value, words,
++			       err, sizeof (err));
++	    if (e != NULL)
++	      as_bad_where (df->file, df->line, "%s", e);
++	    else
++	      md_number_to_chars (df->frag->fr_literal + at,
++				  words[df->ctr_field.word], 4);
++	  }
++	else
++	  {
++	    unsigned int word;
++
++	    at = df->where;
++	    word = dvp_read_word (df->frag->fr_literal + at);
++	    e = dvp_encode_field (df->vu_field, value, &word,
++				  err, sizeof (err));
++	    if (e != NULL)
++	      as_bad_where (df->file, df->line, _("%s: %s"), df->what, e);
++	    else
++	      md_number_to_chars (df->frag->fr_literal + at, word, 4);
++	  }
++	free (df);
++      }
++    dvp_deferred_fields = NULL;
++    dvp_deferred_fields_tail = &dvp_deferred_fields;
++  }
++
++  /* The tags whose count is the extent of a payload named elsewhere.  Left until
++     now because that payload may be written after the tag that refers to it, and
++     because this runs before the section is laid out, which is what makes a
++     symbol's value readable as an offset within its own frag.  */
++  for (x = dvp_pending_extents; x != NULL; x = xnext)
++    {
++      dvp_val qwc;
++
++      xnext = x->next;
++      if (dvp_payload_quadwords (x->op, x->name, &qwc, x->file, x->line))
++	dvp_patch_count (x->op, &x->field, qwc, x->frag, x->where);
++      free (x);
++    }
++  dvp_pending_extents = NULL;
++  dvp_pending_extents_tail = &dvp_pending_extents;
++}
++
++/* --- directives ---------------------------------------------------------- */
++
++static void
++s_dvp_vu (int ignore ATTRIBUTE_UNUSED)
++{
++  char *p = dvp_skip_white (input_line_pointer);
++
++  if (!is_end_of_stmt (*p) && *p != '\n')
++    {
++      as_bad (_(".vu takes no arguments"));
++      ignore_rest_of_line ();
++      return;
++    }
++  if (dvp_in_vu_mode)
++    {
++      as_bad (_("already assembling VU microcode; .vu cannot be nested"));
++      demand_empty_rest_of_line ();
++      return;
++    }
++  /* An `mpg' block is already assembling microinstructions, so `.vu' inside one
++     asks for what is already happening: it is accepted and does nothing.  In
++     particular it does not switch section -- the block's length is measured from
++     the bytes that follow its command word, so those bytes have to stay where
++     they are -- and it does not leave VU mode running past the `.endmpg'.  All
++     three were measured.  */
++  if (dvp_blk.op != NULL && dvp_blk.op->kind == DVP_CTR_MPG)
++    {
++      demand_empty_rest_of_line ();
++      return;
++    }
++  /* A DMA tag's payload is the other exception: the microcode `.vu' introduces
++     is emitted straight after the tag, in the same section, so it is part of
++     that transfer and the payload goes on until its `.enddmadata'.  Every other
++     block is measured in units the microcode is not, so `.vu' inside one is
++     refused, and the reference refuses those too.  */
++  if (dvp_blk.op != NULL && dvp_blk.op->kind != DVP_CTR_DMA)
++    {
++      as_bad (_(".vu cannot start while the %s block is open; close it with "
++		"%s first"), dvp_blk.op->name, dvp_blk.op->terminator);
++      demand_empty_rest_of_line ();
++      return;
++    }
++  if (dvp_dmadata_open)
++    {
++      as_bad (_(".vu cannot start inside the .dmadata block \"%s\""),
++	      dvp_dmadata_name);
++      demand_empty_rest_of_line ();
++      return;
++    }
++  /* `.vu' says how the lines that follow are read.  It does not start a
++     program unit and does not change section: the microcode goes wherever the
++     source already was, so `.section .other' followed by `.vu' assembles into
++     `.other', and a `.vu' after an `.endmpg' with nothing between gets no
++     marker -- the unit the `mpg' opened was already taken.  A unit is opened by
++     the start of the assembly, by a container command, and by a label written
++     in VU mode.  It does reset the running `mpg *' load address.  */
++  dvp_in_vu_mode = 1;
++  dvp_mpgloc = 0;
++  demand_empty_rest_of_line ();
++}
++
++/* `.nop [N]' asks for at least N bytes of no-operation.
++
++   Stock GAS implements it by calling md_assemble ("nop") until enough bytes
++   appear.  That cannot terminate here: a DVP microinstruction line carries two
++   operations, so a bare `nop' is half a statement in VU mode, and outside VU
++   mode `nop' is not a container command at all -- either way md_assemble
++   reports an error and emits nothing, and the loop asks forever.  So this
++   target works the count out arithmetically and always makes progress.  The
++   no-operation is a whole microinstruction in VU mode and a VIF no-op
++   otherwise.  */
++
++static void dvp_assemble_vu (char *);
++
++/* An explicit ceiling: past this the source almost certainly meant `.space',
++   and filling it would look like a hang.  */
++#define DVP_NOP_MAX_BYTES	(1 << 20)
++
++static void
++s_dvp_nop (int ignore ATTRIBUTE_UNUSED)
++{
++  char *p = dvp_skip_white (input_line_pointer);
++  offsetT want = 0;
++  dvp_val unit, n, i;
++
++  if (!dvp_cleanroom_extensions)
++    {
++      /* The reference has no working `.nop': a bare one is a diagnostic there
++	 and a counted one never finishes at all, because stock GAS implements
++	 the directive by assembling `nop' until enough bytes appear and a DVP
++	 `nop' is never a whole statement.  So the default language does not have
++	 the directive either, and says so -- what it does *not* do is reproduce
++	 the reference's non-termination, which is the one thing no measurement
++	 can ask for.  The working implementation below is available under
++	 `--cleanroom-extensions'.  */
++      as_bad (_(".nop is not part of this assembly language; write .space for "
++		"bytes, or pass --cleanroom-extensions for the counted "
++		"no-operation form"));
++      ignore_rest_of_line ();
++      return;
++    }
++
++  if (!is_end_of_stmt (*p) && *p != 0)
++    {
++      expressionS ex;
++
++      expression (&ex);
++      if (ex.X_op != O_constant)
++	{
++	  as_bad (_(".nop needs a byte count known at assembly time"));
++	  ignore_rest_of_line ();
++	  return;
++	}
++      want = ex.X_add_number;
++    }
++  demand_empty_rest_of_line ();
++
++  if (want < 0)
++    {
++      as_bad (_(".nop cannot emit %lld bytes of no-operation"), (dvp_val) want);
++      return;
++    }
++  if (want > DVP_NOP_MAX_BYTES)
++    {
++      as_bad (_(".nop is limited to %lld bytes of no-operation here; %lld would "
++		"almost certainly be better written as .space"),
++	      (dvp_val) DVP_NOP_MAX_BYTES, (dvp_val) want);
++      return;
++    }
++
++  if (dvp_blk.op != NULL && dvp_blk.op->block == DVP_BLK_DATA)
++    {
++      as_bad (_(".nop cannot put no-operations inside the %s block, which holds "
++		"data rather than commands; use .space for padding bytes"),
++	      dvp_blk.op->name);
++      return;
++    }
++
++  unit = dvp_assembling_vu () ? DVP_INSN_BYTES : DVP_VIFCODE_BYTES;
++  n = (dvp_val) ((want + unit - 1) / unit);
++  if (n < 1)
++    n = 1;			/* a bare `.nop' still emits one */
++
++  for (i = 0; i < n; i++)
++    {
++      /* md_assemble is allowed to modify the text it is handed, so it gets a
++	 writable copy rather than a literal.  */
++      char text[16];
++
++      if (dvp_assembling_vu ())
++	{
++	  strcpy (text, "nop nop");
++	  dvp_assemble_vu (text);
++	}
++      else
++	{
++	  strcpy (text, "vifnop");
++	  dvp_assemble_container (text);
++	}
++    }
++}
++
++const pseudo_typeS md_pseudo_table[] =
++{
++  { "vu",  s_dvp_vu,  0 },
++  { "endunpack",  s_dvp_endblock, 0 },
++  { "endmpg",     s_dvp_endblock, 1 },
++  { "enddirect",  s_dvp_endblock, 2 },
++  { "endgif",     s_dvp_endblock, 3 },
++  { "dmadata",    s_dvp_dmadata,    0 },
++  { "enddmadata", s_dvp_enddmadata, 0 },
++  { "dmapackvif", s_dvp_dmapackvif, 0 },
++  /* Overridden because stock GAS's implementation cannot terminate in a target
++     whose no-operation is not a whole statement; see s_dvp_nop.  */
++  { "nop", s_dvp_nop, 0 },
++  /* `.end' is deliberately NOT overridden: it is stock GAS's end-of-assembly
++     directive, and that is what DVP source has always meant by it.  VU mode
++     therefore runs to the end of the input.  */
++  /* A DVP "word" is 32 bits and a "quad" is the 128-bit quadword the VU and
++     the DMA controller move around, which is not what stock GAS assumes.  */
++  { "word", cons, 4 },
++  { "quad", cons, 16 },
++  { NULL,  NULL,      0 }
++};
++
++/* --- start-up ------------------------------------------------------------ */
++
++static void
++dvp_create_sections (void)
++{
++  asection *save = now_seg;
++  subsegT save_sub = now_subseg;
++  char *p;
++
++  /* Section alignment is recorded as the contents demand it: emitting a VU
++     microinstruction records eight-byte alignment (see md_assemble), while a
++     .vu block holding only data stays byte aligned.  */
++  bfd_set_section_alignment (data_section, 0);
++  bfd_set_section_alignment (bss_section, 0);
++
++  dvp_ovlytab_section = subseg_new (DVP_OVLYTAB_SECTION, 0);
++  bfd_set_section_flags (dvp_ovlytab_section, SEC_DATA | SEC_HAS_CONTENTS);
++  bfd_set_section_alignment (dvp_ovlytab_section, 2);
++  elf_section_type (dvp_ovlytab_section) = SHT_DVP_OVERLAY_TABLE;
++  elf_section_data (dvp_ovlytab_section)->this_hdr.sh_entsize
++    = DVP_OVLYTAB_ENTSIZE;
++
++  dvp_ovlystrtab_section = subseg_new (DVP_OVLYSTRTAB_SECTION, 0);
++  bfd_set_section_flags (dvp_ovlystrtab_section, SEC_DATA | SEC_HAS_CONTENTS);
++  bfd_set_section_alignment (dvp_ovlystrtab_section, 0);
++  elf_section_type (dvp_ovlystrtab_section) = SHT_STRTAB;
++  /* A string table always opens with the empty string.  */
++  p = frag_more (1);
++  *p = 0;
++  dvp_ovlystrtab_next = 1;
++
++  subseg_set (save, save_sub);
++}
++
++/* Put every section symbol ahead of every ordinary local symbol.
++
++   The reference's symbol tables are in that shape and BFD's are not: BFD keeps
++   creation order, and adds a symbol for any section that never needed one at
++   the *end* of the local symbols.
++
++   Two steps.  First every section without a symbol gets one, in section order,
++   which puts them where BFD would have.  Then the section symbols move to the
++   front, keeping their order relative to each other, so one created early stays
++   ahead of one created late and both stay ahead of the labels.  */
++
++void
++dvp_adjust_symtab (void)
++{
++  symbolS *sym, *next, *tail = NULL;
++  asection *sec;
++
++  for (sec = stdoutput->sections; sec != NULL; sec = sec->next)
++    if (seg_info (sec) != NULL && seg_info (sec)->sym == NULL)
++      (void) section_symbol (sec);
++
++  for (sym = symbol_rootP; sym != NULL; sym = next)
++    {
++      next = symbol_next (sym);
++      if (!symbol_section_p (sym))
++	continue;
++      if (symbol_previous (sym) != tail)
++	{
++	  symbol_remove (sym, &symbol_rootP, &symbol_lastP);
++	  if (tail == NULL)
++	    symbol_insert (sym, symbol_rootP, &symbol_rootP, &symbol_lastP);
++	  else
++	    symbol_append (sym, tail, &symbol_rootP, &symbol_lastP);
++	}
++      tail = sym;
++    }
++}
++
++void
++md_begin (void)
++{
++  bfd_set_arch_mach (stdoutput, TARGET_ARCH, bfd_mach_dvp);
++  dvp_set_object_flags ();
++  dvp_create_sections ();
++  /* A file that starts with VIF commands opens a VIF command run at offset
++     zero; `.vu' takes the other path and never asks for one.  */
++  dvp_vif_unit_pending = 1;
++  /* ...and a program unit is open from the start, so the first microinstruction
++     a file assembles is named whether a container command came before it or
++     not.  */
++  dvp_unit_pending = 1;
++}
++
++/* --- expression hook ----------------------------------------------------- */
++
++/* Convert TEXT to an IEEE-754 single precision bit pattern using GAS's own
++   converter, so no host floating point format is assumed.
++
++   ENDP is left where the conversion stopped.  A conversion that consumed
++   nothing is still a conversion -- the decimal parser answers +0.0 for text
++   with no digits and reports failure by not advancing -- so the caller decides
++   whether the leftover text is an error.  A NULL return means GAS could not
++   build the number at all, which it has already reported.  */
++
++static int
++dvp_float_bits (char *text, char **endp, unsigned int *bits)
++{
++  LITTLENUM_TYPE words[2];
++  char *end = atof_ieee (text, 'f', words);
++
++  if (end == NULL)
++    return 0;
++  *bits = ((unsigned int) words[0] << 16) | (unsigned int) words[1];
++  *endp = end;
++  return 1;
++}
++
++/* `loi' takes a 32-bit payload, and its grammar is its own -- not the
++   expression grammar the other immediates use.  The payload is read with a
++   hand-written scanner:
++
++     * `0x' or `0X' introduces a raw 32-bit pattern read with strtoul in base
++       16.  strtoul's own grammar applies, whole: `0x' with no digits after it
++       is zero, `0x-1' is a negation, and a value wider than 32 bits keeps its
++       low 32 bits rather than being an error.
++     * Otherwise a leading `0' followed by any letter is dropped -- the two
++       characters, not a base -- and what is left is converted as a decimal
++       float.  So `0b101010' is the float 101010.0, `0f1.0' and `0d1.5' and
++       `0q123' are 1.0, 1.5 and 123.0, and `0e1' is 1.0 rather than zero.
++     * The conversion is GAS's own `atof_ieee', so `inf', `-inf', `nan' and
++       `snan' are the numbers GAS makes of them.
++
++   Nothing here is an expression: `0xffffffff+0', `L-L' and `~0' are refused,
++   because the scanner stops and the leftover text has nowhere to go.  */
++
++static const char *
++dvp_get_loi_payload (char **pp, struct dvp_operand *o, char *err, size_t errlen)
++{
++  char *p = *pp;
++  unsigned int bits;
++  char *end;
++
++  o->has_expr = 0;
++  o->deferred = 0;
++
++  if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X'))
++    {
++      unsigned long v = strtoul (p + 2, &end, 16);
++
++      /* The field is the whole lower word, so a wider value keeps its low 32
++	 bits.  That is the reference's arithmetic, not a repair of it.  */
++      o->value = (dvp_val) (unsigned int) v;
++      *pp = end;
++      return NULL;
++    }
++
++  /* A leading `0' and one letter are dropped before the decimal conversion.  */
++  if (p[0] == '0' && ISALPHA ((unsigned char) p[1]))
++    p += 2;
++
++  if (!dvp_float_bits (p, &end, &bits))
++    {
++      /* GAS has already said what went wrong -- it is the only party that knows
++	 -- so this only has to stop.  The reference reaches this state with a
++	 null pointer in hand and dies on it; refusing the line is the same
++	 verdict without the crash.  */
++      snprintf (err, errlen, "this loi payload is not a number GAS can build");
++      return err;
++    }
++  o->value = (dvp_val) bits;
++  *pp = end;
++  return NULL;
++}
++
++static const char *
++dvp_get_expr (void *ctx ATTRIBUTE_UNUSED, char **pp, struct dvp_operand *o,
++	      int is_branch, char *err, size_t errlen)
++{
++  expressionS *ex;
++  char *save;
++
++  if (o->field->kind == DVP_FLD_IMM && o->field->width == 32)
++    return dvp_get_loi_payload (pp, o, err, errlen);
++
++  if (dvp_nexprs >= (int) (sizeof (dvp_exprs) / sizeof (dvp_exprs[0])))
++    {
++      snprintf (err, errlen, "too many expressions on one line");
++      return err;
++    }
++  ex = &dvp_exprs[dvp_nexprs];
++
++  save = input_line_pointer;
++  input_line_pointer = dvp_skip_white (*pp);
++  {
++    /* Only the scaled immediate, and never a branch: bracketing the call rather
++       than the function keeps every other operand -- branch targets above all --
++       folding exactly as it does today.  */
++    int scaled = (!is_branch && o->field->reloc == BFD_RELOC_DVP_15);
++
++    dvp_own_expr += scaled;
++    expression (ex);
++    dvp_own_expr -= scaled;
++  }
++  *pp = input_line_pointer;
++  input_line_pointer = save;
++
++  switch (ex->X_op)
++    {
++    case O_absent:
++      snprintf (err, errlen, "an operand is missing here");
++      return err;
++    case O_illegal:
++      snprintf (err, errlen, "this operand is not a valid expression");
++      return err;
++    case O_big:
++      snprintf (err, errlen,
++		"this operand is too large to be an instruction field");
++      return err;
++    case O_constant:
++      o->has_expr = 0;
++      o->value = (dvp_val) ex->X_add_number;
++      return NULL;
++    default:
++      break;
++    }
++
++  /* The value is not known yet.  Only a branch target and the 15-bit immediate
++     can carry a relocation; an immediate that cannot is settled at the end of
++     the assembly instead, encoded as zero for now.  A branch target
++     has nowhere to wait -- the displacement is measured from where the branch
++     lands, which is what the relocation is for -- so one whose field carries no
++     relocation is still an error.  */
++  if (o->field->reloc == BFD_RELOC_NONE)
++    {
++      if (is_branch)
++	{
++	  snprintf (err, errlen,
++		    "this operand must be a value known at assembly time; "
++		    "a branch target here cannot be relocated");
++	  return err;
++	}
++      o->has_expr = 0;
++      o->deferred = 1;
++      o->value = 0;
++      o->expr = ex;
++      ++dvp_nexprs;
++      return NULL;
++    }
++  o->has_expr = 1;
++  o->expr = ex;
++  ++dvp_nexprs;
++  return NULL;
++}
++
++static const struct dvp_parse_hooks dvp_hooks = { dvp_get_expr, NULL };
++
++/* --- assembling a line --------------------------------------------------- */
++
++/* The VU byte address of the microinstruction being assembled, set by
++   dvp_assemble_vu while its `mpg' block is still open and read by the two
++   dvp_add_fixups calls that follow it.  */
++static addressT dvp_insn_vu_pc;
++static int dvp_insn_vu_pc_known;
++
++static void
++dvp_add_fixups (const struct dvp_insn *insn, char *frag_base, int word_offset)
++{
++  int i;
++
++  for (i = 0; i < insn->noperands; i++)
++    {
++      const struct dvp_operand *o = &insn->operands[i];
++      fixS *fixp;
++      int pcrel;
++
++      if (dvp_blk.op != NULL && dvp_blk.op->kind == DVP_CTR_MPG
++	  && dvp_blk.ovly_sec == NULL && (o->deferred || o->has_expr))
++	{
++	  /* Same rule as a label: with the command word gone there is no
++	     overlay, so an operand inside the block that still has to be
++	     settled has no origin to be settled against.  Measured under
++	     `-no-dma-vif' only; the block itself is still assembled.  */
++	  as_bad (_("this %s operand is inside an %s block whose command word "
++		    "the option that removes VIF command words has removed, "
++		    "so there is nothing left to measure it from"),
++		  insn->opcode->name, dvp_blk.op->name);
++	  continue;
++	}
++      if (o->deferred)
++	{
++	  /* Settled at the end of the assembly rather than by the linker: the
++	     field carries no relocation, so there would be nothing to settle
++	     it.  */
++	  dvp_defer_field (NULL, NULL, o->field, frag_now,
++			   (unsigned long) (frag_base - frag_now->fr_literal)
++			   + word_offset,
++			   (const expressionS *) o->expr,
++			   insn->opcode->name);
++	  continue;
++	}
++      if (!o->has_expr)
++	continue;
++      pcrel = (o->field->kind == DVP_FLD_DISP);
++      fixp = fix_new_exp (frag_now,
++			  (frag_base - frag_now->fr_literal) + word_offset,
++			  4, (expressionS *) o->expr, pcrel,
++			  (bfd_reloc_code_real_type) o->field->reloc);
++      fixp->tc_fix_data.field = o->field;
++      fixp->tc_fix_data.vu_pc = dvp_insn_vu_pc;
++      fixp->tc_fix_data.vu_pc_known = dvp_insn_vu_pc_known;
++      if (pcrel && dvp_vif_command_seen)
++	dvp_note_late_branch (fixp);
++    }
++}
++
++static void
++dvp_assemble_vu (char *str)		/* forward declared above s_dvp_nop */
++{
++  char err[DVP_ERRLEN];
++  struct dvp_insn upper, lower;
++  unsigned int upper_word = 0, lower_word = 0;
++  const char *e;
++  char *p = str;
++  char *f;
++
++  dvp_nexprs = 0;
++
++  /* Before any operand is read, so the marker's name is in the symbol table
++     ahead of every symbol this line names.  */
++  dvp_reserve_unit_marker ();
++
++  e = dvp_vu_parse_operation (&p, DVP_PIPE_UPPER, &upper, &dvp_hooks,
++			      err, sizeof (err));
++  if (e != NULL)
++    {
++      as_bad ("%s", e);
++      return;
++    }
++
++  /* Whitespace between the two operations is optional, not required.  Where
++     the upper operation ends in something that cannot absorb a mnemonic --
++     `nop', and the twenty-two forms whose last operand is the literal I or Q --
++     the lower one may abut it, and `nopnop', `nopwaitq' and
++     `addi.xy vf01,vf02,Inop' are all real source.  Everywhere else the upper
++     operation ends in a register, and a glued mnemonic is read as text after
++     that register and refused there, which is what keeps `add.xy
++     vf01,vf02,vf03nop' an error without a rule of its own.  */
++  p = dvp_vu_skip_wide_space (p);
++  if (*p == 0)
++    {
++      as_bad (_("this line has an upper operation but no lower operation; "
++		"add \"nop\" if the lower pipe should do nothing"));
++      return;
++    }
++
++  e = dvp_vu_parse_operation (&p, DVP_PIPE_LOWER, &lower, &dvp_hooks,
++			      err, sizeof (err));
++  if (e != NULL)
++    {
++      as_bad ("%s", e);
++      return;
++    }
++
++  p = dvp_vu_skip_wide_space (p);
++  if (*p != 0)
++    {
++      as_bad (_("unexpected text \"%s\" after the lower operation"), p);
++      return;
++    }
++
++  /* Encode before allocating any space, so a rejected line contributes
++     nothing at all to the section.  */
++  e = dvp_vu_encode (&upper, &upper_word, err, sizeof (err));
++  if (e != NULL)
++    {
++      as_bad ("%s", e);
++      return;
++    }
++  e = dvp_vu_encode (&lower, &lower_word, err, sizeof (err));
++  if (e != NULL)
++    {
++      as_bad ("%s", e);
++      return;
++    }
++  if (lower.opcode->insn_flags & DVP_INSN_LOI)
++    upper_word |= 1u << DVP_FLAG_I_BIT;
++
++  /* Inside an `mpg' block a run holds at most DVP_MPG_SPLIT_AT instructions,
++     because that is all the command's count field can express.  A longer block
++     is emitted as several commands, each loading where the last left off.  */
++  if (dvp_blk.op != NULL && dvp_blk.op->kind == DVP_CTR_MPG
++      && dvp_blk.run_insns == DVP_MPG_SPLIT_AT)
++    dvp_mpg_new_run ();
++
++  /* A microinstruction is eight bytes and must sit on an eight-byte boundary,
++     even if data directives left the section somewhere else.  Align before the
++     unit marker so the marker records the instruction's real offset.  */
++  {
++    /* A label waiting for this instruction moves only where the alignment
++       inserts something, and whether it does is a question about the finished
++       section rather than about the position the file has reached: bytes given
++       to a lower subsection further down are laid out in front of this one.  So
++       the frags are recorded and the answer is taken in dvp_settle_layout.  */
++    fragS *alignfrag;
++
++    record_alignment (now_seg, 3);
++    alignfrag = frag_now;
++    frag_align (3, 0, 0);
++    dvp_defer_pending_label (alignfrag, frag_now);
++  }
++
++  dvp_emit_unit_marker ();
++
++  /* The instruction's own address in VU bytes, taken while the block is open.
++     Only a block with an overlay has one: with the command word suppressed there
++     is no load address to measure from.  */
++  dvp_insn_vu_pc_known = (dvp_blk.op != NULL
++			  && dvp_blk.op->kind == DVP_CTR_MPG
++			  && dvp_blk.ovly_sec != NULL
++			  && dvp_offset_known);
++  dvp_insn_vu_pc = dvp_insn_vu_pc_known
++		   ? (addressT) dvp_blk.vu_addr * DVP_MICROINSN_BYTES
++		     + (dvp_here () - dvp_blk.payload)
++		   : 0;
++
++  f = frag_more (DVP_INSN_BYTES);
++  md_number_to_chars (f + DVP_LOWER_WORD_OFFSET, lower_word, 4);
++  md_number_to_chars (f + DVP_UPPER_WORD_OFFSET, upper_word, 4);
++
++  dvp_add_fixups (&lower, f, DVP_LOWER_WORD_OFFSET);
++  dvp_add_fixups (&upper, f, DVP_UPPER_WORD_OFFSET);
++
++  if (dvp_blk.op != NULL && dvp_blk.op->kind == DVP_CTR_MPG)
++    ++dvp_blk.run_insns;
++}
++
++/* A line is either a VU microinstruction pair or a container command; which one
++   depends on the mode the source has put the assembler in.  */
++
++void
++md_assemble (char *str)
++{
++  if (dvp_assembling_vu ())
++    dvp_assemble_vu (str);
++  else
++    dvp_assemble_container (str);
++}
++
++/* --- fixups -------------------------------------------------------------- */
++
++long
++dvp_pcrel_from_section (fixS *fixP, segT sec ATTRIBUTE_UNUSED)
++{
++  /* A branch displacement counts from the instruction after the branch.
++
++     Inside an `mpg' block that is a position in VU memory, not in the transfer:
++     the command words interleaved with the microcode mean the two disagree, and
++     the target -- an overlay label -- is measured in VU bytes.  Both ends have to
++     be in one origin, so the VU address recorded when the instruction was
++     assembled is used where there is one.  */
++  if (fixP->tc_fix_data.vu_pc_known)
++    return fixP->tc_fix_data.vu_pc + DVP_INSN_BYTES;
++  return fixP->fx_where + fixP->fx_frag->fr_address + DVP_INSN_BYTES;
++}
++
++/* Must this overlay-label fixup keep its relocation rather than be claimed as a
++   settled number?  The two clauses are the two ways a fixup naming a promoted
++   label can reach md_apply_fix without the settle pass having folded it.  */
++
++static int
++dvp_overlay_fixup_keeps_reloc (fixS *fixP)
++{
++  return !fixP->fx_pcrel && dvp_overlay_binding_defers (fixP->fx_addsy);
++}
++
++void
++md_apply_fix (fixS *fixP, valueT *valP, segT seg ATTRIBUTE_UNUSED)
++{
++  const struct dvp_vu_field *field = fixP->tc_fix_data.field;
++  char *buf = fixP->fx_frag->fr_literal + fixP->fx_where;
++  offsetT value = *valP;
++  unsigned int word;
++  char err[DVP_ERRLEN];
++  const char *e;
++
++  if (fixP->fx_r_type == BFD_RELOC_NONE)
++    {
++      fixP->fx_done = 1;
++      return;
++    }
++
++  if (fixP->fx_r_type == BFD_RELOC_DVP_DMA_ADDR)
++    {
++      /* A DMA tag addresses quadwords, so the field cannot express the low
++	 DVP_DMAADDR_LSB bits of an address: a misaligned one is reported here
++	 rather than rounded down to the previous quadword.  */
++      if ((value & (((offsetT) 1 << DVP_DMAADDR_LSB) - 1)) != 0)
++	{
++	  as_bad_where (fixP->fx_file, fixP->fx_line,
++			_("a DMA tag can only address a quadword boundary, and "
++			  "%lld is not one"), (dvp_val) value);
++	  fixP->fx_done = 1;
++	  return;
++	}
++      if (((valueT) value & ~(valueT) DVP_DMAADDR_MASK) != 0)
++	{
++	  as_bad_where (fixP->fx_file, fixP->fx_line,
++			_("the DMA tag address %lld does not fit the %d-bit "
++			  "field"), (dvp_val) value, DVP_DMAADDR_WIDTH
++			+ DVP_DMAADDR_LSB);
++	  fixP->fx_done = 1;
++	  return;
++	}
++      word = dvp_read_word (buf);
++      word &= ~DVP_DMAADDR_MASK;
++      word |= (unsigned int) value & DVP_DMAADDR_MASK;
++      md_number_to_chars (buf, word, 4);
++      if (fixP->fx_addsy == NULL)
++	fixP->fx_done = 1;
++      return;
++    }
++
++  if (field == NULL)
++    {
++      /* Not an instruction field: this fixup came from a data directive, or
++	 from one of the two vtable pseudo-operations.  */
++      if (fixP->fx_r_type == BFD_RELOC_VTABLE_INHERIT
++	  || fixP->fx_r_type == BFD_RELOC_VTABLE_ENTRY)
++	{
++	  /* Bookkeeping for the linker's unused-virtual-function pass.  Neither
++	     writes anything into the section -- both howtos have a zero mask --
++	     and neither is settled here.  */
++	  fixP->fx_done = 0;
++	  return;
++	}
++      if (fixP->fx_addsy == NULL)
++	{
++	  if (fixP->fx_size >= 1 && fixP->fx_size <= 8)
++	    md_number_to_chars (buf, value, fixP->fx_size);
++	  else
++	    as_bad_where (fixP->fx_file, fixP->fx_line,
++			  _("a %d-byte datum cannot be fixed up"),
++			  (int) fixP->fx_size);
++	  fixP->fx_done = 1;
++	  return;
++	}
++      /* A label inside an `mpg' block is not a place in this section: it names
++	 a word of the overlay the block loads, and its value is that word's
++	 place in VU memory.  Where the settle pass folded it, the number is
++	 settled and no relocation is left behind.
++
++	 Only where it folded.  A global or weak label it declined is still a
++	 symbol, and claiming it here would store the unrelocated zero and drop
++	 the relocation with it.  Such a fixup falls through to the ordinary
++	 data path below, as does a pc-relative one -- fixup_segment raises that
++	 flag when it folds a same-section subtrahend.  */
++      if (dvp_is_overlay_section (S_GET_SEGMENT (fixP->fx_addsy))
++	  && !dvp_overlay_fixup_keeps_reloc (fixP))
++	{
++	  if (fixP->fx_size >= 1 && fixP->fx_size <= 8)
++	    md_number_to_chars (buf, value, fixP->fx_size);
++	  else
++	    as_bad_where (fixP->fx_file, fixP->fx_line,
++			  _("a %d-byte datum cannot be fixed up"),
++			  (int) fixP->fx_size);
++	  fixP->fx_done = 1;
++	  return;
++	}
++
++      /* A whole word or a whole doubleword can name a symbol; anything narrower
++	 is refused rather than quietly cut down.  Both relocation forms carry
++	 their addend in the data, not in the relocation entry, so the value is
++	 stored here either way.  */
++      if (fixP->fx_r_type != BFD_RELOC_32 && fixP->fx_r_type != BFD_RELOC_64)
++	{
++	  as_bad_where (fixP->fx_file, fixP->fx_line,
++			_("a %d-byte data reference to \"%s\" cannot be "
++			  "relocated in a DVP object; only .word and .8byte "
++			  "can name a symbol whose value is not known yet"),
++			(int) fixP->fx_size, S_GET_NAME (fixP->fx_addsy));
++	  fixP->fx_done = 1;
++	  return;
++	}
++      if (fixP->fx_r_type == BFD_RELOC_64)
++	/* A doubleword naming a symbol carries a *32-bit* addend, widened back
++	   out: `.8byte ext+0x80000000' stores 0xffffffff80000000, and
++	   `.8byte ext+0x100000000' stores nothing.  A doubleword with no symbol
++	   is an ordinary 64-bit constant and keeps every bit of it; the two were
++	   measured side by side.  */
++	md_number_to_chars (buf, (valueT) (offsetT) (int32_t) (uint32_t) value,
++			    8);
++      else
++	md_number_to_chars (buf, value, 4);
++      return;
++    }
++
++  if (field->kind == DVP_FLD_DISP)
++    {
++      if (fixP->fx_addsy != NULL && dvp_is_late_branch (fixP))
++	{
++	  /* The branch did not resolve, so it would have to be left to the
++	     link -- and the displacement it would leave counts from a section
++	     offset that the command words interleaved with this microcode have
++	     already made meaningless.  */
++	  as_bad_where (fixP->fx_file, fixP->fx_line,
++			_("\"%s\" is not defined in this section, so this branch "
++			  "would have to be settled by the link -- and a VIF or "
++			  "container command has already been emitted here, so "
++			  "the displacement the link would work from is not the "
++			  "one this branch means"),
++			S_GET_NAME (fixP->fx_addsy));
++	  fixP->fx_done = 1;
++	  return;
++	}
++      if (fixP->fx_addsy != NULL)
++	{
++	  /* What a surviving branch relocation leaves in the field.
++
++	     For a symbol this assembly *defines* -- global or weak, in this
++	     section or another -- it is the displacement worked out here.  For
++	     one it does not define there is no displacement to work out, and
++	     what stays is the addend less the eight-byte bias between the
++	     branch and the instruction its displacement counts from, which is
++	     position-independent.  A common symbol counts as one it does not
++	     define: its value is a size, not a place.
++
++	     The linker reads the field the same way in both cases:
++	     dvp_elf_branch_reloc adds the *change* in the two positions, which
++	     is zero for a defined symbol that has not moved.  */
++	  if (S_IS_DEFINED (fixP->fx_addsy)
++	      && !S_IS_COMMON (fixP->fx_addsy))
++	    value += S_GET_VALUE (fixP->fx_addsy);
++	  else
++	    value += fixP->fx_where + fixP->fx_frag->fr_address;
++	}
++
++      if (value % DVP_INSN_BYTES != 0)
++	{
++	  if (fixP->fx_addsy != NULL)
++	    as_bad_where (fixP->fx_file, fixP->fx_line,
++			  _("the offset applied to branch target \"%s\" is "
++			    "%lld bytes, which is not a whole number of "
++			    "%d-byte microinstructions"),
++			  S_GET_NAME (fixP->fx_addsy),
++			  (dvp_val) (value + DVP_INSN_BYTES), DVP_INSN_BYTES);
++	  else
++	    as_bad_where (fixP->fx_file, fixP->fx_line,
++			  _("branch target is %lld bytes away, which is not a "
++			    "whole number of %d-byte microinstructions"),
++			  (dvp_val) value, DVP_INSN_BYTES);
++	  fixP->fx_done = 1;
++	  return;
++	}
++      value /= DVP_INSN_BYTES;
++    }
++
++  if (field->kind == DVP_FLD_IMM && field->reloc == BFD_RELOC_DVP_15)
++    {
++      /* This field holds eight-byte units when it carries a relocation, so what
++	 goes in it is the addend divided by eight and an addend that is not a
++	 multiple of eight has no encoding at all.  A value the
++	 assembler already knew never reached a fixup, so it is not scaled here
++	 and is stored exactly as the source wrote it.  */
++      if (value % (offsetT) DVP_IMM15_RELOC_SCALE != 0)
++	{
++	  if (fixP->fx_addsy != NULL)
++	    as_bad_where (fixP->fx_file, fixP->fx_line,
++			  _("the offset applied to \"%s\" is %lld bytes, and "
++			    "this field can only hold a multiple of %u"),
++			  S_GET_NAME (fixP->fx_addsy), (dvp_val) value,
++			  DVP_IMM15_RELOC_SCALE);
++	  else
++	    as_bad_where (fixP->fx_file, fixP->fx_line,
++			  _("this operand works out to %lld, and a relocated "
++			    "immediate here can only hold a multiple of %u"),
++			  (dvp_val) value, DVP_IMM15_RELOC_SCALE);
++	  fixP->fx_done = 1;
++	  return;
++	}
++      value /= (offsetT) DVP_IMM15_RELOC_SCALE;
++      if (value < 0 || value > (offsetT) DVP_IMM15_MAX)
++	{
++	  /* Say what the *source* wrote, not the scaled number: a message about
++	     32768 would be about a value nobody typed.  */
++	  as_bad_where (fixP->fx_file, fixP->fx_line,
++			_("the offset applied here is %lld bytes, and this "
++			  "field reaches %u"),
++			(dvp_val) (value * (offsetT) DVP_IMM15_RELOC_SCALE),
++			DVP_IMM15_RELOC_MAX);
++	  fixP->fx_done = 1;
++	  return;
++	}
++    }
++
++  word = dvp_read_word (buf);
++  e = dvp_encode_field (field, (dvp_val) value, &word, err, sizeof (err));
++  if (e != NULL)
++    {
++      if (field->kind == DVP_FLD_DISP)
++	as_bad_where (fixP->fx_file, fixP->fx_line,
++		      _("branch is too far: %s"), e);
++      else
++	as_bad_where (fixP->fx_file, fixP->fx_line, "%s", e);
++      fixP->fx_done = 1;
++      return;
++    }
++  md_number_to_chars (buf, word, 4);
++
++  if (fixP->fx_addsy == NULL)
++    fixP->fx_done = 1;
++}
++
++arelent *
++tc_gen_reloc (asection *sec ATTRIBUTE_UNUSED, fixS *fixP)
++{
++  arelent *reloc = XNEW (arelent);
++
++  reloc->sym_ptr_ptr = XNEW (asymbol *);
++  *reloc->sym_ptr_ptr = symbol_get_bfdsym (fixP->fx_addsy);
++  reloc->address = fixP->fx_frag->fr_address + fixP->fx_where;
++  reloc->howto = bfd_reloc_type_lookup (stdoutput, fixP->fx_r_type);
++  if (reloc->howto == NULL)
++    {
++      as_bad_where (fixP->fx_file, fixP->fx_line,
++		    _("cannot represent this relocation in a DVP object"));
++      return NULL;
++    }
++  /* Every DVP relocation is REL form, so the addend belongs in the
++     instruction or data word rather than in the relocation entry -- md_apply_fix
++     has already put it there.  Leaving a copy here as well would make BFD add
++     it a second time when it installs the relocation.  */
++  reloc->addend = 0;
++  return reloc;
++}
++
++/* --- odds and ends ------------------------------------------------------- */
++
++/* Round SIZE up to the boundary SEGMENT is aligned to.
++
++   The arithmetic has to be done in the type the answer is returned in: `1 <<
++   align' for an alignment of 2**31 shifts a one into an `int's sign bit, which
++   is undefined behaviour rather than a large number, and what the undefined
++   result went on to produce was a request to write two gigabytes of padding.
++
++   So the shift is checked against the width of the destination type before it
++   is made, and the rounding is checked for wrap-around before it is applied.
++   Stock GAS already clamps a recorded alignment to the address width, so an
++   alignment this refuses cannot be reached from `.p2align'; the check is here
++   because arithmetic depending on somebody else's clamp is waiting to go
++   wrong.  */
++
++valueT
++md_section_align (segT segment, valueT size)
++{
++  unsigned int align = (unsigned int) bfd_section_alignment (segment);
++  unsigned int bits = (unsigned int) (sizeof (valueT) * CHAR_BIT);
++  valueT mask;
++
++  if (align >= bits)
++    {
++      as_bad (_("this section is aligned to 2**%u, which is wider than the "
++		"%u-bit arithmetic sections are laid out with"), align, bits);
++      return size;
++    }
++
++  mask = ((valueT) 1 << align) - 1;
++  if (size > (valueT) -1 - mask)
++    {
++      as_bad (_("rounding this section up to a 2**%u boundary does not fit in "
++		"the %u bits a section size has"), align, bits);
++      return size;
++    }
++  return (size + mask) & ~mask;
++}
++
++const char *
++md_atof (int type, char *litP, int *sizeP)
++{
++  return ieee_md_atof (type, litP, sizeP, false);
++}
++
++/* The C-name checks, defined with the rest of the `--c-array' machinery at the
++   end of this file.  An explicit array name is validated here, where the option
++   is read, rather than at the end of the assembly: the name is wrong before a
++   single line has been assembled, and reporting it then costs the user a whole
++   run to find out.  */
++static int dvp_is_c_identifier (const char *);
++static int dvp_is_c_reserved (const char *);
++
++/* `--c-array-name=NAME'.  The name goes into the generated C verbatim, so it has
++   to be something C will take: an identifier, and not a reserved word.  Unlike a name derived from the output file name, this one is
++   the user's word about a C identifier, so it is reported rather than repaired --
++   silently assembling a different name than the one asked for would leave the
++   header that declares it wrong.  */
++
++static int
++dvp_set_c_array_name (const char *arg)
++{
++  if (!dvp_is_c_identifier (arg))
++    {
++      as_bad (_("--c-array-name=%s is not a C identifier, and the name goes "
++		"into the generated C as it stands; write a letter or \"_\" "
++		"followed by letters, digits and \"_\""),
++	      (arg == NULL || *arg == 0) ? "\"\"" : arg);
++      return 0;
++    }
++  if (dvp_is_c_reserved (arg))
++    {
++      as_bad (_("--c-array-name=%s names a reserved word of C, so the generated "
++		"array declaration would not compile; pick another name"), arg);
++      return 0;
++    }
++  dvp_c_array_name = arg;
++  return 1;
++}
++
++/* `-mabi=NAME'.  Returns 1 when NAME is one of the five, and reports the five by
++   name when it is not, so the diagnostic says what to write instead.  */
++
++static int
++dvp_set_abi (const char *arg)
++{
++  size_t i;
++
++  if (arg != NULL)
++    for (i = 0; i < sizeof (dvp_abi_names) / sizeof (dvp_abi_names[0]); i++)
++      if (strcmp (arg, dvp_abi_names[i].name) == 0)
++	{
++	  dvp_abi_flags = dvp_abi_names[i].flags;
++	  return 1;
++	}
++  as_bad (_("\"%s\" is not an ABI this target knows; write one of "
++	    "32, o64, n32, 64 or eabi"), arg == NULL ? "" : arg);
++  return 0;
++}
++
++int
++md_parse_option (int c, const char *arg)
++{
++  switch (c)
++    {
++    case OPTION_RAW:
++      dvp_raw_file = arg;
++      return 1;
++    case OPTION_C_ARRAY:
++      dvp_c_array_file = arg;
++      return 1;
++    case OPTION_C_ARRAY_NAME:
++      /* A refused name is still a handled option: returning 0 would make stock
++	 GAS report an unrecognised option on top of the real diagnostic.  */
++      (void) dvp_set_c_array_name (arg);
++      return 1;
++    case OPTION_NO_DMA:
++      dvp_no_dma = 1;
++      return 1;
++    case OPTION_NO_DMA_VIF:
++      /* Both: the VIF words a DMA tag carries go with the tag.  */
++      dvp_no_dma = 1;
++      dvp_no_dma_vif = 1;
++      return 1;
++    case OPTION_NO_ABICALLS:
++      dvp_abicalls = 0;
++      return 1;
++    case OPTION_MABI:
++      return dvp_set_abi (arg);
++    case OPTION_ABI_32:
++      return dvp_set_abi ("32");
++    case OPTION_ABI_N32:
++      return dvp_set_abi ("n32");
++    case OPTION_ABI_64:
++      return dvp_set_abi ("64");
++    case OPTION_STRICT_MARKERS:
++      dvp_strict_marker_names = 1;
++      return 1;
++    case OPTION_CLEANROOM_EXT:
++      dvp_cleanroom_extensions = 1;
++      /* Read by do_scrub_begin, which runs after the options are parsed.  */
++      dvp_comment_chars = dvp_comment_chars_extended;
++      /* `.reloc' reaches the relocation names through BFD, which has no view of
++	 this assembler's options, so the switch lives there and is set here.  */
++      dvp_elf_private_reloc_names = true;
++      return 1;
++    default:
++      return 0;
++    }
++}
++
++void
++md_show_usage (FILE *stream)
++{
++  fprintf (stream, _("\
++DVP target options:\n\
++  -no-dma, --no-dma     leave the DMA tags out: no tag bytes, but the VIF\n\
++                        command words a tag carries are still written\n\
++  -no-dma-vif, --no-dma-vif\n\
++                        leave out both the DMA tags and the VIF command\n\
++                        words, keeping the payloads and the microcode\n\
++  -no-abicalls, --no-abicalls\n\
++                        do not claim the PIC calling conventions\n\
++  -32, -mabi=32, --mabi=32\n\
++                        name the o32 ABI in the object\n\
++  -n32, -mabi=n32, --mabi=n32\n\
++                        name the n32 ABI (the default)\n\
++  -64, -mabi=64, --mabi=64\n\
++                        name the n64 ABI\n\
++  -mabi=o64, --mabi=o64 name the o64 ABI\n\
++  -mabi=eabi, --mabi=eabi\n\
++                        name the EABI\n\
++\n\
++Every option above may be written with one dash or with two.\n\
++\n\
++Extensions, which this assembler adds and the reference does not have:\n\
++  --raw=FILE            also write the microcode section as raw bytes\n\
++  --c-array=FILE        also write the microcode section as a C array\n\
++  --c-array-name=NAME   name that array NAME, which must be a C identifier and\n\
++                        not a reserved word (default: from the file name,\n\
++                        sanitised)\n\
++  --cleanroom-extensions\n\
++                        also accept the syntax this assembler has beyond the\n\
++                        reference's, which the reference itself refuses: the\n\
++                        R_DVP_* names for `.reloc', and \"*\" as a GIF tag's\n\
++                        length\n\
++  --strict-marker-names refuse a source that gives one of the assembler's own\n\
++                        generated names (\".vu.0\" and the like) a value, even\n\
++                        where the reference would let the generated one\n\
++                        replace it\n\
++\n\
++The ELF object is always written, and those three options only add a second\n\
++copy of the microcode beside it; none of them changes the object.\n\
++\n\
++Source entering VU microcode mode with .vu carries one upper-pipe operation\n\
++and one lower-pipe operation per line, in that order.  Before that, each line\n\
++names a VIF command, a DMA tag, a GIF tag, or the opener of a block whose\n\
++length is written \"*\" to have it counted for you.\n"));
++}
++
++/* --- optional extra outputs ---------------------------------------------- */
++
++/* Collect a section's final bytes out of its frag chain.  By the time
++   tc_frob_file_after_relocs runs, every frag is an rs_fill of FR_FIX literal
++   bytes followed by FR_OFFSET copies of an FR_VAR-byte pattern, which is
++   exactly what GAS itself is about to write out.
++
++   The total is accumulated with an explicit ceiling and an explicit overflow
++   check, so a section too large for this to hand out in one buffer is refused
++   with a diagnostic rather than silently wrapping into a short one.  */
++
++#define DVP_EXTRA_OUTPUT_MAX	((size_t) 1 << 31)
++
++static char *
++dvp_section_bytes (asection *sec, size_t *lenp)
++{
++  segment_info_type *seginfo = seg_info (sec);
++  size_t len = 0, i;
++  char *buf;
++  fragS *f;
++
++  *lenp = 0;
++  if (seginfo == NULL || seginfo->frchainP == NULL)
++    return NULL;
++
++  for (f = seginfo->frchainP->frch_root; f != NULL; f = f->fr_next)
++    {
++      size_t add;
++
++      if (f->fr_offset < 0 || f->fr_var < 0)
++	{
++	  as_bad (_("cannot write the microcode out separately: a fragment of "
++		    "section %s has a negative size"),
++		  bfd_section_name (sec));
++	  return NULL;
++	}
++      add = (size_t) f->fr_fix;
++      if (f->fr_var != 0
++	  && (size_t) f->fr_offset > (DVP_EXTRA_OUTPUT_MAX
++				      / (size_t) f->fr_var))
++	len = DVP_EXTRA_OUTPUT_MAX + 1;
++      else
++	{
++	  add += (size_t) f->fr_offset * (size_t) f->fr_var;
++	  if (add > DVP_EXTRA_OUTPUT_MAX - len)
++	    len = DVP_EXTRA_OUTPUT_MAX + 1;
++	  else
++	    len += add;
++	}
++      if (len > DVP_EXTRA_OUTPUT_MAX)
++	{
++	  as_bad (_("cannot write the microcode out separately: section %s is "
++		    "larger than the %lu bytes --raw and --c-array can hand "
++		    "out at once"), bfd_section_name (sec),
++		  (unsigned long) DVP_EXTRA_OUTPUT_MAX);
++	  return NULL;
++	}
++    }
++  if (len == 0)
++    return NULL;
++
++  buf = XNEWVEC (char, len);
++  len = 0;
++  for (f = seginfo->frchainP->frch_root; f != NULL; f = f->fr_next)
++    {
++      if (f->fr_fix)
++	{
++	  memcpy (buf + len, f->fr_literal, f->fr_fix);
++	  len += f->fr_fix;
++	}
++      if (f->fr_var > 0)
++	for (i = 0; i < (size_t) f->fr_offset; i++)
++	  {
++	    memcpy (buf + len, f->fr_literal + f->fr_fix, f->fr_var);
++	    len += f->fr_var;
++	  }
++    }
++  *lenp = len;
++  return buf;
++}
++
++/* The reserved words of C, so a name that is a perfectly good identifier and
++   still will not compile is caught.  C23's list, which is a superset of every
++   earlier one, plus the alternative spellings <stdbool.h> and <iso646.h> make
++   into keywords -- a macro name collides just as loudly as a keyword does.
++   Sorted, and searched with a plain loop: the list is short and this runs once.  */
++
++static const char *const dvp_c_reserved[] =
++{
++  "_Alignas", "_Alignof", "_Atomic", "_BitInt", "_Bool", "_Complex",
++  "_Decimal128", "_Decimal32", "_Decimal64", "_Generic", "_Imaginary",
++  "_Noreturn", "_Static_assert", "_Thread_local",
++  "alignas", "alignof", "and", "and_eq", "auto", "bitand", "bitor", "bool",
++  "break", "case", "char", "compl", "const", "constexpr", "continue",
++  "default", "do", "double", "else", "enum", "extern", "false", "float",
++  "for", "goto", "if", "inline", "int", "long", "not", "not_eq", "nullptr",
++  "or", "or_eq", "register", "restrict", "return", "short", "signed",
++  "sizeof", "static", "static_assert", "struct", "switch", "thread_local",
++  "true", "typedef", "typeof", "typeof_unqual", "union", "unsigned", "void",
++  "volatile", "while", "xor", "xor_eq",
++};
++
++static int
++dvp_is_c_reserved (const char *name)
++{
++  size_t i;
++
++  for (i = 0; i < sizeof (dvp_c_reserved) / sizeof (dvp_c_reserved[0]); i++)
++    if (strcmp (name, dvp_c_reserved[i]) == 0)
++      return 1;
++  return 0;
++}
++
++/* True when NAME is spelled the way C spells an identifier: a letter or `_',
++   then letters, digits and `_'.  Deliberately ASCII-only.  C allows more through
++   universal character names and, as an extension, through some UTF-8, but which
++   of those a given compiler takes is not something this assembler can know, and
++   emitting a name only some compilers accept is worse than saying so.  */
++
++static int
++dvp_is_c_identifier (const char *name)
++{
++  const char *p;
++
++  if (name == NULL || *name == 0)
++    return 0;
++  if (!ISALPHA ((unsigned char) name[0]) && name[0] != '_')
++    return 0;
++  for (p = name + 1; *p; p++)
++    if (!ISALNUM ((unsigned char) *p) && *p != '_')
++      return 0;
++  return 1;
++}
++
++/* Turn a file name into something usable as a C identifier.
++
++   The file name is not the user's word about what a C identifier should be --
++   it is a path, and `--c-array=vu_blob.c' is asking for an array, not naming
++   one -- so a derived name is repaired rather than refused.  Every
++   character C cannot take becomes `_', a leading digit and an empty base get a
++   leading `_', and a name that comes out as a reserved word gets a trailing
++   `_'.  The mapping is a function of the path alone, so the same output file
++   always gets the same array name.  */
++
++static char *
++dvp_identifier_from_path (const char *path)
++{
++  const char *base = path;
++  const char *p;
++  char *out;
++  size_t i, n;
++
++  for (p = path; *p; p++)
++    if (*p == '/')
++      base = p + 1;
++
++  n = strlen (base);
++  /* Room for a leading `_', a trailing `_' and the terminator.  */
++  out = XNEWVEC (char, n + 3);
++  i = 0;
++  if (n == 0 || ISDIGIT ((unsigned char) base[0]))
++    out[i++] = '_';
++  for (p = base; *p; p++)
++    out[i++] = (ISALNUM ((unsigned char) *p) || *p == '_') ? *p : '_';
++  out[i] = 0;
++  /* `--c-array=int' derives `int', which is an identifier and still will not
++     compile.  A trailing `_' is the smallest repair that keeps the name
++     recognisable and cannot itself collide, because a reserved word never ends
++     in one.  */
++  if (dvp_is_c_reserved (out))
++    {
++      out[i++] = '_';
++      out[i] = 0;
++    }
++  return out;
++}
++
++/* --- writing an extra output ---------------------------------------------
++
++   Two properties.
++
++   *Nothing an assembly reads, and nothing it writes as its object, may be
++   opened for one of these.*  `--raw' and `--c-array' take a path from the
++   command line, so they could truncate a source file, an object, or each other.
++   Stock GAS makes this check for its own `-o' against the positional inputs --
++   by inode and device, because a string comparison sees neither `./a.s' against
++   `a.s' nor a symbolic link nor a second hard link -- and these two outputs get
++   the same check against the same set, plus the `-o' path and each other.
++
++   *And a write that fails must leave what was there before.*  So the bytes go
++   to a temporary file in the destination's own directory, so the rename cannot
++   cross a filesystem, and the rename is what publishes them.  */
++
++/* The paths every input file was opened under, in the order they were read.  */
++
++struct dvp_input_path
++{
++  struct dvp_input_path *next;
++  char *path;
++};
++
++static struct dvp_input_path *dvp_input_paths;
++static struct dvp_input_path **dvp_input_paths_tail = &dvp_input_paths;
++
++/* PATH's directory, made absolute, with the last component put back on.
++
++   For a file that does not exist there is no inode to compare, and this is what
++   is compared instead: it collapses `.', `..' and a symbolic link in the
++   directory part, which is every aliasing shape reachable for a path that is
++   about to be created.  NULL if the directory cannot be resolved.  */
++
++static char *
++dvp_resolved_path (const char *path)
++{
++  const char *slash = strrchr (path, '/');
++  const char *base = slash != NULL ? slash + 1 : path;
++  char *dir, *real, *out;
++
++  if (slash == NULL)
++    dir = xstrdup (".");
++  else if (slash == path)
++    dir = xstrdup ("/");
++  else
++    dir = xmemdup0 (path, (size_t) (slash - path));
++
++  real = lrealpath (dir);
++  free (dir);
++  if (real == NULL)
++    return NULL;
++  out = concat (real, "/", base, NULL);
++  free (real);
++  return out;
++}
++
++/* Whether A and B name one file.  */
++
++static int
++dvp_same_file (const char *a, const char *b)
++{
++  struct stat sa, sb;
++  char *ra, *rb;
++  int same;
++
++  if (a == NULL || b == NULL || *a == 0 || *b == 0)
++    return 0;
++  if (strcmp (a, b) == 0)
++    return 1;
++
++  /* Both exist: the filesystem answers, and it answers for hard links and for
++     symbolic links too, because stat follows them.  An inode of zero is not a
++     real serial number on some filesystems, so it is not evidence.  */
++  if (stat (a, &sa) == 0 && stat (b, &sb) == 0
++      && S_ISREG (sa.st_mode) && S_ISREG (sb.st_mode))
++    return sa.st_ino != 0 && sa.st_ino == sb.st_ino && sa.st_dev == sb.st_dev;
++
++  ra = dvp_resolved_path (a);
++  rb = dvp_resolved_path (b);
++  same = ra != NULL && rb != NULL && strcmp (ra, rb) == 0;
++  free (ra);
++  free (rb);
++  return same;
++}
++
++/* One collision, reported once.  Returns 1 when there was one.  */
++
++static int
++dvp_report_collision (const char *out, const char *out_what,
++		      const char *other, const char *other_what)
++{
++  if (!dvp_same_file (out, other))
++    return 0;
++  as_bad (_("%s would write over %s (\"%s\" and \"%s\" are the same file); "
++	    "give one of them a different path"),
++	  out_what, other_what, out, other);
++  return 1;
++}
++
++/* Whether PATH, about to be written as WHAT, collides with anything.  */
++
++static int
++dvp_extra_output_collides (const char *path, const char *what)
++{
++  const struct dvp_input_path *in;
++  int bad = 0;
++
++  if (path == NULL)
++    return 0;
++  if (out_file_name != NULL)
++    bad |= dvp_report_collision (path, what, out_file_name,
++				 _("the object file"));
++  for (in = dvp_input_paths; in != NULL; in = in->next)
++    bad |= dvp_report_collision (path, what, in->path, _("an input file"));
++  return bad;
++}
++
++/* Check both extra outputs against everything, including each other.  */
++
++static int
++dvp_extra_outputs_collide (void)
++{
++  int bad = 0;
++
++  bad |= dvp_extra_output_collides (dvp_raw_file, _("the --raw output"));
++  bad |= dvp_extra_output_collides (dvp_c_array_file, _("the --c-array output"));
++  if (dvp_raw_file != NULL && dvp_c_array_file != NULL)
++    bad |= dvp_report_collision (dvp_raw_file, _("the --raw output"),
++				 dvp_c_array_file, _("the --c-array output"));
++  return bad;
++}
++
++/* Every file the assembly opens is offered here, before it is read.  Reporting
++   at that point rather than at the end is what keeps the check useful: an error
++   stops the object being written and stops these outputs being written too, so
++   the input is still there afterwards.  */
++
++void
++dvp_note_input_file (const char *name)
++{
++  struct dvp_input_path *in;
++
++  if (name == NULL || *name == 0)	/* standard input */
++    return;
++  for (in = dvp_input_paths; in != NULL; in = in->next)
++    if (strcmp (in->path, name) == 0)
++      return;
++
++  in = XNEW (struct dvp_input_path);
++  in->next = NULL;
++  in->path = xstrdup (name);
++  *dvp_input_paths_tail = in;
++  dvp_input_paths_tail = &in->next;
++
++  (void) dvp_report_collision (dvp_raw_file, _("the --raw output"),
++			       name, _("an input file"));
++  (void) dvp_report_collision (dvp_c_array_file, _("the --c-array output"),
++			       name, _("an input file"));
++}
++
++/* The three paths that are all known as soon as the options are parsed, checked
++   before anything at all has been created.  A collision here is fatal rather
++   than reported: there is nothing further to learn from the run, and stopping
++   now is what leaves every named file exactly as it was.  */
++
++void
++dvp_after_parse_args (void)
++{
++  const char *raw = dvp_raw_file, *carr = dvp_c_array_file;
++
++  if (raw != NULL && carr != NULL && dvp_same_file (raw, carr))
++    as_fatal (_("--raw and --c-array name the same file (\"%s\" and \"%s\"); "
++		"one of them would be overwritten by the other"), raw, carr);
++  if (raw != NULL && out_file_name != NULL && dvp_same_file (raw, out_file_name))
++    as_fatal (_("--raw and -o name the same file (\"%s\" and \"%s\"); the raw "
++		"microcode would be written over the object"),
++	      raw, out_file_name);
++  if (carr != NULL && out_file_name != NULL
++      && dvp_same_file (carr, out_file_name))
++    as_fatal (_("--c-array and -o name the same file (\"%s\" and \"%s\"); the "
++		"generated C would be written over the object"),
++	      carr, out_file_name);
++}
++
++/* --- the atomic write itself --------------------------------------------- */
++
++/* A deliberate failure, for the tests that check what a failed write leaves
++   behind.  Read from the environment because the four failures it names --
++   a temporary file that cannot be created, a write that does not complete, a
++   close that reports an error and a rename that does not happen -- are between
++   them not reachable from a test that only has a filesystem to work with.  Two
++   of them are reachable (an unwritable directory, and a destination that is a
++   directory) and are tested that way as well; this exists for the other two,
++   and is inert unless the variable is set.  */
++
++static int
++dvp_write_fails_at (const char *stage)
++{
++  const char *want = getenv ("DVP_AS_TEST_EXTRA_OUTPUT_FAIL");
++
++  return want != NULL && strcmp (want, stage) == 0;
++}
++
++/* Emit the contents of one extra output.  */
++
++struct dvp_extra_output
++{
++  int c_array;			/* C source rather than raw bytes */
++  const char *name;		/* the array's name, for C */
++  const char *bytes;
++  size_t len;
++};
++
++static void
++dvp_emit_extra_output (FILE *fp, const struct dvp_extra_output *o)
++{
++  size_t i;
++
++  if (!o->c_array)
++    {
++      if (o->len != 0)
++	(void) fwrite (o->bytes, 1, o->len, fp);
++      return;
++    }
++
++  fprintf (fp, "/* VU microcode emitted by dvp-elf-as.  Do not edit.  */\n\n");
++  if (o->len == 0)
++    {
++      /* An empty program, in C that a standard compiler accepts.  C has no
++	 zero-length array and no empty initialiser: `unsigned char a[] = {};'
++	 is a C23 extension, and `a[0]' is an extension of its own, so the two
++	 together were rejected by `-std=c99 -pedantic-errors -Wall -Werror'
++	 and by the same at `-std=c17'.  The array carries one pad byte so that
++	 it is an object with an address like any other, and the length beside
++	 it stays the logical length, which is zero -- so every consumer that
++	 reads the size gets the same answer it would have got from a
++	 zero-length array, and none of them has to special-case this.  */
++      fprintf (fp, "/* This program is empty.  Standard C has no zero-length\n"
++		   "   array, so the array below carries one pad byte; the\n"
++		   "   length of the microcode is %s_size, which is zero.  */\n",
++	       o->name);
++      fprintf (fp, "const unsigned char %s[1] = { 0 };\n\n", o->name);
++    }
++  else
++    {
++      fprintf (fp, "const unsigned char %s[] =\n{", o->name);
++      for (i = 0; i < o->len; i++)
++	fprintf (fp, "%s0x%02x%s", (i % 12) == 0 ? "\n  " : " ",
++		 (unsigned char) o->bytes[i], (i + 1 == o->len) ? "" : ",");
++      fprintf (fp, "\n};\n\n");
++    }
++  fprintf (fp, "const unsigned long %s_size = %luUL;\n",
++	   o->name, (unsigned long) o->len);
++}
++
++/* PATH's directory with a template for mkstemp in it.  The temporary file has
++   to be in that directory: rename is only atomic within one filesystem, and
++   copying across one would put back exactly the half-written file this is
++   here to prevent.  */
++
++static char *
++dvp_temp_template (const char *path)
++{
++  const char *slash = strrchr (path, '/');
++  size_t dirlen = slash != NULL ? (size_t) (slash - path) + 1 : 0;
++  static const char stem[] = ".dvp-elf-as-tmpXXXXXX";
++  char *tmp = XNEWVEC (char, dirlen + sizeof (stem));
++
++  memcpy (tmp, path, dirlen);
++  memcpy (tmp + dirlen, stem, sizeof (stem));
++  return tmp;
++}
++
++static void
++dvp_write_atomically (const char *path, const char *what,
++		      const struct dvp_extra_output *o)
++{
++  char *tmp = dvp_temp_template (path);
++  int fd;
++  FILE *fp;
++  mode_t mask;
++
++  fd = dvp_write_fails_at ("temp") ? -1 : mkstemp (tmp);
++  if (fd < 0)
++    {
++      as_bad (_("cannot create a temporary file beside \"%s\" for %s, so "
++		"nothing was written and anything already there is "
++		"unchanged"), path, what);
++      free (tmp);
++      return;
++    }
++
++  /* mkstemp opens at 0600.  An output the user asked for is an ordinary file,
++     so it gets the mode an ordinary file would have had.  */
++  mask = umask (0);
++  (void) umask (mask);
++  (void) fchmod (fd, (mode_t) (0666 & ~mask));
++
++  fp = fdopen (fd, o->c_array ? "w" : "wb");
++  if (fp == NULL)
++    {
++      (void) close (fd);
++      (void) unlink (tmp);
++      as_bad (_("cannot write the temporary file for %s beside \"%s\""),
++	      what, path);
++      free (tmp);
++      return;
++    }
++
++  dvp_emit_extra_output (fp, o);
++
++  if (ferror (fp) || dvp_write_fails_at ("write")
++      || fflush (fp) != 0)
++    {
++      (void) fclose (fp);
++      (void) unlink (tmp);
++      as_bad (_("could not write %s to \"%s\"; it has been left as it was"),
++	      what, path);
++      free (tmp);
++      return;
++    }
++  if (fclose (fp) != 0 || dvp_write_fails_at ("close"))
++    {
++      (void) unlink (tmp);
++      as_bad (_("could not close the temporary file for %s beside \"%s\"; "
++		"\"%s\" has been left as it was"), what, path, path);
++      free (tmp);
++      return;
++    }
++  if (dvp_write_fails_at ("rename") || rename (tmp, path) != 0)
++    {
++      (void) unlink (tmp);
++      as_bad (_("could not put %s in place as \"%s\"; it has been left as it "
++		"was"), what, path);
++      free (tmp);
++      return;
++    }
++  free (tmp);
++}
++
++void
++dvp_write_extra_outputs (void)
++{
++  char *bytes;
++  size_t len;
++
++  if (dvp_raw_file == NULL && dvp_c_array_file == NULL)
++    return;
++
++  /* The last word on collisions.  The command line was checked when it was
++     parsed and every input as it was opened, so this catches only what changed
++     underneath in between -- a link made, a file created -- and it is cheap
++     enough to be worth having on the path that does the writing.  */
++  if (dvp_extra_outputs_collide ())
++    return;
++
++  /* A run that reported an error writes no object, so it must not leave a
++     stale extra artifact behind either.  */
++  if (had_errors ())
++    return;
++
++  /* Relocations have already been written by the time this runs, so the count
++     is final.  A section that still needs one has no final bytes to hand out,
++     and quietly emitting the unrelocated ones would be worse than refusing.  */
++  if (text_section->reloc_count != 0)
++    {
++      as_bad (_("the microcode section still has %u reference%s that only a "
++		"linker can resolve, so it has no final bytes to write; "
++		"--raw and --c-array need a self-contained program"),
++	      text_section->reloc_count,
++	      text_section->reloc_count == 1 ? "" : "s");
++      return;
++    }
++
++  bytes = dvp_section_bytes (text_section, &len);
++  if (had_errors ())
++    return;			/* the section was too large to hand out */
++
++  if (dvp_raw_file != NULL)
++    {
++      struct dvp_extra_output o;
++
++      o.c_array = 0;
++      o.name = NULL;
++      o.bytes = bytes;
++      o.len = len;
++      dvp_write_atomically (dvp_raw_file, _("the raw microcode"), &o);
++    }
++  if (dvp_c_array_file != NULL)
++    {
++      struct dvp_extra_output o;
++      char *derived = NULL;
++
++      o.c_array = 1;
++      o.name = dvp_c_array_name;
++      if (o.name == NULL)
++	o.name = derived = dvp_identifier_from_path (dvp_c_array_file);
++      o.bytes = bytes;
++      o.len = len;
++      dvp_write_atomically (dvp_c_array_file, _("the generated C array"), &o);
++      free (derived);
++    }
++  free (bytes);
++}
+--- /dev/null
++++ b/gas/config/tc-dvp.h
+@@ -0,0 +1,192 @@
++/* tc-dvp.h -- assembler target definitions for the PlayStation 2 DVP.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of GAS, the GNU Assembler.
++
++   GAS is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3, or (at your option)
++   any later version.
++
++   GAS is distributed in the hope that it will be useful, but WITHOUT
++   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++   for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with GAS; see the file COPYING.  If not, write to the Free
++   Software Foundation, 51 Franklin Street - Fifth Floor, Boston, MA
++   02110-1301, USA.  */
++
++/* The file name is what GAS's build system mandates for target cpu `dvp';
++   the contents are original.  */
++
++#define TC_DVP 1
++
++#define TARGET_ARCH		bfd_arch_dvp
++#define TARGET_FORMAT		"elf32-littlemips"
++#define TARGET_BYTES_BIG_ENDIAN	0
++
++/* Instruction words are built as host integers and serialised here, so bit
++   layout and byte order stay independent concerns.  */
++#define md_number_to_chars	number_to_chars_littleendian
++
++/* A DVP object's sections are named for the VU, not for a CPU.  Overriding
++   these three names makes GAS create exactly the sections a DVP object has,
++   with the usual text/data/bss attributes, instead of creating .text, .data
++   and .bss that would have no meaning in a DVP object.  */
++#define TEXT_SECTION_NAME	".vutext"
++#define DATA_SECTION_NAME	".vudata"
++#define BSS_SECTION_NAME	".vubss"
++
++/* A promoted function's code remains at its `_$' transfer alias.  */
++#define md_func_label_prefix	"_$"
++
++/* Operand whitespace is significant here, so GAS's line scrubber must not
++   throw it away.
++
++   Stock GAS drops a space in an operand whenever the characters either side are
++   not both symbol constituents, and re-inserts it when they are.  That makes
++   `+ 1' and `+1' the same text by the time a target sees them, because `+' is
++   not a symbol constituent -- and they are *not* the same text for a GIF tag's
++   keyword value, where the digits have to follow the sign directly.
++
++   Keeping the spaces costs nothing elsewhere: every reader in tc-dvp.c skips
++   whitespace where whitespace is allowed, so the only places a space now
++   survives are the places one was always meant to be an error.  */
++#define TC_KEEP_OPERAND_SPACES	1
++
++/* Which characters start a comment is settled after the options are parsed, so
++   the scrubber reads this rather than `comment_chars': a mid-line `#' is a
++   comment only under `--cleanroom-extensions'.  This is the hook stock GAS
++   provides for a target that has to change the set (app.c defaults it to
++   `comment_chars').  */
++extern const char *dvp_comment_chars;
++#define tc_comment_chars	dvp_comment_chars
++
++#define WORKING_DOT_WORD	1
++#define LOCAL_LABELS_FB		1
++
++/* There is nothing to relax: every VU microinstruction is eight bytes.  */
++#define md_convert_frag(B, S, F)		as_fatal (_("dvp: unexpected frag relaxation"))
++#define md_estimate_size_before_relax(F, S)	(as_fatal (_("dvp: unexpected frag relaxation")), 0)
++
++#define md_undefined_symbol(NAME)	((symbolS *) 0)
++#define md_operand(X)			do { ; } while (0)
++
++/* Fixups remember which instruction field they belong to, so the placement
++   rules live in exactly one place: the generated opcode table.  */
++struct dvp_vu_field;
++/* Per-fixup data.  FIELD is the VU operand field the fixup came from, or NULL
++   for a fixup that did not (a data directive's, a container's).  VU_PC is the
++   branch's own address in VU bytes, recorded while the `mpg' block that gives it
++   an origin is still open -- a displacement has to be worked out with both ends
++   in one coordinate system, and the transfer position the frag knows is the
++   other one.  VU_PC_KNOWN says whether it was recorded at all.  */
++struct dvp_fix_data
++{
++  const struct dvp_vu_field *field;
++  addressT vu_pc;
++  int vu_pc_known;
++};
++
++/* Whether GAS may fold a difference of two symbols in one section at parse time.
++
++   It normally may, and normally should.  The exception is an operand whose
++   field scales what it is given: a promoted `mpg' label's value is a VU byte
++   address, the field holds eight-byte units, and the scaling is applied where
++   the fixup is encoded.  A difference folded before that point arrives as a
++   written-out constant and is stored as written -- eight times what the source
++   asked for.  Declining the fold for those operands, and only those, keeps the
++   subtraction alive as far as the fixup.
++
++   Scoped by a counter the two operand readers raise around their own
++   `expression' call, so a branch target in particular still folds.  */
++
++extern int dvp_allow_local_subtract (void *, void *, segT);
++#define md_allow_local_subtract(L, R, SEG)	\
++  dvp_allow_local_subtract ((L), (R), (SEG))
++
++/* Stock pseudo_set has a second same-frag subtraction fold after expression()
++   returns.  Bracket that reader so overlay differences stay symbolic, then let
++   the target veto that second fold as well.  The expression reaches an imm15
++   fixup with its label-derived origin intact instead of becoming a literal.  */
++extern void dvp_pseudo_set_begin (symbolS *);
++extern void dvp_pseudo_set_end (symbolS *, expressionS *);
++extern int dvp_allow_equated_local_subtract (symbolS *, expressionS *);
++#define md_pseudo_set_begin(S) dvp_pseudo_set_begin (S)
++#define md_pseudo_set_end(S, E) dvp_pseudo_set_end ((S), (E))
++#define md_allow_equated_local_subtract(S, E) \
++  dvp_allow_equated_local_subtract ((S), (E))
++
++#define TC_FIX_TYPE		struct dvp_fix_data
++#define TC_INIT_FIX_DATA(FIX)	((FIX)->tc_fix_data.field = NULL,	\
++				 (FIX)->tc_fix_data.vu_pc = 0,		\
++				 (FIX)->tc_fix_data.vu_pc_known = 0)
++
++/* Container commands and blocks live outside `.vu' mode; md_assemble sends a
++   line to whichever of the two layers is in force.  */
++extern void dvp_md_finish (void);
++#define md_finish()		dvp_md_finish ()
++
++/* Called at the end of every positional input file, the last one included.  A
++   DMA tag's payload may not span one; see dvp_input_file_end.  */
++extern void dvp_input_file_end (void);
++#define md_cleanup()		dvp_input_file_end ()
++
++extern long dvp_pcrel_from_section (struct fix *, segT);
++#define MD_PCREL_FROM_SECTION(FIX, SEC)	dvp_pcrel_from_section (FIX, SEC)
++
++extern void dvp_frob_label (symbolS *);
++#define tc_frob_label(SYM)	dvp_frob_label (SYM)
++
++/* A label written just before a VU microinstruction names the instruction, and
++   so has to move across the padding the instruction's alignment inserts.  This
++   is where a data directive says the label is naming the data instead.  */
++extern void dvp_cons_align (int);
++#define md_cons_align(N)	dvp_cons_align (N)
++
++/* Section symbols come before ordinary local symbols, which is the shape the
++   reference's symbol tables have and not the one BFD produces on its own.  This
++   runs after every symbol exists and before the table is handed to BFD.  */
++extern void dvp_adjust_symtab (void);
++#define tc_adjust_symtab()	dvp_adjust_symtab ()
++
++/* A container block's length, and an automatic DMA quadword count, are measured
++   from the bytes that follow the command word, so they need those bytes to be
++   one contiguous run in one subsection.  Every ELF section-changing directive
++   calls this hook, which is where a switch in the middle of one is caught.  */
++extern void dvp_section_changed (void);
++#define md_elf_section_change_hook()	dvp_section_changed ()
++
++/* --raw and --c-array ask for a copy of the microcode beside the object.  By
++   this hook the frags hold their final bytes, and the object file has not been
++   written yet, so the two outputs cannot disagree.  */
++extern void dvp_write_extra_outputs (void);
++#define tc_frob_file_after_relocs()	dvp_write_extra_outputs ()
++
++/* Every file the assembly opens -- each positional input, each `.include' and
++   `.incbin', and the name a `.file' directive gives -- passes through GAS's
++   dependency recorder, which is the one place all of them meet.  The extra
++   outputs must not be allowed to write over any of them, and the check has to
++   happen while the file is still there, so it happens as each is opened.  */
++extern void dvp_note_input_file (const char *);
++#define md_register_input_file(NAME)	dvp_note_input_file (NAME)
++
++/* And the three paths the command line alone settles -- `-o', `--raw' and
++   `--c-array' -- checked against each other before anything is created.  */
++extern void dvp_after_parse_args (void);
++#define md_after_parse_args()		dvp_after_parse_args ()
++
++/* Differences between labels are meaningful (they are used to size VU
++   programs), and a plain absolute expression is legal wherever an immediate
++   is.  */
++#define DIFF_EXPR_OK		1
++
++/* When a fixup survives as a relocation, the symbol's value belongs to the
++   linker, not to the field: adding it here as well would count it twice once
++   the relocation is applied.  This is the usual choice for an ELF target and
++   it is what makes a DVP object relocatable in the ordinary sense.  See
++   a deliberate deviation.  */
++#define MD_APPLY_SYM_VALUE(FIX)	0
+--- a/gas/configure.tgt
++++ b/gas/configure.tgt
+@@ -335,6 +335,7 @@
+   mn10300-*-linux*)			fmt=elf em=linux ;;
+   mn10300-*-*)				fmt=elf ;;
+ 
++  dvp-*-*)				fmt=elf endian=little ;;
+   moxie-*-uclinux)			fmt=elf em=linux ;;
+   moxie-*-moxiebox*)                    fmt=elf endian=little ;;
+   moxie-*-*)				fmt=elf ;;
+--- a/gas/depend.c
++++ b/gas/depend.c
+@@ -57,6 +57,10 @@
+ register_dependency (const char *filename)
+ {
+   struct dependency *dep;
++
++#ifdef md_register_input_file
++  md_register_input_file (filename);
++#endif
+ 
+   if (dep_file == NULL)
+     return;
+--- a/gas/read.c
++++ b/gas/read.c
+@@ -4127,6 +4127,9 @@
+ 
+   know (symbolP);		/* NULL pointer is logic error.  */
+ 
++#ifdef md_pseudo_set_begin
++  md_pseudo_set_begin (symbolP);
++#endif
+ #ifdef md_expr_init_rest
+   md_expr_init_rest (&exp);
+ #endif
+@@ -4135,6 +4138,9 @@
+   else
+     (void) expr (0, &exp, expr_defer_incl_dot);
+ 
++#ifdef md_pseudo_set_end
++  md_pseudo_set_end (symbolP, &exp);
++#endif
+   if (exp.X_op == O_illegal)
+     as_bad (_("illegal expression"));
+   else if (exp.X_op == O_absent)
+@@ -4148,6 +4154,9 @@
+     }
+   else if (exp.X_op == O_subtract
+ 	   && !S_IS_FORWARD_REF (symbolP)
++#ifdef md_allow_equated_local_subtract
++	   && md_allow_equated_local_subtract (symbolP, &exp)
++#endif
+ 	   && SEG_NORMAL (S_GET_SEGMENT (exp.X_add_symbol))
+ 	   && (symbol_get_frag (exp.X_add_symbol)
+ 	       == symbol_get_frag (exp.X_op_symbol)))
+@@ -6656,10 +6665,14 @@
+ /* Output debugging information to mark a function entry point or end point.
+    END_P is zero for .func, and non-zero for .endfunc.  */
+ 
++#ifndef md_func_label_prefix
++#define md_func_label_prefix NULL
++#endif
++
+ void
+ s_func (int end_p)
+ {
+-  do_s_func (end_p, NULL);
++  do_s_func (end_p, md_func_label_prefix);
+ }
+ 
+ /* Subroutine of s_func so targets can choose a different default prefix.
+--- /dev/null
++++ b/include/elf/dvp.h
+@@ -0,0 +1,182 @@
++/* DVP ELF support for BFD.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of BFD, the Binary File Descriptor library.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++#ifndef _ELF_DVP_H
++#define _ELF_DVP_H
++
++#include "elf/reloc-macros.h"
++#include "elf/mips.h"
++
++/* Relocation type numbers.
++
++   These are the numbers the existing PlayStation 2 tool flow already puts in
++   DVP objects, so a new assembler has to agree with them for anything to link:
++   a `.word' naming an undefined symbol produces type 2, an undefined branch
++   target 120, and an undefined `iaddiu' immediate 123.  This header is the only
++   place the numbers appear.
++
++   All three are REL form: the addend is carried in the instruction or data
++   word, not in the relocation entry.  */
++
++START_RELOC_NUMBERS (elf_dvp_reloc_type)
++  RELOC_NUMBER (R_DVP_NONE, 0)
++  /* Plain 32-bit absolute word, as produced by `.word symbol'.  Type number 2
++     is also what MIPS ELF uses for its 32-bit absolute relocation, and DVP
++     objects declare EM_MIPS, so a MIPS-aware consumer that only needs to fix
++     up data words agrees with us by construction.  */
++  RELOC_NUMBER (R_DVP_32, 2)
++  /* 11-bit signed displacement in units of 64-bit microinstructions, relative
++     to the instruction after the branch.  Occupies bits 10..0 of the lower
++     word.  */
++  RELOC_NUMBER (R_DVP_11_PCREL, 120)
++  /* Address field of a DMA tag.  A DMA tag addresses quadwords, so the field
++     holds value bits 30..4 in word bits 30..4 and encodes neither the low four
++     bits nor bit 31.  Established by observation: `dmaref 4, sym' produces
++     type 121.  */
++  RELOC_NUMBER (R_DVP_DMA_ADDR, 121)
++  /* 15-bit unsigned immediate, split: value bits 10..0 land in word bits 10..0
++     and value bits 14..11 land in word bits 24..21.  */
++  RELOC_NUMBER (R_DVP_15, 123)
++END_RELOC_NUMBERS (R_DVP_max)
++
++/* Set by the assembler when it is asked for its clean-room extensions, so
++   `.reloc' answers to R_DVP_* as well as the MIPS names.  Default off: the
++   reference refuses those spellings.  */
++extern bool dvp_elf_private_reloc_names;
++
++/* Field placement for the relocatable instruction fields.  Only two
++   instruction fields can carry a relocation, and both are described here so
++   that BFD can place a linker-computed value without depending on the
++   assembler's opcode table.  */
++
++/* Bits 10..0 of the lower word: the signed branch displacement, counted in
++   microinstructions.  */
++#define DVP_DISP11_MASK		0x000007ffu
++#define DVP_DISP11_WIDTH	11
++
++/* The 15-bit `iaddiu'/`isubiu' immediate, split into two runs of bits.  */
++#define DVP_IMM15_LO_MASK	0x000007ffu
++#define DVP_IMM15_LO_WIDTH	11
++#define DVP_IMM15_HI_MASK	0x01e00000u
++#define DVP_IMM15_HI_SHIFT	21
++#define DVP_IMM15_MASK		(DVP_IMM15_LO_MASK | DVP_IMM15_HI_MASK)
++#define DVP_IMM15_WIDTH		15
++#define DVP_IMM15_MAX		((1u << DVP_IMM15_WIDTH) - 1)
++
++/* When this field carries a *relocation* it does not hold a byte count: it
++   holds eight-byte units, so a relocated addend is stored divided by eight and
++   an addend that is not a multiple of eight has no encoding.  A value the
++   assembler already knows is not scaled -- the scaling belongs to the
++   relocation -- so this shift is applied where a fixup is, and nowhere else.  */
++#define DVP_IMM15_RELOC_SHIFT	3
++#define DVP_IMM15_RELOC_SCALE	(1u << DVP_IMM15_RELOC_SHIFT)
++/* The largest byte value the scaled field can express.  */
++#define DVP_IMM15_RELOC_MAX	(DVP_IMM15_MAX * DVP_IMM15_RELOC_SCALE)
++
++/* The DMA tag address field.  A tag addresses quadwords: value bits
++   30..DVP_DMAADDR_LSB land in the same word bits, and neither the low bits nor
++   bit 31 is encoded, so an address that is not quadword aligned is an error
++   rather than a silently truncated value.  */
++#define DVP_DMAADDR_LSB		4
++#define DVP_DMAADDR_WIDTH	27
++#define DVP_DMAADDR_MASK	0x7ffffff0u
++
++/* Bytes per DMA and GIF tag, and per VIF command word.  */
++#define DVP_TAG_BYTES		16
++#define DVP_TAG_HALF_BYTES	8
++#define DVP_VIFCODE_BYTES	4
++
++/* `.dmadata NAME' marks where its region ends by defining this name prefixed to
++   NAME.  A local label, so it never reaches the object's symbol table, and it is
++   what an out-of-line tag's automatic count measures against.  */
++#define DVP_END_PREFIX		".L.end."
++
++/* Bytes per VU microinstruction.  opcode/dvp-vu.h states the same size as
++   DVP_INSN_BYTES for the assembler's benefit; tc-dvp.c asserts they agree.  */
++#define DVP_MICROINSN_BYTES	8
++
++/* The object flag word DVP objects carry; the EE tool flow expects it.
++
++   Its parts are generic MIPS psABI bits, and naming them here is what makes the
++   ABI selectors expressible as a choice of one field rather than a table of
++   five magic numbers.  The names and values come from `include/elf/mips.h' in
++   the pristine Binutils tree:
++
++     EF_MIPS_ARCH_3      0x20000000   the ISA level the word names
++     EF_MIPS_MACH_5900   0x00920000   the machine: the EE core
++     EF_MIPS_CPIC        0x00000004   calls follow the PIC conventions
++     EF_MIPS_ABI2        0x00000020   n32
++     EF_MIPS_ABI_O32     0x00001000   the EF_MIPS_ABI (0x0000f000) field
++     EF_MIPS_ABI_O64     0x00002000
++     EF_MIPS_ABI_EABI32  0x00003000
++
++   The default is n32 with CPIC, which is 0x20920024.  */
++#define EF_DVP_BASE		(EF_MIPS_ARCH_3 | EF_MIPS_MACH_5900)
++#define EF_DVP_ABI_DEFAULT	EF_MIPS_ABI2
++#define EF_DVP_OBJECT		(EF_DVP_BASE | EF_DVP_ABI_DEFAULT \
++				 | EF_MIPS_CPIC)
++
++/* Processor-specific section types.  */
++#define SHT_DVP_OVERLAY_TABLE	0x7ffff420
++/* One generated section per overlay, holding zeroes the size of the microcode
++   the overlay's `mpg' command transfers.  Observed on reference output alongside
++   the table entry that names it.  */
++#define SHT_DVP_OVERLAY		0x7ffff421
++
++/* Marker byte stored in st_other on symbols defined inside a `.vu' block.  The
++   synthetic unit markers carry their own bytes; those are in the generated
++   container table (DVP_MARK_*_OTHER) because they were measured with it.  */
++#define STO_DVP_VU		0xeb
++
++/* Section names.  */
++#define DVP_VUTEXT_SECTION	".vutext"
++#define DVP_VUDATA_SECTION	".vudata"
++#define DVP_VUBSS_SECTION	".vubss"
++#define DVP_OVLYTAB_SECTION	".DVP.ovlytab"
++#define DVP_OVLYSTRTAB_SECTION	".DVP.ovlystrtab"
++
++/* Bytes per overlay table entry, and where each of its three words sits: a
++   string-table offset naming the overlay, the microcode's offset in the section
++   it was assembled into, and the overlay's load address in bytes.  The first two
++   carry a 32-bit relocation, so their offsets are named rather than open coded.  */
++#define DVP_OVLYTAB_ENTSIZE	12
++#define DVP_OVLYTAB_NAME_OFFSET	0
++#define DVP_OVLYTAB_CODE_OFFSET	4
++#define DVP_OVLYTAB_ADDR_OFFSET	8
++
++/* An overlay's generated section is named for what it holds: the prefix, the
++   overlay's own name, its load address in bytes, the source line the `mpg'
++   command was written on, and its index in the table.  The reference's name has
++   one more component -- a token folded from the input file's path, so that
++   assembling one source twice does not produce one object.  Leaving that out is
++   a deliberate deviation, and is what makes this assembler's output
++   reproducible.
++
++   Nothing gives an overlay a name of its own, so the name component is empty
++   and the double separator that leaves is the reference's own shape.  */
++#define DVP_OVERLAY_PREFIX	".DVP.overlay."
++#define DVP_OVERLAY_START_PREFIX "__start_"
++
++/* A label inside an `mpg' block belongs to the overlay, so that is where it is
++   defined; this prefix spells the alias that stands where the code really is.  */
++#define DVP_OVERLAY_ALIAS_PREFIX "_$"
++
++#endif /* _ELF_DVP_H */
+--- /dev/null
++++ b/include/opcode/dvp-val.h
+@@ -0,0 +1,60 @@
++/* dvp-val.h -- the type an operand value is carried in.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of the GNU opcodes library.
++
++   This library is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3, or (at your option)
++   any later version.
++
++   It is distributed in the hope that it will be useful, but WITHOUT
++   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
++   License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++#ifndef DVP_VAL_H
++#define DVP_VAL_H
++
++#include <stdint.h>
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/* An operand's value, and the range check that goes with it.
++
++   Deliberately not `long': that is the one integer type in C whose width
++   differs across the host shapes a cross assembler is built for -- 64 bits on
++   LP64, 32 on ILP32 and 32 on LLP64.  This target has operands taking *any*
++   32-bit pattern -- `stmask', all four `strow' and `stcol' lanes, an `loi'
++   literal, a raw container word -- so their range is 0..0xffffffff, which a
++   signed 32-bit `long' cannot hold: the range constant is itself out of range,
++   a width-32 field mask shift is undefined, and a value the source wrote in
++   full comes back negative or refused.
++
++   So the type is stated: signed, so a negative operand is a value a range check
++   can refuse rather than a wrapped one it accepts, and 64 bits, so every value
++   in 0..0xffffffff and every rejected value just outside it are distinguishable
++   on every host.  */
++
++typedef int64_t dvp_val;
++typedef uint64_t dvp_uval;
++
++/* Printing one.  `long long' is the widest conversion C99 states, and every
++   value above fits it on every host, so a diagnostic naming an operand casts
++   to it rather than guessing at the host's spelling of a 64-bit type.  */
++#define DVP_VAL_PRINT(V)	((long long) (V))
++#define DVP_VAL_FMT		"%lld"
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* DVP_VAL_H */
+--- /dev/null
++++ b/include/opcode/dvp-vif-consts.h
+@@ -0,0 +1,70 @@
++/* DVP container table -- GENERATED, DO NOT EDIT.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of the GNU Binutils.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++/* Generated from an authored container grammar and measured encodings.  */
++
++
++#ifndef DVP_VIF_CONSTS_H
++#define DVP_VIF_CONSTS_H
++
++#define DVP_CTR_MAX_HEADER 5
++
++/* Instructions one MPG command can carry; a longer block is
++   emitted as several commands.  */
++#define DVP_MPG_SPLIT_AT 256
++
++/* st_other marker bytes and name prefixes for the synthetic
++   unit symbols.  */
++
++#define DVP_MARK_DMA_OTHER 0xe8
++#define DVP_MARK_DMA_PREFIX ".dma."
++
++#define DVP_MARK_GIF_OTHER 0xea
++#define DVP_MARK_GIF_PREFIX ".gif."
++
++#define DVP_MARK_VIF_OTHER 0xe9
++#define DVP_MARK_VIF_PREFIX ".vif."
++
++#define DVP_MARK_VU_OTHER 0xeb
++#define DVP_MARK_VU_PREFIX ".vu."
++
++/* Synthetic unit names an inline DMA payload reserves ahead of the
++   tag's own pair.  Measured: a tag that opens a payload is not named
++   from zero even when it is the first thing in the file.  */
++#define DVP_DMA_PAYLOAD_UNITS 1
++
++/* A DMA tag's trailing eight bytes carry two VIF command words
++   unless packing is switched off.  */
++#define DVP_PACKVIF_SLOTS 2
++#define DVP_PACKVIF_DEFAULT 1
++
++/* The commands measured to set the write cycle that an unpack's
++   automatic count is divided by, the operand positions of the two
++   halves of that setting, and whether a cycle length of zero
++   leaves any count expressible.  */
++#define DVP_CYCLE_COMMANDS { "stcycl", "stcycle" }
++#define DVP_CYCLE_NCOMMANDS 2
++#define DVP_CYCLE_WL_OPERAND 0
++#define DVP_CYCLE_CL_OPERAND 1
++#define DVP_CYCLE_ZERO_CL_REFUSES 1
++
++
++#endif /* DVP_VIF_CONSTS_H */
+--- /dev/null
++++ b/include/opcode/dvp-vif.h
+@@ -0,0 +1,339 @@
++/* Declarative description of the PlayStation 2 DVP container commands.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of the GNU Binutils.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++/* Outside a `.vu' block, the first token on a DVP source line names a
++   *container* command: a VIF command, a DMA tag, a GIF tag, or the opener of a
++   block whose length the assembler computes for itself.  There are no
++   container directives other than the block terminators; everything else here
++   is a mnemonic.
++
++   As in opcode/dvp-vu.h, bit layout is expressed only as shifts and widths, so
++   it is independent of how the host compiler packs structures, and byte order
++   is applied separately when words are written to a fragment.  */
++
++#ifndef DVP_VIF_H
++#define DVP_VIF_H
++
++#include <stddef.h>
++#include "opcode/dvp-val.h"
++
++/* Measured scalar constants, generated alongside the container table.  */
++#include "opcode/dvp-vif-consts.h"
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/* Bracketed modifier letters, written immediately after the mnemonic:
++   `stcycl[i] 1,1', `unpack[imu] v4_32, 0, *', `dmacnt[s] 4'.
++
++   S, ZERO and ONE are named after their spelling and nothing else; what they
++   *mean* is not established here, so the table records the bits and no more.
++   ZERO and ONE are the two written values of one two-bit field: ZERO stores
++   0b10 and ONE stores 0b11, so neither is the default and the field's third
++   state is what you get by writing no letter at all.  Because they share a
++   field they cannot both be given, and MOD_CONFLICT says so.  */
++#define DVP_MOD_I	1	/* raise the interrupt bit */
++#define DVP_MOD_M	2	/* unpack: apply the write mask */
++#define DVP_MOD_U	4	/* unpack: payload is unsigned */
++#define DVP_MOD_R	8	/* unpack: address is relative to the base */
++#define DVP_MOD_S	16	/* DMA tag: raises the top bit of the tag's
++				   second word */
++#define DVP_MOD_ZERO	32	/* DMA tag: the lower of the two written values
++				   of the two-bit field in the tag's first
++				   word */
++#define DVP_MOD_ONE	64	/* DMA tag: the higher of the two */
++
++#define DVP_MOD_COUNT	7	/* i, m, u, r, s, 0, 1 -- MOD_BIT's order */
++
++enum dvp_ctr_kind
++{
++  DVP_CTR_VIF,		/* one command word, plus any whole data words */
++  DVP_CTR_UNPACK,	/* command word then a data block */
++  DVP_CTR_MPG,		/* command word then a block of microinstructions */
++  DVP_CTR_DIRECT,	/* command word then a quadword-aligned data block */
++  DVP_CTR_GIF,		/* a whole tag quadword then a data block */
++  DVP_CTR_DMA		/* a whole tag quadword */
++};
++
++enum dvp_ctr_block
++{
++  DVP_BLK_NONE,		/* emits its command and nothing else */
++  DVP_BLK_DATA,		/* opens a block of data, closed by TERMINATOR */
++  DVP_BLK_VU		/* opens a block of microinstructions */
++};
++
++enum dvp_ctr_class
++{
++  DVP_CO_U8,		/* 8-bit unsigned immediate */
++  DVP_CO_U16,		/* 16-bit unsigned immediate */
++  DVP_CO_MODE,		/* small enumerated mode, numeric or named */
++  DVP_CO_NAME,		/* enumerated state that has *only* a named spelling:
++			   `mskpath3 enable'.  A number here is an error,
++			   which is what separates it from DVP_CO_MODE */
++  DVP_CO_WORD,		/* a whole extra 32-bit data word */
++  DVP_CO_VADDR,		/* VU memory address */
++  DVP_CO_NUM,		/* element count, 1..COUNT_MAX, or `*' */
++  DVP_CO_QWCOUNT,	/* quadword count held in the command word, or `*' */
++  DVP_CO_QWC,		/* DMA quadword count, or `*' */
++  DVP_CO_DMAADDR	/* DMA address; may name a symbol */
++};
++
++/* One operand's placement.  VALUE_LSB is the lowest value bit the field
++   encodes: a DMA tag addresses quadwords, so its address field does not encode
++   value bits below VALUE_LSB and a value with any of them set is an error here
++   rather than a silently dropped one.  */
++
++struct dvp_ctr_field
++{
++  unsigned char cls;		/* enum dvp_ctr_class */
++  unsigned char word;		/* which header word the field sits in */
++  unsigned char value_lsb;
++  unsigned char shift;		/* word bit that VALUE_LSB lands in */
++  unsigned char width;		/* number of value bits encoded */
++};
++
++/* A named value for a DVP_CO_MODE operand.  */
++struct dvp_ctr_mode
++{
++  const char *name;
++  unsigned int value;
++};
++
++/* A GIF tag's operands are written as keywords rather than positionally:
++   `gifimage nloop=4, eop', `gifpacked prim=7,regs={prim,rgbaq},nloop=2,eop'.
++
++   KIND says what shape the keyword takes.  A DVP_KW_VALUE keyword needs its `='
++   and a value; leaving it out means "work it out", and so does `=*', which is
++   this project's own spelling.  A DVP_KW_FLAG is bare.  A DVP_KW_REGS is the
++   braced register list, whose entries go into the descriptor's register fields
++   and whose length goes into NREG.
++
++   The keywords appear in the order the table lists them: one may be left out,
++   but the ones given keep that order.  REQUIRED marks a keyword that cannot be
++   left out at all.
++
++   PRE_BIT is a companion bit the tag raises because the keyword was given at
++   all, regardless of its value -- the GIF tag's PRE, "a primitive is given".
++   -1 means the keyword has no such bit.  */
++
++enum dvp_ctr_kwkind
++{
++  DVP_KW_VALUE,
++  DVP_KW_FLAG,
++  DVP_KW_REGS
++};
++
++/* How a keyword's value may be written.  A GIF tag's keyword value is a
++   written-out integer rather than an expression, and the two value keywords do
++   not read one the same way: measured, not assumed, because reading `prim=010'
++   as ten rather than eight silently encodes the wrong primitive.  */
++
++enum dvp_ctr_kwnum
++{
++  DVP_KWNUM_DECIMAL,		/* decimal only; a leading zero is still decimal */
++  DVP_KWNUM_C			/* 0x hexadecimal, leading-zero octal, decimal */
++};
++
++struct dvp_ctr_keyword
++{
++  const char *name;
++  unsigned char kind;		/* enum dvp_ctr_kwkind */
++  unsigned char required;
++  unsigned char word;
++  unsigned char shift;
++  unsigned char width;
++  signed char pre_word;
++  signed char pre_bit;
++  unsigned char numform;	/* enum dvp_ctr_kwnum, for DVP_KW_VALUE */
++};
++
++struct dvp_ctr_format
++{
++  const char *name;
++  unsigned int fixed;		/* command word for this unpack format */
++  unsigned char elem_bytes;	/* payload bytes one element occupies */
++};
++
++struct dvp_ctr_opcode
++{
++  const char *name;
++  unsigned char kind;		/* enum dvp_ctr_kind */
++  unsigned char block;		/* enum dvp_ctr_block */
++  unsigned char nheader;	/* header words emitted before the payload */
++  unsigned char cmd_slot;	/* which header word carries the fields */
++  unsigned char pre_align;	/* byte alignment required before the header */
++  unsigned char payload_align;	/* byte alignment the payload must start on */
++  unsigned char sec_align;	/* byte alignment this construct records */
++  unsigned char end_align;	/* byte alignment the block's payload is padded
++				   out to when it closes, or 0 for none.  This
++				   is what the *next* construct of the same
++				   stream needs, not a property of the payload:
++				   a VIF command word has to start on a
++				   four-byte boundary, so an `unpack' block
++				   pads its payload out to one */
++  unsigned char mods;		/* DVP_MOD_* letters this command accepts */
++  unsigned char nfields;
++  unsigned char nmodes;
++  unsigned char nkeywords;
++  unsigned char unit_bytes;	/* payload bytes per counted unit */
++  unsigned char round_up;	/* automatic count rounds up, not down */
++  unsigned char optional_last;	/* the last operand may be left out */
++  /* Non-zero on a DMA tag whose written or automatic count *opens* the payload
++     it counts, which then ends at TERMINATOR.  The other tags describe a
++     payload that lives elsewhere and open nothing.  */
++  unsigned char inline_payload;
++  unsigned char closes_vif_unit;
++  /* The largest count the field can express, measured rather than taken from
++     the field's width: where it is one more than the field can hold, that
++     largest count is stored as zero.  Wider than the field because 65536 in a
++     sixteen-bit field is exactly that case.  */
++  unsigned int count_max;
++  unsigned char validate_count;	/* an explicit count must match the payload */
++  /* A GIF tag with a register list.  NREG holds the list's length, spelling its
++     maximum as zero exactly as the counted blocks do; the entries go into
++     consecutive REGS_WIDTH-bit fields starting at REGS_SHIFT of word REGS_WORD
++     and running on into the words after it.  LOOP_BYTES_PER_REG is how many
++     payload bytes one loop takes for each named register, so the block's
++     counted unit is that times the list's length.  NREGS is zero on a tag with
++     no register list.  */
++  unsigned char nreg_word;
++  unsigned char nreg_shift;
++  unsigned char nreg_width;
++  unsigned char nreg_zero_means_max;
++  unsigned char regs_word;
++  unsigned char regs_shift;
++  unsigned char regs_width;
++  unsigned char loop_bytes_per_reg;
++  unsigned char nregs;		/* named registers in REGS, 0 if none */
++  unsigned int nreg_max;	/* longest list the descriptor holds */
++  unsigned int fixed[DVP_CTR_MAX_HEADER];
++  const struct dvp_ctr_field *fields;
++  const struct dvp_ctr_mode *modes;
++  const struct dvp_ctr_mode *regs;	/* named GS registers, NREGS of them */
++  const struct dvp_ctr_keyword *keywords;
++  const char *terminator;
++  /* Which word bits each letter raises, and which header word -- counted from
++     CMD_SLOT -- they sit in.  A mask rather than a bit index, because a letter
++     may raise more than one: the DMA precedence letters raise two, being the
++     two written values of one two-bit field.  A MOD_MASK of zero means the
++     command does not accept the letter -- MODS says which it does.
++
++     MOD_CONFLICT[k] is the set of letters letter k may not be given with, held
++     pairwise rather than inferred from the masks: two letters can overlap in a
++     field and still be allowed, and two that do not overlap can still be
++     refused together.  */
++  unsigned int mod_mask[DVP_MOD_COUNT];
++  signed char mod_word[DVP_MOD_COUNT];
++  unsigned char mod_conflict[DVP_MOD_COUNT];
++};
++
++extern const struct dvp_ctr_opcode dvp_ctr_opcodes[];
++extern const int dvp_ctr_num_opcodes;
++extern const struct dvp_ctr_format *const dvp_ctr_formats;
++extern const int dvp_ctr_num_formats;
++
++/* --- lookup and encoding (pure: no I/O, no symbol table) ----------------- */
++
++extern const struct dvp_ctr_opcode *dvp_ctr_lookup (const char *name);
++extern const struct dvp_ctr_format *dvp_ctr_format_lookup (const char *name);
++
++/* Parse a bracketed modifier group at *PP, if there is one.  Only the letters
++   OP takes are accepted; a letter written more than once is the same modifier
++   named more than once and is accepted; two letters OP's MOD_CONFLICT says share
++   a field are refused.  Returns NULL, or ERR filled in.  */
++extern const char *dvp_ctr_parse_mods (char **pp,
++				       const struct dvp_ctr_opcode *op,
++				       unsigned int *mods,
++				       char *err, size_t errlen);
++
++/* Raise the bits a parsed modifier set contributes, in whichever header words
++   they belong to.  WORDS points at the command's header words.  */
++extern void dvp_ctr_apply_mods (const struct dvp_ctr_opcode *op,
++				unsigned int mods, unsigned int *words);
++
++/* The inclusive value range FIELD accepts.  */
++extern void dvp_ctr_field_range (const struct dvp_ctr_opcode *op,
++				 const struct dvp_ctr_field *field,
++				 dvp_val *lo, dvp_val *hi);
++
++/* Place VALUE into WORDS according to FIELD, range-checking first.  Returns
++   NULL, or ERR with an original message naming the value and the range.  */
++extern const char *dvp_ctr_place (const struct dvp_ctr_opcode *op,
++				  const struct dvp_ctr_field *field,
++				  dvp_val value, unsigned int *words,
++				  char *err, size_t errlen);
++
++/* Look a named mode up on OP.  Returns -1 if there is no such name.  */
++extern dvp_val dvp_ctr_mode_value (const struct dvp_ctr_opcode *op,
++				const char *name);
++
++/* Look a named GS register up on OP.  Returns -1 if there is no such name.  */
++extern dvp_val dvp_ctr_reg_value (const struct dvp_ctr_opcode *op,
++			       const char *name);
++
++/* Place the Nth entry of a register list into the descriptor.  */
++extern void dvp_ctr_place_reg (const struct dvp_ctr_opcode *op, int n,
++			       unsigned int value, unsigned int *words);
++
++/* Look a keyword up on OP.  NULL if OP has no such keyword.  */
++extern const struct dvp_ctr_keyword *
++dvp_ctr_keyword_lookup (const struct dvp_ctr_opcode *op, const char *name);
++
++/* Encode a count into the command word: COUNT_MAX is representable and is
++   stored as zero, which is what the count field's width forces.  */
++extern const char *dvp_ctr_place_count (const struct dvp_ctr_opcode *op,
++					const struct dvp_ctr_field *field,
++					dvp_val count, unsigned int *words,
++					char *err, size_t errlen);
++
++/* The same encoding for a count that is not the command's own length: a GIF
++   register list's NREG has its own ceiling and its own zero convention, so the
++   two are passed in rather than read off the opcode.  */
++extern const char *dvp_ctr_place_count_max (unsigned int count_max,
++					    int zero_means_max,
++					    const struct dvp_ctr_field *field,
++					    dvp_val count, unsigned int *words,
++					    char *err, size_t errlen);
++
++/* Non-zero when a stored zero in FIELD is the spelling of OP's largest count
++   rather than of nothing -- that is, when the largest count accepted is one
++   more than the field can hold.
++
++   The answer is not uniform across this target's count fields: `unpack' and
++   `mpg' spell 256 as zero in an eight-bit field, `direct' and `directhl' spell
++   65536 as zero in a sixteen-bit one, and a GIF tag's NLOOP and a DMA tag's
++   quadword count spell zero as nothing but zero.
++
++   It matters because an *automatic* count of zero on one of the first four
++   would be the assembler emitting the maximum while claiming to have counted
++   the payload.  */
++extern int dvp_ctr_zero_means_max (const struct dvp_ctr_opcode *op,
++				   const struct dvp_ctr_field *field);
++
++/* The count OP's largest value is, for a diagnostic that has to name it.  */
++extern dvp_val dvp_ctr_count_max (const struct dvp_ctr_opcode *op);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* DVP_VIF_H */
+--- /dev/null
++++ b/include/opcode/dvp-vu.h
+@@ -0,0 +1,251 @@
++/* Declarative description of the PlayStation 2 VU microinstruction set.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of the GNU Binutils.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++/* A VU microinstruction is a 64-bit pair: one operation for the upper
++   (floating point) pipe and one for the lower pipe.  Each pipe's operation is
++   a 32-bit word.  Bit layout is described here entirely with shifts, widths
++   and explicit bit maps -- never with C bitfields -- so that layout is
++   independent of how the host compiler happens to pack structures, and so the
++   whole table can be regenerated from measurements.  Byte order is applied
++   separately, when the words are written to a fragment.  */
++
++#ifndef DVP_VU_H
++#define DVP_VU_H
++
++#include <stddef.h>
++#include "opcode/dvp-val.h"
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++#define DVP_PIPE_UPPER 0
++#define DVP_PIPE_LOWER 1
++
++/* Bytes per microinstruction, and the byte offset of each pipe's word.  */
++#define DVP_INSN_BYTES		8
++#define DVP_LOWER_WORD_OFFSET	0
++#define DVP_UPPER_WORD_OFFSET	4
++
++/* Register file sizes.  */
++#define DVP_NUM_VF	32
++#define DVP_NUM_VI	16
++
++/* Destination-component mask.  Bit 3 is x, bit 0 is w; the mask sits in the
++   instruction word at DVP_DEST_SHIFT with x most significant.  */
++#define DVP_DEST_SHIFT	21
++#define DVP_DEST_X	8
++#define DVP_DEST_Y	4
++#define DVP_DEST_Z	2
++#define DVP_DEST_W	1
++#define DVP_DEST_ALL	(DVP_DEST_X | DVP_DEST_Y | DVP_DEST_Z | DVP_DEST_W)
++
++/* Upper-pipe instruction flag bits.  */
++#define DVP_FLAG_I_BIT	31
++#define DVP_FLAG_E_BIT	30
++#define DVP_FLAG_M_BIT	29
++#define DVP_FLAG_D_BIT	28
++#define DVP_FLAG_T_BIT	27
++
++/* Field kinds.  */
++enum dvp_field_kind
++{
++  DVP_FLD_VF,		/* vf register, 0..31 */
++  DVP_FLD_VI,		/* vi register, 0..15 */
++  DVP_FLD_BC,		/* broadcast component selector, x=0 .. w=3 */
++  DVP_FLD_DEST,		/* destination component mask */
++  DVP_FLD_IMM,		/* integer immediate placed through BITMAP */
++  DVP_FLD_DISP		/* pc-relative branch displacement */
++};
++
++/* How a mnemonic treats a `.dest' specifier.  */
++enum dvp_dest_mode
++{
++  DVP_DEST_NONE,	/* no specifier permitted */
++  DVP_DEST_MASK,	/* any non-empty subset; omitting it means all four */
++  DVP_DEST_SINGLE,	/* exactly one component, and it is mandatory */
++  DVP_DEST_FIXED	/* one particular mask, spelled out and mandatory */
++};
++
++/* Per-instruction properties.  */
++#define DVP_INSN_NONE	0
++#define DVP_INSN_LOI	1	/* payload replaces the lower word wholesale */
++
++/* One operand field.
++
++   For DVP_FLD_IMM the placement is a bit map rather than a shift, because some
++   immediates are split across non-adjacent parts of the word and one does not
++   encode its low bits at all.  BITMAP[k] is the word bit immediate bit k lands
++   in, or -1 if that bit is not encoded -- in which case a non-zero value there
++   is an error, never a silent truncation.  */
++
++#define DVP_BIT_DROPPED (-1)
++
++struct dvp_vu_field
++{
++  unsigned char kind;			/* enum dvp_field_kind */
++  unsigned char shift;			/* for everything except DVP_FLD_IMM */
++  unsigned char width;			/* value width in bits */
++  unsigned char is_signed;		/* immediates and displacements */
++  const signed char *bitmap;		/* DVP_FLD_IMM only, WIDTH entries */
++  int reloc;				/* bfd_reloc_code_real_type, or 0 */
++};
++
++/* One mnemonic.
++
++   SYNTAX describes the operands that follow the mnemonic (and its optional
++   flag group and destination specifier).  Codes:
++
++     %f  vf register
++     %s  vf register whose optional component suffix names BC_SUFFIX, the one
++         component the mnemonic itself broadcasts, rather than the destination
++         specifier
++     %i  vi register
++     %b  broadcast selector; must abut the register it follows
++     %m  immediate
++     %t  branch target
++     %1  the fixed `vi01' operand -- a register lexeme whose value must be one,
++         so `vi1', `vi0001', `vi 1' and `vi+1' all name it.  Encodes nothing and
++         uses no FIELDS entry.
++     %d  an optional trailing single-component decoration after a memory
++         address, as in `ilw.x vi01, 0(vi02)x'.  It repeats the mnemonic's
++         destination component, must name exactly one, and encodes nothing.
++
++   The accumulator is written as the literal keyword below, named rather than
++   spelled inline because it is the one operand keyword that may repeat the
++   destination specifier as a suffix.
++
++   Every other character is a required literal.  Runs of identifier characters
++   are matched case-insensitively as whole words; punctuation is matched with
++   optional surrounding whitespace.  The n-th code in SYNTAX uses FIELDS[n].  If
++   DEST_FIELD is not -1 it indexes the field describing the destination mask,
++   written as part of the mnemonic rather than as an operand.  */
++
++#define DVP_ACC_KEYWORD "ACC"
++
++struct dvp_vu_opcode
++{
++  const char *name;
++  const char *syntax;
++  unsigned char pipe;
++  unsigned int fixed;			/* bits present regardless of operands */
++  unsigned char dest_mode;		/* enum dvp_dest_mode */
++  signed char dest_field;
++  unsigned char dest_fixed;		/* DVP_DEST_FIXED: the required mask */
++  unsigned char dest_or;		/* components forced on regardless of
++					   what the source spelled */
++  /* Any vf operand may repeat the destination specifier as a suffix, which
++     changes no bit.  On a `%s' operand the suffix names this one component
++     instead -- the one the mnemonic broadcasts.  Zero on everything else.  */
++  char bc_suffix;
++  unsigned char nfields;
++  const struct dvp_vu_field *fields;
++  unsigned char insn_flags;
++};
++
++extern const struct dvp_vu_opcode dvp_vu_opcodes[];
++extern const int dvp_vu_num_opcodes;
++
++/* --- parsing and encoding ------------------------------------------------ */
++
++/* A parsed operand.  When HAS_EXPR is set the value is not yet known and the
++   assembler adapter owns EXPR; otherwise VALUE is final.  */
++struct dvp_operand
++{
++  const struct dvp_vu_field *field;
++  dvp_val value;
++  int has_expr;
++  /* Set when the operand's value is not known yet and the field cannot carry a
++     relocation, so the assembler encodes zero now and settles the field once
++     every symbol is defined.  VALUE is that zero, so this layer encodes the
++     operand exactly as a written-out zero; nothing here reads EXPR.  */
++  int deferred;
++  void *expr;			/* expressionS *, opaque to this layer */
++};
++
++#define DVP_MAX_OPERANDS 8
++
++/* A whole operation, ready to encode.  */
++struct dvp_insn
++{
++  const struct dvp_vu_opcode *opcode;
++  unsigned int flag_bits;		/* upper-pipe flag group */
++  unsigned int dest;			/* component mask, or 0 */
++  int noperands;
++  struct dvp_operand operands[DVP_MAX_OPERANDS];
++};
++
++/* The one thing this layer cannot do itself: evaluate an expression.  The
++   adapter advances *PP, and either sets OP->value with HAS_EXPR clear, or
++   records the expression with HAS_EXPR set.  IS_BRANCH distinguishes a branch
++   target from a plain immediate.  Returns NULL, or ERR filled in.  */
++struct dvp_parse_hooks
++{
++  const char *(*get_expr) (void *ctx, char **pp, struct dvp_operand *op,
++			   int is_branch, char *err, size_t errlen);
++  void *ctx;
++};
++
++/* The narrowest and widest value a field accepts.  */
++extern void dvp_field_range (const struct dvp_vu_field *, dvp_val *lo,
++			     dvp_val *hi);
++
++/* Place VALUE into *WORD according to FIELD.  Pure: no I/O, no symbol lookup,
++   no diagnostics emitted.  Returns NULL, or ERR with an original message.  */
++extern const char *dvp_encode_field (const struct dvp_vu_field *field,
++				     dvp_val value, unsigned int *word,
++				     char *err, size_t errlen);
++
++/* Encode a fully validated operation.  Pure; returns NULL or ERR.  */
++extern const char *dvp_vu_encode (const struct dvp_insn *, unsigned int *word,
++				  char *err, size_t errlen);
++
++/* Look a mnemonic up in one pipe.  NULL if it is not there.  */
++extern const struct dvp_vu_opcode *dvp_vu_lookup (const char *name, int pipe);
++
++/* Parse a bracketed instruction flag group at *PP, if there is one.  */
++extern const char *dvp_parse_flags (char **pp, unsigned int *bits,
++				    char *err, size_t errlen);
++
++/* Parse the operands described by OP->syntax.  */
++extern const char *dvp_vu_parse_operands (const struct dvp_vu_opcode *op,
++					  char **pp, struct dvp_insn *insn,
++					  const struct dvp_parse_hooks *hooks,
++					  char *err, size_t errlen);
++
++/* Whether C is whitespace in the three places that take a vertical tab and a
++   form feed as well as a space and a tab, and the skip that goes with it.  See
++   the comment beside them in dvp-vu.c: the set of places is measured, and this
++   is deliberately not the assembler's general idea of whitespace.  */
++extern int dvp_vu_is_wide_space (int c);
++extern char *dvp_vu_skip_wide_space (char *p);
++
++/* Parse one complete operation for PIPE, mnemonic through last operand.  */
++extern const char *dvp_vu_parse_operation (char **pp, int pipe,
++					   struct dvp_insn *insn,
++					   const struct dvp_parse_hooks *hooks,
++					   char *err, size_t errlen);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* DVP_VU_H */
+--- a/opcodes/Makefile.am
++++ b/opcodes/Makefile.am
+@@ -151,6 +151,9 @@
+ 	frv-dis.c \
+ 	frv-ibld.c \
+ 	frv-opc.c \
++	dvp-dis.c \
++	dvp-vif.c \
++	dvp-vu.c \
+ 	ft32-dis.c \
+ 	ft32-opc.c \
+ 	h8300-dis.c \
+--- a/opcodes/Makefile.in
++++ b/opcodes/Makefile.in
+@@ -557,6 +557,9 @@
+ 	frv-dis.c \
+ 	frv-ibld.c \
+ 	frv-opc.c \
++	dvp-dis.c \
++	dvp-vif.c \
++	dvp-vu.c \
+ 	ft32-dis.c \
+ 	ft32-opc.c \
+ 	h8300-dis.c \
+--- a/opcodes/configure
++++ b/opcodes/configure
+@@ -14339,6 +14339,7 @@
+ 	bfd_dlx_arch)		ta="$ta dlx-dis.lo" ;;
+ 	bfd_fr30_arch)		ta="$ta fr30-asm.lo fr30-desc.lo fr30-dis.lo fr30-ibld.lo fr30-opc.lo" using_cgen=yes ;;
+ 	bfd_frv_arch)		ta="$ta frv-asm.lo frv-desc.lo frv-dis.lo frv-ibld.lo frv-opc.lo" using_cgen=yes ;;
++	bfd_dvp_arch)		ta="$ta dvp-vu.lo dvp-vif.lo dvp-dis.lo" ;;
+ 	bfd_ft32_arch)		ta="$ta ft32-opc.lo ft32-dis.lo" ;;
+ 	bfd_moxie_arch)		ta="$ta moxie-dis.lo moxie-opc.lo" ;;
+ 	bfd_h8300_arch)		ta="$ta h8300-dis.lo" ;;
+--- a/opcodes/configure.ac
++++ b/opcodes/configure.ac
+@@ -278,6 +278,7 @@
+ 	bfd_dlx_arch)		ta="$ta dlx-dis.lo" ;;
+ 	bfd_fr30_arch)		ta="$ta fr30-asm.lo fr30-desc.lo fr30-dis.lo fr30-ibld.lo fr30-opc.lo" using_cgen=yes ;;
+ 	bfd_frv_arch)		ta="$ta frv-asm.lo frv-desc.lo frv-dis.lo frv-ibld.lo frv-opc.lo" using_cgen=yes ;;
++	bfd_dvp_arch)		ta="$ta dvp-vu.lo dvp-vif.lo dvp-dis.lo" ;;
+ 	bfd_ft32_arch)		ta="$ta ft32-opc.lo ft32-dis.lo" ;;
+ 	bfd_moxie_arch)		ta="$ta moxie-dis.lo moxie-opc.lo" ;;
+ 	bfd_h8300_arch)		ta="$ta h8300-dis.lo" ;;
+--- a/opcodes/disassemble.c
++++ b/opcodes/disassemble.c
+@@ -70,6 +70,7 @@
+ #define ARCH_microblaze
+ #define ARCH_mn10200
+ #define ARCH_mn10300
++#define ARCH_dvp
+ #define ARCH_moxie
+ #define ARCH_mt
+ #define ARCH_msp430
+@@ -502,6 +503,11 @@
+       disassemble = print_insn_frv;
+       break;
+ #endif
++#ifdef ARCH_dvp
++    case bfd_arch_dvp:
++      disassemble = print_insn_dvp;
++      break;
++#endif
+ #ifdef ARCH_moxie
+     case bfd_arch_moxie:
+       disassemble = print_insn_moxie;
+--- a/opcodes/disassemble.h
++++ b/opcodes/disassemble.h
+@@ -70,6 +70,7 @@
+ extern int print_insn_mmix		(bfd_vma, disassemble_info *);
+ extern int print_insn_mn10200		(bfd_vma, disassemble_info *);
+ extern int print_insn_mn10300		(bfd_vma, disassemble_info *);
++extern int print_insn_dvp		(bfd_vma, disassemble_info *);
+ extern int print_insn_moxie		(bfd_vma, disassemble_info *);
+ extern int print_insn_msp430		(bfd_vma, disassemble_info *);
+ extern int print_insn_mt                (bfd_vma, disassemble_info *);
+--- /dev/null
++++ b/opcodes/dvp-dis.c
+@@ -0,0 +1,831 @@
++/* PlayStation 2 DVP instruction printing.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of the GNU Binutils.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++/* A DVP object holds four different instruction streams in one section, and
++   nothing in the bytes says which is which: a DMA tag, a VIF command, a GIF tag
++   and a VU microinstruction pair are all just words.  What distinguishes them is
++   the marker symbol the assembler puts at the start of each run, whose
++   `st_other' carries an STO_DVP_* value.  So this reads the
++   symbols covering the address it is asked about, and decodes accordingly; with
++   no symbols to go on it says so rather than guessing.
++
++   The marker bytes are the ones the container table carries
++   (DVP_MARK_*_OTHER), which is where they were measured; `STO_DVP_VU' in
++   elf/dvp.h is the same byte under the name a `.vu' label's marker has.
++
++   The printers work from the same tables the assembler parses with, so what
++   comes out is what the assembler takes back in.  That is the property worth
++   having and it is the one the tests check: for representative content of each
++   stream, disassembling and reassembling reproduces the bytes.  */
++
++#include "sysdep.h"
++#include <stdio.h>
++#include <string.h>
++#include "bfd.h"
++#include "dis-asm.h"
++#include "elf-bfd.h"
++#include "elf/dvp.h"
++#include "opcode/dvp-vu.h"
++#include "opcode/dvp-vif.h"
++#include "opintl.h"
++#include "disassemble.h"
++
++/* --- reading ------------------------------------------------------------- */
++
++static int
++dvp_read_words (bfd_vma addr, disassemble_info *info, unsigned int *out, int n)
++{
++  bfd_byte buf[4 * 8];
++  int status, i;
++
++  if (n > 8)
++    n = 8;
++  status = (*info->read_memory_func) (addr, buf, 4 * n, info);
++  if (status != 0)
++    {
++      (*info->memory_error_func) (status, addr, info);
++      return 0;
++    }
++  for (i = 0; i < n; i++)
++    out[i] = (unsigned int) bfd_getl32 (buf + 4 * i);
++  return 1;
++}
++
++/* --- which stream ------------------------------------------------------- */
++
++/* The marker symbol nearest at or before ADDR decides.  A DVP marker is a
++   symbol whose `st_other' names one of the four streams; ordinary symbols
++   carry none and are passed over.  */
++
++static int
++dvp_stream_at (bfd_vma addr, disassemble_info *info)
++{
++  int best = -1;
++  bfd_vma best_at = 0;
++  long i;
++
++  if (info->flavour != bfd_target_elf_flavour || info->symbols == NULL)
++    return -1;
++  for (i = 0; i < info->num_symbols; i++)
++    {
++      asymbol *sym = info->symbols[i];
++      elf_symbol_type *elf = (elf_symbol_type *) sym;
++      unsigned int sto;
++      bfd_vma at;
++      int kind;
++
++      if (sym == NULL || sym->section != info->section)
++	continue;
++      sto = elf->internal_elf_sym.st_other;
++      switch (sto)
++	{
++	case DVP_MARK_DMA_OTHER: kind = DVP_MARK_DMA_OTHER; break;
++	case DVP_MARK_VIF_OTHER: kind = DVP_MARK_VIF_OTHER; break;
++	case DVP_MARK_GIF_OTHER: kind = DVP_MARK_GIF_OTHER; break;
++	case DVP_MARK_VU_OTHER:  kind = DVP_MARK_VU_OTHER;  break;
++	default: continue;
++	}
++      at = sym->value + sym->section->vma;
++      if (at > addr)
++	continue;
++      if (best < 0 || at >= best_at)
++	{
++	  best = kind;
++	  best_at = at;
++	}
++    }
++  return best;
++}
++
++/* --- VU ----------------------------------------------------------------- */
++
++static const char *const dvp_dis_comp = "xyzw";
++
++static void
++dvp_dis_dest (disassemble_info *info, unsigned int mask)
++{
++  static const unsigned char bit[4] = { DVP_DEST_X, DVP_DEST_Y, DVP_DEST_Z,
++					DVP_DEST_W };
++  int i;
++
++  for (i = 0; i < 4; i++)
++    if (mask & bit[i])
++      (*info->fprintf_func) (info->stream, "%c", dvp_dis_comp[i]);
++}
++
++static unsigned int
++dvp_dis_field (const struct dvp_vu_field *f, unsigned int word)
++{
++  unsigned int v = 0;
++  int i;
++
++  if (f->kind == DVP_FLD_IMM && f->bitmap != NULL)
++    {
++      for (i = 0; i < f->width; i++)
++	if (f->bitmap[i] >= 0 && (word >> f->bitmap[i]) & 1)
++	  v |= 1u << i;
++      return v;
++    }
++  return (word >> f->shift) & ((f->width >= 32) ? 0xffffffffu
++					        : ((1u << f->width) - 1));
++}
++
++/* Print one pipe's operation.  Returns 0 if no table entry matches WORD.  */
++
++static int
++dvp_dis_vu_one (disassemble_info *info, unsigned int word, int pipe,
++		bfd_vma addr, int print)
++{
++  const struct dvp_vu_opcode *best = NULL;
++  unsigned int dest = 0;
++  const char *syn;
++  int i, nf;
++
++  /* The entry every bit of which the word satisfies.
++
++     An entry's set bits alone do not identify an operation: an opcode field is
++     sparse, so a subset match is ambiguous.  The signature is the whole word
++     outside the operands, compared exactly.  A mnemonic with a *fixed*
++     destination specifier -- `opmula', `opmsub', `clipw' -- has a destination
++     field in FIELDS whose bits belong to the signature rather than being free,
++     so its required value is folded into the signature here.  */
++  for (i = 0; i < dvp_vu_num_opcodes; i++)
++    {
++      const struct dvp_vu_opcode *op = &dvp_vu_opcodes[i];
++      unsigned int free_bits = 0, want = op->fixed;
++      int j;
++
++      if (op->pipe != (unsigned char) pipe)
++	continue;
++      /* `loi' is not a lower-pipe encoding.  Its operand replaces the lower
++	 word wholesale, and the upper pipe's I bit is the only indication that
++	 those 32 bits are a payload.  dvp_dis_vu handles that paired form
++	 before asking this matcher.  */
++      if (op->insn_flags & DVP_INSN_LOI)
++	continue;
++      for (j = 0; j < op->nfields; j++)
++	{
++	  const struct dvp_vu_field *f = &op->fields[j];
++	  unsigned int span;
++	  int k;
++
++	  if (j == op->dest_field && op->dest_mode == DVP_DEST_FIXED)
++	    {
++	      want |= (unsigned int) op->dest_fixed << f->shift;
++	      continue;
++	    }
++	  if (f->kind == DVP_FLD_IMM && f->bitmap != NULL)
++	    {
++	      for (k = 0; k < f->width; k++)
++		if (f->bitmap[k] >= 0)
++		  free_bits |= 1u << f->bitmap[k];
++	      continue;
++	    }
++	  span = (f->width >= 32) ? 0xffffffffu : ((1u << f->width) - 1);
++	  free_bits |= span << f->shift;
++	}
++      /* The upper pipe's flag bits are written as a group, not encoded by a
++	 field, so they are free too.  */
++      if (pipe == DVP_PIPE_UPPER)
++	free_bits |= 0xf8000000u;
++      if ((word & ~free_bits) != (want & ~free_bits))
++	continue;
++      /* An exact signature identifies one entry.  Where two share one they are
++	 spellings of the same operation, and the table's order decides.  */
++      if (best == NULL)
++	best = op;
++    }
++  if (best == NULL)
++    return 0;
++  if (!print)
++    return 1;
++
++  if (best->dest_field >= 0)
++    dest = dvp_dis_field (&best->fields[best->dest_field], word);
++  else if (best->dest_mode == DVP_DEST_FIXED)
++    dest = best->dest_fixed;
++
++  (*info->fprintf_func) (info->stream, "%s", best->name);
++  if (pipe == DVP_PIPE_UPPER)
++    {
++      unsigned int flags = word >> 27;
++
++      if (flags & 0x1f)
++	{
++	  (*info->fprintf_func) (info->stream, "[");
++	  if (word & (1u << DVP_FLAG_I_BIT))
++	    (*info->fprintf_func) (info->stream, "i");
++	  if (word & (1u << DVP_FLAG_E_BIT))
++	    (*info->fprintf_func) (info->stream, "e");
++	  if (word & (1u << DVP_FLAG_M_BIT))
++	    (*info->fprintf_func) (info->stream, "m");
++	  if (word & (1u << DVP_FLAG_D_BIT))
++	    (*info->fprintf_func) (info->stream, "d");
++	  if (word & (1u << DVP_FLAG_T_BIT))
++	    (*info->fprintf_func) (info->stream, "t");
++	  (*info->fprintf_func) (info->stream, "]");
++	}
++    }
++  if (best->dest_mode != DVP_DEST_NONE)
++    {
++      (*info->fprintf_func) (info->stream, ".");
++      dvp_dis_dest (info, dest);
++    }
++  if (best->syntax[0] == 0)
++    return 1;
++  (*info->fprintf_func) (info->stream, " ");
++
++  nf = 0;
++  for (syn = best->syntax; *syn; )
++    {
++      if (*syn == '%')
++	{
++	  int code = syn[1];
++	  const struct dvp_vu_field *f;
++	  unsigned int v;
++
++	  syn += 2;
++	  if (code == '1')
++	    {
++	      (*info->fprintf_func) (info->stream, "vi01");
++	      continue;
++	    }
++	  if (code == 'd')
++	    continue;		/* decoration; the mnemonic already said it */
++	  f = &best->fields[nf++];
++	  v = dvp_dis_field (f, word);
++	  switch (code)
++	    {
++	    case 'f':
++	      (*info->fprintf_func) (info->stream, "vf%02u", v);
++	      break;
++	    case 's':
++	      (*info->fprintf_func) (info->stream, "vf%02u", v);
++	      if (best->bc_suffix)
++		(*info->fprintf_func) (info->stream, "%c", best->bc_suffix);
++	      break;
++	    case 'i':
++	      (*info->fprintf_func) (info->stream, "vi%02u", v);
++	      break;
++	    case 'b':
++	      (*info->fprintf_func) (info->stream, "%c",
++				     dvp_dis_comp[v & 3]);
++	      break;
++	    case 'm':
++	      if (f->is_signed && f->width < 32
++		  && (v & (1u << (f->width - 1))))
++		(*info->fprintf_func) (info->stream, "%ld",
++				       (long) v - (1L << f->width));
++	      else
++		(*info->fprintf_func) (info->stream, "%lu", (unsigned long) v);
++	      break;
++	    case 't':
++	      {
++		long disp = (long) v;
++
++		if (f->width < 32 && (v & (1u << (f->width - 1))))
++		  disp -= 1L << f->width;
++		/* The displacement, written the way the assembler reads one: a
++		   branch operand that is an absolute value *is* the
++		   displacement, so this is source the assembler takes back.
++		   The target is named in a comment, which the assembler
++		   ignores.  */
++		(*info->fprintf_func) (info->stream, "%ld", disp);
++		(*info->fprintf_func) (info->stream, "\t; ");
++		(*info->print_address_func)
++		  (addr + DVP_INSN_BYTES + (disp * DVP_INSN_BYTES), info);
++	      }
++	      break;
++	    default:
++	      (*info->fprintf_func) (info->stream, "?");
++	      break;
++	    }
++	  continue;
++	}
++      if (*syn == ' ')
++	{
++	  ++syn;
++	  continue;
++	}
++      (*info->fprintf_func) (info->stream, "%c", *syn);
++      ++syn;
++    }
++  return 1;
++}
++
++static int
++dvp_dis_vu (bfd_vma addr, disassemble_info *info)
++{
++  unsigned int w[2];
++  unsigned int upper, lower;
++  int upper_known, lower_known, is_loi;
++
++  if (!dvp_read_words (addr, info, w, 2))
++    return -1;
++  upper = w[DVP_UPPER_WORD_OFFSET / 4];
++  lower = w[DVP_LOWER_WORD_OFFSET / 4];
++  upper_known = dvp_dis_vu_one (info, upper, DVP_PIPE_UPPER, addr, 0);
++  is_loi = (upper & (1u << DVP_FLAG_I_BIT)) != 0;
++  lower_known = is_loi || dvp_dis_vu_one (info, lower, DVP_PIPE_LOWER,
++					 addr, 0);
++
++  /* A half-decoded pair is worse than an explicit data pair: it looks like
++     source, but the unknown half cannot be assembled.  `.word' is valid in VU
++     mode and preserves both words exactly, so it is the lossless spelling
++     whenever either operation is unknown.  */
++  if (!upper_known || !lower_known)
++    {
++      (*info->fprintf_func) (info->stream, ".word 0x%08x, 0x%08x",
++			     lower, upper);
++      return DVP_INSN_BYTES;
++    }
++
++  dvp_dis_vu_one (info, upper, DVP_PIPE_UPPER, addr, 1);
++  (*info->fprintf_func) (info->stream, "\t");
++  /* The upper word's I flag says the lower word is not an operation at all but
++     the 32-bit payload of `loi'.  */
++  if (is_loi)
++    (*info->fprintf_func) (info->stream, "loi 0x%08x",
++				   lower);
++  else
++    dvp_dis_vu_one (info, lower, DVP_PIPE_LOWER, addr, 1);
++  return DVP_INSN_BYTES;
++}
++
++/* --- containers -------------------------------------------------------- */
++
++static dvp_val
++dvp_dis_ctr_field (const struct dvp_ctr_opcode *op,
++		   const struct dvp_ctr_field *f, const unsigned int *words)
++{
++  unsigned int w = words[f->word];
++  unsigned int mask;
++  dvp_val v;
++
++  (void) op;
++  /* A whole data word occupies its word entirely, and the table says so by
++     giving it no width at all -- the encoder writes the word rather than
++     placing a field in it.  */
++  if (f->cls == DVP_CO_WORD)
++    return (dvp_val) w;
++  mask = (f->width >= 32) ? 0xffffffffu : ((1u << f->width) - 1);
++  v = (w >> f->shift) & mask;
++  return v << f->value_lsb;
++}
++
++static void
++dvp_dis_ctr_mods (disassemble_info *info, const struct dvp_ctr_opcode *op,
++		  const unsigned int *words)
++{
++  static const char letters[DVP_MOD_COUNT] = { 'i', 'm', 'u', 'r', 's', '0', '1' };
++  char group[DVP_MOD_COUNT + 1];
++  int n = 0, i, j;
++
++  for (i = 0; i < DVP_MOD_COUNT; i++)
++    {
++      unsigned int mask = op->mod_mask[i];
++      unsigned int field;
++      int word;
++
++      if (!(op->mods & (1u << i)) || mask == 0)
++	continue;
++      word = op->cmd_slot + op->mod_word[i];
++      if (word < 0 || word >= DVP_CTR_MAX_HEADER)
++	continue;
++      /* Two letters that are two values of one field overlap, so a letter
++	 cannot be recognised by testing that its own bits are present: the DMA
++	 `0' stores 0b10 and `1' stores 0b11, and a subset test says `0' is
++	 present in both.  The field a letter belongs to is its own bits together
++	 with those of every letter it conflicts with, and the value in that
++	 field has to be the letter's exactly.  */
++      field = mask;
++      for (j = 0; j < DVP_MOD_COUNT; j++)
++	if ((op->mod_conflict[i] & (1u << j))
++	    && op->mod_word[j] == op->mod_word[i])
++	  field |= op->mod_mask[j];
++      if ((words[word] & field) == mask)
++	group[n++] = letters[i];
++    }
++  group[n] = 0;
++  if (n)
++    (*info->fprintf_func) (info->stream, "[%s]", group);
++}
++
++/* The VIF command byte, and the range of it the unpack family occupies: an
++   unpack's command word comes from its data format rather than from the
++   mnemonic, so the format table is what identifies one.  */
++#define DVP_DIS_CMD_MASK	0x7f000000u
++/* An unpack command byte is 0b011xxxxx: the two top bits say "unpack", the
++   next says whether the write mask applies, and the low four name the data
++   format.  The mask bit is a *modifier*, so it comes out of both the family
++   test and the format lookup.  */
++#define DVP_DIS_UNPACK_FAMILY	0x60000000u
++#define DVP_DIS_UNPACK_MASKBIT	0x10000000u
++#define DVP_DIS_FORMAT_MASK	(DVP_DIS_CMD_MASK & ~DVP_DIS_UNPACK_MASKBIT)
++
++static int
++dvp_dis_is_unpack (unsigned int word)
++{
++  return (word & DVP_DIS_UNPACK_FAMILY) == DVP_DIS_UNPACK_FAMILY;
++}
++
++static const struct dvp_ctr_format *
++dvp_dis_format (unsigned int word)
++{
++  int i;
++
++  for (i = 0; i < dvp_ctr_num_formats; i++)
++    if ((dvp_ctr_formats[i].fixed & DVP_DIS_FORMAT_MASK)
++	== (word & DVP_DIS_FORMAT_MASK))
++      return &dvp_ctr_formats[i];
++  return NULL;
++}
++
++/* The table entry whose fixed bits are all present, preferring the one with the
++   most of them.  An entry with no fixed bits at all is never chosen this way --
++   it would match every word -- so `unpack' is looked up by its format instead.  */
++
++static const struct dvp_ctr_opcode *
++dvp_dis_ctr_lookup (int kind, const unsigned int *words, unsigned int mask,
++		    int word)
++{
++  const struct dvp_ctr_opcode *best = NULL;
++  unsigned int best_bits = 0;
++  int i;
++
++  for (i = 0; i < dvp_ctr_num_opcodes; i++)
++    {
++      const struct dvp_ctr_opcode *op = &dvp_ctr_opcodes[i];
++      /* WORD is where the bits that tell these commands apart live.  It is not
++	 always the command slot: a GIF tag's three forms are distinguished by a
++	 mode field in the *second* word of the tag.  */
++      int w = word < 0 ? op->cmd_slot : word;
++      unsigned int fixed = op->fixed[w] & mask;
++      unsigned int bits = 0, b;
++
++      if (op->kind != (unsigned char) kind
++	  && !(kind == DVP_CTR_VIF && (op->kind == DVP_CTR_MPG
++				       || op->kind == DVP_CTR_DIRECT)))
++	continue;
++      if ((words[w] & mask) != fixed)
++	continue;
++      for (b = fixed; b; b >>= 1)
++	bits += b & 1;
++      if (best == NULL || bits > best_bits)
++	{
++	  best = op;
++	  best_bits = bits;
++	}
++    }
++  return best;
++}
++
++static void
++dvp_dis_ctr_operands (disassemble_info *info, const struct dvp_ctr_opcode *op,
++		      const unsigned int *words, int lead_comma)
++{
++  int i;
++
++  if (op->nkeywords)
++    {
++      const char *sep = " ";
++      int k;
++
++      for (k = 0; k < op->nkeywords; k++)
++	{
++	  const struct dvp_ctr_keyword *kw = &op->keywords[k];
++	  unsigned int v = (words[kw->word] >> kw->shift)
++			   & ((1u << kw->width) - 1);
++
++	  if (kw->kind == DVP_KW_FLAG)
++	    {
++	      if (v)
++		{
++		  (*info->fprintf_func) (info->stream, "%s%s", sep, kw->name);
++		  sep = ",";
++		}
++	      continue;
++	    }
++	  if (kw->kind == DVP_KW_REGS)
++	    {
++	      unsigned int nreg = (words[op->nreg_word] >> op->nreg_shift)
++				  & ((1u << op->nreg_width) - 1);
++	      unsigned int r;
++
++	      if (nreg == 0 && op->nreg_zero_means_max)
++		nreg = op->nreg_max;
++	      (*info->fprintf_func) (info->stream, "%s%s={", sep, kw->name);
++	      for (r = 0; r < nreg; r++)
++		{
++		  unsigned int bitpos = op->regs_shift + r * op->regs_width;
++		  unsigned int word = op->regs_word + bitpos / 32;
++		  unsigned int val;
++		  int j;
++
++		  if (word >= DVP_CTR_MAX_HEADER)
++		    break;
++		  val = (words[word] >> (bitpos % 32))
++			& ((1u << op->regs_width) - 1);
++		  if (r)
++		    (*info->fprintf_func) (info->stream, ",");
++		  for (j = 0; j < op->nregs; j++)
++		    if (op->regs[j].value == val)
++		      break;
++		  if (j < op->nregs)
++		    (*info->fprintf_func) (info->stream, "%s",
++					   op->regs[j].name);
++		  else
++		    (*info->fprintf_func) (info->stream, "0x%x", val);
++		}
++	      (*info->fprintf_func) (info->stream, "}");
++	      sep = ",";
++	      continue;
++	    }
++	  if (kw->pre_bit >= 0
++	      && !((words[kw->pre_word] >> kw->pre_bit) & 1))
++	    continue;			/* the tag says this one was left out */
++	  (*info->fprintf_func) (info->stream, "%s%s=%u", sep, kw->name, v);
++	  sep = ",";
++	}
++      return;
++    }
++
++  for (i = 0; i < op->nfields; i++)
++    {
++      const struct dvp_ctr_field *f = &op->fields[i];
++      dvp_val v = dvp_dis_ctr_field (op, f, words);
++
++      /* A count of zero on the one command whose count may be left out is the
++	 bare form.  Printing `dmaend 0' would round-trip the word and still be
++	 wrong: a written count opens a payload, so the source would want a
++	 `.enddmadata' the original did not have.  */
++      if (op->optional_last && i == op->nfields - 1 && v == 0
++	  && (f->cls == DVP_CO_QWC || f->cls == DVP_CO_QWCOUNT
++	      || f->cls == DVP_CO_NUM))
++	break;
++
++      if (i)
++	(*info->fprintf_func) (info->stream, ",");
++      else if (!lead_comma)
++	(*info->fprintf_func) (info->stream, " ");
++      switch (f->cls)
++	{
++	case DVP_CO_MODE:
++	case DVP_CO_NAME:
++	  {
++	    int j;
++
++	    for (j = 0; j < op->nmodes; j++)
++	      if ((dvp_val) op->modes[j].value == v)
++		break;
++	    if (j < op->nmodes)
++	      (*info->fprintf_func) (info->stream, "%s", op->modes[j].name);
++	    else
++	      (*info->fprintf_func) (info->stream, "%lu", (unsigned long) v);
++	  }
++	  break;
++	case DVP_CO_NUM:
++	case DVP_CO_QWCOUNT:
++	case DVP_CO_QWC:
++	  if (v == 0 && dvp_ctr_zero_means_max (op, f))
++	    (*info->fprintf_func) (info->stream, "%lu",
++				   (unsigned long) dvp_ctr_count_max (op));
++	  else
++	    (*info->fprintf_func) (info->stream, "%lu", (unsigned long) v);
++	  break;
++	case DVP_CO_VADDR:
++	case DVP_CO_DMAADDR:
++	  (*info->fprintf_func) (info->stream, "0x%lx", (unsigned long) v);
++	  break;
++	default:
++	  (*info->fprintf_func) (info->stream, "%lu", (unsigned long) v);
++	  break;
++	}
++    }
++}
++
++/* The write cycle the disassembled stream has set, so an `unpack' payload's
++   length can be worked out.  The cycle divides the element count and was set by
++   an earlier command, so it is tracked as the stream is printed; where nothing
++   has set it the ratio is one to one.  */
++static int dvp_dis_wl = -1;
++static int dvp_dis_cl = -1;
++
++/* Where the cycle was last set, so it can be forgotten when the disassembler
++   moves on.  It is state about *one* command stream: carried into another
++   object, or backwards over a section already walked, it would measure a
++   payload by a setting from somewhere else.  */
++static const void *dvp_dis_stream;
++static bfd_vma dvp_dis_at;
++
++static void
++dvp_dis_note_position (bfd_vma addr, disassemble_info *info)
++{
++  if (info->section != dvp_dis_stream || addr < dvp_dis_at)
++    {
++      dvp_dis_wl = dvp_dis_cl = -1;
++      dvp_dis_stream = info->section;
++    }
++  dvp_dis_at = addr;
++}
++
++/* Bytes of payload an `unpack' of NUM elements in FMT transfers under the
++   cycle in force.  The element is VN+1 components of 32>>VL bits, and a cycle
++   with WL > CL transfers CL of every WL, so the two cases differ.  */
++
++static int
++dvp_dis_unpack_bytes (const struct dvp_ctr_format *fmt, unsigned int num)
++{
++  int vl = (int) ((fmt->fixed >> 24) & 3);
++  int vn = (int) ((fmt->fixed >> 26) & 3);
++  int wl = dvp_dis_wl, cl = dvp_dis_cl;
++  int n, words;
++
++  if (wl < 0 || cl < 0)
++    wl = cl = 1;
++  if (num == 0)
++    num = 256;
++  if (wl == 0)
++    wl = 256;
++  if (wl <= cl)
++    n = (int) num;
++  else
++    {
++      int whole = (int) num % wl;
++
++      n = cl * (int) num / wl + (whole < cl ? whole : cl);
++    }
++  words = (((32 >> vl) * (vn + 1)) * n + 31) / 32;
++  return words * 4;
++}
++
++/* How many bytes the command at ADDR occupies, its payload included, so that a
++   payload is not read back as though it were a run of commands.  */
++
++static int
++dvp_dis_ctr_len (const struct dvp_ctr_opcode *op, const unsigned int *words,
++		 const struct dvp_ctr_format *fmt)
++{
++  dvp_val count;
++  const struct dvp_ctr_field *f;
++
++  if (op->kind == DVP_CTR_DMA)
++    /* A DMA tag's quadword is sixteen bytes, but its upper half holds two VIF
++       command words with a marker symbol of their own, so the tag itself is the
++       lower half.  */
++    return DVP_TAG_HALF_BYTES;
++  if (op->kind == DVP_CTR_GIF)
++    {
++      /* The tag, and the transfer it describes.  Returning only the tag left
++	 objdump decoding the payload as though it were another run of tags.  */
++      const struct dvp_ctr_keyword *k;
++      dvp_val nloop = 0, bytes;
++      int i;
++
++      for (i = 0; i < op->nkeywords; i++)
++	if (strcmp (op->keywords[i].name, "nloop") == 0)
++	  {
++	    k = &op->keywords[i];
++	    nloop = (words[k->word] >> k->shift) & ((1u << k->width) - 1);
++	    break;
++	  }
++      if (op->nregs == 0)
++	bytes = nloop * op->unit_bytes;
++      else
++	{
++	  unsigned int nreg = (words[op->nreg_word] >> op->nreg_shift)
++			      & ((1u << op->nreg_width) - 1);
++
++	  if (nreg == 0 && op->nreg_zero_means_max)
++	    nreg = op->nreg_max;
++	  bytes = nloop * nreg * op->loop_bytes_per_reg;
++	  /* A register list transfers half a quadword per register, so an odd
++	     number of halves is padded out to the quadword the next tag starts
++	     on.  */
++	  bytes = (bytes + DVP_TAG_BYTES - 1) / DVP_TAG_BYTES * DVP_TAG_BYTES;
++	}
++      return DVP_TAG_BYTES + (int) bytes;
++    }
++  if (op->nfields == 0)
++    return (int) op->nheader * 4;
++  f = &op->fields[op->nfields - 1];
++  if (f->cls != DVP_CO_NUM && f->cls != DVP_CO_QWCOUNT)
++    return (int) op->nheader * 4;
++  count = dvp_dis_ctr_field (op, f, words);
++  if (count == 0 && dvp_ctr_zero_means_max (op, f))
++    count = dvp_ctr_count_max (op);
++  if (op->kind == DVP_CTR_UNPACK && fmt != NULL)
++    return 4 + dvp_dis_unpack_bytes (fmt, (unsigned int) count);
++  return (int) op->nheader * 4 + (int) count * op->unit_bytes;
++}
++
++static int
++dvp_dis_container (bfd_vma addr, disassemble_info *info, int kind)
++{
++  unsigned int words[DVP_CTR_MAX_HEADER];
++  const struct dvp_ctr_opcode *op = NULL;
++  const struct dvp_ctr_format *fmt = NULL;
++  unsigned int mask;
++  int nwords, sigword;
++
++  memset (words, 0, sizeof (words));
++  switch (kind)
++    {
++    case DVP_CTR_DMA: nwords = 2;  mask = 0x70000000u; sigword = -1; break;
++    case DVP_CTR_GIF: nwords = 4;  mask = 0x0c000000u; sigword = 1;  break;
++    default:          nwords = 1;  mask = DVP_DIS_CMD_MASK; sigword = -1; break;
++    }
++  if (!dvp_read_words (addr, info, words, nwords))
++    return -1;
++
++  if (kind == DVP_CTR_VIF && dvp_dis_is_unpack (words[0]))
++    {
++      fmt = dvp_dis_format (words[0]);
++      if (fmt != NULL)
++	op = dvp_ctr_lookup ("unpack");
++    }
++  if (op == NULL)
++    op = dvp_dis_ctr_lookup (kind, words, mask, sigword);
++  if (op == NULL)
++    {
++      (*info->fprintf_func) (info->stream, ".word 0x%08x", words[0]);
++      return 4;
++    }
++  /* A five-word VIF command carries its data words after the command word.  A
++     DMA tag does not: its own half is two words, and the two after it are a VIF
++     command run with a marker symbol of their own.  */
++  if (kind != DVP_CTR_DMA && kind != DVP_CTR_GIF
++      && op->nheader > nwords
++      && !dvp_read_words (addr, info, words, op->nheader))
++    return -1;
++
++  (*info->fprintf_func) (info->stream, "%s", op->name);
++  if (op->kind != DVP_CTR_GIF)
++    dvp_dis_ctr_mods (info, op, words);
++  if (fmt != NULL)
++    (*info->fprintf_func) (info->stream, " %s,", fmt->name);
++  dvp_dis_ctr_operands (info, op, words, fmt != NULL);
++  /* A cycle-setting command changes what a later `unpack' payload measures.  */
++  if (op->nfields == 2 && (op->name[0] == 's' && op->name[1] == 't'
++			   && strncmp (op->name, "stcycl", 6) == 0))
++    {
++      dvp_dis_wl = (int) dvp_dis_ctr_field (op, &op->fields[0], words);
++      dvp_dis_cl = (int) dvp_dis_ctr_field (op, &op->fields[1], words);
++    }
++  return dvp_dis_ctr_len (op, words, fmt);
++}
++
++/* --- entry point ------------------------------------------------------- */
++
++int
++print_insn_dvp (bfd_vma addr, disassemble_info *info)
++{
++  int stream;
++
++  dvp_dis_note_position (addr, info);
++  stream = dvp_stream_at (addr, info);
++
++  switch (stream)
++    {
++    case DVP_MARK_VU_OTHER:
++      return dvp_dis_vu (addr, info);
++    case DVP_MARK_DMA_OTHER:
++      return dvp_dis_container (addr, info, DVP_CTR_DMA);
++    case DVP_MARK_GIF_OTHER:
++      return dvp_dis_container (addr, info, DVP_CTR_GIF);
++    case DVP_MARK_VIF_OTHER:
++      return dvp_dis_container (addr, info, DVP_CTR_VIF);
++    default:
++      break;
++    }
++  /* Nothing says which stream this is.  A DVP section's streams are told apart
++     by their marker symbols and by nothing in the bytes.  */
++  {
++    unsigned int w;
++
++    if (!dvp_read_words (addr, info, &w, 1))
++      return -1;
++    (*info->fprintf_func) (info->stream, ".word 0x%08x", w);
++    (*info->fprintf_func) (info->stream,
++			   _("\t; no DVP marker symbol covers this address"));
++  }
++  return 4;
++}
+--- /dev/null
++++ b/opcodes/dvp-vif-tbl.h
+@@ -0,0 +1,185 @@
++/* DVP container table -- GENERATED, DO NOT EDIT.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of the GNU Binutils.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++/* Generated from an authored container grammar and measured encodings.  */
++
++
++static const struct dvp_ctr_field dvp_f_0[] =	/* stcycl */
++{
++  { DVP_CO_U8, 0, 0, 8, 8 },
++  { DVP_CO_U8, 0, 0, 0, 8 },
++};
++static const struct dvp_ctr_field dvp_f_1[] =	/* mskpath3 */
++{
++  { DVP_CO_NAME, 0, 0, 15, 1 },
++};
++static const struct dvp_ctr_mode dvp_m_0[] =	/* mskpath3 */
++{
++  { "enable", 0u },
++  { "disable", 1u },
++};
++static const struct dvp_ctr_field dvp_f_2[] =	/* offset base itop mark mscal mscalf */
++{
++  { DVP_CO_U16, 0, 0, 0, 16 },
++};
++static const struct dvp_ctr_field dvp_f_3[] =	/* stmod */
++{
++  { DVP_CO_MODE, 0, 0, 0, 2 },
++};
++static const struct dvp_ctr_mode dvp_m_1[] =	/* stmod */
++{
++  { "direct", 0u },
++  { "add", 1u },
++  { "addrow", 2u },
++};
++static const struct dvp_ctr_field dvp_f_4[] =	/* stmask */
++{
++  { DVP_CO_WORD, 1, 0, 0, 0 },
++};
++static const struct dvp_ctr_field dvp_f_5[] =	/* strow stcol */
++{
++  { DVP_CO_WORD, 1, 0, 0, 0 },
++  { DVP_CO_WORD, 2, 0, 0, 0 },
++  { DVP_CO_WORD, 3, 0, 0, 0 },
++  { DVP_CO_WORD, 4, 0, 0, 0 },
++};
++static const struct dvp_ctr_field dvp_f_6[] =	/* unpack */
++{
++  { DVP_CO_VADDR, 0, 0, 0, 10 },
++  { DVP_CO_NUM, 0, 0, 16, 8 },
++};
++static const struct dvp_ctr_field dvp_f_7[] =	/* mpg */
++{
++  { DVP_CO_VADDR, 0, 0, 0, 16 },
++  { DVP_CO_NUM, 0, 0, 16, 8 },
++};
++static const struct dvp_ctr_field dvp_f_8[] =	/* direct directhl */
++{
++  { DVP_CO_QWCOUNT, 0, 0, 0, 16 },
++};
++static const struct dvp_ctr_keyword dvp_k_0[] =	/* gifimage */
++{
++  { "nloop", DVP_KW_VALUE, 0, 0, 0, 15, -1, -1, DVP_KWNUM_DECIMAL },
++  { "eop", DVP_KW_FLAG, 0, 0, 15, 1, -1, -1, DVP_KWNUM_DECIMAL },
++};
++static const struct dvp_ctr_keyword dvp_k_1[] =	/* gifpacked */
++{
++  { "prim", DVP_KW_VALUE, 0, 1, 15, 11, 1, 14, DVP_KWNUM_C },
++  { "regs", DVP_KW_REGS, 1, 2, 0, 4, -1, -1, DVP_KWNUM_DECIMAL },
++  { "nloop", DVP_KW_VALUE, 0, 0, 0, 15, -1, -1, DVP_KWNUM_DECIMAL },
++  { "eop", DVP_KW_FLAG, 0, 0, 15, 1, -1, -1, DVP_KWNUM_DECIMAL },
++};
++static const struct dvp_ctr_mode dvp_r_0[] =	/* gifpacked gifreglist */
++{
++  { "prim", 0u },
++  { "rgbaq", 1u },
++  { "st", 2u },
++  { "uv", 3u },
++  { "xyzf2", 4u },
++  { "xyz2", 5u },
++  { "tex0_1", 6u },
++  { "tex0_2", 7u },
++  { "clamp_1", 8u },
++  { "clamp_2", 9u },
++  { "xyzf", 10u },
++  { "unused11", 11u },
++  { "xyzf3", 12u },
++  { "xyz3", 13u },
++  { "a_d", 14u },
++  { "nop", 15u },
++};
++static const struct dvp_ctr_keyword dvp_k_2[] =	/* gifreglist */
++{
++  { "regs", DVP_KW_REGS, 1, 2, 0, 4, -1, -1, DVP_KWNUM_DECIMAL },
++  { "nloop", DVP_KW_VALUE, 0, 0, 0, 15, -1, -1, DVP_KWNUM_DECIMAL },
++  { "eop", DVP_KW_FLAG, 0, 0, 15, 1, -1, -1, DVP_KWNUM_DECIMAL },
++};
++static const struct dvp_ctr_field dvp_f_9[] =	/* dmacnt dmaret dmaend */
++{
++  { DVP_CO_QWC, 0, 0, 0, 16 },
++};
++static const struct dvp_ctr_field dvp_f_10[] =	/* dmanext dmaref dmarefs dmarefe dmacall */
++{
++  { DVP_CO_QWC, 0, 0, 0, 16 },
++  { DVP_CO_DMAADDR, 1, 4, 4, 27 },
++};
++
++static const struct dvp_ctr_format dvp_ctr_formats_tbl[] =
++{
++  { "s_16", 0x61000000u, 2 },
++  { "s_32", 0x60000000u, 4 },
++  { "s_8", 0x62000000u, 1 },
++  { "v2_16", 0x65000000u, 4 },
++  { "v2_32", 0x64000000u, 8 },
++  { "v2_8", 0x66000000u, 2 },
++  { "v3_16", 0x69000000u, 6 },
++  { "v3_32", 0x68000000u, 12 },
++  { "v3_8", 0x6a000000u, 3 },
++  { "v4_16", 0x6d000000u, 8 },
++  { "v4_32", 0x6c000000u, 16 },
++  { "v4_5", 0x6f000000u, 2 },
++  { "v4_8", 0x6e000000u, 4 },
++};
++
++const struct dvp_ctr_opcode dvp_ctr_opcodes[] =
++{
++  { "vifnop", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, NULL, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "stcycl", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x01000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_0, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "stcycle", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x01000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_0, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "mskpath3", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x06000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_1, dvp_m_0, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "offset", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x02000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_2, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "base", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x03000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_2, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "itop", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x04000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_2, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "stmod", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x05000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_3, dvp_m_1, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "mark", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x07000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_2, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "flushe", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x10000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, NULL, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "flush", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x11000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, NULL, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "flusha", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x13000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, NULL, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "mscal", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x14000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_2, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "mscalf", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x15000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_2, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "mscnt", DVP_CTR_VIF, DVP_BLK_NONE, 1, 0, 0, 0, 0, 0, DVP_MOD_I, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x17000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, NULL, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "stmask", DVP_CTR_VIF, DVP_BLK_NONE, 2, 0, 0, 0, 0, 0, DVP_MOD_I, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x20000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_4, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "strow", DVP_CTR_VIF, DVP_BLK_NONE, 5, 0, 0, 0, 0, 0, DVP_MOD_I, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x30000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_5, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "stcol", DVP_CTR_VIF, DVP_BLK_NONE, 5, 0, 0, 0, 0, 0, DVP_MOD_I, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x31000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_5, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "unpack", DVP_CTR_UNPACK, DVP_BLK_DATA, 1, 0, 0, 0, 0, 4, DVP_MOD_I | DVP_MOD_M | DVP_MOD_U | DVP_MOD_R, 2, 0, 0, 0, 0, 0, 0, 0, 256, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_6, NULL, NULL, NULL, ".endunpack", { 0x80000000u, 0x10000000u, 0x00004000u, 0x00008000u, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "mpg", DVP_CTR_MPG, DVP_BLK_VU, 1, 0, 0, 8, 8, 0, DVP_MOD_I, 2, 0, 0, 8, 0, 0, 0, 1, 256, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x4a000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_7, NULL, NULL, NULL, ".endmpg", { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "direct", DVP_CTR_DIRECT, DVP_BLK_DATA, 1, 0, 0, 16, 16, 0, DVP_MOD_I, 1, 0, 0, 16, 0, 0, 0, 1, 65536, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x50000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_8, NULL, NULL, NULL, ".enddirect", { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "directhl", DVP_CTR_DIRECT, DVP_BLK_DATA, 1, 0, 0, 16, 16, 0, DVP_MOD_I, 1, 0, 0, 16, 0, 0, 0, 1, 65536, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x51000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_8, NULL, NULL, NULL, ".enddirect", { 0x80000000u, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "gifimage", DVP_CTR_GIF, DVP_BLK_DATA, 4, 0, 16, 0, 16, 0, 0, 0, 0, 2, 16, 1, 0, 0, 1, 32767, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x00000000u, 0x08000000u, 0x00000000u, 0x00000000u, 0x00000000u }, NULL, NULL, NULL, dvp_k_0, ".endgif", { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "gifpacked", DVP_CTR_GIF, DVP_BLK_DATA, 4, 0, 16, 0, 16, 16, 0, 0, 0, 4, 16, 0, 0, 0, 1, 32767, 1, 1, 28, 4, 1, 2, 0, 4, 16, 16, 16, { 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, NULL, NULL, dvp_r_0, dvp_k_1, ".endgif", { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "gifreglist", DVP_CTR_GIF, DVP_BLK_DATA, 4, 0, 16, 0, 16, 16, 0, 0, 0, 3, 16, 0, 0, 0, 1, 32767, 1, 1, 28, 4, 1, 2, 0, 4, 8, 16, 16, { 0x00000000u, 0x04000000u, 0x00000000u, 0x00000000u, 0x00000000u }, NULL, NULL, dvp_r_0, dvp_k_2, ".endgif", { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } },
++  { "dmacnt", DVP_CTR_DMA, DVP_BLK_DATA, 4, 0, 16, 0, 16, 16, DVP_MOD_I | DVP_MOD_S | DVP_MOD_ZERO | DVP_MOD_ONE, 1, 0, 0, 16, 1, 0, 1, 1, 65535, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x10000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_9, NULL, NULL, NULL, ".enddmadata", { 0x80000000u, 0, 0, 0, 0x80000000u, 0x08000000u, 0x0c000000u }, { 0, 0, 0, 0, 1, 0, 0 }, { 0, 0, 0, 0, 0, DVP_MOD_ONE, DVP_MOD_ZERO } },
++  { "dmanext", DVP_CTR_DMA, DVP_BLK_DATA, 4, 0, 16, 0, 16, 16, DVP_MOD_I | DVP_MOD_S | DVP_MOD_ZERO | DVP_MOD_ONE, 2, 0, 0, 16, 1, 0, 1, 1, 65535, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x20000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_10, NULL, NULL, NULL, ".enddmadata", { 0x80000000u, 0, 0, 0, 0x80000000u, 0x08000000u, 0x0c000000u }, { 0, 0, 0, 0, 1, 0, 0 }, { 0, 0, 0, 0, 0, DVP_MOD_ONE, DVP_MOD_ZERO } },
++  { "dmaref", DVP_CTR_DMA, DVP_BLK_NONE, 4, 0, 16, 0, 16, 0, DVP_MOD_I | DVP_MOD_S | DVP_MOD_ZERO | DVP_MOD_ONE, 2, 0, 0, 16, 1, 0, 0, 0, 65535, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x30000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_10, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0x80000000u, 0x08000000u, 0x0c000000u }, { 0, 0, 0, 0, 1, 0, 0 }, { 0, 0, 0, 0, 0, DVP_MOD_ONE, DVP_MOD_ZERO } },
++  { "dmarefs", DVP_CTR_DMA, DVP_BLK_NONE, 4, 0, 16, 0, 16, 0, DVP_MOD_I | DVP_MOD_S | DVP_MOD_ZERO | DVP_MOD_ONE, 2, 0, 0, 16, 1, 0, 0, 0, 65535, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x40000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_10, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0x80000000u, 0x08000000u, 0x0c000000u }, { 0, 0, 0, 0, 1, 0, 0 }, { 0, 0, 0, 0, 0, DVP_MOD_ONE, DVP_MOD_ZERO } },
++  { "dmarefe", DVP_CTR_DMA, DVP_BLK_NONE, 4, 0, 16, 0, 16, 0, DVP_MOD_I | DVP_MOD_S | DVP_MOD_ZERO | DVP_MOD_ONE, 2, 0, 0, 16, 1, 0, 0, 0, 65535, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_10, NULL, NULL, NULL, NULL, { 0x80000000u, 0, 0, 0, 0x80000000u, 0x08000000u, 0x0c000000u }, { 0, 0, 0, 0, 1, 0, 0 }, { 0, 0, 0, 0, 0, DVP_MOD_ONE, DVP_MOD_ZERO } },
++  { "dmacall", DVP_CTR_DMA, DVP_BLK_DATA, 4, 0, 16, 0, 16, 16, DVP_MOD_I | DVP_MOD_S | DVP_MOD_ZERO | DVP_MOD_ONE, 2, 0, 0, 16, 1, 0, 1, 1, 65535, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x50000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_10, NULL, NULL, NULL, ".enddmadata", { 0x80000000u, 0, 0, 0, 0x80000000u, 0x08000000u, 0x0c000000u }, { 0, 0, 0, 0, 1, 0, 0 }, { 0, 0, 0, 0, 0, DVP_MOD_ONE, DVP_MOD_ZERO } },
++  { "dmaret", DVP_CTR_DMA, DVP_BLK_DATA, 4, 0, 16, 0, 16, 16, DVP_MOD_I | DVP_MOD_S | DVP_MOD_ZERO | DVP_MOD_ONE, 1, 0, 0, 16, 1, 0, 1, 1, 65535, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x60000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_9, NULL, NULL, NULL, ".enddmadata", { 0x80000000u, 0, 0, 0, 0x80000000u, 0x08000000u, 0x0c000000u }, { 0, 0, 0, 0, 1, 0, 0 }, { 0, 0, 0, 0, 0, DVP_MOD_ONE, DVP_MOD_ZERO } },
++  { "dmaend", DVP_CTR_DMA, DVP_BLK_DATA, 4, 0, 16, 0, 16, 16, DVP_MOD_I | DVP_MOD_S | DVP_MOD_ZERO | DVP_MOD_ONE, 1, 0, 0, 16, 1, 1, 1, 1, 65535, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0x70000000u, 0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u }, dvp_f_9, NULL, NULL, NULL, ".enddmadata", { 0x80000000u, 0, 0, 0, 0x80000000u, 0x08000000u, 0x0c000000u }, { 0, 0, 0, 0, 1, 0, 0 }, { 0, 0, 0, 0, 0, DVP_MOD_ONE, DVP_MOD_ZERO } },
++};
++
++const int dvp_ctr_num_opcodes
++  = (int) (sizeof (dvp_ctr_opcodes) / sizeof (dvp_ctr_opcodes[0]));
++
++const struct dvp_ctr_format *const dvp_ctr_formats
++  = dvp_ctr_formats_tbl;
++const int dvp_ctr_num_formats
++  = (int) (sizeof (dvp_ctr_formats_tbl) / sizeof (dvp_ctr_formats_tbl[0]));
+--- /dev/null
++++ b/opcodes/dvp-vif.c
+@@ -0,0 +1,392 @@
++/* PlayStation 2 DVP container command lookup, validation and encoding.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of the GNU Binutils.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++/* Like opcodes/dvp-vu.c, this file knows nothing about GNU as.  It owns the
++   container table, the modifier grammar, and the arithmetic that puts a value
++   into a command word.  Everything that needs a symbol table, a fragment or a
++   diagnostic channel lives in gas/config/tc-dvp.c.
++
++   Nothing here truncates, masks or wraps: an out-of-range value, or one whose
++   low bits the field does not encode, is reported to the caller.  */
++
++#include "sysdep.h"
++#include <stdio.h>
++#include <string.h>
++#include <limits.h>
++#include "bfd.h"
++#include "opcode/dvp-vif.h"
++
++#include "dvp-vif-tbl.h"
++
++static int
++dvp_ctr_tolower (int c)
++{
++  return (c >= 'A' && c <= 'Z') ? c - 'A' + 'a' : c;
++}
++
++static int
++dvp_ctr_casecmp (const char *a, const char *b)
++{
++  for (; *a && *b; a++, b++)
++    if (dvp_ctr_tolower ((unsigned char) *a)
++	!= dvp_ctr_tolower ((unsigned char) *b))
++      return 1;
++  return *a || *b;
++}
++
++/* --------------------------------------------------------------- table access */
++
++const struct dvp_ctr_opcode *
++dvp_ctr_lookup (const char *name)
++{
++  int i;
++
++  for (i = 0; i < dvp_ctr_num_opcodes; i++)
++    if (dvp_ctr_casecmp (dvp_ctr_opcodes[i].name, name) == 0)
++      return &dvp_ctr_opcodes[i];
++  return NULL;
++}
++
++const struct dvp_ctr_format *
++dvp_ctr_format_lookup (const char *name)
++{
++  int i;
++
++  for (i = 0; i < dvp_ctr_num_formats; i++)
++    if (dvp_ctr_casecmp (dvp_ctr_formats[i].name, name) == 0)
++      return &dvp_ctr_formats[i];
++  return NULL;
++}
++
++dvp_val
++dvp_ctr_mode_value (const struct dvp_ctr_opcode *op, const char *name)
++{
++  int i;
++
++  for (i = 0; i < op->nmodes; i++)
++    if (dvp_ctr_casecmp (op->modes[i].name, name) == 0)
++      return (dvp_val) op->modes[i].value;
++  return -1;
++}
++
++dvp_val
++dvp_ctr_reg_value (const struct dvp_ctr_opcode *op, const char *name)
++{
++  int i;
++
++  for (i = 0; i < op->nregs; i++)
++    if (dvp_ctr_casecmp (op->regs[i].name, name) == 0)
++      return (dvp_val) op->regs[i].value;
++  return -1;
++}
++
++/* The Nth entry of a register list.  Entries are consecutive fields of the
++   descriptor, so one that runs past a word carries on in the next.  */
++
++void
++dvp_ctr_place_reg (const struct dvp_ctr_opcode *op, int n, unsigned int value,
++		   unsigned int *words)
++{
++  unsigned int per_word = 32u / op->regs_width;
++  unsigned int mask = (1u << op->regs_width) - 1;
++  unsigned int word = op->regs_word + (unsigned int) n / per_word;
++  unsigned int shift = op->regs_shift
++		       + ((unsigned int) n % per_word) * op->regs_width;
++
++  words[word] &= ~(mask << shift);
++  words[word] |= (value & mask) << shift;
++}
++
++const struct dvp_ctr_keyword *
++dvp_ctr_keyword_lookup (const struct dvp_ctr_opcode *op, const char *name)
++{
++  int i;
++
++  for (i = 0; i < op->nkeywords; i++)
++    if (dvp_ctr_casecmp (op->keywords[i].name, name) == 0)
++      return &op->keywords[i];
++  return NULL;
++}
++
++/* ------------------------------------------------------------------ modifiers */
++
++static const char dvp_ctr_mod_letters[DVP_MOD_COUNT] =
++  { 'i', 'm', 'u', 'r', 's', '0', '1' };
++
++/* The letter DVP_MOD_* bit BIT stands for, for a diagnostic that has to name
++   it.  */
++
++static int
++dvp_ctr_mod_letter (unsigned int bit)
++{
++  int i;
++
++  for (i = 0; i < DVP_MOD_COUNT; i++)
++    if (bit == (1u << i))
++      return dvp_ctr_mod_letters[i];
++  return '?';
++}
++
++const char *
++dvp_ctr_parse_mods (char **pp, const struct dvp_ctr_opcode *op,
++		    unsigned int *mods, char *err, size_t errlen)
++{
++  unsigned int allowed = op->mods;
++  char *p = *pp;
++  int i;
++
++  *mods = 0;
++  if (*p != '[')
++    return NULL;
++  /* Three commands have no bracketed group at all, and an empty one is not
++     "no modifiers" there but a bracket where the operands were expected.  */
++  if (op->kind == DVP_CTR_GIF)
++    {
++      snprintf (err, errlen,
++		"a GIF tag takes no bracketed modifiers, so \"[\" cannot "
++		"follow \"%s\"", op->name);
++      return err;
++    }
++  ++p;
++  while (*p && *p != ']')
++    {
++      int c = dvp_ctr_tolower ((unsigned char) *p);
++      unsigned int bit = 0;
++      unsigned int clash;
++
++      for (i = 0; i < DVP_MOD_COUNT; i++)
++	if (dvp_ctr_mod_letters[i] == c)
++	  bit = 1u << i;
++      if (bit == 0 || (bit & allowed) == 0)
++	{
++	  char have[DVP_MOD_COUNT + 1];
++	  int n = 0;
++
++	  for (i = 0; i < DVP_MOD_COUNT; i++)
++	    if (allowed & (1u << i))
++	      have[n++] = dvp_ctr_mod_letters[i];
++	  have[n] = 0;
++	  if (n == 0)
++	    snprintf (err, errlen,
++		      "\"%c\": this command takes no modifier letters", *p);
++	  else
++	    snprintf (err, errlen,
++		      "\"%c\" is not a modifier letter this command takes; it "
++		      "takes %s", *p, have);
++	  return err;
++	}
++      /* Two letters that put different values into one field cannot both be
++	 given: whichever the encoder applied second would silently win.  */
++      clash = 0;
++      for (i = 0; i < DVP_MOD_COUNT; i++)
++	if (bit == (1u << i))
++	  clash = op->mod_conflict[i] & *mods;
++      if (clash != 0)
++	{
++	  unsigned int other = clash & (~clash + 1u);
++
++	  snprintf (err, errlen,
++		    "\"%c\" and \"%c\" are two values of one field, so only one "
++		    "of them can be given", dvp_ctr_mod_letter (other), *p);
++	  return err;
++	}
++      /* A letter written again names the same modifier: it raises the same
++	 bits, so it is accepted and changes nothing.  */
++      *mods |= bit;
++      ++p;
++    }
++  if (*p != ']')
++    {
++      snprintf (err, errlen, "the modifier group is missing its closing \"]\"");
++      return err;
++    }
++  *pp = p + 1;
++  return NULL;
++}
++
++void
++dvp_ctr_apply_mods (const struct dvp_ctr_opcode *op, unsigned int mods,
++		    unsigned int *words)
++{
++  int i;
++
++  for (i = 0; i < DVP_MOD_COUNT; i++)
++    if (mods & (1u << i))
++      words[op->cmd_slot + op->mod_word[i]] |= op->mod_mask[i];
++}
++
++/* -------------------------------------------------------------- field placing */
++
++void
++dvp_ctr_field_range (const struct dvp_ctr_opcode *op,
++		     const struct dvp_ctr_field *field, dvp_val *lo, dvp_val *hi)
++{
++  switch (field->cls)
++    {
++    case DVP_CO_WORD:
++      /* A whole data word is unsigned: 0 .. 2**32-1.  The negative half of the
++	 width is deliberately not taken -- that would let the field's *width*
++	 decide what a negative value means, and encode a number the source did
++	 not write.  `stmask 0xffffffff' is how a source asks for every bit.  */
++      *lo = 0;
++      *hi = (dvp_val) 0xffffffffu;
++      return;
++    case DVP_CO_NUM:
++    case DVP_CO_QWCOUNT:
++    case DVP_CO_QWC:
++      *lo = 0;
++      *hi = op->count_max;
++      return;
++    case DVP_CO_MODE:
++      *lo = 0;
++      *hi = (dvp_val) op->modes[op->nmodes - 1].value;
++      return;
++    case DVP_CO_DMAADDR:
++      *lo = 0;
++      /* The field encodes value bits VALUE_LSB..VALUE_LSB+WIDTH-1.  */
++      *hi = (dvp_val) (((((dvp_uval) 1 << (field->value_lsb + field->width))
++			- 1)
++		       & ~(((dvp_uval) 1 << field->value_lsb) - 1)));
++      return;
++    default:
++      *lo = 0;
++      /* The field encodes value bits VALUE_LSB..VALUE_LSB+WIDTH-1, so a field
++	 that drops low bits reaches proportionally further.  VALUE_LSB is zero
++	 for every field written out, but not for an `mpg' load address, which
++	 is taken in eight-byte steps and reaches 0x7fff8.  */
++      *hi = (dvp_val) (((((dvp_uval) 1 << (field->value_lsb + field->width))
++			- 1)
++		       & ~(((dvp_uval) 1 << field->value_lsb) - 1)));
++      return;
++    }
++}
++
++const char *
++dvp_ctr_place (const struct dvp_ctr_opcode *op,
++	       const struct dvp_ctr_field *field, dvp_val value,
++	       unsigned int *words, char *err, size_t errlen)
++{
++  dvp_val lo, hi;
++  dvp_uval v;
++
++  dvp_ctr_field_range (op, field, &lo, &hi);
++  if (value < lo || value > hi)
++    {
++      snprintf (err, errlen,
++		"%s: the value " DVP_VAL_FMT " is outside the permitted range "
++		DVP_VAL_FMT ".." DVP_VAL_FMT,
++		op->name, DVP_VAL_PRINT (value), DVP_VAL_PRINT (lo),
++		DVP_VAL_PRINT (hi));
++      return err;
++    }
++
++  if (field->cls == DVP_CO_WORD)
++    {
++      /* A whole data word carries any 32-bit pattern, so it has no field to
++	 shift into -- but the range check above is what stops a wider value
++	 being cut down to its low 32 bits by this assignment.  */
++      words[field->word] = (unsigned int) value;
++      return NULL;
++    }
++  if (field->value_lsb != 0
++      && (value & (dvp_val) (((dvp_uval) 1 << field->value_lsb) - 1)) != 0)
++    {
++      snprintf (err, errlen,
++		"%s: " DVP_VAL_FMT " does not fit this field, which cannot "
++		"express its low %u bits; use a multiple of " DVP_VAL_FMT,
++		op->name, DVP_VAL_PRINT (value), (unsigned) field->value_lsb,
++		DVP_VAL_PRINT ((dvp_val) ((dvp_uval) 1 << field->value_lsb)));
++      return err;
++    }
++
++  v = ((dvp_uval) value >> field->value_lsb)
++      & (((dvp_uval) 1 << field->width) - 1);
++  words[field->word] &= ~(unsigned int) ((((dvp_uval) 1 << field->width) - 1)
++					 << field->shift);
++  words[field->word] |= (unsigned int) (v << field->shift);
++  return NULL;
++}
++
++int
++dvp_ctr_zero_means_max (const struct dvp_ctr_opcode *op,
++			const struct dvp_ctr_field *field)
++{
++  dvp_uval holds;
++
++  if (field->width == 0 || field->width >= sizeof (dvp_uval) * CHAR_BIT)
++    return 0;
++  holds = ((dvp_uval) 1 << field->width) - 1;
++  return (dvp_uval) op->count_max > holds;
++}
++
++dvp_val
++dvp_ctr_count_max (const struct dvp_ctr_opcode *op)
++{
++  return (dvp_val) op->count_max;
++}
++
++const char *
++dvp_ctr_place_count_max (unsigned int count_max, int zero_means_max,
++			 const struct dvp_ctr_field *field, dvp_val count,
++			 unsigned int *words, char *err, size_t errlen)
++{
++  dvp_uval v;
++
++  if (count < 0 || count > (dvp_val) count_max)
++    {
++      snprintf (err, errlen,
++		"a count of " DVP_VAL_FMT " is outside the permitted range "
++		"0..%u", DVP_VAL_PRINT (count), count_max);
++      return err;
++    }
++  /* Where COUNT_MAX is one more than the field can hold -- 256 in an
++     eight-bit element count, sixteen register-list entries in four bits --
++     the largest count is stored as zero.  Where COUNT_MAX is exactly what
++     the field holds, this masking is the identity.  */
++  (void) zero_means_max;
++  v = (dvp_uval) count & (((dvp_uval) 1 << field->width) - 1);
++  words[field->word] &= ~(unsigned int) ((((dvp_uval) 1 << field->width) - 1)
++					 << field->shift);
++  words[field->word] |= (unsigned int) (v << field->shift);
++  return NULL;
++}
++
++const char *
++dvp_ctr_place_count (const struct dvp_ctr_opcode *op,
++		     const struct dvp_ctr_field *field, dvp_val count,
++		     unsigned int *words, char *err, size_t errlen)
++{
++  const char *e = dvp_ctr_place_count_max (op->count_max,
++					   dvp_ctr_zero_means_max (op, field),
++					   field, count, words, err, errlen);
++
++  if (e == NULL)
++    return NULL;
++  /* The shared encoder does not know the command's name; prefix it here so the
++     message reads the way every other container diagnostic does.  */
++  {
++    char tmp[512];
++
++    snprintf (tmp, sizeof (tmp), "%s: %s", op->name, e);
++    snprintf (err, errlen, "%s", tmp);
++  }
++  return err;
++}
+--- /dev/null
++++ b/opcodes/dvp-vu-tbl.h
+@@ -0,0 +1,340 @@
++/* DVP VU opcode table -- generated, do not edit.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++   This file is part of the GNU Binutils.  GPLv3-or-later; see COPYING3.  */
++
++static const signed char dvp_bm_0[5] =
++  { 6, 7, 8, 9, 10 };
++static const signed char dvp_bm_1[15] =
++  { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 21, 22, 23, 24 };
++static const signed char dvp_bm_2[24] =
++  { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 };
++static const signed char dvp_bm_3[12] =
++  { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 21 };
++static const signed char dvp_bm_4[12] =
++  { -1, -1, -1, -1, -1, -1, 6, 7, 8, 9, 10, 21 };
++static const signed char dvp_bm_5[11] =
++  { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
++static const signed char dvp_bm_6[32] =
++  { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 };
++
++static const struct dvp_vu_field dvp_flds_0[] = {
++  { DVP_FLD_VF, 6, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 6 */
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_1[] = {
++  { DVP_FLD_VF, 6, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 6 */
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_2[] = {
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_3[] = {
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_4[] = {
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_5[] = {
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++};
++static const struct dvp_vu_field dvp_flds_6[] = {
++  { DVP_FLD_VF, 6, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 6 */
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++};
++static const struct dvp_vu_field dvp_flds_7[] = {
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_BC, 21, 2, 0, NULL, BFD_RELOC_NONE },   /* bc at bit 21 */
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++  { DVP_FLD_BC, 23, 2, 0, NULL, BFD_RELOC_NONE },   /* bc at bit 23 */
++};
++static const struct dvp_vu_field dvp_flds_8[] = {
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++  { DVP_FLD_BC, 23, 2, 0, NULL, BFD_RELOC_NONE },   /* bc at bit 23 */
++};
++static const struct dvp_vu_field dvp_flds_9[] = {
++  { DVP_FLD_VI, 6, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 6 */
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++};
++static const struct dvp_vu_field dvp_flds_10[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++  { DVP_FLD_IMM, 0, 5, 1, dvp_bm_0, BFD_RELOC_NONE },   /* imm5 bitmap [6, 7, 8, 9, 10] */
++};
++static const struct dvp_vu_field dvp_flds_11[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++  { DVP_FLD_IMM, 0, 15, 0, dvp_bm_1, BFD_RELOC_DVP_15 },   /* imm15 bitmap [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 21, 22, 23, 24] */
++};
++static const struct dvp_vu_field dvp_flds_12[] = {
++  { DVP_FLD_IMM, 0, 24, 0, dvp_bm_2, BFD_RELOC_NONE },   /* imm24 bitmap [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23] */
++};
++static const struct dvp_vu_field dvp_flds_13[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++};
++static const struct dvp_vu_field dvp_flds_14[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++};
++static const struct dvp_vu_field dvp_flds_15[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_IMM, 0, 12, 0, dvp_bm_3, BFD_RELOC_NONE },   /* imm12 bitmap [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 21] */
++};
++static const struct dvp_vu_field dvp_flds_16[] = {
++  { DVP_FLD_IMM, 0, 12, 0, dvp_bm_4, BFD_RELOC_NONE },   /* imm12 bitmap [None, None, None, None, None, None, 6, 7, 8, 9, 10, 21] */
++};
++static const struct dvp_vu_field dvp_flds_17[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_IMM, 0, 11, 1, dvp_bm_5, BFD_RELOC_NONE },   /* imm11 bitmap [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] */
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_18[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_19[] = {
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++  { DVP_FLD_IMM, 0, 11, 1, dvp_bm_5, BFD_RELOC_NONE },   /* imm11 bitmap [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] */
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_20[] = {
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_21[] = {
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_IMM, 0, 11, 1, dvp_bm_5, BFD_RELOC_NONE },   /* imm11 bitmap [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] */
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_22[] = {
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_23[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_BC, 21, 2, 0, NULL, BFD_RELOC_NONE },   /* bc at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_24[] = {
++  { DVP_FLD_VF, 16, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 16 */
++  { DVP_FLD_DEST, 21, 4, 0, NULL, BFD_RELOC_NONE },   /* dest mask at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_25[] = {
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++  { DVP_FLD_BC, 21, 2, 0, NULL, BFD_RELOC_NONE },   /* bc at bit 21 */
++};
++static const struct dvp_vu_field dvp_flds_26[] = {
++  { DVP_FLD_VF, 11, 5, 0, NULL, BFD_RELOC_NONE },   /* vf at bit 11 */
++};
++static const struct dvp_vu_field dvp_flds_27[] = {
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++};
++static const struct dvp_vu_field dvp_flds_28[] = {
++  { DVP_FLD_DISP, 0, 11, 1, NULL, BFD_RELOC_DVP_11_PCREL },   /* pc-relative displacement at bit 0 */
++};
++static const struct dvp_vu_field dvp_flds_29[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_DISP, 0, 11, 1, NULL, BFD_RELOC_DVP_11_PCREL },   /* pc-relative displacement at bit 0 */
++};
++static const struct dvp_vu_field dvp_flds_30[] = {
++  { DVP_FLD_VI, 16, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 16 */
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++  { DVP_FLD_DISP, 0, 11, 1, NULL, BFD_RELOC_DVP_11_PCREL },   /* pc-relative displacement at bit 0 */
++};
++static const struct dvp_vu_field dvp_flds_31[] = {
++  { DVP_FLD_VI, 11, 4, 0, NULL, BFD_RELOC_NONE },   /* vi at bit 11 */
++  { DVP_FLD_DISP, 0, 11, 1, NULL, BFD_RELOC_DVP_11_PCREL },   /* pc-relative displacement at bit 0 */
++};
++static const struct dvp_vu_field dvp_flds_32[] = {
++  { DVP_FLD_IMM, 0, 32, 1, dvp_bm_6, BFD_RELOC_NONE },   /* 32-bit payload occupies the whole word */
++};
++
++const struct dvp_vu_opcode dvp_vu_opcodes[] =
++{
++  { "add", "%f, %f, %f", DVP_PIPE_UPPER, 0x00000028u, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_0, DVP_INSN_NONE },
++  { "addx", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000000u, DVP_DEST_MASK, 3, 0, 0, 'x', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "addy", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000001u, DVP_DEST_MASK, 3, 0, 0, 'y', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "addz", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000002u, DVP_DEST_MASK, 3, 0, 0, 'z', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "addw", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000003u, DVP_DEST_MASK, 3, 0, 0, 'w', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "addi", "%f, %f, I", DVP_PIPE_UPPER, 0x00000022u, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "sub", "%f, %f, %f", DVP_PIPE_UPPER, 0x0000002cu, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_0, DVP_INSN_NONE },
++  { "subx", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000004u, DVP_DEST_MASK, 3, 0, 0, 'x', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "suby", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000005u, DVP_DEST_MASK, 3, 0, 0, 'y', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "subz", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000006u, DVP_DEST_MASK, 3, 0, 0, 'z', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "subw", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000007u, DVP_DEST_MASK, 3, 0, 0, 'w', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "subi", "%f, %f, I", DVP_PIPE_UPPER, 0x00000026u, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "mul", "%f, %f, %f", DVP_PIPE_UPPER, 0x0000002au, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_0, DVP_INSN_NONE },
++  { "mulx", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000018u, DVP_DEST_MASK, 3, 0, 0, 'x', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "muly", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000019u, DVP_DEST_MASK, 3, 0, 0, 'y', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "mulz", "%f, %f, %s", DVP_PIPE_UPPER, 0x0000001au, DVP_DEST_MASK, 3, 0, 0, 'z', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "mulw", "%f, %f, %s", DVP_PIPE_UPPER, 0x0000001bu, DVP_DEST_MASK, 3, 0, 0, 'w', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "muli", "%f, %f, I", DVP_PIPE_UPPER, 0x0000001eu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "max", "%f, %f, %f", DVP_PIPE_UPPER, 0x0000002bu, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maxx", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000010u, DVP_DEST_MASK, 3, 0, 0, 'x', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maxy", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000011u, DVP_DEST_MASK, 3, 0, 0, 'y', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maxz", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000012u, DVP_DEST_MASK, 3, 0, 0, 'z', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maxw", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000013u, DVP_DEST_MASK, 3, 0, 0, 'w', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maxi", "%f, %f, I", DVP_PIPE_UPPER, 0x0000001du, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "mini", "%f, %f, %f", DVP_PIPE_UPPER, 0x0000002fu, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_0, DVP_INSN_NONE },
++  { "minix", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000014u, DVP_DEST_MASK, 3, 0, 0, 'x', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "miniy", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000015u, DVP_DEST_MASK, 3, 0, 0, 'y', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "miniz", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000016u, DVP_DEST_MASK, 3, 0, 0, 'z', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "miniw", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000017u, DVP_DEST_MASK, 3, 0, 0, 'w', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "minii", "%f, %f, I", DVP_PIPE_UPPER, 0x0000001fu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "addq", "%f, %f, Q", DVP_PIPE_UPPER, 0x00000020u, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "subq", "%f, %f, Q", DVP_PIPE_UPPER, 0x00000024u, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "mulq", "%f, %f, Q", DVP_PIPE_UPPER, 0x0000001cu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "madd", "%f, %f, %f", DVP_PIPE_UPPER, 0x00000029u, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maddx", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000008u, DVP_DEST_MASK, 3, 0, 0, 'x', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maddy", "%f, %f, %s", DVP_PIPE_UPPER, 0x00000009u, DVP_DEST_MASK, 3, 0, 0, 'y', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maddz", "%f, %f, %s", DVP_PIPE_UPPER, 0x0000000au, DVP_DEST_MASK, 3, 0, 0, 'z', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maddw", "%f, %f, %s", DVP_PIPE_UPPER, 0x0000000bu, DVP_DEST_MASK, 3, 0, 0, 'w', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "maddi", "%f, %f, I", DVP_PIPE_UPPER, 0x00000023u, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "maddq", "%f, %f, Q", DVP_PIPE_UPPER, 0x00000021u, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "msub", "%f, %f, %f", DVP_PIPE_UPPER, 0x0000002du, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_0, DVP_INSN_NONE },
++  { "msubx", "%f, %f, %s", DVP_PIPE_UPPER, 0x0000000cu, DVP_DEST_MASK, 3, 0, 0, 'x', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "msuby", "%f, %f, %s", DVP_PIPE_UPPER, 0x0000000du, DVP_DEST_MASK, 3, 0, 0, 'y', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "msubz", "%f, %f, %s", DVP_PIPE_UPPER, 0x0000000eu, DVP_DEST_MASK, 3, 0, 0, 'z', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "msubw", "%f, %f, %s", DVP_PIPE_UPPER, 0x0000000fu, DVP_DEST_MASK, 3, 0, 0, 'w', 4, dvp_flds_0, DVP_INSN_NONE },
++  { "msubi", "%f, %f, I", DVP_PIPE_UPPER, 0x00000027u, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "msubq", "%f, %f, Q", DVP_PIPE_UPPER, 0x00000025u, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_1, DVP_INSN_NONE },
++  { "adda", "ACC, %f, %f", DVP_PIPE_UPPER, 0x000002bcu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_2, DVP_INSN_NONE },
++  { "addax", "ACC, %f, %s", DVP_PIPE_UPPER, 0x0000003cu, DVP_DEST_MASK, 2, 0, 0, 'x', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "adday", "ACC, %f, %s", DVP_PIPE_UPPER, 0x0000003du, DVP_DEST_MASK, 2, 0, 0, 'y', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "addaz", "ACC, %f, %s", DVP_PIPE_UPPER, 0x0000003eu, DVP_DEST_MASK, 2, 0, 0, 'z', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "addaw", "ACC, %f, %s", DVP_PIPE_UPPER, 0x0000003fu, DVP_DEST_MASK, 2, 0, 0, 'w', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "addai", "ACC, %f, I", DVP_PIPE_UPPER, 0x0000023eu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "addaq", "ACC, %f, Q", DVP_PIPE_UPPER, 0x0000023cu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "suba", "ACC, %f, %f", DVP_PIPE_UPPER, 0x000002fcu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_2, DVP_INSN_NONE },
++  { "subax", "ACC, %f, %s", DVP_PIPE_UPPER, 0x0000007cu, DVP_DEST_MASK, 2, 0, 0, 'x', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "subay", "ACC, %f, %s", DVP_PIPE_UPPER, 0x0000007du, DVP_DEST_MASK, 2, 0, 0, 'y', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "subaz", "ACC, %f, %s", DVP_PIPE_UPPER, 0x0000007eu, DVP_DEST_MASK, 2, 0, 0, 'z', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "subaw", "ACC, %f, %s", DVP_PIPE_UPPER, 0x0000007fu, DVP_DEST_MASK, 2, 0, 0, 'w', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "subai", "ACC, %f, I", DVP_PIPE_UPPER, 0x0000027eu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "subaq", "ACC, %f, Q", DVP_PIPE_UPPER, 0x0000027cu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "mula", "ACC, %f, %f", DVP_PIPE_UPPER, 0x000002beu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_2, DVP_INSN_NONE },
++  { "mulax", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000001bcu, DVP_DEST_MASK, 2, 0, 0, 'x', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "mulay", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000001bdu, DVP_DEST_MASK, 2, 0, 0, 'y', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "mulaz", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000001beu, DVP_DEST_MASK, 2, 0, 0, 'z', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "mulaw", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000001bfu, DVP_DEST_MASK, 2, 0, 0, 'w', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "mulai", "ACC, %f, I", DVP_PIPE_UPPER, 0x000001feu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "mulaq", "ACC, %f, Q", DVP_PIPE_UPPER, 0x000001fcu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "madda", "ACC, %f, %f", DVP_PIPE_UPPER, 0x000002bdu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_2, DVP_INSN_NONE },
++  { "maddax", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000000bcu, DVP_DEST_MASK, 2, 0, 0, 'x', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "madday", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000000bdu, DVP_DEST_MASK, 2, 0, 0, 'y', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "maddaz", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000000beu, DVP_DEST_MASK, 2, 0, 0, 'z', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "maddaw", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000000bfu, DVP_DEST_MASK, 2, 0, 0, 'w', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "maddai", "ACC, %f, I", DVP_PIPE_UPPER, 0x0000023fu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "maddaq", "ACC, %f, Q", DVP_PIPE_UPPER, 0x0000023du, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "msuba", "ACC, %f, %f", DVP_PIPE_UPPER, 0x000002fdu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_2, DVP_INSN_NONE },
++  { "msubax", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000000fcu, DVP_DEST_MASK, 2, 0, 0, 'x', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "msubay", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000000fdu, DVP_DEST_MASK, 2, 0, 0, 'y', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "msubaz", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000000feu, DVP_DEST_MASK, 2, 0, 0, 'z', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "msubaw", "ACC, %f, %s", DVP_PIPE_UPPER, 0x000000ffu, DVP_DEST_MASK, 2, 0, 0, 'w', 3, dvp_flds_2, DVP_INSN_NONE },
++  { "msubai", "ACC, %f, I", DVP_PIPE_UPPER, 0x0000027fu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "msubaq", "ACC, %f, Q", DVP_PIPE_UPPER, 0x0000027du, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_3, DVP_INSN_NONE },
++  { "abs", "%f, %f", DVP_PIPE_UPPER, 0x000001fdu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "ftoi0", "%f, %f", DVP_PIPE_UPPER, 0x0000017cu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "ftoi4", "%f, %f", DVP_PIPE_UPPER, 0x0000017du, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "ftoi12", "%f, %f", DVP_PIPE_UPPER, 0x0000017eu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "ftoi15", "%f, %f", DVP_PIPE_UPPER, 0x0000017fu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "itof0", "%f, %f", DVP_PIPE_UPPER, 0x0000013cu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "itof4", "%f, %f", DVP_PIPE_UPPER, 0x0000013du, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "itof12", "%f, %f", DVP_PIPE_UPPER, 0x0000013eu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "itof15", "%f, %f", DVP_PIPE_UPPER, 0x0000013fu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "opmula", "ACC, %f, %f", DVP_PIPE_UPPER, 0x01c002feu, DVP_DEST_FIXED, -1, 14, 0, 0, 2, dvp_flds_5, DVP_INSN_NONE },
++  { "opmsub", "%f, %f, %f", DVP_PIPE_UPPER, 0x01c0002eu, DVP_DEST_FIXED, -1, 14, 0, 0, 3, dvp_flds_6, DVP_INSN_NONE },
++  { "clipw", "%f, %s", DVP_PIPE_UPPER, 0x01c001ffu, DVP_DEST_FIXED, -1, 14, 0, 'w', 2, dvp_flds_5, DVP_INSN_NONE },
++  { "nop", "", DVP_PIPE_UPPER, 0x000002ffu, DVP_DEST_NONE, -1, 0, 0, 0, 0, NULL, DVP_INSN_NONE },
++  { "nop", "", DVP_PIPE_LOWER, 0x8000033cu, DVP_DEST_NONE, -1, 0, 0, 0, 0, NULL, DVP_INSN_NONE },
++  { "div", "Q, %f%b, %f%b", DVP_PIPE_LOWER, 0x800003bcu, DVP_DEST_NONE, -1, 0, 0, 0, 4, dvp_flds_7, DVP_INSN_NONE },
++  { "rsqrt", "Q, %f%b, %f%b", DVP_PIPE_LOWER, 0x800003beu, DVP_DEST_NONE, -1, 0, 0, 0, 4, dvp_flds_7, DVP_INSN_NONE },
++  { "sqrt", "Q, %f%b", DVP_PIPE_LOWER, 0x800003bdu, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_8, DVP_INSN_NONE },
++  { "waitq", "", DVP_PIPE_LOWER, 0x800003bfu, DVP_DEST_NONE, -1, 0, 0, 0, 0, NULL, DVP_INSN_NONE },
++  { "iadd", "%i, %i, %i", DVP_PIPE_LOWER, 0x80000030u, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_9, DVP_INSN_NONE },
++  { "isub", "%i, %i, %i", DVP_PIPE_LOWER, 0x80000031u, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_9, DVP_INSN_NONE },
++  { "iand", "%i, %i, %i", DVP_PIPE_LOWER, 0x80000034u, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_9, DVP_INSN_NONE },
++  { "ior", "%i, %i, %i", DVP_PIPE_LOWER, 0x80000035u, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_9, DVP_INSN_NONE },
++  { "iaddi", "%i, %i, %m", DVP_PIPE_LOWER, 0x80000032u, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_10, DVP_INSN_NONE },
++  { "iaddiu", "%i, %i, %m", DVP_PIPE_LOWER, 0x10000000u, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_11, DVP_INSN_NONE },
++  { "isubiu", "%i, %i, %m", DVP_PIPE_LOWER, 0x12000000u, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_11, DVP_INSN_NONE },
++  { "fcand", "%1, %m", DVP_PIPE_LOWER, 0x24000000u, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_12, DVP_INSN_NONE },
++  { "fcor", "%1, %m", DVP_PIPE_LOWER, 0x26000000u, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_12, DVP_INSN_NONE },
++  { "fceq", "%1, %m", DVP_PIPE_LOWER, 0x20000000u, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_12, DVP_INSN_NONE },
++  { "fcset", "%m", DVP_PIPE_LOWER, 0x22000000u, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_12, DVP_INSN_NONE },
++  { "fcget", "%i", DVP_PIPE_LOWER, 0x38000000u, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_13, DVP_INSN_NONE },
++  { "fmand", "%i, %i", DVP_PIPE_LOWER, 0x34000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_14, DVP_INSN_NONE },
++  { "fmor", "%i, %i", DVP_PIPE_LOWER, 0x36000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_14, DVP_INSN_NONE },
++  { "fmeq", "%i, %i", DVP_PIPE_LOWER, 0x30000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_14, DVP_INSN_NONE },
++  { "fsand", "%i, %m", DVP_PIPE_LOWER, 0x2c000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_15, DVP_INSN_NONE },
++  { "fsor", "%i, %m", DVP_PIPE_LOWER, 0x2e000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_15, DVP_INSN_NONE },
++  { "fseq", "%i, %m", DVP_PIPE_LOWER, 0x28000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_15, DVP_INSN_NONE },
++  { "fsset", "%m", DVP_PIPE_LOWER, 0x2a000000u, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_16, DVP_INSN_NONE },
++  { "ilw", "%i, %m(%i)%d", DVP_PIPE_LOWER, 0x08000000u, DVP_DEST_SINGLE, 3, 0, 0, 0, 4, dvp_flds_17, DVP_INSN_NONE },
++  { "isw", "%i, %m(%i)%d", DVP_PIPE_LOWER, 0x0a000000u, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_17, DVP_INSN_NONE },
++  { "ilwr", "%i, (%i)%d", DVP_PIPE_LOWER, 0x800003feu, DVP_DEST_SINGLE, 2, 0, 0, 0, 3, dvp_flds_18, DVP_INSN_NONE },
++  { "iswr", "%i, (%i)%d", DVP_PIPE_LOWER, 0x800003ffu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_18, DVP_INSN_NONE },
++  { "lq", "%f, %m(%i)", DVP_PIPE_LOWER, 0x00000000u, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_19, DVP_INSN_NONE },
++  { "lqd", "%f, (--%i)", DVP_PIPE_LOWER, 0x8000037eu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_20, DVP_INSN_NONE },
++  { "lqi", "%f, (%i++)", DVP_PIPE_LOWER, 0x8000037cu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_20, DVP_INSN_NONE },
++  { "sq", "%f, %m(%i)", DVP_PIPE_LOWER, 0x02000000u, DVP_DEST_MASK, 3, 0, 0, 0, 4, dvp_flds_21, DVP_INSN_NONE },
++  { "sqd", "%f, (--%i)", DVP_PIPE_LOWER, 0x8000037fu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_22, DVP_INSN_NONE },
++  { "sqi", "%f, (%i++)", DVP_PIPE_LOWER, 0x8000037du, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_22, DVP_INSN_NONE },
++  { "mfir", "%f, %i", DVP_PIPE_LOWER, 0x800003fdu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_20, DVP_INSN_NONE },
++  { "mtir", "%i, %f%b", DVP_PIPE_LOWER, 0x800003fcu, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_23, DVP_INSN_NONE },
++  { "move", "%f, %f", DVP_PIPE_LOWER, 0x8000033cu, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "mr32", "%f, %f", DVP_PIPE_LOWER, 0x8000033du, DVP_DEST_MASK, 2, 0, 0, 0, 3, dvp_flds_4, DVP_INSN_NONE },
++  { "mfp", "%f, P", DVP_PIPE_LOWER, 0x8000067cu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_24, DVP_INSN_NONE },
++  { "waitp", "", DVP_PIPE_LOWER, 0x800007bfu, DVP_DEST_NONE, -1, 0, 0, 0, 0, NULL, DVP_INSN_NONE },
++  { "rinit", "R, %f%b", DVP_PIPE_LOWER, 0x8000043eu, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_25, DVP_INSN_NONE },
++  { "rxor", "R, %f%b", DVP_PIPE_LOWER, 0x8000043fu, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_25, DVP_INSN_NONE },
++  { "rget", "%f, R", DVP_PIPE_LOWER, 0x8000043du, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_24, DVP_INSN_NONE },
++  { "rnext", "%f, R", DVP_PIPE_LOWER, 0x8000043cu, DVP_DEST_MASK, 1, 0, 0, 0, 2, dvp_flds_24, DVP_INSN_NONE },
++  { "esadd", "P, %f", DVP_PIPE_LOWER, 0x81c0073cu, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_26, DVP_INSN_NONE },
++  { "ersadd", "P, %f", DVP_PIPE_LOWER, 0x81c0073du, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_26, DVP_INSN_NONE },
++  { "eleng", "P, %f", DVP_PIPE_LOWER, 0x81c0073eu, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_26, DVP_INSN_NONE },
++  { "erleng", "P, %f", DVP_PIPE_LOWER, 0x81c0073fu, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_26, DVP_INSN_NONE },
++  { "eatanxy", "P, %f", DVP_PIPE_LOWER, 0x8180077cu, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_26, DVP_INSN_NONE },
++  { "eatanxz", "P, %f", DVP_PIPE_LOWER, 0x8140077du, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_26, DVP_INSN_NONE },
++  { "esum", "P, %f", DVP_PIPE_LOWER, 0x81e0077eu, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_26, DVP_INSN_NONE },
++  { "ercpr", "P, %f%b", DVP_PIPE_LOWER, 0x800007beu, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_25, DVP_INSN_NONE },
++  { "esqrt", "P, %f%b", DVP_PIPE_LOWER, 0x800007bcu, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_25, DVP_INSN_NONE },
++  { "ersqrt", "P, %f%b", DVP_PIPE_LOWER, 0x800007bdu, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_25, DVP_INSN_NONE },
++  { "esin", "P, %f%b", DVP_PIPE_LOWER, 0x800007fcu, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_25, DVP_INSN_NONE },
++  { "eatan", "P, %f%b", DVP_PIPE_LOWER, 0x800007fdu, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_25, DVP_INSN_NONE },
++  { "eexp", "P, %f%b", DVP_PIPE_LOWER, 0x800007feu, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_25, DVP_INSN_NONE },
++  { "xtop", "%i", DVP_PIPE_LOWER, 0x800006bcu, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_13, DVP_INSN_NONE },
++  { "xitop", "%i", DVP_PIPE_LOWER, 0x800006bdu, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_13, DVP_INSN_NONE },
++  { "xgkick", "%i", DVP_PIPE_LOWER, 0x800006fcu, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_27, DVP_INSN_NONE },
++  { "jr", "%i", DVP_PIPE_LOWER, 0x48000000u, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_27, DVP_INSN_NONE },
++  { "jalr", "%i, %i", DVP_PIPE_LOWER, 0x4a000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_14, DVP_INSN_NONE },
++  { "b", "%t", DVP_PIPE_LOWER, 0x40000000u, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_28, DVP_INSN_NONE },
++  { "bal", "%i, %t", DVP_PIPE_LOWER, 0x42000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_29, DVP_INSN_NONE },
++  { "ibeq", "%i, %i, %t", DVP_PIPE_LOWER, 0x50000000u, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_30, DVP_INSN_NONE },
++  { "ibne", "%i, %i, %t", DVP_PIPE_LOWER, 0x52000000u, DVP_DEST_NONE, -1, 0, 0, 0, 3, dvp_flds_30, DVP_INSN_NONE },
++  { "ibgez", "%i, %t", DVP_PIPE_LOWER, 0x5e000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_31, DVP_INSN_NONE },
++  { "ibgtz", "%i, %t", DVP_PIPE_LOWER, 0x5a000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_31, DVP_INSN_NONE },
++  { "iblez", "%i, %t", DVP_PIPE_LOWER, 0x5c000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_31, DVP_INSN_NONE },
++  { "ibltz", "%i, %t", DVP_PIPE_LOWER, 0x58000000u, DVP_DEST_NONE, -1, 0, 0, 0, 2, dvp_flds_31, DVP_INSN_NONE },
++  { "loi", "%m", DVP_PIPE_LOWER, 0x00000000u, DVP_DEST_NONE, -1, 0, 0, 0, 1, dvp_flds_32, DVP_INSN_LOI },
++};
++
++const int dvp_vu_num_opcodes = 166;
++
+--- /dev/null
++++ b/opcodes/dvp-vu.c
+@@ -0,0 +1,1047 @@
++/* PlayStation 2 VU microinstruction parsing, validation and encoding.
++
++   Copyright (C) 2026 Free Software Foundation, Inc.
++
++   This file is part of the GNU Binutils.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++/* This file knows nothing about GNU as.  It parses the parts of a VU operation
++   that need no symbol table (mnemonic, flag group, destination specifier,
++   registers, broadcast selectors), validates every operand strictly, and
++   encodes a validated operation into a 32-bit word.  Expressions are handed
++   back to the caller through a hook, because only the assembler can evaluate
++   them.
++
++   Nothing here truncates, masks or wraps an out-of-range value: every such
++   case is reported to the caller, which turns it into a diagnostic.  */
++
++#include "sysdep.h"
++#include <stdio.h>
++#include <string.h>
++#include <ctype.h>
++#include "bfd.h"
++#include "opcode/dvp-vu.h"
++
++#include "dvp-vu-tbl.h"
++
++/* ------------------------------------------------------------------ helpers */
++
++static int
++dvp_tolower (int c)
++{
++  return (c >= 'A' && c <= 'Z') ? c - 'A' + 'a' : c;
++}
++
++static int
++dvp_ident_char (int c)
++{
++  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')
++	 || (c >= 'A' && c <= 'Z') || c == '_' || c == '$' || c == '.';
++}
++
++static char *
++dvp_skip_space (char *p)
++{
++  while (*p == ' ' || *p == '\t')
++    ++p;
++  return p;
++}
++
++/* Three places in *this* grammar take a vertical tab or a form feed as well:
++   the separator between the two pipe operations, the gap between a register
++   class name and its number, and whatever follows the last operand.
++   Everywhere else -- after a mnemonic, either side of a comma, before an
++   immediate, before a component suffix or a broadcast selector, and inside a
++   memory operand's parentheses -- both are refused.  Hence the widening is
++   applied by hand at those three call sites rather than folded in here.  */
++
++int
++dvp_vu_is_wide_space (int c)
++{
++  return c == ' ' || c == '\t' || c == '\v' || c == '\f';
++}
++
++char *
++dvp_vu_skip_wide_space (char *p)
++{
++  while (dvp_vu_is_wide_space ((unsigned char) *p))
++    ++p;
++  return p;
++}
++
++static int
++dvp_casecmp (const char *a, const char *b, size_t n)
++{
++  size_t i;
++  for (i = 0; i < n; i++)
++    if (dvp_tolower ((unsigned char) a[i]) != dvp_tolower ((unsigned char) b[i]))
++      return 1;
++  return 0;
++}
++
++/* --------------------------------------------------------------- table access */
++
++const struct dvp_vu_opcode *
++dvp_vu_lookup (const char *name, int pipe)
++{
++  int i;
++  for (i = 0; i < dvp_vu_num_opcodes; i++)
++    if (dvp_vu_opcodes[i].pipe == (unsigned char) pipe
++	&& strcmp (dvp_vu_opcodes[i].name, name) == 0)
++      return &dvp_vu_opcodes[i];
++  return NULL;
++}
++
++/* ------------------------------------------------------------ field encoding */
++
++void
++dvp_field_range (const struct dvp_vu_field *f, dvp_val *lo, dvp_val *hi)
++{
++  switch (f->kind)
++    {
++    case DVP_FLD_VF:
++      *lo = 0; *hi = DVP_NUM_VF - 1;
++      break;
++    case DVP_FLD_VI:
++      *lo = 0; *hi = DVP_NUM_VI - 1;
++      break;
++    case DVP_FLD_BC:
++      *lo = 0; *hi = 3;
++      break;
++    case DVP_FLD_DEST:
++      *lo = 1; *hi = DVP_DEST_ALL;
++      break;
++    case DVP_FLD_IMM:
++    case DVP_FLD_DISP:
++    default:
++      if (f->is_signed)
++	{
++	  *lo = -((dvp_val) 1 << (f->width - 1));
++	  *hi = ((dvp_val) 1 << (f->width - 1)) - 1;
++	}
++      else
++	{
++	  /* An unsigned field takes unsigned values only.  Accepting the
++	     negative spelling of a bit pattern would mean `iaddiu ..., -1'
++	     quietly became 32767, and would let the width decide what a given
++	     negative value meant.  */
++	  *lo = 0;
++	  *hi = ((dvp_val) 1 << f->width) - 1;
++	}
++      break;
++    }
++}
++
++const char *
++dvp_encode_field (const struct dvp_vu_field *f, dvp_val value,
++		  unsigned int *word, char *err, size_t errlen)
++{
++  dvp_val lo, hi;
++  dvp_uval mask, v;
++  unsigned int k;
++
++  dvp_field_range (f, &lo, &hi);
++  if (value < lo || value > hi)
++    {
++      snprintf (err, errlen,
++		"value " DVP_VAL_FMT " is outside the permitted range "
++		DVP_VAL_FMT " to " DVP_VAL_FMT,
++		DVP_VAL_PRINT (value), DVP_VAL_PRINT (lo), DVP_VAL_PRINT (hi));
++      return err;
++    }
++
++  mask = ((dvp_uval) 1 << f->width) - 1;
++  v = ((dvp_uval) value) & mask;
++
++  if (f->kind != DVP_FLD_IMM)
++    {
++      *word |= (unsigned int) (v << f->shift);
++      return NULL;
++    }
++
++  for (k = 0; k < f->width; k++)
++    {
++      if (((v >> k) & 1) == 0)
++	continue;
++      if (f->bitmap[k] == DVP_BIT_DROPPED)
++	{
++	  /* Report the whole run of dropped low bits at once: it is far more
++	     useful than naming one bit.  */
++	  unsigned int last = 0;
++	  unsigned int j;
++	  for (j = 0; j < f->width; j++)
++	    if (f->bitmap[j] == DVP_BIT_DROPPED)
++	      last = j;
++	  snprintf (err, errlen,
++		    "value " DVP_VAL_FMT " sets bit %u, but this instruction "
++		    "does not encode immediate bits %u to 0",
++		    DVP_VAL_PRINT (value), k, last);
++	  return err;
++	}
++      *word |= 1u << (unsigned int) f->bitmap[k];
++    }
++  return NULL;
++}
++
++const char *
++dvp_vu_encode (const struct dvp_insn *insn, unsigned int *word,
++	       char *err, size_t errlen)
++{
++  const struct dvp_vu_opcode *op = insn->opcode;
++  unsigned int w = op->fixed;
++  int i;
++
++  if (op->insn_flags & DVP_INSN_LOI)
++    {
++      /* The payload is the entire word.  */
++      *word = (unsigned int) insn->operands[0].value;
++      return NULL;
++    }
++
++  w |= insn->flag_bits;
++
++  if (op->dest_field >= 0)
++    {
++      const char *e = dvp_encode_field (&op->fields[op->dest_field],
++					(dvp_val) (insn->dest | op->dest_or),
++					&w, err, errlen);
++      if (e)
++	return e;
++    }
++  else if (op->dest_mode == DVP_DEST_FIXED)
++    w |= ((unsigned int) op->dest_fixed) << DVP_DEST_SHIFT;
++
++  for (i = 0; i < insn->noperands; i++)
++    {
++      const struct dvp_operand *o = &insn->operands[i];
++      const char *e;
++      if (o->has_expr)
++	continue;			/* the caller will relocate it */
++      e = dvp_encode_field (o->field, o->value, &w, err, errlen);
++      if (e)
++	return e;
++    }
++
++  *word = w;
++  return NULL;
++}
++
++/* ------------------------------------------------------------------ parsing */
++
++/* `[iemdt]' -- one bracketed group, attached to the upper mnemonic, before any
++   destination specifier.
++
++   The group is a set of letters and nothing more: it may be empty, so `nop[]'
++   is `nop', and a letter may repeat, so `nop[ii]' is `nop[i]'.  An error is
++   anything that is not a flag letter: an unknown letter, whitespace inside the
++   group, a missing `]', a second group, or a group after the destination
++   specifier.  */
++
++const char *
++dvp_parse_flags (char **pp, unsigned int *bits, char *err, size_t errlen)
++{
++  char *p = *pp;
++
++  *bits = 0;
++  if (*p != '[')
++    return NULL;
++  ++p;
++  for (; *p && *p != ']'; ++p)
++    {
++      int bit;
++      switch (dvp_tolower ((unsigned char) *p))
++	{
++	case 'i': bit = DVP_FLAG_I_BIT; break;
++	case 'e': bit = DVP_FLAG_E_BIT; break;
++	case 'm': bit = DVP_FLAG_M_BIT; break;
++	case 'd': bit = DVP_FLAG_D_BIT; break;
++	case 't': bit = DVP_FLAG_T_BIT; break;
++	default:
++	  snprintf (err, errlen,
++		    "'%c' is not an instruction flag; the flags are i, e, m, "
++		    "d and t", *p);
++	  return err;
++	}
++      *bits |= 1u << bit;
++    }
++  if (*p != ']')
++    {
++      snprintf (err, errlen, "instruction flag group is missing its ']'");
++      return err;
++    }
++  *pp = p + 1;
++  return NULL;
++}
++
++/* One component letter's mask bit, or zero.  The destination specifier and an
++   operand's optional suffix are the same notation, so they read it here.  */
++
++static unsigned int
++dvp_component_bit (int c)
++{
++  switch (dvp_tolower ((unsigned char) c))
++    {
++    case 'x': return DVP_DEST_X;
++    case 'y': return DVP_DEST_Y;
++    case 'z': return DVP_DEST_Z;
++    case 'w': return DVP_DEST_W;
++    default:  return 0;
++    }
++}
++
++/* Spell a mask back out, for a diagnostic that names what was expected.  */
++
++static void
++dvp_component_spell (unsigned int mask, char out[5])
++{
++  int n = 0;
++
++  if (mask & DVP_DEST_X) out[n++] = 'x';
++  if (mask & DVP_DEST_Y) out[n++] = 'y';
++  if (mask & DVP_DEST_Z) out[n++] = 'z';
++  if (mask & DVP_DEST_W) out[n++] = 'w';
++  out[n] = 0;
++}
++
++/* `.xyzw' -- a destination component mask.  */
++
++static const char *
++dvp_parse_dest_mask (char **pp, unsigned int *dest, int *nwritten,
++		     char *err, size_t errlen)
++{
++  char *p = *pp;
++  unsigned int mask = 0;
++
++  *nwritten = 0;
++  if (!dvp_ident_char ((unsigned char) *p))
++    {
++      snprintf (err, errlen,
++		"destination specifier is empty; name at least one of "
++		"x, y, z and w");
++      return err;
++    }
++  for (; dvp_ident_char ((unsigned char) *p); ++p)
++    {
++      unsigned int bit = dvp_component_bit (*p);
++
++      if (bit == 0)
++	{
++	  snprintf (err, errlen,
++		    "'%c' is not a destination component; use x, y, z or w",
++		    *p);
++	  return err;
++	}
++      /* A component named twice is the same component named twice: `add.xx' is
++	 `add.x', and `add.xyzwx' is `add.xyzw'.  Repetition is not part of the
++	 mask, so the letter set is still recoverable from the word.
++
++	 A mnemonic that addresses exactly one component is the exception, and
++	 the exception is about characters rather than about the set: `ilw.xx'
++	 names one component twice and is refused, while `isw.xx' -- the same
++	 repetition on a mnemonic whose specifier is a set -- is accepted.  So
++	 the count is reported and the caller applies it.  */
++      mask |= bit;
++      ++*nwritten;
++    }
++  *dest = mask;
++  *pp = p;
++  return NULL;
++}
++
++/* An operand's optional component suffix: `vf01xy' beside `add.xy'.  It is
++   decoration -- it changes no bit -- but it has to say the same thing as the
++   operation does, so WANT names the components it must spell.  WANT of zero
++   means a suffix is an error.  Called only where a suffix is possible, with
++   *PP on its first character.  */
++
++static const char *
++dvp_parse_component_suffix (char **pp, unsigned int want, int exactly_one,
++			    const char *what, char *err, size_t errlen)
++{
++  char *p = *pp;
++  char *start = p;
++  unsigned int mask = 0;
++  int nwritten = 0;
++  char spell[5];
++
++  if (want == 0)
++    {
++      snprintf (err, errlen,
++		"%s does not take a component suffix here, because this "
++		"operation has no destination specifier to repeat", what);
++      return err;
++    }
++  for (; dvp_ident_char ((unsigned char) *p); ++p)
++    {
++      unsigned int bit = dvp_component_bit (*p);
++
++      if (bit == 0)
++	{
++	  snprintf (err, errlen,
++		    "'%c' is not a component; a suffix on %s names x, y, z "
++		    "or w", *p, what);
++	  return err;
++	}
++      /* Named twice is the same component named twice, exactly as in a
++	 destination specifier: `vf03xx' beside `add.x' is `vf03x'.  The suffix
++	 is decoration and moves no bit; what must hold is that it names the
++	 same *set* the operation does, which is the check below.
++
++	 A suffix repeating the *broadcast* component is the exception: `vf00zz'
++	 beside `msubz' is refused where `vf00xx' beside `add.x' is accepted, so
++	 the repetition is counted and EXACTLY_ONE says which rule applies.  */
++      mask |= bit;
++      ++nwritten;
++    }
++  if (exactly_one && nwritten > 1)
++    {
++      snprintf (err, errlen,
++		"this suffix names one component twice; %s broadcasts a "
++		"single component, so write it once", what);
++      return err;
++    }
++  if (mask != want)
++    {
++      dvp_component_spell (want, spell);
++      snprintf (err, errlen,
++		"this suffix names %.*s, but %s takes %s here",
++		(int) (p - start), start, what, spell);
++      return err;
++    }
++  *pp = p;
++  return NULL;
++}
++
++/* A register, `vf03' or `vi07', case-insensitive, leading zeros allowed.
++
++   SUFFIX is the components an optional component suffix must name, or zero when
++   none is allowed.  SUFFIX_ONE says that suffix must be a single character --
++   true for the one component a broadcasting mnemonic names, false for a repeat
++   of the destination specifier.  BC_FOLLOWS says a broadcast selector comes
++   next instead, so the letters after the digits belong to it.
++
++   The number is read as `strtol' in base ten on the text just past the class
++   name.  That grammar is wider than a digit run: leading whitespace is skipped,
++   so `vi 01' and `vi  1' both name vi01, and a sign is accepted, so `vf+1' is
++   vf01 and `vf-0' is vf00.  A negative register is refused by the range check
++   rather than the lexer, and so is a class name with no number.  Space is
++   allowed there and nowhere else in the operand: `v i01', `vf01 .xyzw' and
++   `vf03 x' stay errors.  */
++
++/* The reference's `strtol (start, &end, 10)', as far as this grammar can
++   observe it.  Returns non-zero when a number was read, with *ENDP just past it
++   and *VALP its magnitude; *NEGP says a `-' preceded it.  Returns zero, leaving
++   *ENDP alone, when there is no number.  */
++
++static int
++dvp_reg_strtol (char *p, char **endp, dvp_val *valp, int *negp)
++{
++  char *q = dvp_vu_skip_wide_space (p);
++  int neg = 0;
++  dvp_val n = 0;
++
++  if (*q == '+' || *q == '-')
++    {
++      neg = (*q == '-');
++      ++q;
++    }
++  if (!isdigit ((unsigned char) *q))
++    return 0;
++  while (isdigit ((unsigned char) *q))
++    {
++      n = n * 10 + (*q - '0');
++      if (n > 100000)
++	n = 100000;			/* keep the message, and the value, finite */
++      ++q;
++    }
++  *endp = q;
++  *valp = n;
++  *negp = neg;
++  return 1;
++}
++
++static const char *
++dvp_parse_reg (char **pp, int want_vf, int bc_follows, unsigned int suffix,
++	       int suffix_one, dvp_val *value, char *err, size_t errlen)
++{
++  char *p = dvp_skip_space (*pp);
++  char *start = p;
++  const char *want = want_vf ? "vf" : "vi";
++  dvp_val n = 0;
++  int neg = 0;
++  int have_suffix;
++  char *end;
++
++  if (dvp_casecmp (p, want, 2) != 0 || !dvp_reg_strtol (p + 2, &end, &n, &neg))
++    {
++      /* Name the wrong class explicitly when that is what happened.  */
++      const char *other = want_vf ? "vi" : "vf";
++      dvp_val on;
++      int oneg;
++      char *oend;
++
++      if (dvp_casecmp (p, other, 2) == 0
++	  && dvp_reg_strtol (p + 2, &oend, &on, &oneg))
++	{
++	  snprintf (err, errlen,
++		    "%.*s is a %s register here, but a %s register is required",
++		    (int) (oend - start), start, other, want);
++	  return err;
++	}
++      snprintf (err, errlen, "expected a %s register", want);
++      return err;
++    }
++  p = end;
++  /* A vf operand may repeat the operation's components here; anything else is
++     text that does not belong to the operand.  The register number is checked
++     first, so `vf99xy' reports the register rather than the suffix.  */
++  have_suffix = (!bc_follows && want_vf
++		 && dvp_component_bit ((unsigned char) *p) != 0);
++  if (!bc_follows && !have_suffix && dvp_ident_char ((unsigned char) *p))
++    {
++      /* A component letter on an operand that cannot take one is worth naming
++	 as such: it is what someone writing `vi01x' or `add.xy vf01z' meant to
++	 do, and "unexpected text" would send them looking for a typo.  */
++      if (dvp_component_bit ((unsigned char) *p) != 0
++	  && !dvp_ident_char ((unsigned char) p[1]))
++	snprintf (err, errlen,
++		  "a %s register does not take a component suffix", want);
++      else
++	snprintf (err, errlen, "unexpected text after a %s register", want);
++      return err;
++    }
++  if (neg && n != 0)
++    {
++      snprintf (err, errlen,
++		"%.*s is not a register; the %s registers are %s00 to %s%d",
++		(int) (p - start), start, want, want, want,
++		(want_vf ? DVP_NUM_VF : DVP_NUM_VI) - 1);
++      return err;
++    }
++  if (n >= (want_vf ? DVP_NUM_VF : DVP_NUM_VI))
++    {
++      snprintf (err, errlen,
++		"%.*s is not a register; the %s registers are %s00 to %s%d",
++		(int) (p - start), start, want, want, want,
++		(want_vf ? DVP_NUM_VF : DVP_NUM_VI) - 1);
++      return err;
++    }
++  if (have_suffix)
++    {
++      const char *e = dvp_parse_component_suffix (&p, suffix, suffix_one,
++						  "a vf register", err, errlen);
++      if (e)
++	return e;
++    }
++  *value = n;
++  *pp = p;
++  return NULL;
++}
++
++/* `vi01', the one register three flag operations may name.  The reference tests
++   the number rather than the spelling, so `vi1', `vi0001', `vi 1' and `vi+1'
++   all name it and anything whose value is not one does not.  */
++
++static const char *
++dvp_parse_vi01 (char **pp, char *err, size_t errlen)
++{
++  char *p = dvp_skip_space (*pp);
++  dvp_val n = 0;
++  int neg = 0;
++  char *end;
++
++  if (dvp_casecmp (p, "vi", 2) != 0
++      || !dvp_reg_strtol (p + 2, &end, &n, &neg)
++      || neg || n != 1)
++    {
++      snprintf (err, errlen, "this operation names vi01 here");
++      return err;
++    }
++  *pp = end;
++  return NULL;
++}
++
++/* A broadcast selector: a bare x, y, z or w abutting the register.  */
++
++static const char *
++dvp_parse_bc (char **pp, dvp_val *value, char *err, size_t errlen)
++{
++  char *p = *pp;
++  int v;
++
++  switch (dvp_tolower ((unsigned char) *p))
++    {
++    case 'x': v = 0; break;
++    case 'y': v = 1; break;
++    case 'z': v = 2; break;
++    case 'w': v = 3; break;
++    default:
++      snprintf (err, errlen,
++		"this operand needs a broadcast component: append x, y, z "
++		"or w to the register");
++      return err;
++    }
++  if (dvp_ident_char ((unsigned char) p[1]))
++    {
++      snprintf (err, errlen, "unexpected text after a broadcast component");
++      return err;
++    }
++  *value = v;
++  *pp = p + 1;
++  return NULL;
++}
++
++/* Walk SYNTAX over the operand text at *PP, filling INSN.  */
++
++const char *
++dvp_vu_parse_operands (const struct dvp_vu_opcode *op, char **pp,
++		       struct dvp_insn *insn,
++		       const struct dvp_parse_hooks *hooks,
++		       char *err, size_t errlen)
++{
++  const char *syn = op->syntax;
++  char *p = *pp;
++  const char *e;
++  int nf = 0;
++
++  insn->noperands = 0;
++  while (*syn)
++    {
++      if (*syn == '%' && syn[1] == '1')
++	{
++	  /* The fixed `vi01' operand.  It encodes nothing, so it takes no
++	     field.  */
++	  syn += 2;
++	  p = dvp_skip_space (p);
++	  e = dvp_parse_vi01 (&p, err, errlen);
++	  if (e)
++	    return e;
++	  continue;
++	}
++
++      if (*syn == '%' && syn[1] == 'd')
++	{
++	  /* The optional single-component decoration a memory operand may carry
++	     after its closing parenthesis: `ilw.x vi01,0(vi02)x'.  It encodes
++	     nothing but must say the same thing, and must name one component.
++	     Written twice the same letter collapses; two different letters do
++	     not, and neither does a letter the mnemonic did not name.  */
++	  unsigned int mask = 0;
++	  char spell[5];
++
++	  syn += 2;
++	  if (dvp_component_bit ((unsigned char) *p) == 0)
++	    continue;			/* not written at all, which is fine */
++	  while (dvp_component_bit ((unsigned char) *p) != 0)
++	    {
++	      mask |= dvp_component_bit ((unsigned char) *p);
++	      ++p;
++	    }
++	  if ((mask & (mask - 1)) != 0)
++	    {
++	      snprintf (err, errlen,
++			"this suffix names more than one component; write one "
++			"of x, y, z and w, or leave it out");
++	      return err;
++	    }
++	  if (mask != insn->dest)
++	    {
++	      dvp_component_spell (insn->dest, spell);
++	      snprintf (err, errlen,
++			"this suffix does not name the component '%s' "
++			"addresses, which is %s", op->name, spell);
++	      return err;
++	    }
++	  continue;
++	}
++
++      if (*syn == '%')
++	{
++	  int code = syn[1];
++	  const struct dvp_vu_field *f;
++	  struct dvp_operand *o;
++	  dvp_val value = 0;
++
++	  syn += 2;
++	  if (nf >= op->nfields || nf >= DVP_MAX_OPERANDS)
++	    {
++	      snprintf (err, errlen, "internal error: %s has too many operands",
++			op->name);
++	      return err;
++	    }
++	  f = &op->fields[nf];
++	  o = &insn->operands[nf];
++	  o->field = f;
++	  o->has_expr = 0;
++	  o->deferred = 0;
++	  o->expr = NULL;
++
++	  switch (code)
++	    {
++	    case 'f':
++	    case 's':
++	    case 'i':
++	      p = dvp_skip_space (p);
++	      /* What an optional component suffix must name: the operation's
++		 destination specifier, or -- on a `%s' operand -- the one
++		 component the mnemonic broadcasts.  An operation with no
++		 specifier has nothing to repeat, so no suffix is accepted.  */
++	      e = dvp_parse_reg (&p, code != 'i',
++				 syn[0] == '%' && syn[1] == 'b',
++				 code == 's'
++				 ? dvp_component_bit (op->bc_suffix)
++				 : insn->dest,
++				 code == 's',
++				 &value, err, errlen);
++	      if (e)
++		return e;
++	      o->value = value;
++	      break;
++	    case 'b':
++	      /* Deliberately no whitespace skip: the selector abuts.  */
++	      e = dvp_parse_bc (&p, &value, err, errlen);
++	      if (e)
++		return e;
++	      o->value = value;
++	      break;
++	    case 'm':
++	    case 't':
++	      p = dvp_skip_space (p);
++	      /* An operation whose whole operand list is one expression refuses
++		 a leading '(', and only there.  `fcset (7)', `fsset (0)' and
++		 `b (L)' are errors, while the same parenthesised expression is
++		 accepted wherever it is not the sole operand -- `fcand vi01,(7)',
++		 `iaddi vi01,vi02,(3)', `bal vi01,(L)' -- as is a parenthesis
++		 inside the expression, as in `fcset 0+(7)'.
++
++		 "Sole operand" is a property of the written form, not the field
++		 count: `fcand vi01,%m' encodes one field yet accepts `(7)'.  So
++		 the test is that this operand is the whole of the syntax.  */
++	      if (syn == op->syntax + 2 && *syn == 0 && *p == '(')
++		{
++		  snprintf (err, errlen,
++			    "%s takes one operand, and it may not be written "
++			    "inside parentheses", op->name);
++		  return err;
++		}
++	      e = hooks->get_expr (hooks->ctx, &p, o, code == 't',
++				   err, errlen);
++	      if (e)
++		return e;
++	      break;
++	    default:
++	      snprintf (err, errlen, "internal error: bad syntax code '%c'",
++			code);
++	      return err;
++	    }
++	  ++nf;
++	  insn->noperands = nf;
++	  continue;
++	}
++
++      if (*syn == ' ')
++	{
++	  p = dvp_skip_space (p);
++	  ++syn;
++	  continue;
++	}
++
++      if (dvp_ident_char ((unsigned char) *syn))
++	{
++	  const char *w = syn;
++	  size_t len = 0;
++	  int accumulator;
++
++	  while (dvp_ident_char ((unsigned char) syn[len]))
++	    ++len;
++	  syn += len;
++	  p = dvp_skip_space (p);
++	  if (dvp_casecmp (p, w, len) != 0)
++	    {
++	      snprintf (err, errlen, "expected '%.*s' here", (int) len, w);
++	      return err;
++	    }
++	  /* The accumulator is a destination like any other, so it may repeat
++	     the specifier as a suffix; the other operand keywords -- I, Q, P,
++	     R -- may not, which is measured and not assumed.  */
++	  accumulator = (len == strlen (DVP_ACC_KEYWORD)
++			 && dvp_casecmp (w, DVP_ACC_KEYWORD, len) == 0);
++	  /* The accumulator ends a word: `ACC' may be followed by a component
++	     suffix and then by nothing else that is part of a name.  The
++	     one-letter operand keywords -- I, Q, P and R -- end nothing, and a
++	     lower operation may abut them, which is what makes
++	     `addi.xy vf01,vf02,Inop' a line and not a typo.  */
++	  if (accumulator && dvp_ident_char ((unsigned char) p[len]))
++	    {
++	      if (dvp_component_bit ((unsigned char) p[len]) == 0)
++		{
++		  snprintf (err, errlen, "expected '%.*s' here", (int) len, w);
++		  return err;
++		}
++	      p += len;
++	      e = dvp_parse_component_suffix (&p, insn->dest, 0,
++					      DVP_ACC_KEYWORD, err, errlen);
++	      if (e)
++		return e;
++	      continue;
++	    }
++	  p += len;
++	  continue;
++	}
++
++      /* Punctuation, possibly doubled (++ or --).  */
++      {
++	char c0 = *syn++;
++	int two = (*syn == c0 && (c0 == '+' || c0 == '-'));
++	if (two)
++	  ++syn;
++	p = dvp_skip_space (p);
++	if (p[0] != c0 || (two && p[1] != c0))
++	  {
++	    if (two)
++	      snprintf (err, errlen, "expected '%c%c' here", c0, c0);
++	    else
++	      snprintf (err, errlen, "expected '%c' here", c0);
++	    return err;
++	  }
++	p += two ? 2 : 1;
++      }
++    }
++
++  if (nf != op->nfields - (op->dest_field >= 0 ? 1 : 0))
++    {
++      snprintf (err, errlen, "internal error: %s consumed %d of %d operands",
++		op->name, nf, (int) op->nfields);
++      return err;
++    }
++
++  *pp = p;
++  return NULL;
++}
++
++/* Parse one whole operation for PIPE.  On success *PP points just past it.  */
++
++const char *
++dvp_vu_parse_operation (char **pp, int pipe, struct dvp_insn *insn,
++			const struct dvp_parse_hooks *hooks,
++			char *err, size_t errlen)
++{
++  char *p = dvp_skip_space (*pp);
++  char name[32];
++  size_t len = 0;
++  const struct dvp_vu_opcode *op;
++  unsigned int flag_bits = 0;
++  unsigned int dest = 0;
++  int have_dest = 0;
++  int dest_written = 0;
++  const char *e;
++
++  while (len < sizeof (name) - 1
++	 && ((p[len] >= 'a' && p[len] <= 'z')
++	     || (p[len] >= 'A' && p[len] <= 'Z')
++	     || (p[len] >= '0' && p[len] <= '9')
++	     || p[len] == '_'))
++    {
++      name[len] = (char) dvp_tolower ((unsigned char) p[len]);
++      ++len;
++    }
++  name[len] = 0;
++  if (len == 0)
++    {
++      snprintf (err, errlen, "expected %s-pipe operation",
++		pipe == DVP_PIPE_UPPER ? "an upper" : "a lower");
++      return err;
++    }
++
++  /* The longest run of name characters is the mnemonic on every ordinary line.
++     Where that run is not a mnemonic, one that takes no operands may still be
++     hiding at the front of it: `nopnop' is an upper `nop' and a lower `nop'.
++     Only an operand-less mnemonic can do this -- every other is followed by
++     required whitespace -- which is why the search is for one of those.  */
++  if (dvp_vu_lookup (name, pipe) == NULL)
++    {
++      char pre[sizeof (name)];
++      size_t k;
++
++      memcpy (pre, name, len + 1);
++      for (k = len; k > 0; --k)
++	{
++	  const struct dvp_vu_opcode *cand;
++
++	  pre[k] = 0;
++	  cand = dvp_vu_lookup (pre, pipe);
++	  if (cand != NULL && cand->syntax[0] == 0)
++	    break;
++	}
++      if (k > 0)
++	{
++	  memcpy (name, pre, k + 1);
++	  len = k;
++	}
++    }
++  if (len == sizeof (name) - 1
++      && ((p[len] >= 'a' && p[len] <= 'z') || (p[len] >= 'A' && p[len] <= 'Z')
++	  || (p[len] >= '0' && p[len] <= '9') || p[len] == '_'))
++    {
++      /* Say so rather than looking up the first NAME characters: a diagnostic
++	 that named a truncated mnemonic would be talking about a different
++	 word from the one in the source.  */
++      snprintf (err, errlen,
++		"this operation name is longer than the %lu characters a VU "
++		"mnemonic can have", (unsigned long) sizeof (name) - 1);
++      return err;
++    }
++  p += len;
++
++  if (*p == '[')
++    {
++      if (pipe != DVP_PIPE_UPPER)
++	{
++	  snprintf (err, errlen,
++		    "instruction flags belong on the upper operation, not on "
++		    "'%s'", name);
++	  return err;
++	}
++      e = dvp_parse_flags (&p, &flag_bits, err, errlen);
++      if (e)
++	return e;
++    }
++
++  /* The destination specifier is written with `.' or with `/'; the two are one
++     spelling of one thing and produce identical bytes.  Only one of them, and
++     only once.  */
++  if (*p == '.' || *p == '/')
++    {
++      ++p;
++      e = dvp_parse_dest_mask (&p, &dest, &dest_written, err, errlen);
++      if (e)
++	return e;
++      have_dest = 1;
++      if (*p == '.' || *p == '/')
++	{
++	  snprintf (err, errlen,
++		    "'%s' has two destination specifiers; write one, after the "
++		    "mnemonic", name);
++	  return err;
++	}
++      if (*p == '[')
++	{
++	  snprintf (err, errlen,
++		    "instruction flags must come before the destination "
++		    "specifier, as in '%s[i].%s'", name,
++		    dest == DVP_DEST_ALL ? "xyzw" : "x");
++	  return err;
++	}
++    }
++
++  op = dvp_vu_lookup (name, pipe);
++  if (op == NULL)
++    {
++      const struct dvp_vu_opcode *other
++	= dvp_vu_lookup (name, pipe == DVP_PIPE_UPPER ? DVP_PIPE_LOWER
++						      : DVP_PIPE_UPPER);
++      if (other != NULL)
++	snprintf (err, errlen,
++		  "'%s' is a %s-pipe operation, but %s-pipe operation is "
++		  "expected here; each line carries one upper operation "
++		  "followed by one lower operation", name,
++		  pipe == DVP_PIPE_UPPER ? "lower" : "upper",
++		  pipe == DVP_PIPE_UPPER ? "an upper" : "a lower");
++      else
++	snprintf (err, errlen, "unknown VU operation '%s'", name);
++      return err;
++    }
++
++  switch (op->dest_mode)
++    {
++    case DVP_DEST_NONE:
++      if (have_dest)
++	{
++	  snprintf (err, errlen, "'%s' does not take a destination specifier",
++		    name);
++	  return err;
++	}
++      break;
++    case DVP_DEST_MASK:
++      if (!have_dest)
++	dest = DVP_DEST_ALL;		/* omitted means every component */
++      break;
++    case DVP_DEST_SINGLE:
++      if (!have_dest)
++	{
++	  snprintf (err, errlen,
++		    "'%s' needs a destination component, as in '%s.x'",
++		    name, name);
++	  return err;
++	}
++      if ((dest & (dest - 1)) != 0 || dest_written != 1)
++	{
++	  snprintf (err, errlen,
++		    "'%s' addresses exactly one component; name only one of "
++		    "x, y, z and w, and name it once", name);
++	  return err;
++	}
++      break;
++    case DVP_DEST_FIXED:
++      if (!have_dest || dest != op->dest_fixed)
++	{
++	  char want[5];
++	  int n = 0;
++	  if (op->dest_fixed & DVP_DEST_X) want[n++] = 'x';
++	  if (op->dest_fixed & DVP_DEST_Y) want[n++] = 'y';
++	  if (op->dest_fixed & DVP_DEST_Z) want[n++] = 'z';
++	  if (op->dest_fixed & DVP_DEST_W) want[n++] = 'w';
++	  want[n] = 0;
++	  snprintf (err, errlen, "'%s' is written '%s.%s'", name, name, want);
++	  return err;
++	}
++      break;
++    default:
++      break;
++    }
++
++  /* An operation that takes operands is separated from them by whitespace, and
++     the separation is required: `add[i]vf01,vf02,vf03' and `b+8' are not this
++     grammar.  An operation that takes none -- `nop', `waitp', `waitq' --
++     requires nothing after it, which lets a lower operation abut an upper
++     `nop'.  */
++  if (op->syntax[0] != 0)
++    {
++      char *after = dvp_skip_space (p);
++
++      if (after == p)
++	{
++	  snprintf (err, errlen,
++		    "'%s' needs whitespace between it and its first operand",
++		    name);
++	  return err;
++	}
++      p = after;
++    }
++
++  insn->opcode = op;
++  insn->flag_bits = flag_bits;
++  insn->dest = dest;
++  insn->noperands = 0;
++
++  e = dvp_vu_parse_operands (op, &p, insn, hooks, err, errlen);
++  if (e)
++    return e;
++
++  *pp = p;
++  return NULL;
++}

--- a/utils/kos-chain/patches/targets/binutils-2.47-kos.diff
+++ b/utils/kos-chain/patches/targets/binutils-2.47-kos.diff
@@ -1,0 +1,67 @@
+Emotion Engine (EE, mips64r5900el-ps2-elf) tweaks for binutils 2.47.
+
+Upstream 2.47 already provides the R5900 core (gas -march=r5900, the MMI and
+VU0 macro-mode opcodes, the elf32lr5900 linker emulations, the mips*-ps2-elf*
+target, and all MIPS relocations incl. TLS). This patch adds only three small
+EE-specific fixes on top:
+
+  * opcodes/mips-opc.c: an EE-form "sqrt.s D,T" whose source operand is read
+    from the ft field (the generic "sqrt.s D,S" encodes it wrong for R5900).
+  * ld/emulparams/elf32lr5900{,n32}.sh: drop "unset GENERATE_SHLIB_SCRIPT" so
+    the R5900 linker emulations can still generate shared-library link scripts.
+  * configure{,.ac}: an empty mips64r5900el-ps2-elf case ahead of the mips*
+    catch-all so gprof is NOT disabled for the EE target.
+
+diff -ruN pristine/configure ee/configure
+--- pristine/configure	2026-06-07 16:00:00
++++ ee/configure	2026-07-14 22:05:55
+@@ -4190,6 +4190,8 @@
+   | mips*-*-irix* | mips*-*-lnews* | mips*-*-riscos*)
+     noconfigdirs="$noconfigdirs ld gas gprof"
+     ;;
++  mips64r5900el-ps2-elf)
++    ;;
+   mips*-*-*)
+     noconfigdirs="$noconfigdirs gprof"
+     ;;
+diff -ruN pristine/configure.ac ee/configure.ac
+--- pristine/configure.ac	2026-06-07 16:00:00
++++ ee/configure.ac	2026-07-14 22:05:55
+@@ -1359,6 +1359,8 @@
+   | mips*-*-irix* | mips*-*-lnews* | mips*-*-riscos*)
+     noconfigdirs="$noconfigdirs ld gas gprof"
+     ;;
++  mips64r5900el-ps2-elf)
++    ;;
+   mips*-*-*)
+     noconfigdirs="$noconfigdirs gprof"
+     ;;
+diff -ruN pristine/ld/emulparams/elf32lr5900.sh ee/ld/emulparams/elf32lr5900.sh
+--- pristine/ld/emulparams/elf32lr5900.sh	2026-06-07 16:00:00
++++ ee/ld/emulparams/elf32lr5900.sh	2026-07-14 22:05:55
+@@ -13,5 +13,3 @@
+ 
+ unset DATA_ADDR
+ SHLIB_TEXT_START_ADDR=0
+-unset GENERATE_SHLIB_SCRIPT
+-
+diff -ruN pristine/ld/emulparams/elf32lr5900n32.sh ee/ld/emulparams/elf32lr5900n32.sh
+--- pristine/ld/emulparams/elf32lr5900n32.sh	2026-06-07 16:00:00
++++ ee/ld/emulparams/elf32lr5900n32.sh	2026-07-14 22:05:55
+@@ -19,5 +19,3 @@
+ 
+ unset DATA_ADDR
+ SHLIB_TEXT_START_ADDR=0
+-unset GENERATE_SHLIB_SCRIPT
+-
+diff -ruN pristine/opcodes/mips-opc.c ee/opcodes/mips-opc.c
+--- pristine/opcodes/mips-opc.c	2026-06-07 16:00:00
++++ ee/opcodes/mips-opc.c	2026-07-14 22:05:55
+@@ -1950,6 +1950,7 @@
+ {"sqc2",		"+7,o(b)",	0xf8000000, 0xfc000000,	RD_3|RD_C2|SM,		0,		EE,		0,	0 },
+ {"sqc2",		"+7,A(b)",	0,    (int) M_SQC2_AB,	INSN_MACRO,		0,		EE,		0,	0 },
+ {"sqrt.d",		"D,S",		0x46200004, 0xffff003f, WR_1|RD_2|FP_D,		0,		I2,		0,	SF },
++{"sqrt.s",		"D,T",      0x46000004, 0xffe0f83f, WR_1|RD_2|FP_S,		0,		EE,		0,	0 },
+ {"sqrt.s",		"D,S",		0x46000004, 0xffff003f, WR_1|RD_2|FP_S,		0,		I2,		0,	0 },
+ {"sqrt.ps",		"D,S",		0x46c00004, 0xffff003f, WR_1|RD_2|FP_D,		0,		SB1,		0,	0 },
+ {"srav",		"d,t,s",	0x00000007, 0xfc0007ff,	WR_1|RD_2|RD_3,		0,		I1,		0,	0 },

--- a/utils/kos-chain/patches/targets/gcc-16.1.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.1.0-kos.diff
@@ -145,3 +145,565 @@ diff -ruN gcc-16.1.0/libstdc++-v3/configure gcc-16.1.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
+
+--- gcc-16.1.0/gcc/config.gcc
++++ gcc-16.1.0-kos/gcc/config.gcc
+@@ -2879,7 +2879,7 @@
+ 	tmake_file="mips/t-elf"
+ 	;;
+ mips64r5900-*-elf* | mips64r5900el-*-elf*)
+-	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h"
++	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h mips/ps2.h"
+ 	tmake_file="mips/t-elf"
+ 	tm_defines="${tm_defines} MIPS_ISA_DEFAULT=MIPS_ISA_MIPS3 MIPS_ABI_DEFAULT=ABI_N32"
+ 	;;
+
+--- gcc-16.1.0/gcc/config/mips/ps2.h
++++ gcc-16.1.0-kos/gcc/config/mips/ps2.h
+@@ -0,0 +1,8 @@
++/* KallistiOS: PlayStation 2 Emotion Engine target tweaks on top of the
++   generic mips64r5900*-elf configuration.  */
++
++/* Do not place data in gp-relative small-data sections by default; KOS
++   does not set up $gp for small data, and newlib/libstdc++ are built
++   with -G0 to match.  */
++#undef MIPS_DEFAULT_GVALUE
++#define MIPS_DEFAULT_GVALUE 0
+
+--- gcc-16.1.0/gcc/config/mips/5900.md
++++ gcc-16.1.0-kos/gcc/config/mips/5900.md
+@@ -0,0 +1,121 @@
++;; Copyright (C) 2002-2015 Free Software Foundation, Inc.
++;;
++;; This file is part of GCC.
++;;
++;; GCC is free software; you can redistribute it and/or modify
++;; it under the terms of the GNU General Public License as published by
++;; the Free Software Foundation; either version 3, or (at your option)
++;; any later version.
++;;
++;; GCC is distributed in the hope that it will be useful,
++;; but WITHOUT ANY WARRANTY; without even the implied warranty of
++;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++;; GNU General Public License for more details.
++;;
++;; You should have received a copy of the GNU General Public License
++;; along with GCC; see the file COPYING3.  If not see
++;; <http://www.gnu.org/licenses/>.
++;;
++;; R5900 instruction patterns and pipeline tuning.
++
++(define_automaton "r5900_alu,r5900_fpu,r5900_br,r5900_ls")
++
++(define_cpu_unit "r5900_alu0,r5900_alu1" "r5900_alu")
++(define_cpu_unit "r5900_c1" "r5900_fpu")
++(define_cpu_unit "r5900_br" "r5900_br")
++(define_cpu_unit "r5900_ls" "r5900_ls")
++
++(define_insn_reservation "r5900_alu" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "unknown,prefetch,prefetchx,condmove,const,arith,
++			shift,slt,clz,trap,multi,nop,logical,signext,move"))
++ "r5900_alu0|r5900_alu1")
++
++(define_insn_reservation "r5900_loadstore" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "load,store"))
++ "r5900_ls")
++
++(define_insn_reservation "r5900_fploadstore" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fpload,fpstore"))
++ "r5900_c1,nothing")
++
++(define_insn_reservation "r5900_fcvt" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fcvt"))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fmove" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fabs,fneg,fmove"))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fcmp" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fcmp"))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fadd" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fadd"))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fmul_single" 4
++  (and (eq_attr "cpu" "r5900")
++       (and (eq_attr "type" "fmul,fmadd")
++            (eq_attr "mode" "SF")))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fdiv_single" 8
++  (and (eq_attr "cpu" "r5900")
++       (and (eq_attr "type" "fdiv,frdiv")
++            (eq_attr "mode" "SF")))
++ "r5900_c1*7,nothing")
++
++(define_insn_reservation "r5900_fsqrt_single" 8
++  (and (eq_attr "cpu" "r5900")
++       (and (eq_attr "type" "fsqrt")
++            (eq_attr "mode" "SF")))
++ "r5900_c1*7,nothing")
++
++(define_insn_reservation "r5900_frsqrt_single" 14
++  (and (eq_attr "cpu" "r5900")
++       (and (eq_attr "type" "frsqrt")
++            (eq_attr "mode" "SF")))
++ "r5900_c1*13,nothing")
++
++(define_insn_reservation "r5900_xfer" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mfc,mtc"))
++ "r5900_c1+r5900_ls,nothing")
++
++(define_insn_reservation "r5900_branch" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "branch,jump,call"))
++ "r5900_br")
++
++(define_insn_reservation "r5900_hilo" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mfhi,mflo,mthi,mtlo"))
++ "r5900_alu0")
++
++(define_insn_reservation "r5900_imul" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "imul,imul3,imadd"))
++ "r5900_alu0*2,nothing*2")
++
++(define_insn_reservation "r5900_idiv" 37
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "idiv,idiv3"))
++ "r5900_alu0*37")
++
++;; RSQRT
++(define_insn "rsqrtsf"
++  [(set (match_operand:SF 0 "register_operand" "=f")
++	(div:SF (match_operand:SF 1 "register_operand" "f")
++		  (sqrt:SF (match_operand:SF 2 "register_operand" "f"))))]
++  "TARGET_MIPS5900"
++  "rsqrt.s\t%0,%1,%2"
++  [(set_attr "type" "frsqrt")
++   (set_attr "mode" "SF")])
+
+--- gcc-16.1.0/gcc/config/mips/mips.cc
++++ gcc-16.1.0-kos/gcc/config/mips/mips.cc
+@@ -3609,6 +3609,9 @@
+ /* The __tls_get_attr symbol.  */
+ static GTY(()) rtx mips_tls_symbol;
+ 
++/* The __r5900_get_tp symbol — R5900-specific TLS-pointer helper.  */
++static GTY(()) rtx mips_r5900_get_tp_symbol;
++
+ /* Return an instruction sequence that calls __tls_get_addr.  SYM is
+    the TLS symbol we are referencing and TYPE is the symbol type to use
+    (either global dynamic or local dynamic).  V0 is an RTX for the
+@@ -3653,6 +3656,28 @@
+ 	mips16_rdhwr_stub = new mips16_rdhwr_one_only_stub ();
+       fn = mips16_stub_call_address (mips16_rdhwr_stub);
+       emit_insn (PMODE_INSN (gen_tls_get_tp_mips16, (tp, fn)));
++    }
++  else if (TARGET_MIPS5900)
++    {
++      /* The R5900 cannot read the thread pointer via rdhwr — that opcode
++	 is `sq $rt, -6085($zero)` on this core and the hardware executes
++	 it as a silent 128-bit store rather than a trap-and-emulate-able
++	 unimplemented-instruction exception.  Call the kernel-provided
++	 helper __r5900_get_tp instead, following the same libcall pattern
++	 used for __tls_get_addr in the global-/local-dynamic TLS models
++	 above.  The helper returns the (bias-adjusted) thread pointer in
++	 $v0 per the standard MIPS calling convention; we then move that
++	 into the destination register the caller asked us to populate.  */
++      rtx v0 = gen_rtx_REG (Pmode, GP_RETURN);
++      rtx_insn *insn;
++
++      if (!mips_r5900_get_tp_symbol)
++	mips_r5900_get_tp_symbol = init_one_libfunc ("__r5900_get_tp");
++
++      insn = mips_expand_call (MIPS_CALL_NORMAL, v0, mips_r5900_get_tp_symbol,
++			       const0_rtx, NULL_RTX, false);
++      RTL_CONST_CALL_P (insn) = 1;
++      emit_move_insn (tp, v0);
+     }
+   else
+     emit_insn (PMODE_INSN (gen_tls_get_tp, (tp)));
+@@ -20582,6 +20607,11 @@
+   if (TARGET_MIPS5900 && TARGET_HARD_FLOAT_ABI && TARGET_DOUBLE_FLOAT)
+     error ("unsupported combination: %s",
+ 	   "-march=r5900 -mhard-float -mdouble-float");
++
++  /* The R5900 does not support some MIPS16 instructions.  */
++  if (TARGET_MIPS5900 && ((mips_base_compression_flags & MASK_MIPS16) != 0))
++	  error("unsupported combination: %s",
++		  "-march=r5900 -mips16");
+ 
+   /* If a -mlong* option was given, check that it matches the ABI,
+      otherwise infer the -mlong* setting from the other options.  */
+
+--- gcc-16.1.0/gcc/config/mips/mips.md
++++ gcc-16.1.0-kos/gcc/config/mips/mips.md
+@@ -1124,6 +1124,7 @@
+ 
+ (define_delay (and (eq_attr "type" "branch")
+ 		   (not (match_test "TARGET_MIPS16"))
++		   (not (match_test "TARGET_FIX_R5900"))
+ 		   (eq_attr "branch_likely" "yes"))
+   [(eq_attr "can_delay" "yes")
+    (nil)
+@@ -1133,6 +1134,7 @@
+ ;; not annul on false.
+ (define_delay (and (eq_attr "type" "branch,simd_branch")
+ 		   (not (match_test "TARGET_MIPS16"))
++		   (not (match_test "TARGET_FIX_R5900"))
+ 		   (ior (match_test "TARGET_CB_NEVER")
+ 			(and (eq_attr "compact_form" "maybe")
+ 			     (not (match_test "TARGET_CB_ALWAYS")))
+@@ -1203,6 +1205,7 @@
+ (include "5000.md")
+ (include "5400.md")
+ (include "5500.md")
++(include "5900.md")
+ (include "6000.md")
+ (include "7000.md")
+ (include "9000.md")
+@@ -1811,7 +1814,7 @@
+ 		 (match_operand:SI 3 "register_operand" "l,l,l,d")))
+    (clobber (match_scratch:SI 4 "=X,X,3,l"))
+    (clobber (match_scratch:SI 5 "=X,X,X,&d"))]
+-  "TARGET_MIPS3900 && !TARGET_MIPS16"
++  "(TARGET_MIPS3900 || TARGET_MIPS5900) && !TARGET_MIPS16"
+   "@
+     madd\t%1,%2
+     madd\t%1,%2
+
+--- gcc-16.1.0/include/longlong.h
++++ gcc-16.1.0-kos/include/longlong.h
+@@ -853,6 +853,17 @@
+ #endif
+ 
+ #if defined (__mips__) && W_TYPE_SIZE == 32
++/* Force R5900 to use mult for mulsidi3, this is used in muldi3 */
++#ifdef _MIPS_ARCH_R5900
++#define __umulsidi3(u, v) \
++  ({UDItype __w;							\
++    __asm__ ("multu	%1,%2\n\tpmfhl.lw %0"				\
++	     : "=d" (__w)						\
++	     : "d" ((USItype) (u)),					\
++	       "d" ((USItype) (v))					\
++	     : "hi", "lo");						\
++    __w; })
++#endif
+ #define umul_ppmm(w1, w0, u, v)						\
+   do {									\
+     UDItype __x = (UDItype) (USItype) (u) * (USItype) (v);		\
+
+--- gcc-16.1.0/libgcc/config.host
++++ gcc-16.1.0-kos/libgcc/config.host
+@@ -155,7 +155,11 @@
+ 	cpu_type=mips
+ 	tmake_file="mips/t-mips"
+ 	if test "${libgcc_cv_mips_hard_float}" = yes; then
++	    if test "${libgcc_cv_mips_single_float}" = yes; then
++                tmake_file="${tmake_file} t-hardfp-sf t-hardfp"
++	    else
+ 		tmake_file="${tmake_file} t-hardfp-sfdf t-hardfp"
++	    fi
+ 	else
+ 		tmake_file="${tmake_file} t-softfp-sfdf"
+ 	fi
+@@ -1064,19 +1068,16 @@
+ mips*-*-linux*)				# Linux MIPS, either endian.
+ 	extra_parts="$extra_parts crtfastmath.o"
+ 	tmake_file="${tmake_file} t-crtfm"
+-	case ${host} in
+-	  mips64r5900* | mipsr5900*)
+-	    # The MIPS16 support code uses floating point
+-	    # instructions that are not supported on r5900.
+-	    ;;
+-	  *)
++    if test "${libgcc_cv_mips16}" = yes; then
+ 	    tmake_file="${tmake_file} mips/t-mips16 t-slibgcc-libgcc"
+-	    ;;
+-	esac
++    fi
+ 	md_unwind_header=mips/linux-unwind.h
+ 	;;
+ mips*-sde-elf*)
+-	tmake_file="$tmake_file mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	case "${with_newlib}" in
+ 	  yes)
+ 	    # newlib / libgloss.
+@@ -1106,7 +1107,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips-*-elf* | mipsel-*-elf*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mipsr5900-*-elf* | mipsr5900el-*-elf*)
+@@ -1114,7 +1118,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips64-*-elf* | mips64el-*-elf*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips64r5900-*-elf* | mips64r5900el-*-elf*)
+@@ -1130,7 +1137,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips*-*-rtems*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips-wrs-vxworks)
+
+--- gcc-16.1.0/libgcc/config/mips/sfp-machine.h
++++ gcc-16.1.0-kos/libgcc/config/mips/sfp-machine.h
+@@ -22,7 +22,7 @@
+ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ <http://www.gnu.org/licenses/>.  */
+ 
+-#ifdef __mips64
++#if defined(__mips64) && !defined(_MIPS_ARCH_R5900)
+ #define _FP_W_TYPE_SIZE		64
+ #define _FP_W_TYPE		unsigned long long
+ #define _FP_WS_TYPE		signed long long
+
+--- gcc-16.1.0/libgcc/config/t-hardfp-sf
++++ gcc-16.1.0-kos/libgcc/config/t-hardfp-sf
+@@ -0,0 +1,32 @@
++# Copyright (C) 2014-2015 Free Software Foundation, Inc.
++
++# This file is part of GCC.
++
++# GCC is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3, or (at your option)
++# any later version.
++
++# GCC is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++
++# You should have received a copy of the GNU General Public License
++# along with GCC; see the file COPYING3.  If not see
++# <http://www.gnu.org/licenses/>.
++
++hardfp_float_modes := sf
++# di and ti are provided by libgcc2.c where needed.
++hardfp_int_modes := si
++hardfp_extensions :=
++hardfp_truncations :=
++
++# Emulate 64 bit float:
++FPBIT = true
++DPBIT = true
++# Don't build functions handled by 32 bit hardware:
++LIB2FUNCS_EXCLUDE = _addsub_sf _mul_sf _div_sf \
++    _fpcmp_parts_sf _compare_sf _eq_sf _ne_sf _gt_sf _ge_sf \
++    _lt_sf _le_sf _unord_sf _si_to_sf _sf_to_si _negate_sf \
++    _thenan_sf _sf_to_usi _usi_to_sf
+
+--- gcc-16.1.0/libgcc/configure
++++ gcc-16.1.0-kos/libgcc/configure
+@@ -5164,6 +5164,48 @@
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_hard_float" >&5
+ $as_echo "$libgcc_cv_mips_hard_float" >&6; }
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target is single-float" >&5
++$as_echo_n "checking whether the target is single-float... " >&6; }
++if test "${libgcc_cv_mips_single_float+set}" = set; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#ifndef __mips_single_float
++     #error FOO
++     #endif
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  libgcc_cv_mips_single_float=yes
++else
++  libgcc_cv_mips_single_float=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_single_float" >&5
++$as_echo "$libgcc_cv_mips_single_float" >&6; }
++  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target supports the MIPS16 ASE" >&5
++$as_echo_n "checking whether the target supports MIPS16 ASE... " >&6; }
++if test "${libgcc_cv_mips16+set}" = set; then :
++  $as_echo_n "(cached) " >&6
++else
++  CFLAGS_hold=$CFLAGS
++		 CFLAGS="$CFLAGS -mips16"
++		 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++int i;
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  libgcc_cv_mips16=yes
++else
++  libgcc_cv_mips16=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++	CFLAGS=$CFLAGS_hold
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips16" >&5
++$as_echo "$libgcc_cv_mips16" >&6; }
+ esac
+ 
+ # Determine the version of glibc, if any, used on the target.
+
+--- gcc-16.1.0/libgcc/configure.ac
++++ gcc-16.1.0-kos/libgcc/configure.ac
+@@ -356,6 +356,23 @@
+     ])],
+     [libgcc_cv_mips_hard_float=yes],
+     [libgcc_cv_mips_hard_float=no])])
++  AC_CACHE_CHECK([whether the target is single-float],
++		 [libgcc_cv_mips_single_float],
++		 [AC_COMPILE_IFELSE(
++    [#ifndef __mips_single_float
++     #error FOO
++     #endif],
++    [libgcc_cv_mips_single_float=yes],
++    [libgcc_cv_mips_single_float=no])])
++  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
++  AC_CACHE_CHECK([whether the target supports the MIPS16 ASE],
++		 [libgcc_cv_mips16],
++		 [CFLAGS_hold=$CFLAGS
++		 CFLAGS="$CFLAGS -mips16"
++		 AC_COMPILE_IFELSE([[int i;]],
++    [libgcc_cv_mips16=yes],
++    [libgcc_cv_mips16=no])
++	CFLAGS=$CFLAGS_hold])
+ esac
+ 
+ # Determine the version of glibc, if any, used on the target.
+
+
+--- gcc-16.1.0/gcc/builtins.cc
++++ gcc-16.1.0-kos/gcc/builtins.cc
+@@ -10301,6 +10301,8 @@
+     default:
+       gcc_unreachable ();
+     }
++
++  unsigned int llu_size = TYPE_PRECISION (long_long_unsigned_type_node);
+ 
+   if (TYPE_PRECISION (arg0_type)
+       <= TYPE_PRECISION (long_long_unsigned_type_node))
+@@ -10324,10 +10326,10 @@
+ 	  fcodei = fcodell;
+ 	}
+     }
+-  else if (TYPE_PRECISION (arg0_type) <= MAX_FIXED_MODE_SIZE)
++  else if (TYPE_PRECISION (arg0_type) <= 2 * llu_size)
+     {
+       cast_type
+-	= build_nonstandard_integer_type (MAX_FIXED_MODE_SIZE,
++	= build_nonstandard_integer_type (2 * llu_size,
+ 					  TYPE_UNSIGNED (arg0_type));
+       gcc_assert (TYPE_PRECISION (cast_type)
+ 		  == 2 * TYPE_PRECISION (long_long_unsigned_type_node));
+@@ -10361,7 +10363,7 @@
+       arg2 = NULL_TREE;
+     }
+   tree call = NULL_TREE, tem;
+-  if (TYPE_PRECISION (arg0_type) == MAX_FIXED_MODE_SIZE
++  if (TYPE_PRECISION (arg0_type) == 2 * llu_size
+       && (TYPE_PRECISION (arg0_type)
+ 	  == 2 * TYPE_PRECISION (long_long_unsigned_type_node))
+       /* If the target supports the optab, then don't do the expansion. */
+@@ -10374,7 +10376,7 @@
+ 		   : long_long_integer_type_node);
+       tree hi = fold_build2 (RSHIFT_EXPR, arg0_type, arg0,
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2));
++					    llu_size));
+       hi = fold_convert (type, hi);
+       tree lo = fold_convert (type, arg0);
+       switch (fcode)
+@@ -10383,7 +10385,7 @@
+ 	  call = fold_builtin_bit_query (loc, fcode, lo, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  if (arg2)
+ 	    call = fold_build3 (COND_EXPR, integer_type_node,
+ 				fold_build2 (NE_EXPR, boolean_type_node,
+@@ -10400,7 +10402,7 @@
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  if (arg2)
+ 	    call = fold_build3 (COND_EXPR, integer_type_node,
+ 				fold_build2 (NE_EXPR, boolean_type_node,
+@@ -10417,14 +10419,14 @@
+ 	  tem = fold_builtin_bit_query (loc, fcode, lo, NULL_TREE);
+ 	  tem = fold_build2 (PLUS_EXPR, integer_type_node, tem,
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2));
++					    llu_size));
+ 	  tem = fold_build3 (COND_EXPR, integer_type_node,
+ 			     fold_build2 (LT_EXPR, boolean_type_node,
+ 					  fold_build2 (BIT_XOR_EXPR, type,
+ 						       lo, hi),
+ 					  build_zero_cst (type)),
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2 - 1),
++					    llu_size - 1),
+ 			     tem);
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = save_expr (call);
+@@ -10432,15 +10434,15 @@
+ 			      fold_build2 (NE_EXPR, boolean_type_node,
+ 					   call,
+ 					   build_int_cst (integer_type_node,
+-							  MAX_FIXED_MODE_SIZE
+-							  / 2 - 1)),
++							  llu_size
++							  - 1)),
+ 			      call, tem);
+ 	  break;
+ 	case BUILT_IN_FFSG:
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  call = fold_build3 (COND_EXPR, integer_type_node,
+ 			      fold_build2 (NE_EXPR, boolean_type_node,
+ 					   hi, build_zero_cst (type)),

--- a/utils/kos-chain/patches/targets/gcc-16.2.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.2.0-kos.diff
@@ -157,3 +157,553 @@ diff -ruN gcc-16.2.0/libgcc/config/sh/t-sh gcc-16.2.0-kos/libgcc/config/sh/t-sh
  	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
  
  OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o
+
+--- gcc-16.2.0/gcc/config.gcc
++++ gcc-16.2.0-kos/gcc/config.gcc
+@@ -2879,7 +2879,7 @@
+ 	tmake_file="mips/t-elf"
+ 	;;
+ mips64r5900-*-elf* | mips64r5900el-*-elf*)
+-	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h"
++	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h mips/ps2.h"
+ 	tmake_file="mips/t-elf"
+ 	tm_defines="${tm_defines} MIPS_ISA_DEFAULT=MIPS_ISA_MIPS3 MIPS_ABI_DEFAULT=ABI_N32"
+ 	;;
+
+--- gcc-16.2.0/gcc/config/mips/ps2.h
++++ gcc-16.2.0-kos/gcc/config/mips/ps2.h
+@@ -0,0 +1,8 @@
++/* KallistiOS: PlayStation 2 Emotion Engine target tweaks on top of the
++   generic mips64r5900*-elf configuration.  */
++
++/* Do not place data in gp-relative small-data sections by default; KOS
++   does not set up $gp for small data, and newlib/libstdc++ are built
++   with -G0 to match.  */
++#undef MIPS_DEFAULT_GVALUE
++#define MIPS_DEFAULT_GVALUE 0
+
+--- gcc-16.2.0/gcc/config/mips/5900.md
++++ gcc-16.2.0-kos/gcc/config/mips/5900.md
+@@ -0,0 +1,109 @@
++;; Clean-room DFA pipeline description for the PlayStation 2 Emotion Engine
++;; (MIPS R5900).  Written from the public R5900 architecture (a dual-issue,
++;; in-order MIPS III core with MMI extensions and a single-precision FPU) using
++;; the conventions of the upstream MIPS scheduler descriptions.  Not derived
++;; from any third-party source.
++;;
++;; The R5900 issues up to two instructions per cycle.  It has two integer ALU
++;; slots, one load/store slot, one multiply/divide (MAC) unit, one FPU, and a
++;; branch unit.  Floating point is single precision only; double-precision
++;; operations are software floating point and do not reach this description.
++
++(define_automaton "r5900_cpu")
++
++(define_cpu_unit "r5900_alu0" "r5900_cpu")   ; integer ALU slot 0
++(define_cpu_unit "r5900_alu1" "r5900_cpu")   ; integer ALU slot 1
++(define_cpu_unit "r5900_ls"   "r5900_cpu")   ; load / store
++(define_cpu_unit "r5900_mac"  "r5900_cpu")   ; integer multiply / divide
++(define_cpu_unit "r5900_fpu"  "r5900_cpu")   ; single-precision FPU
++(define_cpu_unit "r5900_br"   "r5900_cpu")   ; branch
++
++;; Anything unusual serialises the whole core.
++(define_insn_reservation "r5900_unknown" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "unknown,multi,atomic,syncloop"))
++  "r5900_alu0+r5900_alu1+r5900_ls+r5900_mac+r5900_fpu+r5900_br")
++
++;; Integer ALU: single cycle, either slot.
++(define_insn_reservation "r5900_alu" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "arith,shift,signext,slt,clz,const,logical,move,nop,trap,condmove"))
++  "r5900_alu0|r5900_alu1")
++
++;; Loads and stores.
++(define_insn_reservation "r5900_load" 3
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "load,fpload,fpidxload"))
++  "r5900_ls")
++
++(define_insn_reservation "r5900_store" 0
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "store,fpstore,fpidxstore"))
++  "r5900_ls")
++
++;; Moves between the GPRs and the coprocessors.
++(define_insn_reservation "r5900_xfer" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mfc,mtc"))
++  "r5900_alu0|r5900_alu1")
++
++;; Branches take one issue slot; misprediction handled by the two-cycle latency.
++(define_insn_reservation "r5900_branch" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "branch,jump,call"))
++  "r5900_br")
++
++;; Integer multiply / multiply-add through the MAC unit.  The R5900 has no
++;; 64-bit hardware multiply, so DI multiplies are library calls and only the
++;; SI form is modelled here.
++(define_insn_reservation "r5900_imul" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "imul,imul3,imadd"))
++  "r5900_mac")
++
++(define_insn_reservation "r5900_mthilo" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mthi,mtlo"))
++  "r5900_mac")
++
++(define_insn_reservation "r5900_mfhilo" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mfhi,mflo"))
++  "r5900_mac")
++
++;; Integer divide is not pipelined and takes many cycles.
++(define_insn_reservation "r5900_idiv" 37
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "idiv"))
++  "r5900_mac*37")
++
++;; Single-precision floating point.  (Double precision is soft float.)
++(define_insn_reservation "r5900_fadd" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fadd"))
++  "r5900_fpu")
++
++(define_insn_reservation "r5900_fmove" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fabs,fneg,fmove,fcmp"))
++  "r5900_fpu")
++
++(define_insn_reservation "r5900_fcvt" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fcvt"))
++  "r5900_fpu")
++
++(define_insn_reservation "r5900_fmul" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fmul,fmadd"))
++  "r5900_fpu")
++
++(define_insn_reservation "r5900_fdiv" 8
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fdiv,frdiv,fsqrt"))
++  "r5900_fpu*8")
++
++(define_insn_reservation "r5900_frsqrt" 14
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "frsqrt"))
++  "r5900_fpu*14")
+
+--- gcc-16.2.0/gcc/config/mips/mips.cc
++++ gcc-16.2.0-kos/gcc/config/mips/mips.cc
+@@ -3609,6 +3609,9 @@
+ /* The __tls_get_attr symbol.  */
+ static GTY(()) rtx mips_tls_symbol;
+ 
++/* The __r5900_get_tp symbol — R5900-specific TLS-pointer helper.  */
++static GTY(()) rtx mips_r5900_get_tp_symbol;
++
+ /* Return an instruction sequence that calls __tls_get_addr.  SYM is
+    the TLS symbol we are referencing and TYPE is the symbol type to use
+    (either global dynamic or local dynamic).  V0 is an RTX for the
+@@ -3653,6 +3656,28 @@
+ 	mips16_rdhwr_stub = new mips16_rdhwr_one_only_stub ();
+       fn = mips16_stub_call_address (mips16_rdhwr_stub);
+       emit_insn (PMODE_INSN (gen_tls_get_tp_mips16, (tp, fn)));
++    }
++  else if (TARGET_MIPS5900)
++    {
++      /* The R5900 cannot read the thread pointer via rdhwr — that opcode
++	 is `sq $rt, -6085($zero)` on this core and the hardware executes
++	 it as a silent 128-bit store rather than a trap-and-emulate-able
++	 unimplemented-instruction exception.  Call the kernel-provided
++	 helper __r5900_get_tp instead, following the same libcall pattern
++	 used for __tls_get_addr in the global-/local-dynamic TLS models
++	 above.  The helper returns the (bias-adjusted) thread pointer in
++	 $v0 per the standard MIPS calling convention; we then move that
++	 into the destination register the caller asked us to populate.  */
++      rtx v0 = gen_rtx_REG (Pmode, GP_RETURN);
++      rtx_insn *insn;
++
++      if (!mips_r5900_get_tp_symbol)
++	mips_r5900_get_tp_symbol = init_one_libfunc ("__r5900_get_tp");
++
++      insn = mips_expand_call (MIPS_CALL_NORMAL, v0, mips_r5900_get_tp_symbol,
++			       const0_rtx, NULL_RTX, false);
++      RTL_CONST_CALL_P (insn) = 1;
++      emit_move_insn (tp, v0);
+     }
+   else
+     emit_insn (PMODE_INSN (gen_tls_get_tp, (tp)));
+@@ -20582,6 +20607,11 @@
+   if (TARGET_MIPS5900 && TARGET_HARD_FLOAT_ABI && TARGET_DOUBLE_FLOAT)
+     error ("unsupported combination: %s",
+ 	   "-march=r5900 -mhard-float -mdouble-float");
++
++  /* The R5900 does not support some MIPS16 instructions.  */
++  if (TARGET_MIPS5900 && ((mips_base_compression_flags & MASK_MIPS16) != 0))
++	  error("unsupported combination: %s",
++		  "-march=r5900 -mips16");
+ 
+   /* If a -mlong* option was given, check that it matches the ABI,
+      otherwise infer the -mlong* setting from the other options.  */
+
+--- gcc-16.2.0/gcc/config/mips/mips.md
++++ gcc-16.2.0-kos/gcc/config/mips/mips.md
+@@ -1124,6 +1124,7 @@
+ 
+ (define_delay (and (eq_attr "type" "branch")
+ 		   (not (match_test "TARGET_MIPS16"))
++		   (not (match_test "TARGET_FIX_R5900"))
+ 		   (eq_attr "branch_likely" "yes"))
+   [(eq_attr "can_delay" "yes")
+    (nil)
+@@ -1133,6 +1134,7 @@
+ ;; not annul on false.
+ (define_delay (and (eq_attr "type" "branch,simd_branch")
+ 		   (not (match_test "TARGET_MIPS16"))
++		   (not (match_test "TARGET_FIX_R5900"))
+ 		   (ior (match_test "TARGET_CB_NEVER")
+ 			(and (eq_attr "compact_form" "maybe")
+ 			     (not (match_test "TARGET_CB_ALWAYS")))
+@@ -1203,6 +1205,7 @@
+ (include "5000.md")
+ (include "5400.md")
+ (include "5500.md")
++(include "5900.md")
+ (include "6000.md")
+ (include "7000.md")
+ (include "9000.md")
+@@ -1811,7 +1814,7 @@
+ 		 (match_operand:SI 3 "register_operand" "l,l,l,d")))
+    (clobber (match_scratch:SI 4 "=X,X,3,l"))
+    (clobber (match_scratch:SI 5 "=X,X,X,&d"))]
+-  "TARGET_MIPS3900 && !TARGET_MIPS16"
++  "(TARGET_MIPS3900 || TARGET_MIPS5900) && !TARGET_MIPS16"
+   "@
+     madd\t%1,%2
+     madd\t%1,%2
+
+--- gcc-16.2.0/include/longlong.h
++++ gcc-16.2.0-kos/include/longlong.h
+@@ -853,6 +853,17 @@
+ #endif
+ 
+ #if defined (__mips__) && W_TYPE_SIZE == 32
++/* Force R5900 to use mult for mulsidi3, this is used in muldi3 */
++#ifdef _MIPS_ARCH_R5900
++#define __umulsidi3(u, v) \
++  ({UDItype __w;							\
++    __asm__ ("multu	%1,%2\n\tpmfhl.lw %0"				\
++	     : "=d" (__w)						\
++	     : "d" ((USItype) (u)),					\
++	       "d" ((USItype) (v))					\
++	     : "hi", "lo");						\
++    __w; })
++#endif
+ #define umul_ppmm(w1, w0, u, v)						\
+   do {									\
+     UDItype __x = (UDItype) (USItype) (u) * (USItype) (v);		\
+
+--- gcc-16.2.0/libgcc/config.host
++++ gcc-16.2.0-kos/libgcc/config.host
+@@ -155,7 +155,11 @@
+ 	cpu_type=mips
+ 	tmake_file="mips/t-mips"
+ 	if test "${libgcc_cv_mips_hard_float}" = yes; then
++	    if test "${libgcc_cv_mips_single_float}" = yes; then
++                tmake_file="${tmake_file} t-hardfp-sf t-hardfp"
++	    else
+ 		tmake_file="${tmake_file} t-hardfp-sfdf t-hardfp"
++	    fi
+ 	else
+ 		tmake_file="${tmake_file} t-softfp-sfdf"
+ 	fi
+@@ -1064,19 +1068,16 @@
+ mips*-*-linux*)				# Linux MIPS, either endian.
+ 	extra_parts="$extra_parts crtfastmath.o"
+ 	tmake_file="${tmake_file} t-crtfm"
+-	case ${host} in
+-	  mips64r5900* | mipsr5900*)
+-	    # The MIPS16 support code uses floating point
+-	    # instructions that are not supported on r5900.
+-	    ;;
+-	  *)
++    if test "${libgcc_cv_mips16}" = yes; then
+ 	    tmake_file="${tmake_file} mips/t-mips16 t-slibgcc-libgcc"
+-	    ;;
+-	esac
++    fi
+ 	md_unwind_header=mips/linux-unwind.h
+ 	;;
+ mips*-sde-elf*)
+-	tmake_file="$tmake_file mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	case "${with_newlib}" in
+ 	  yes)
+ 	    # newlib / libgloss.
+@@ -1106,7 +1107,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips-*-elf* | mipsel-*-elf*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mipsr5900-*-elf* | mipsr5900el-*-elf*)
+@@ -1114,7 +1118,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips64-*-elf* | mips64el-*-elf*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips64r5900-*-elf* | mips64r5900el-*-elf*)
+@@ -1130,7 +1137,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips*-*-rtems*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips-wrs-vxworks)
+
+--- gcc-16.2.0/libgcc/config/mips/sfp-machine.h
++++ gcc-16.2.0-kos/libgcc/config/mips/sfp-machine.h
+@@ -22,7 +22,7 @@
+ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ <http://www.gnu.org/licenses/>.  */
+ 
+-#ifdef __mips64
++#if defined(__mips64) && !defined(_MIPS_ARCH_R5900)
+ #define _FP_W_TYPE_SIZE		64
+ #define _FP_W_TYPE		unsigned long long
+ #define _FP_WS_TYPE		signed long long
+
+--- gcc-16.2.0/libgcc/config/t-hardfp-sf
++++ gcc-16.2.0-kos/libgcc/config/t-hardfp-sf
+@@ -0,0 +1,32 @@
++# Clean-room libgcc fragment for the PlayStation 2 Emotion Engine (MIPS
++# R5900): single-precision floating point in hardware, double precision in
++# software.  Derived from the documented t-hardfp and fp-bit interfaces (the
++# FPBIT_FUNCS/DPBIT_FUNCS lists in libgcc/Makefile.in), not from any
++# third-party source.
++#
++# The R5900 FPU implements only single precision, so the SF arithmetic,
++# comparison and SI-conversion routines come from the hardware path
++# (config/hardfp.c, pulled in by t-hardfp).  Double precision, and the format
++# conversions the hardware lacks, are provided by libgcc's fp-bit emulator via
++# FPBIT/DPBIT.  LIB2FUNCS_EXCLUDE then drops the fp-bit single-precision
++# routines the hardware already supplies; the pack/unpack helpers and the
++# SF->DF / SF->TF conversions are deliberately kept, since hardfp does not
++# provide them (hardfp_extensions is empty).
++
++hardfp_float_modes := sf
++# di and ti conversions come from libgcc2.c where needed.
++hardfp_int_modes := si
++hardfp_extensions :=
++hardfp_truncations :=
++
++# Emulate double precision (and the SF<->DF/TF conversions) in software.
++FPBIT = true
++DPBIT = true
++
++# Do not build the fp-bit single-precision routines that the R5900 FPU
++# implements directly (these are the SF entries of FPBIT_FUNCS that hardfp
++# already covers).
++LIB2FUNCS_EXCLUDE = _addsub_sf _mul_sf _div_sf \
++    _fpcmp_parts_sf _compare_sf _eq_sf _ne_sf _gt_sf _ge_sf \
++    _lt_sf _le_sf _unord_sf _si_to_sf _sf_to_si _negate_sf \
++    _thenan_sf _sf_to_usi _usi_to_sf
+
+--- gcc-16.2.0/libgcc/configure
++++ gcc-16.2.0-kos/libgcc/configure
+@@ -5164,6 +5164,48 @@
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_hard_float" >&5
+ $as_echo "$libgcc_cv_mips_hard_float" >&6; }
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target is single-float" >&5
++$as_echo_n "checking whether the target is single-float... " >&6; }
++if test "${libgcc_cv_mips_single_float+set}" = set; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#ifndef __mips_single_float
++     #error FOO
++     #endif
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  libgcc_cv_mips_single_float=yes
++else
++  libgcc_cv_mips_single_float=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_single_float" >&5
++$as_echo "$libgcc_cv_mips_single_float" >&6; }
++  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target supports the MIPS16 ASE" >&5
++$as_echo_n "checking whether the target supports MIPS16 ASE... " >&6; }
++if test "${libgcc_cv_mips16+set}" = set; then :
++  $as_echo_n "(cached) " >&6
++else
++  CFLAGS_hold=$CFLAGS
++		 CFLAGS="$CFLAGS -mips16"
++		 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++int i;
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  libgcc_cv_mips16=yes
++else
++  libgcc_cv_mips16=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++	CFLAGS=$CFLAGS_hold
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips16" >&5
++$as_echo "$libgcc_cv_mips16" >&6; }
+ esac
+ 
+ # Determine the version of glibc, if any, used on the target.
+
+--- gcc-16.2.0/libgcc/configure.ac
++++ gcc-16.2.0-kos/libgcc/configure.ac
+@@ -356,6 +356,23 @@
+     ])],
+     [libgcc_cv_mips_hard_float=yes],
+     [libgcc_cv_mips_hard_float=no])])
++  AC_CACHE_CHECK([whether the target is single-float],
++		 [libgcc_cv_mips_single_float],
++		 [AC_COMPILE_IFELSE(
++    [#ifndef __mips_single_float
++     #error FOO
++     #endif],
++    [libgcc_cv_mips_single_float=yes],
++    [libgcc_cv_mips_single_float=no])])
++  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
++  AC_CACHE_CHECK([whether the target supports the MIPS16 ASE],
++		 [libgcc_cv_mips16],
++		 [CFLAGS_hold=$CFLAGS
++		 CFLAGS="$CFLAGS -mips16"
++		 AC_COMPILE_IFELSE([[int i;]],
++    [libgcc_cv_mips16=yes],
++    [libgcc_cv_mips16=no])
++	CFLAGS=$CFLAGS_hold])
+ esac
+ 
+ # Determine the version of glibc, if any, used on the target.
+
+
+--- gcc-16.2.0/gcc/builtins.cc
++++ gcc-16.2.0-kos/gcc/builtins.cc
+@@ -10301,6 +10301,8 @@
+     default:
+       gcc_unreachable ();
+     }
++
++  unsigned int llu_size = TYPE_PRECISION (long_long_unsigned_type_node);
+ 
+   if (TYPE_PRECISION (arg0_type)
+       <= TYPE_PRECISION (long_long_unsigned_type_node))
+@@ -10324,10 +10326,10 @@
+ 	  fcodei = fcodell;
+ 	}
+     }
+-  else if (TYPE_PRECISION (arg0_type) <= MAX_FIXED_MODE_SIZE)
++  else if (TYPE_PRECISION (arg0_type) <= 2 * llu_size)
+     {
+       cast_type
+-	= build_nonstandard_integer_type (MAX_FIXED_MODE_SIZE,
++	= build_nonstandard_integer_type (2 * llu_size,
+ 					  TYPE_UNSIGNED (arg0_type));
+       gcc_assert (TYPE_PRECISION (cast_type)
+ 		  == 2 * TYPE_PRECISION (long_long_unsigned_type_node));
+@@ -10361,7 +10363,7 @@
+       arg2 = NULL_TREE;
+     }
+   tree call = NULL_TREE, tem;
+-  if (TYPE_PRECISION (arg0_type) == MAX_FIXED_MODE_SIZE
++  if (TYPE_PRECISION (arg0_type) == 2 * llu_size
+       && (TYPE_PRECISION (arg0_type)
+ 	  == 2 * TYPE_PRECISION (long_long_unsigned_type_node))
+       /* If the target supports the optab, then don't do the expansion. */
+@@ -10374,7 +10376,7 @@
+ 		   : long_long_integer_type_node);
+       tree hi = fold_build2 (RSHIFT_EXPR, arg0_type, arg0,
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2));
++					    llu_size));
+       hi = fold_convert (type, hi);
+       tree lo = fold_convert (type, arg0);
+       switch (fcode)
+@@ -10383,7 +10385,7 @@
+ 	  call = fold_builtin_bit_query (loc, fcode, lo, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  if (arg2)
+ 	    call = fold_build3 (COND_EXPR, integer_type_node,
+ 				fold_build2 (NE_EXPR, boolean_type_node,
+@@ -10400,7 +10402,7 @@
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  if (arg2)
+ 	    call = fold_build3 (COND_EXPR, integer_type_node,
+ 				fold_build2 (NE_EXPR, boolean_type_node,
+@@ -10417,14 +10419,14 @@
+ 	  tem = fold_builtin_bit_query (loc, fcode, lo, NULL_TREE);
+ 	  tem = fold_build2 (PLUS_EXPR, integer_type_node, tem,
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2));
++					    llu_size));
+ 	  tem = fold_build3 (COND_EXPR, integer_type_node,
+ 			     fold_build2 (LT_EXPR, boolean_type_node,
+ 					  fold_build2 (BIT_XOR_EXPR, type,
+ 						       lo, hi),
+ 					  build_zero_cst (type)),
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2 - 1),
++					    llu_size - 1),
+ 			     tem);
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = save_expr (call);
+@@ -10432,15 +10434,15 @@
+ 			      fold_build2 (NE_EXPR, boolean_type_node,
+ 					   call,
+ 					   build_int_cst (integer_type_node,
+-							  MAX_FIXED_MODE_SIZE
+-							  / 2 - 1)),
++							  llu_size
++							  - 1)),
+ 			      call, tem);
+ 	  break;
+ 	case BUILT_IN_FFSG:
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  call = fold_build3 (COND_EXPR, integer_type_node,
+ 			      fold_build2 (NE_EXPR, boolean_type_node,
+ 					   hi, build_zero_cst (type)),

--- a/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
@@ -146,3 +146,565 @@ diff -ruN gcc-17.0.0/libstdc++-v3/configure gcc-17.0.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
+
+--- gcc-17.0.0/gcc/config.gcc
++++ gcc-17.0.0-kos/gcc/config.gcc
+@@ -2826,7 +2826,7 @@
+ 	tmake_file="mips/t-elf"
+ 	;;
+ mips64r5900-*-elf* | mips64r5900el-*-elf*)
+-	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h"
++	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h mips/ps2.h"
+ 	tmake_file="mips/t-elf"
+ 	tm_defines="${tm_defines} MIPS_ISA_DEFAULT=MIPS_ISA_MIPS3 MIPS_ABI_DEFAULT=ABI_N32"
+ 	;;
+
+--- gcc-17.0.0/gcc/config/mips/ps2.h
++++ gcc-17.0.0-kos/gcc/config/mips/ps2.h
+@@ -0,0 +1,8 @@
++/* KallistiOS: PlayStation 2 Emotion Engine target tweaks on top of the
++   generic mips64r5900*-elf configuration.  */
++
++/* Do not place data in gp-relative small-data sections by default; KOS
++   does not set up $gp for small data, and newlib/libstdc++ are built
++   with -G0 to match.  */
++#undef MIPS_DEFAULT_GVALUE
++#define MIPS_DEFAULT_GVALUE 0
+
+--- gcc-17.0.0/gcc/config/mips/5900.md
++++ gcc-17.0.0-kos/gcc/config/mips/5900.md
+@@ -0,0 +1,121 @@
++;; Copyright (C) 2002-2015 Free Software Foundation, Inc.
++;;
++;; This file is part of GCC.
++;;
++;; GCC is free software; you can redistribute it and/or modify
++;; it under the terms of the GNU General Public License as published by
++;; the Free Software Foundation; either version 3, or (at your option)
++;; any later version.
++;;
++;; GCC is distributed in the hope that it will be useful,
++;; but WITHOUT ANY WARRANTY; without even the implied warranty of
++;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++;; GNU General Public License for more details.
++;;
++;; You should have received a copy of the GNU General Public License
++;; along with GCC; see the file COPYING3.  If not see
++;; <http://www.gnu.org/licenses/>.
++;;
++;; R5900 instruction patterns and pipeline tuning.
++
++(define_automaton "r5900_alu,r5900_fpu,r5900_br,r5900_ls")
++
++(define_cpu_unit "r5900_alu0,r5900_alu1" "r5900_alu")
++(define_cpu_unit "r5900_c1" "r5900_fpu")
++(define_cpu_unit "r5900_br" "r5900_br")
++(define_cpu_unit "r5900_ls" "r5900_ls")
++
++(define_insn_reservation "r5900_alu" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "unknown,prefetch,prefetchx,condmove,const,arith,
++			shift,slt,clz,trap,multi,nop,logical,signext,move"))
++ "r5900_alu0|r5900_alu1")
++
++(define_insn_reservation "r5900_loadstore" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "load,store"))
++ "r5900_ls")
++
++(define_insn_reservation "r5900_fploadstore" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fpload,fpstore"))
++ "r5900_c1,nothing")
++
++(define_insn_reservation "r5900_fcvt" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fcvt"))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fmove" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fabs,fneg,fmove"))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fcmp" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fcmp"))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fadd" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fadd"))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fmul_single" 4
++  (and (eq_attr "cpu" "r5900")
++       (and (eq_attr "type" "fmul,fmadd")
++            (eq_attr "mode" "SF")))
++ "r5900_c1,nothing*3")
++
++(define_insn_reservation "r5900_fdiv_single" 8
++  (and (eq_attr "cpu" "r5900")
++       (and (eq_attr "type" "fdiv,frdiv")
++            (eq_attr "mode" "SF")))
++ "r5900_c1*7,nothing")
++
++(define_insn_reservation "r5900_fsqrt_single" 8
++  (and (eq_attr "cpu" "r5900")
++       (and (eq_attr "type" "fsqrt")
++            (eq_attr "mode" "SF")))
++ "r5900_c1*7,nothing")
++
++(define_insn_reservation "r5900_frsqrt_single" 14
++  (and (eq_attr "cpu" "r5900")
++       (and (eq_attr "type" "frsqrt")
++            (eq_attr "mode" "SF")))
++ "r5900_c1*13,nothing")
++
++(define_insn_reservation "r5900_xfer" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mfc,mtc"))
++ "r5900_c1+r5900_ls,nothing")
++
++(define_insn_reservation "r5900_branch" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "branch,jump,call"))
++ "r5900_br")
++
++(define_insn_reservation "r5900_hilo" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mfhi,mflo,mthi,mtlo"))
++ "r5900_alu0")
++
++(define_insn_reservation "r5900_imul" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "imul,imul3,imadd"))
++ "r5900_alu0*2,nothing*2")
++
++(define_insn_reservation "r5900_idiv" 37
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "idiv,idiv3"))
++ "r5900_alu0*37")
++
++;; RSQRT
++(define_insn "rsqrtsf"
++  [(set (match_operand:SF 0 "register_operand" "=f")
++	(div:SF (match_operand:SF 1 "register_operand" "f")
++		  (sqrt:SF (match_operand:SF 2 "register_operand" "f"))))]
++  "TARGET_MIPS5900"
++  "rsqrt.s\t%0,%1,%2"
++  [(set_attr "type" "frsqrt")
++   (set_attr "mode" "SF")])
+
+--- gcc-17.0.0/gcc/config/mips/mips.cc
++++ gcc-17.0.0-kos/gcc/config/mips/mips.cc
+@@ -3609,6 +3609,9 @@
+ /* The __tls_get_attr symbol.  */
+ static GTY(()) rtx mips_tls_symbol;
+ 
++/* The __r5900_get_tp symbol — R5900-specific TLS-pointer helper.  */
++static GTY(()) rtx mips_r5900_get_tp_symbol;
++
+ /* Return an instruction sequence that calls __tls_get_addr.  SYM is
+    the TLS symbol we are referencing and TYPE is the symbol type to use
+    (either global dynamic or local dynamic).  V0 is an RTX for the
+@@ -3653,6 +3656,28 @@
+ 	mips16_rdhwr_stub = new mips16_rdhwr_one_only_stub ();
+       fn = mips16_stub_call_address (mips16_rdhwr_stub);
+       emit_insn (PMODE_INSN (gen_tls_get_tp_mips16, (tp, fn)));
++    }
++  else if (TARGET_MIPS5900)
++    {
++      /* The R5900 cannot read the thread pointer via rdhwr — that opcode
++	 is `sq $rt, -6085($zero)` on this core and the hardware executes
++	 it as a silent 128-bit store rather than a trap-and-emulate-able
++	 unimplemented-instruction exception.  Call the kernel-provided
++	 helper __r5900_get_tp instead, following the same libcall pattern
++	 used for __tls_get_addr in the global-/local-dynamic TLS models
++	 above.  The helper returns the (bias-adjusted) thread pointer in
++	 $v0 per the standard MIPS calling convention; we then move that
++	 into the destination register the caller asked us to populate.  */
++      rtx v0 = gen_rtx_REG (Pmode, GP_RETURN);
++      rtx_insn *insn;
++
++      if (!mips_r5900_get_tp_symbol)
++	mips_r5900_get_tp_symbol = init_one_libfunc ("__r5900_get_tp");
++
++      insn = mips_expand_call (MIPS_CALL_NORMAL, v0, mips_r5900_get_tp_symbol,
++			       const0_rtx, NULL_RTX, false);
++      RTL_CONST_CALL_P (insn) = 1;
++      emit_move_insn (tp, v0);
+     }
+   else
+     emit_insn (PMODE_INSN (gen_tls_get_tp, (tp)));
+@@ -20582,6 +20607,11 @@
+   if (TARGET_MIPS5900 && TARGET_HARD_FLOAT_ABI && TARGET_DOUBLE_FLOAT)
+     error ("unsupported combination: %s",
+ 	   "-march=r5900 -mhard-float -mdouble-float");
++
++  /* The R5900 does not support some MIPS16 instructions.  */
++  if (TARGET_MIPS5900 && ((mips_base_compression_flags & MASK_MIPS16) != 0))
++	  error("unsupported combination: %s",
++		  "-march=r5900 -mips16");
+ 
+   /* If a -mlong* option was given, check that it matches the ABI,
+      otherwise infer the -mlong* setting from the other options.  */
+
+--- gcc-17.0.0/gcc/config/mips/mips.md
++++ gcc-17.0.0-kos/gcc/config/mips/mips.md
+@@ -1124,6 +1124,7 @@
+ 
+ (define_delay (and (eq_attr "type" "branch")
+ 		   (not (match_test "TARGET_MIPS16"))
++		   (not (match_test "TARGET_FIX_R5900"))
+ 		   (eq_attr "branch_likely" "yes"))
+   [(eq_attr "can_delay" "yes")
+    (nil)
+@@ -1133,6 +1134,7 @@
+ ;; not annul on false.
+ (define_delay (and (eq_attr "type" "branch,simd_branch")
+ 		   (not (match_test "TARGET_MIPS16"))
++		   (not (match_test "TARGET_FIX_R5900"))
+ 		   (ior (match_test "TARGET_CB_NEVER")
+ 			(and (eq_attr "compact_form" "maybe")
+ 			     (not (match_test "TARGET_CB_ALWAYS")))
+@@ -1203,6 +1205,7 @@
+ (include "5000.md")
+ (include "5400.md")
+ (include "5500.md")
++(include "5900.md")
+ (include "6000.md")
+ (include "7000.md")
+ (include "9000.md")
+@@ -1811,7 +1814,7 @@
+ 		 (match_operand:SI 3 "register_operand" "l,l,l,d")))
+    (clobber (match_scratch:SI 4 "=X,X,3,l"))
+    (clobber (match_scratch:SI 5 "=X,X,X,&d"))]
+-  "TARGET_MIPS3900 && !TARGET_MIPS16"
++  "(TARGET_MIPS3900 || TARGET_MIPS5900) && !TARGET_MIPS16"
+   "@
+     madd\t%1,%2
+     madd\t%1,%2
+
+--- gcc-17.0.0/include/longlong.h
++++ gcc-17.0.0-kos/include/longlong.h
+@@ -853,6 +853,17 @@
+ #endif
+ 
+ #if defined (__mips__) && W_TYPE_SIZE == 32
++/* Force R5900 to use mult for mulsidi3, this is used in muldi3 */
++#ifdef _MIPS_ARCH_R5900
++#define __umulsidi3(u, v) \
++  ({UDItype __w;							\
++    __asm__ ("multu	%1,%2\n\tpmfhl.lw %0"				\
++	     : "=d" (__w)						\
++	     : "d" ((USItype) (u)),					\
++	       "d" ((USItype) (v))					\
++	     : "hi", "lo");						\
++    __w; })
++#endif
+ #define umul_ppmm(w1, w0, u, v)						\
+   do {									\
+     UDItype __x = (UDItype) (USItype) (u) * (USItype) (v);		\
+
+--- gcc-17.0.0/libgcc/config.host
++++ gcc-17.0.0-kos/libgcc/config.host
+@@ -151,7 +151,11 @@
+ 	cpu_type=mips
+ 	tmake_file="mips/t-mips"
+ 	if test "${libgcc_cv_mips_hard_float}" = yes; then
++	    if test "${libgcc_cv_mips_single_float}" = yes; then
++                tmake_file="${tmake_file} t-hardfp-sf t-hardfp"
++	    else
+ 		tmake_file="${tmake_file} t-hardfp-sfdf t-hardfp"
++	    fi
+ 	else
+ 		tmake_file="${tmake_file} t-softfp-sfdf"
+ 	fi
+@@ -1065,19 +1069,16 @@
+ mips*-*-linux*)				# Linux MIPS, either endian.
+ 	extra_parts="$extra_parts crtfastmath.o"
+ 	tmake_file="${tmake_file} t-crtfm"
+-	case ${host} in
+-	  mips64r5900* | mipsr5900*)
+-	    # The MIPS16 support code uses floating point
+-	    # instructions that are not supported on r5900.
+-	    ;;
+-	  *)
++    if test "${libgcc_cv_mips16}" = yes; then
+ 	    tmake_file="${tmake_file} mips/t-mips16 t-slibgcc-libgcc"
+-	    ;;
+-	esac
++    fi
+ 	md_unwind_header=mips/linux-unwind.h
+ 	;;
+ mips*-sde-elf*)
+-	tmake_file="$tmake_file mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	case "${with_newlib}" in
+ 	  yes)
+ 	    # newlib / libgloss.
+@@ -1107,7 +1108,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips-*-elf* | mipsel-*-elf*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mipsr5900-*-elf* | mipsr5900el-*-elf*)
+@@ -1115,7 +1119,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips64-*-elf* | mips64el-*-elf*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips64r5900-*-elf* | mips64r5900el-*-elf*)
+@@ -1131,7 +1138,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips*-*-rtems*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips-wrs-vxworks)
+
+--- gcc-17.0.0/libgcc/config/mips/sfp-machine.h
++++ gcc-17.0.0-kos/libgcc/config/mips/sfp-machine.h
+@@ -22,7 +22,7 @@
+ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ <http://www.gnu.org/licenses/>.  */
+ 
+-#ifdef __mips64
++#if defined(__mips64) && !defined(_MIPS_ARCH_R5900)
+ #define _FP_W_TYPE_SIZE		64
+ #define _FP_W_TYPE		unsigned long long
+ #define _FP_WS_TYPE		signed long long
+
+--- gcc-17.0.0/libgcc/config/t-hardfp-sf
++++ gcc-17.0.0-kos/libgcc/config/t-hardfp-sf
+@@ -0,0 +1,32 @@
++# Copyright (C) 2014-2015 Free Software Foundation, Inc.
++
++# This file is part of GCC.
++
++# GCC is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3, or (at your option)
++# any later version.
++
++# GCC is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++
++# You should have received a copy of the GNU General Public License
++# along with GCC; see the file COPYING3.  If not see
++# <http://www.gnu.org/licenses/>.
++
++hardfp_float_modes := sf
++# di and ti are provided by libgcc2.c where needed.
++hardfp_int_modes := si
++hardfp_extensions :=
++hardfp_truncations :=
++
++# Emulate 64 bit float:
++FPBIT = true
++DPBIT = true
++# Don't build functions handled by 32 bit hardware:
++LIB2FUNCS_EXCLUDE = _addsub_sf _mul_sf _div_sf \
++    _fpcmp_parts_sf _compare_sf _eq_sf _ne_sf _gt_sf _ge_sf \
++    _lt_sf _le_sf _unord_sf _si_to_sf _sf_to_si _negate_sf \
++    _thenan_sf _sf_to_usi _usi_to_sf
+
+--- gcc-17.0.0/libgcc/configure
++++ gcc-17.0.0-kos/libgcc/configure
+@@ -5163,6 +5163,48 @@
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_hard_float" >&5
+ $as_echo "$libgcc_cv_mips_hard_float" >&6; }
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target is single-float" >&5
++$as_echo_n "checking whether the target is single-float... " >&6; }
++if test "${libgcc_cv_mips_single_float+set}" = set; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#ifndef __mips_single_float
++     #error FOO
++     #endif
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  libgcc_cv_mips_single_float=yes
++else
++  libgcc_cv_mips_single_float=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_single_float" >&5
++$as_echo "$libgcc_cv_mips_single_float" >&6; }
++  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target supports the MIPS16 ASE" >&5
++$as_echo_n "checking whether the target supports MIPS16 ASE... " >&6; }
++if test "${libgcc_cv_mips16+set}" = set; then :
++  $as_echo_n "(cached) " >&6
++else
++  CFLAGS_hold=$CFLAGS
++		 CFLAGS="$CFLAGS -mips16"
++		 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++int i;
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  libgcc_cv_mips16=yes
++else
++  libgcc_cv_mips16=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++	CFLAGS=$CFLAGS_hold
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips16" >&5
++$as_echo "$libgcc_cv_mips16" >&6; }
+ esac
+ 
+ # Determine the version of glibc, if any, used on the target.
+
+--- gcc-17.0.0/libgcc/configure.ac
++++ gcc-17.0.0-kos/libgcc/configure.ac
+@@ -356,6 +356,23 @@
+     ])],
+     [libgcc_cv_mips_hard_float=yes],
+     [libgcc_cv_mips_hard_float=no])])
++  AC_CACHE_CHECK([whether the target is single-float],
++		 [libgcc_cv_mips_single_float],
++		 [AC_COMPILE_IFELSE(
++    [#ifndef __mips_single_float
++     #error FOO
++     #endif],
++    [libgcc_cv_mips_single_float=yes],
++    [libgcc_cv_mips_single_float=no])])
++  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
++  AC_CACHE_CHECK([whether the target supports the MIPS16 ASE],
++		 [libgcc_cv_mips16],
++		 [CFLAGS_hold=$CFLAGS
++		 CFLAGS="$CFLAGS -mips16"
++		 AC_COMPILE_IFELSE([[int i;]],
++    [libgcc_cv_mips16=yes],
++    [libgcc_cv_mips16=no])
++	CFLAGS=$CFLAGS_hold])
+ esac
+ 
+ # Determine the version of glibc, if any, used on the target.
+
+
+--- gcc-17.0.0/gcc/builtins.cc
++++ gcc-17.0.0-kos/gcc/builtins.cc
+@@ -10327,6 +10327,8 @@
+     default:
+       gcc_unreachable ();
+     }
++
++  unsigned int llu_size = TYPE_PRECISION (long_long_unsigned_type_node);
+ 
+   if (TYPE_PRECISION (arg0_type)
+       <= TYPE_PRECISION (long_long_unsigned_type_node))
+@@ -10350,10 +10352,10 @@
+ 	  fcodei = fcodell;
+ 	}
+     }
+-  else if (TYPE_PRECISION (arg0_type) <= MAX_FIXED_MODE_SIZE)
++  else if (TYPE_PRECISION (arg0_type) <= 2 * llu_size)
+     {
+       cast_type
+-	= build_nonstandard_integer_type (MAX_FIXED_MODE_SIZE,
++	= build_nonstandard_integer_type (2 * llu_size,
+ 					  TYPE_UNSIGNED (arg0_type));
+       gcc_assert (TYPE_PRECISION (cast_type)
+ 		  == 2 * TYPE_PRECISION (long_long_unsigned_type_node));
+@@ -10387,7 +10389,7 @@
+       arg2 = NULL_TREE;
+     }
+   tree call = NULL_TREE, tem;
+-  if (TYPE_PRECISION (arg0_type) == MAX_FIXED_MODE_SIZE
++  if (TYPE_PRECISION (arg0_type) == 2 * llu_size
+       && (TYPE_PRECISION (arg0_type)
+ 	  == 2 * TYPE_PRECISION (long_long_unsigned_type_node))
+       /* If the target supports the optab, then don't do the expansion. */
+@@ -10400,7 +10402,7 @@
+ 		   : long_long_integer_type_node);
+       tree hi = fold_build2 (RSHIFT_EXPR, arg0_type, arg0,
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2));
++					    llu_size));
+       hi = fold_convert (type, hi);
+       tree lo = fold_convert (type, arg0);
+       switch (fcode)
+@@ -10409,7 +10411,7 @@
+ 	  call = fold_builtin_bit_query (loc, fcode, lo, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  if (arg2)
+ 	    call = fold_build3 (COND_EXPR, integer_type_node,
+ 				fold_build2 (NE_EXPR, boolean_type_node,
+@@ -10426,7 +10428,7 @@
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  if (arg2)
+ 	    call = fold_build3 (COND_EXPR, integer_type_node,
+ 				fold_build2 (NE_EXPR, boolean_type_node,
+@@ -10443,14 +10445,14 @@
+ 	  tem = fold_builtin_bit_query (loc, fcode, lo, NULL_TREE);
+ 	  tem = fold_build2 (PLUS_EXPR, integer_type_node, tem,
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2));
++					    llu_size));
+ 	  tem = fold_build3 (COND_EXPR, integer_type_node,
+ 			     fold_build2 (LT_EXPR, boolean_type_node,
+ 					  fold_build2 (BIT_XOR_EXPR, type,
+ 						       lo, hi),
+ 					  build_zero_cst (type)),
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2 - 1),
++					    llu_size - 1),
+ 			     tem);
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = save_expr (call);
+@@ -10458,15 +10460,15 @@
+ 			      fold_build2 (NE_EXPR, boolean_type_node,
+ 					   call,
+ 					   build_int_cst (integer_type_node,
+-							  MAX_FIXED_MODE_SIZE
+-							  / 2 - 1)),
++							  llu_size
++							  - 1)),
+ 			      call, tem);
+ 	  break;
+ 	case BUILT_IN_FFSG:
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  call = fold_build3 (COND_EXPR, integer_type_node,
+ 			      fold_build2 (NE_EXPR, boolean_type_node,
+ 					   hi, build_zero_cst (type)),

--- a/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
@@ -158,3 +158,553 @@ diff -ruN gcc-17.0.0/libgcc/config/sh/t-sh gcc-17.0.0-kos/libgcc/config/sh/t-sh
  	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
  
  OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o
+
+--- gcc-17.0.0/gcc/config.gcc
++++ gcc-17.0.0-kos/gcc/config.gcc
+@@ -2826,7 +2826,7 @@
+ 	tmake_file="mips/t-elf"
+ 	;;
+ mips64r5900-*-elf* | mips64r5900el-*-elf*)
+-	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h"
++	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h mips/ps2.h"
+ 	tmake_file="mips/t-elf"
+ 	tm_defines="${tm_defines} MIPS_ISA_DEFAULT=MIPS_ISA_MIPS3 MIPS_ABI_DEFAULT=ABI_N32"
+ 	;;
+
+--- gcc-17.0.0/gcc/config/mips/ps2.h
++++ gcc-17.0.0-kos/gcc/config/mips/ps2.h
+@@ -0,0 +1,8 @@
++/* KallistiOS: PlayStation 2 Emotion Engine target tweaks on top of the
++   generic mips64r5900*-elf configuration.  */
++
++/* Do not place data in gp-relative small-data sections by default; KOS
++   does not set up $gp for small data, and newlib/libstdc++ are built
++   with -G0 to match.  */
++#undef MIPS_DEFAULT_GVALUE
++#define MIPS_DEFAULT_GVALUE 0
+
+--- gcc-17.0.0/gcc/config/mips/5900.md
++++ gcc-17.0.0-kos/gcc/config/mips/5900.md
+@@ -0,0 +1,109 @@
++;; Clean-room DFA pipeline description for the PlayStation 2 Emotion Engine
++;; (MIPS R5900).  Written from the public R5900 architecture (a dual-issue,
++;; in-order MIPS III core with MMI extensions and a single-precision FPU) using
++;; the conventions of the upstream MIPS scheduler descriptions.  Not derived
++;; from any third-party source.
++;;
++;; The R5900 issues up to two instructions per cycle.  It has two integer ALU
++;; slots, one load/store slot, one multiply/divide (MAC) unit, one FPU, and a
++;; branch unit.  Floating point is single precision only; double-precision
++;; operations are software floating point and do not reach this description.
++
++(define_automaton "r5900_cpu")
++
++(define_cpu_unit "r5900_alu0" "r5900_cpu")   ; integer ALU slot 0
++(define_cpu_unit "r5900_alu1" "r5900_cpu")   ; integer ALU slot 1
++(define_cpu_unit "r5900_ls"   "r5900_cpu")   ; load / store
++(define_cpu_unit "r5900_mac"  "r5900_cpu")   ; integer multiply / divide
++(define_cpu_unit "r5900_fpu"  "r5900_cpu")   ; single-precision FPU
++(define_cpu_unit "r5900_br"   "r5900_cpu")   ; branch
++
++;; Anything unusual serialises the whole core.
++(define_insn_reservation "r5900_unknown" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "unknown,multi,atomic,syncloop"))
++  "r5900_alu0+r5900_alu1+r5900_ls+r5900_mac+r5900_fpu+r5900_br")
++
++;; Integer ALU: single cycle, either slot.
++(define_insn_reservation "r5900_alu" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "arith,shift,signext,slt,clz,const,logical,move,nop,trap,condmove"))
++  "r5900_alu0|r5900_alu1")
++
++;; Loads and stores.
++(define_insn_reservation "r5900_load" 3
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "load,fpload,fpidxload"))
++  "r5900_ls")
++
++(define_insn_reservation "r5900_store" 0
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "store,fpstore,fpidxstore"))
++  "r5900_ls")
++
++;; Moves between the GPRs and the coprocessors.
++(define_insn_reservation "r5900_xfer" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mfc,mtc"))
++  "r5900_alu0|r5900_alu1")
++
++;; Branches take one issue slot; misprediction handled by the two-cycle latency.
++(define_insn_reservation "r5900_branch" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "branch,jump,call"))
++  "r5900_br")
++
++;; Integer multiply / multiply-add through the MAC unit.  The R5900 has no
++;; 64-bit hardware multiply, so DI multiplies are library calls and only the
++;; SI form is modelled here.
++(define_insn_reservation "r5900_imul" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "imul,imul3,imadd"))
++  "r5900_mac")
++
++(define_insn_reservation "r5900_mthilo" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mthi,mtlo"))
++  "r5900_mac")
++
++(define_insn_reservation "r5900_mfhilo" 2
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "mfhi,mflo"))
++  "r5900_mac")
++
++;; Integer divide is not pipelined and takes many cycles.
++(define_insn_reservation "r5900_idiv" 37
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "idiv"))
++  "r5900_mac*37")
++
++;; Single-precision floating point.  (Double precision is soft float.)
++(define_insn_reservation "r5900_fadd" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fadd"))
++  "r5900_fpu")
++
++(define_insn_reservation "r5900_fmove" 1
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fabs,fneg,fmove,fcmp"))
++  "r5900_fpu")
++
++(define_insn_reservation "r5900_fcvt" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fcvt"))
++  "r5900_fpu")
++
++(define_insn_reservation "r5900_fmul" 4
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fmul,fmadd"))
++  "r5900_fpu")
++
++(define_insn_reservation "r5900_fdiv" 8
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "fdiv,frdiv,fsqrt"))
++  "r5900_fpu*8")
++
++(define_insn_reservation "r5900_frsqrt" 14
++  (and (eq_attr "cpu" "r5900")
++       (eq_attr "type" "frsqrt"))
++  "r5900_fpu*14")
+
+--- gcc-17.0.0/gcc/config/mips/mips.cc
++++ gcc-17.0.0-kos/gcc/config/mips/mips.cc
+@@ -3609,6 +3609,9 @@
+ /* The __tls_get_attr symbol.  */
+ static GTY(()) rtx mips_tls_symbol;
+ 
++/* The __r5900_get_tp symbol — R5900-specific TLS-pointer helper.  */
++static GTY(()) rtx mips_r5900_get_tp_symbol;
++
+ /* Return an instruction sequence that calls __tls_get_addr.  SYM is
+    the TLS symbol we are referencing and TYPE is the symbol type to use
+    (either global dynamic or local dynamic).  V0 is an RTX for the
+@@ -3653,6 +3656,28 @@
+ 	mips16_rdhwr_stub = new mips16_rdhwr_one_only_stub ();
+       fn = mips16_stub_call_address (mips16_rdhwr_stub);
+       emit_insn (PMODE_INSN (gen_tls_get_tp_mips16, (tp, fn)));
++    }
++  else if (TARGET_MIPS5900)
++    {
++      /* The R5900 cannot read the thread pointer via rdhwr — that opcode
++	 is `sq $rt, -6085($zero)` on this core and the hardware executes
++	 it as a silent 128-bit store rather than a trap-and-emulate-able
++	 unimplemented-instruction exception.  Call the kernel-provided
++	 helper __r5900_get_tp instead, following the same libcall pattern
++	 used for __tls_get_addr in the global-/local-dynamic TLS models
++	 above.  The helper returns the (bias-adjusted) thread pointer in
++	 $v0 per the standard MIPS calling convention; we then move that
++	 into the destination register the caller asked us to populate.  */
++      rtx v0 = gen_rtx_REG (Pmode, GP_RETURN);
++      rtx_insn *insn;
++
++      if (!mips_r5900_get_tp_symbol)
++	mips_r5900_get_tp_symbol = init_one_libfunc ("__r5900_get_tp");
++
++      insn = mips_expand_call (MIPS_CALL_NORMAL, v0, mips_r5900_get_tp_symbol,
++			       const0_rtx, NULL_RTX, false);
++      RTL_CONST_CALL_P (insn) = 1;
++      emit_move_insn (tp, v0);
+     }
+   else
+     emit_insn (PMODE_INSN (gen_tls_get_tp, (tp)));
+@@ -20582,6 +20607,11 @@
+   if (TARGET_MIPS5900 && TARGET_HARD_FLOAT_ABI && TARGET_DOUBLE_FLOAT)
+     error ("unsupported combination: %s",
+ 	   "-march=r5900 -mhard-float -mdouble-float");
++
++  /* The R5900 does not support some MIPS16 instructions.  */
++  if (TARGET_MIPS5900 && ((mips_base_compression_flags & MASK_MIPS16) != 0))
++	  error("unsupported combination: %s",
++		  "-march=r5900 -mips16");
+ 
+   /* If a -mlong* option was given, check that it matches the ABI,
+      otherwise infer the -mlong* setting from the other options.  */
+
+--- gcc-17.0.0/gcc/config/mips/mips.md
++++ gcc-17.0.0-kos/gcc/config/mips/mips.md
+@@ -1124,6 +1124,7 @@
+ 
+ (define_delay (and (eq_attr "type" "branch")
+ 		   (not (match_test "TARGET_MIPS16"))
++		   (not (match_test "TARGET_FIX_R5900"))
+ 		   (eq_attr "branch_likely" "yes"))
+   [(eq_attr "can_delay" "yes")
+    (nil)
+@@ -1133,6 +1134,7 @@
+ ;; not annul on false.
+ (define_delay (and (eq_attr "type" "branch,simd_branch")
+ 		   (not (match_test "TARGET_MIPS16"))
++		   (not (match_test "TARGET_FIX_R5900"))
+ 		   (ior (match_test "TARGET_CB_NEVER")
+ 			(and (eq_attr "compact_form" "maybe")
+ 			     (not (match_test "TARGET_CB_ALWAYS")))
+@@ -1203,6 +1205,7 @@
+ (include "5000.md")
+ (include "5400.md")
+ (include "5500.md")
++(include "5900.md")
+ (include "6000.md")
+ (include "7000.md")
+ (include "9000.md")
+@@ -1811,7 +1814,7 @@
+ 		 (match_operand:SI 3 "register_operand" "l,l,l,d")))
+    (clobber (match_scratch:SI 4 "=X,X,3,l"))
+    (clobber (match_scratch:SI 5 "=X,X,X,&d"))]
+-  "TARGET_MIPS3900 && !TARGET_MIPS16"
++  "(TARGET_MIPS3900 || TARGET_MIPS5900) && !TARGET_MIPS16"
+   "@
+     madd\t%1,%2
+     madd\t%1,%2
+
+--- gcc-17.0.0/include/longlong.h
++++ gcc-17.0.0-kos/include/longlong.h
+@@ -853,6 +853,17 @@
+ #endif
+ 
+ #if defined (__mips__) && W_TYPE_SIZE == 32
++/* Force R5900 to use mult for mulsidi3, this is used in muldi3 */
++#ifdef _MIPS_ARCH_R5900
++#define __umulsidi3(u, v) \
++  ({UDItype __w;							\
++    __asm__ ("multu	%1,%2\n\tpmfhl.lw %0"				\
++	     : "=d" (__w)						\
++	     : "d" ((USItype) (u)),					\
++	       "d" ((USItype) (v))					\
++	     : "hi", "lo");						\
++    __w; })
++#endif
+ #define umul_ppmm(w1, w0, u, v)						\
+   do {									\
+     UDItype __x = (UDItype) (USItype) (u) * (USItype) (v);		\
+
+--- gcc-17.0.0/libgcc/config.host
++++ gcc-17.0.0-kos/libgcc/config.host
+@@ -151,7 +151,11 @@
+ 	cpu_type=mips
+ 	tmake_file="mips/t-mips"
+ 	if test "${libgcc_cv_mips_hard_float}" = yes; then
++	    if test "${libgcc_cv_mips_single_float}" = yes; then
++                tmake_file="${tmake_file} t-hardfp-sf t-hardfp"
++	    else
+ 		tmake_file="${tmake_file} t-hardfp-sfdf t-hardfp"
++	    fi
+ 	else
+ 		tmake_file="${tmake_file} t-softfp-sfdf"
+ 	fi
+@@ -1065,19 +1069,16 @@
+ mips*-*-linux*)				# Linux MIPS, either endian.
+ 	extra_parts="$extra_parts crtfastmath.o"
+ 	tmake_file="${tmake_file} t-crtfm"
+-	case ${host} in
+-	  mips64r5900* | mipsr5900*)
+-	    # The MIPS16 support code uses floating point
+-	    # instructions that are not supported on r5900.
+-	    ;;
+-	  *)
++    if test "${libgcc_cv_mips16}" = yes; then
+ 	    tmake_file="${tmake_file} mips/t-mips16 t-slibgcc-libgcc"
+-	    ;;
+-	esac
++    fi
+ 	md_unwind_header=mips/linux-unwind.h
+ 	;;
+ mips*-sde-elf*)
+-	tmake_file="$tmake_file mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	case "${with_newlib}" in
+ 	  yes)
+ 	    # newlib / libgloss.
+@@ -1107,7 +1108,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips-*-elf* | mipsel-*-elf*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mipsr5900-*-elf* | mipsr5900el-*-elf*)
+@@ -1115,7 +1119,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips64-*-elf* | mips64el-*-elf*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips64r5900-*-elf* | mips64r5900el-*-elf*)
+@@ -1131,7 +1138,10 @@
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips*-*-rtems*)
+-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
++	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
++    if test "${libgcc_cv_mips16}" = yes; then
++	  tmake_file="${tmake_file} mips/t-mips16"
++    fi
+ 	extra_parts="$extra_parts crti.o crtn.o"
+ 	;;
+ mips-wrs-vxworks)
+
+--- gcc-17.0.0/libgcc/config/mips/sfp-machine.h
++++ gcc-17.0.0-kos/libgcc/config/mips/sfp-machine.h
+@@ -22,7 +22,7 @@
+ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ <http://www.gnu.org/licenses/>.  */
+ 
+-#ifdef __mips64
++#if defined(__mips64) && !defined(_MIPS_ARCH_R5900)
+ #define _FP_W_TYPE_SIZE		64
+ #define _FP_W_TYPE		unsigned long long
+ #define _FP_WS_TYPE		signed long long
+
+--- gcc-17.0.0/libgcc/config/t-hardfp-sf
++++ gcc-17.0.0-kos/libgcc/config/t-hardfp-sf
+@@ -0,0 +1,32 @@
++# Clean-room libgcc fragment for the PlayStation 2 Emotion Engine (MIPS
++# R5900): single-precision floating point in hardware, double precision in
++# software.  Derived from the documented t-hardfp and fp-bit interfaces (the
++# FPBIT_FUNCS/DPBIT_FUNCS lists in libgcc/Makefile.in), not from any
++# third-party source.
++#
++# The R5900 FPU implements only single precision, so the SF arithmetic,
++# comparison and SI-conversion routines come from the hardware path
++# (config/hardfp.c, pulled in by t-hardfp).  Double precision, and the format
++# conversions the hardware lacks, are provided by libgcc's fp-bit emulator via
++# FPBIT/DPBIT.  LIB2FUNCS_EXCLUDE then drops the fp-bit single-precision
++# routines the hardware already supplies; the pack/unpack helpers and the
++# SF->DF / SF->TF conversions are deliberately kept, since hardfp does not
++# provide them (hardfp_extensions is empty).
++
++hardfp_float_modes := sf
++# di and ti conversions come from libgcc2.c where needed.
++hardfp_int_modes := si
++hardfp_extensions :=
++hardfp_truncations :=
++
++# Emulate double precision (and the SF<->DF/TF conversions) in software.
++FPBIT = true
++DPBIT = true
++
++# Do not build the fp-bit single-precision routines that the R5900 FPU
++# implements directly (these are the SF entries of FPBIT_FUNCS that hardfp
++# already covers).
++LIB2FUNCS_EXCLUDE = _addsub_sf _mul_sf _div_sf \
++    _fpcmp_parts_sf _compare_sf _eq_sf _ne_sf _gt_sf _ge_sf \
++    _lt_sf _le_sf _unord_sf _si_to_sf _sf_to_si _negate_sf \
++    _thenan_sf _sf_to_usi _usi_to_sf
+
+--- gcc-17.0.0/libgcc/configure
++++ gcc-17.0.0-kos/libgcc/configure
+@@ -5163,6 +5163,48 @@
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_hard_float" >&5
+ $as_echo "$libgcc_cv_mips_hard_float" >&6; }
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target is single-float" >&5
++$as_echo_n "checking whether the target is single-float... " >&6; }
++if test "${libgcc_cv_mips_single_float+set}" = set; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#ifndef __mips_single_float
++     #error FOO
++     #endif
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  libgcc_cv_mips_single_float=yes
++else
++  libgcc_cv_mips_single_float=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_single_float" >&5
++$as_echo "$libgcc_cv_mips_single_float" >&6; }
++  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target supports the MIPS16 ASE" >&5
++$as_echo_n "checking whether the target supports MIPS16 ASE... " >&6; }
++if test "${libgcc_cv_mips16+set}" = set; then :
++  $as_echo_n "(cached) " >&6
++else
++  CFLAGS_hold=$CFLAGS
++		 CFLAGS="$CFLAGS -mips16"
++		 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++int i;
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  libgcc_cv_mips16=yes
++else
++  libgcc_cv_mips16=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++	CFLAGS=$CFLAGS_hold
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips16" >&5
++$as_echo "$libgcc_cv_mips16" >&6; }
+ esac
+ 
+ # Determine the version of glibc, if any, used on the target.
+
+--- gcc-17.0.0/libgcc/configure.ac
++++ gcc-17.0.0-kos/libgcc/configure.ac
+@@ -356,6 +356,23 @@
+     ])],
+     [libgcc_cv_mips_hard_float=yes],
+     [libgcc_cv_mips_hard_float=no])])
++  AC_CACHE_CHECK([whether the target is single-float],
++		 [libgcc_cv_mips_single_float],
++		 [AC_COMPILE_IFELSE(
++    [#ifndef __mips_single_float
++     #error FOO
++     #endif],
++    [libgcc_cv_mips_single_float=yes],
++    [libgcc_cv_mips_single_float=no])])
++  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
++  AC_CACHE_CHECK([whether the target supports the MIPS16 ASE],
++		 [libgcc_cv_mips16],
++		 [CFLAGS_hold=$CFLAGS
++		 CFLAGS="$CFLAGS -mips16"
++		 AC_COMPILE_IFELSE([[int i;]],
++    [libgcc_cv_mips16=yes],
++    [libgcc_cv_mips16=no])
++	CFLAGS=$CFLAGS_hold])
+ esac
+ 
+ # Determine the version of glibc, if any, used on the target.
+
+
+--- gcc-17.0.0/gcc/builtins.cc
++++ gcc-17.0.0-kos/gcc/builtins.cc
+@@ -10327,6 +10327,8 @@
+     default:
+       gcc_unreachable ();
+     }
++
++  unsigned int llu_size = TYPE_PRECISION (long_long_unsigned_type_node);
+ 
+   if (TYPE_PRECISION (arg0_type)
+       <= TYPE_PRECISION (long_long_unsigned_type_node))
+@@ -10350,10 +10352,10 @@
+ 	  fcodei = fcodell;
+ 	}
+     }
+-  else if (TYPE_PRECISION (arg0_type) <= MAX_FIXED_MODE_SIZE)
++  else if (TYPE_PRECISION (arg0_type) <= 2 * llu_size)
+     {
+       cast_type
+-	= build_nonstandard_integer_type (MAX_FIXED_MODE_SIZE,
++	= build_nonstandard_integer_type (2 * llu_size,
+ 					  TYPE_UNSIGNED (arg0_type));
+       gcc_assert (TYPE_PRECISION (cast_type)
+ 		  == 2 * TYPE_PRECISION (long_long_unsigned_type_node));
+@@ -10387,7 +10389,7 @@
+       arg2 = NULL_TREE;
+     }
+   tree call = NULL_TREE, tem;
+-  if (TYPE_PRECISION (arg0_type) == MAX_FIXED_MODE_SIZE
++  if (TYPE_PRECISION (arg0_type) == 2 * llu_size
+       && (TYPE_PRECISION (arg0_type)
+ 	  == 2 * TYPE_PRECISION (long_long_unsigned_type_node))
+       /* If the target supports the optab, then don't do the expansion. */
+@@ -10400,7 +10402,7 @@
+ 		   : long_long_integer_type_node);
+       tree hi = fold_build2 (RSHIFT_EXPR, arg0_type, arg0,
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2));
++					    llu_size));
+       hi = fold_convert (type, hi);
+       tree lo = fold_convert (type, arg0);
+       switch (fcode)
+@@ -10409,7 +10411,7 @@
+ 	  call = fold_builtin_bit_query (loc, fcode, lo, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  if (arg2)
+ 	    call = fold_build3 (COND_EXPR, integer_type_node,
+ 				fold_build2 (NE_EXPR, boolean_type_node,
+@@ -10426,7 +10428,7 @@
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  if (arg2)
+ 	    call = fold_build3 (COND_EXPR, integer_type_node,
+ 				fold_build2 (NE_EXPR, boolean_type_node,
+@@ -10443,14 +10445,14 @@
+ 	  tem = fold_builtin_bit_query (loc, fcode, lo, NULL_TREE);
+ 	  tem = fold_build2 (PLUS_EXPR, integer_type_node, tem,
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2));
++					    llu_size));
+ 	  tem = fold_build3 (COND_EXPR, integer_type_node,
+ 			     fold_build2 (LT_EXPR, boolean_type_node,
+ 					  fold_build2 (BIT_XOR_EXPR, type,
+ 						       lo, hi),
+ 					  build_zero_cst (type)),
+ 			     build_int_cst (integer_type_node,
+-					    MAX_FIXED_MODE_SIZE / 2 - 1),
++					    llu_size - 1),
+ 			     tem);
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = save_expr (call);
+@@ -10458,15 +10460,15 @@
+ 			      fold_build2 (NE_EXPR, boolean_type_node,
+ 					   call,
+ 					   build_int_cst (integer_type_node,
+-							  MAX_FIXED_MODE_SIZE
+-							  / 2 - 1)),
++							  llu_size
++							  - 1)),
+ 			      call, tem);
+ 	  break;
+ 	case BUILT_IN_FFSG:
+ 	  call = fold_builtin_bit_query (loc, fcode, hi, NULL_TREE);
+ 	  call = fold_build2 (PLUS_EXPR, integer_type_node, call,
+ 			      build_int_cst (integer_type_node,
+-					     MAX_FIXED_MODE_SIZE / 2));
++					     llu_size));
+ 	  call = fold_build3 (COND_EXPR, integer_type_node,
+ 			      fold_build2 (NE_EXPR, boolean_type_node,
+ 					   hi, build_zero_cst (type)),

--- a/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
+++ b/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
@@ -1,6 +1,1485 @@
-diff --color -ruN newlib-4.6.0.20260123/newlib/configure.host newlib-4.6.0.20260123-kos/newlib/configure.host
---- newlib-4.6.0.20260123/newlib/configure.host	2024-02-10 09:30:58.772247624 -0600
-+++ newlib-4.6.0.20260123-kos/newlib/configure.host	2024-02-10 09:31:16.329331366 -0600
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/configure newlib-4.6.0.20260123-kos/configure
+--- newlib-4.6.0.20260123/configure	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/configure	2026-07-02 12:52:38
+@@ -3985,6 +3985,9 @@
+   | mips*-*-irix* | mips*-*-lnews* | mips*-*-riscos*)
+     noconfigdirs="$noconfigdirs ld gas gprof"
+     ;;
++  mips*-ps2-*)
++    noconfigdirs="$noconfigdirs target-libgloss"
++    ;;
+   mips*-*-*)
+     noconfigdirs="$noconfigdirs gprof"
+     ;;
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/configure.ac newlib-4.6.0.20260123-kos/configure.ac
+--- newlib-4.6.0.20260123/configure.ac	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/configure.ac	2026-05-13 05:01:13
+@@ -1269,6 +1269,9 @@
+   | mips*-*-irix* | mips*-*-lnews* | mips*-*-riscos*)
+     noconfigdirs="$noconfigdirs ld gas gprof"
+     ;;
++  mips*-ps2-*)
++    noconfigdirs="$noconfigdirs target-libgloss"
++    ;;
+   mips*-*-*)
+     noconfigdirs="$noconfigdirs gprof"
+     ;;
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/Makefile.in newlib-4.6.0.20260123-kos/newlib/Makefile.in
+--- newlib-4.6.0.20260123/newlib/Makefile.in	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/Makefile.in	2026-07-02 13:13:18
+@@ -586,30 +586,30 @@
+ @HAVE_LIBC_SYS_NETWARE_DIR_TRUE@	libc/sys/netware/link.c
+ 
+ @HAVE_LIBC_SYS_OR1K_DIR_TRUE@am__append_53 = libc/sys/or1k/getreent.S libc/sys/or1k/mlock.c
+-@HAVE_LIBC_SYS_RDOS_DIR_TRUE@am__append_54 = \
++@HAVE_LIBC_SYS_RDOS_DIR_TRUE@am__append_55 = \
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/chown.c libc/sys/rdos/close.c libc/sys/rdos/execve.c libc/sys/rdos/fork.c libc/sys/rdos/fstat.c libc/sys/rdos/getenv.c \
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/getpid.c libc/sys/rdos/gettod.c libc/sys/rdos/isatty.c libc/sys/rdos/kill.c libc/sys/rdos/link.c libc/sys/rdos/lseek.c libc/sys/rdos/open.c libc/sys/rdos/rdoshelp.c \
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/rdos.S libc/sys/rdos/read.c libc/sys/rdos/readlink.c libc/sys/rdos/sbrk.c libc/sys/rdos/stat.c libc/sys/rdos/symlink.c libc/sys/rdos/times.c libc/sys/rdos/unlink.c \
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/wait.c libc/sys/rdos/write.c
+ 
+-@HAVE_LIBC_SYS_RTEMS_DIR_TRUE@am__append_55 = libc/sys/rtems/dummysys.c libc/sys/rtems/cpusetalloc.c libc/sys/rtems/cpusetfree.c
+-@HAVE_LIBC_SYS_SH_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@am__append_56 = libc/sys/sh/syscalls.c libc/sys/sh/trap.S libc/sys/sh/creat.c libc/sys/sh/ftruncate.c libc/sys/sh/truncate.c
+-@HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@am__append_57 = \
++@HAVE_LIBC_SYS_RTEMS_DIR_TRUE@am__append_56 = libc/sys/rtems/dummysys.c libc/sys/rtems/cpusetalloc.c libc/sys/rtems/cpusetfree.c
++@HAVE_LIBC_SYS_SH_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@am__append_57 = libc/sys/sh/syscalls.c libc/sys/sh/trap.S libc/sys/sh/creat.c libc/sys/sh/ftruncate.c libc/sys/sh/truncate.c
++@HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@am__append_58 = \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/_exit.c libc/sys/sysmec/access.c libc/sys/sysmec/chmod.c libc/sys/sysmec/chown.c libc/sys/sysmec/close.c libc/sys/sysmec/creat.c libc/sys/sysmec/crt1.c \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/execv.c libc/sys/sysmec/execve.c libc/sys/sysmec/fork.c libc/sys/sysmec/fstat.c libc/sys/sysmec/getpid.c libc/sys/sysmec/isatty.c \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/kill.c libc/sys/sysmec/lseek.c libc/sys/sysmec/open.c libc/sys/sysmec/pipe.c libc/sys/sysmec/read.c \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/sbrk.c libc/sys/sysmec/stat.c libc/sys/sysmec/time.c libc/sys/sysmec/trap.S libc/sys/sysmec/unlink.c libc/sys/sysmec/utime.c libc/sys/sysmec/wait.c libc/sys/sysmec/write.c \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/times.c libc/sys/sysmec/gettime.c
+ 
+-@HAVE_LIBC_SYS_SYSNEC810_DIR_TRUE@am__append_58 = libc/sys/sysnec810/io.S libc/sys/sysnec810/write.c libc/sys/sysnec810/sbrk.c libc/sys/sysnec810/misc.c
+-@HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@am__append_59 = \
++@HAVE_LIBC_SYS_SYSNEC810_DIR_TRUE@am__append_59 = libc/sys/sysnec810/io.S libc/sys/sysnec810/write.c libc/sys/sysnec810/sbrk.c libc/sys/sysnec810/misc.c
++@HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@am__append_60 = \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/_exit.c libc/sys/sysnecv850/access.c libc/sys/sysnecv850/chmod.c libc/sys/sysnecv850/chown.c libc/sys/sysnecv850/close.c libc/sys/sysnecv850/creat.c libc/sys/sysnecv850/crt1.c \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/execv.c libc/sys/sysnecv850/execve.c libc/sys/sysnecv850/fork.c libc/sys/sysnecv850/fstat.c libc/sys/sysnecv850/getpid.c libc/sys/sysnecv850/isatty.c \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/kill.c libc/sys/sysnecv850/lseek.c libc/sys/sysnecv850/open.c libc/sys/sysnecv850/pipe.c libc/sys/sysnecv850/read.c libc/sys/sysnecv850/link.c \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/sbrk.c libc/sys/sysnecv850/stat.c libc/sys/sysnecv850/time.c libc/sys/sysnecv850/trap.S libc/sys/sysnecv850/unlink.c libc/sys/sysnecv850/utime.c libc/sys/sysnecv850/wait.c libc/sys/sysnecv850/write.c \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/times.c libc/sys/sysnecv850/gettime.c libc/sys/sysnecv850/rename.c
+ 
+-@HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@am__append_60 = \
++@HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@am__append_61 = \
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/ioctl.S libc/sys/sysvi386/isatty.c libc/sys/sysvi386/read.S libc/sys/sysvi386/lseek.S libc/sys/sysvi386/close.S libc/sys/sysvi386/sbrk.c libc/sys/sysvi386/fstat.S libc/sys/sysvi386/cerror.S \
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/_exit.S libc/sys/sysvi386/write.S libc/sys/sysvi386/open.S libc/sys/sysvi386/signal.S libc/sys/sysvi386/kill.S libc/sys/sysvi386/getpid.S libc/sys/sysvi386/brk.S libc/sys/sysvi386/fork.S libc/sys/sysvi386/wait.S \
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/execve.S libc/sys/sysvi386/exec.c libc/sys/sysvi386/utime.S libc/sys/sysvi386/fcntl.S libc/sys/sysvi386/chmod.S libc/sys/sysvi386/getuid.S libc/sys/sysvi386/getgid.S libc/sys/sysvi386/time.S \
+@@ -620,14 +620,14 @@
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/chdir.S libc/sys/sysvi386/dup2.c libc/sys/sysvi386/dup.c libc/sys/sysvi386/tcgetattr.c libc/sys/sysvi386/tcsetattr.c libc/sys/sysvi386/speed.c libc/sys/sysvi386/tcline.c \
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/times.S libc/sys/sysvi386/pause.S libc/sys/sysvi386/sleep.c libc/sys/sysvi386/alarm.S libc/sys/sysvi386/access.S libc/sys/sysvi386/_longjmp.S libc/sys/sysvi386/_setjmp.S
+ 
+-@HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@am__append_61 = \
++@HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@am__append_62 = \
+ @HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@	libc/sys/sysvnecv70/ioctl.S libc/sys/sysvnecv70/isatty.S libc/sys/sysvnecv70/read.S libc/sys/sysvnecv70/lseek.S libc/sys/sysvnecv70/close.S libc/sys/sysvnecv70/sbrk.S libc/sys/sysvnecv70/fstat.S \
+ @HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@	libc/sys/sysvnecv70/cerror.S libc/sys/sysvnecv70/exit.S libc/sys/sysvnecv70/write.S libc/sys/sysvnecv70/sysv60.S libc/sys/sysvnecv70/fpx.c libc/sys/sysvnecv70/fps.S libc/sys/sysvnecv70/open.S
+ 
+-@HAVE_LIBC_SYS_TIRTOS_DIR_TRUE@am__append_62 = libc/sys/tirtos/lock.c
+-@HAVE_LIBC_SYS_W65_DIR_TRUE@am__append_63 = libc/sys/w65/syscalls.c libc/sys/w65/trap.c
+-@HAVE_LIBC_SYS_Z8KSIM_DIR_TRUE@am__append_64 = libc/sys/z8ksim/glue.c
+-@HAVE_LIBC_MACHINE_AARCH64_TRUE@am__append_65 = \
++@HAVE_LIBC_SYS_TIRTOS_DIR_TRUE@am__append_63 = libc/sys/tirtos/lock.c
++@HAVE_LIBC_SYS_W65_DIR_TRUE@am__append_64 = libc/sys/w65/syscalls.c libc/sys/w65/trap.c
++@HAVE_LIBC_SYS_Z8KSIM_DIR_TRUE@am__append_65 = libc/sys/z8ksim/glue.c
++@HAVE_LIBC_MACHINE_AARCH64_TRUE@am__append_66 = \
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/memchr-stub.c \
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/memchr.S \
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/memcmp-stub.c \
+@@ -661,7 +661,7 @@
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/strrchr-stub.c \
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/strrchr.S
+ 
+-@HAVE_LIBC_MACHINE_AMDGCN_TRUE@am__append_66 = \
++@HAVE_LIBC_MACHINE_AMDGCN_TRUE@am__append_67 = \
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/_exit.c \
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/abort.c \
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/atexit.c \
+@@ -669,7 +669,7 @@
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/getreent.c \
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/signal.c
+ 
+-@HAVE_LIBC_MACHINE_ARC_TRUE@am__append_67 = \
++@HAVE_LIBC_MACHINE_ARC_TRUE@am__append_68 = \
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/memcmp.S \
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/memcmp-bs-norm.S \
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/memcmp-stub.c \
+@@ -701,7 +701,7 @@
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/strncpy-stub.c \
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/strncpy-bs.S
+ 
+-@HAVE_LIBC_MACHINE_ARC64_TRUE@am__append_68 = \
++@HAVE_LIBC_MACHINE_ARC64_TRUE@am__append_69 = \
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/memcmp.S \
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/memcmp-stub.c \
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/memcpy.S \
+@@ -715,7 +715,7 @@
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/strcmp.S \
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/memchr.S
+ 
+-@HAVE_LIBC_MACHINE_ARM_TRUE@am__append_69 = \
++@HAVE_LIBC_MACHINE_ARM_TRUE@am__append_70 = \
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/setjmp.S libc/machine/arm/strcmp.S libc/machine/arm/strcpy.c \
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/aeabi_memcpy.c libc/machine/arm/aeabi_memcpy-armv7a.S \
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/aeabi_memmove.c libc/machine/arm/aeabi_memmove-soft.S \
+@@ -727,39 +727,39 @@
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/strlen-stub.c \
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/strlen.S
+ 
+-@HAVE_LIBC_MACHINE_BFIN_TRUE@am__append_70 = libc/machine/bfin/setjmp.S libc/machine/bfin/longjmp.S
+-@HAVE_LIBC_MACHINE_CR16_TRUE@am__append_71 = libc/machine/cr16/setjmp.S libc/machine/cr16/getenv.c
+-@HAVE_LIBC_MACHINE_CRIS_TRUE@am__append_72 = libc/machine/cris/setjmp.c libc/machine/cris/memcpy.c libc/machine/cris/memset.c libc/machine/cris/memmove.c libc/machine/cris/libcdtor.c
++@HAVE_LIBC_MACHINE_BFIN_TRUE@am__append_71 = libc/machine/bfin/setjmp.S libc/machine/bfin/longjmp.S
++@HAVE_LIBC_MACHINE_CR16_TRUE@am__append_72 = libc/machine/cr16/setjmp.S libc/machine/cr16/getenv.c
++@HAVE_LIBC_MACHINE_CRIS_TRUE@am__append_73 = libc/machine/cris/setjmp.c libc/machine/cris/memcpy.c libc/machine/cris/memset.c libc/machine/cris/memmove.c libc/machine/cris/libcdtor.c
+ 
+ # We also make a library with just the useful
+ # machine-but-not-system-specific functions, usable as an add-on
+ # by itself together with e.g. uclibc.
+-@HAVE_LIBC_MACHINE_CRIS_TRUE@am__append_73 = libc/machine/cris/libic.a
+-@HAVE_LIBC_MACHINE_CRX_TRUE@am__append_74 = libc/machine/crx/setjmp.S libc/machine/crx/getenv.c
+-@HAVE_LIBC_MACHINE_CSKY_TRUE@am__append_75 = libc/machine/csky/setjmp.S
+-@HAVE_LIBC_MACHINE_D10V_TRUE@am__append_76 = libc/machine/d10v/setjmp.S
+-@HAVE_LIBC_MACHINE_D30V_TRUE@am__append_77 = libc/machine/d30v/setjmp.S
+-@HAVE_LIBC_MACHINE_EPIPHANY_TRUE@am__append_78 = libc/machine/epiphany/setjmp.S
+-@HAVE_LIBC_MACHINE_FR30_TRUE@am__append_79 = libc/machine/fr30/setjmp.S
+-@HAVE_LIBC_MACHINE_FRV_TRUE@am__append_80 = libc/machine/frv/setjmp.S
+-@HAVE_LIBC_MACHINE_FT32_TRUE@am__append_81 = libc/machine/ft32/setjmp.S libc/machine/ft32/strlen.S libc/machine/ft32/memcpy.S libc/machine/ft32/strcmp.S libc/machine/ft32/memset.S libc/machine/ft32/strcpy.S
+-@HAVE_LIBC_MACHINE_H8300_TRUE@am__append_82 = \
++@HAVE_LIBC_MACHINE_CRIS_TRUE@am__append_74 = libc/machine/cris/libic.a
++@HAVE_LIBC_MACHINE_CRX_TRUE@am__append_75 = libc/machine/crx/setjmp.S libc/machine/crx/getenv.c
++@HAVE_LIBC_MACHINE_CSKY_TRUE@am__append_76 = libc/machine/csky/setjmp.S
++@HAVE_LIBC_MACHINE_D10V_TRUE@am__append_77 = libc/machine/d10v/setjmp.S
++@HAVE_LIBC_MACHINE_D30V_TRUE@am__append_78 = libc/machine/d30v/setjmp.S
++@HAVE_LIBC_MACHINE_EPIPHANY_TRUE@am__append_79 = libc/machine/epiphany/setjmp.S
++@HAVE_LIBC_MACHINE_FR30_TRUE@am__append_80 = libc/machine/fr30/setjmp.S
++@HAVE_LIBC_MACHINE_FRV_TRUE@am__append_81 = libc/machine/frv/setjmp.S
++@HAVE_LIBC_MACHINE_FT32_TRUE@am__append_82 = libc/machine/ft32/setjmp.S libc/machine/ft32/strlen.S libc/machine/ft32/memcpy.S libc/machine/ft32/strcmp.S libc/machine/ft32/memset.S libc/machine/ft32/strcpy.S
++@HAVE_LIBC_MACHINE_H8300_TRUE@am__append_83 = \
+ @HAVE_LIBC_MACHINE_H8300_TRUE@	libc/machine/h8300/reg_memcpy.S libc/machine/h8300/reg_memset.S libc/machine/h8300/strcmp.S libc/machine/h8300/memcpy.S libc/machine/h8300/memset.S \
+ @HAVE_LIBC_MACHINE_H8300_TRUE@	libc/machine/h8300/setjmp.S libc/machine/h8300/h8sx_strcpy.S
+ 
+-@HAVE_LIBC_MACHINE_H8500_TRUE@am__append_83 = libc/machine/h8500/divsi3.c libc/machine/h8500/mulsi3.c libc/machine/h8500/divhi3.S libc/machine/h8500/shifts.c libc/machine/h8500/cmpsi.c libc/machine/h8500/psi.S libc/machine/h8500/setjmp.S
+-@HAVE_LIBC_MACHINE_HPPA_TRUE@am__append_84 = \
++@HAVE_LIBC_MACHINE_H8500_TRUE@am__append_84 = libc/machine/h8500/divsi3.c libc/machine/h8500/mulsi3.c libc/machine/h8500/divhi3.S libc/machine/h8500/shifts.c libc/machine/h8500/cmpsi.c libc/machine/h8500/psi.S libc/machine/h8500/setjmp.S
++@HAVE_LIBC_MACHINE_HPPA_TRUE@am__append_85 = \
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/memchr.S libc/machine/hppa/memcmp.S libc/machine/hppa/memcpy.S libc/machine/hppa/memset.S \
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/setjmp.S \
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/strcat.S libc/machine/hppa/strcmp.S \
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/strcpy.S libc/machine/hppa/strlen.S libc/machine/hppa/strncat.S libc/machine/hppa/strncmp.S libc/machine/hppa/strncpy.S
+ 
+-@HAVE_LIBC_MACHINE_I386_TRUE@@MACH_ADD_SETJMP_TRUE@am__append_85 = libc/machine/i386/setjmp.S
+-@HAVE_LIBC_MACHINE_I386_TRUE@am__append_86 = \
++@HAVE_LIBC_MACHINE_I386_TRUE@@MACH_ADD_SETJMP_TRUE@am__append_86 = libc/machine/i386/setjmp.S
++@HAVE_LIBC_MACHINE_I386_TRUE@am__append_87 = \
+ @HAVE_LIBC_MACHINE_I386_TRUE@	libc/machine/i386/memchr.S libc/machine/i386/memcmp.S libc/machine/i386/memcpy.S libc/machine/i386/memset.S libc/machine/i386/strchr.S \
+ @HAVE_LIBC_MACHINE_I386_TRUE@	libc/machine/i386/memmove.S libc/machine/i386/strlen.S libc/machine/i386/i386mach.h
+ 
+-@HAVE_LIBC_MACHINE_I960_TRUE@am__append_87 = \
++@HAVE_LIBC_MACHINE_I960_TRUE@am__append_88 = \
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/memccpy_ca.S \
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/memccpy.S \
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/memchr_ca.S \
+@@ -789,43 +789,43 @@
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/strpbrk.S \
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/strrchr.S
+ 
+-@HAVE_LIBC_MACHINE_IQ2000_TRUE@am__append_88 = libc/machine/iq2000/setjmp.S
+-@HAVE_LIBC_MACHINE_LM32_TRUE@am__append_89 = libc/machine/lm32/setjmp.S
+-@HAVE_LIBC_MACHINE_M32C_TRUE@am__append_90 = libc/machine/m32c/setjmp.S
+-@HAVE_LIBC_MACHINE_M32R_TRUE@am__append_91 = libc/machine/m32r/setjmp.S
+-@HAVE_LIBC_MACHINE_M68HC11_TRUE@am__append_92 = libc/machine/m68hc11/setjmp.S
+-@HAVE_LIBC_MACHINE_M68K_TRUE@am__append_93 = libc/machine/m68k/setjmp.S libc/machine/m68k/strcpy.c libc/machine/m68k/strlen.c libc/machine/m68k/memcpy.S libc/machine/m68k/memset.S
+-@HAVE_LIBC_MACHINE_M88K_TRUE@am__append_94 = libc/machine/m88k/setjmp.S
+-@HAVE_LIBC_MACHINE_MEP_TRUE@am__append_95 = libc/machine/mep/setjmp.S
+-@HAVE_LIBC_MACHINE_MICROBLAZE_TRUE@am__append_96 = libc/machine/microblaze/strlen.c libc/machine/microblaze/strcmp.c libc/machine/microblaze/strcpy.c libc/machine/microblaze/setjmp.S libc/machine/microblaze/longjmp.S
+-@HAVE_LIBC_MACHINE_MIPS_TRUE@am__append_97 = libc/machine/mips/setjmp.S libc/machine/mips/strlen.c libc/machine/mips/strcmp.S libc/machine/mips/strncpy.c libc/machine/mips/memset.c libc/machine/mips/memcpy.c
+-@HAVE_LIBC_MACHINE_MN10200_TRUE@am__append_98 = libc/machine/mn10200/setjmp.S
+-@HAVE_LIBC_MACHINE_MN10300_TRUE@am__append_99 = \
++@HAVE_LIBC_MACHINE_IQ2000_TRUE@am__append_89 = libc/machine/iq2000/setjmp.S
++@HAVE_LIBC_MACHINE_LM32_TRUE@am__append_90 = libc/machine/lm32/setjmp.S
++@HAVE_LIBC_MACHINE_M32C_TRUE@am__append_91 = libc/machine/m32c/setjmp.S
++@HAVE_LIBC_MACHINE_M32R_TRUE@am__append_92 = libc/machine/m32r/setjmp.S
++@HAVE_LIBC_MACHINE_M68HC11_TRUE@am__append_93 = libc/machine/m68hc11/setjmp.S
++@HAVE_LIBC_MACHINE_M68K_TRUE@am__append_94 = libc/machine/m68k/setjmp.S libc/machine/m68k/strcpy.c libc/machine/m68k/strlen.c libc/machine/m68k/memcpy.S libc/machine/m68k/memset.S
++@HAVE_LIBC_MACHINE_M88K_TRUE@am__append_95 = libc/machine/m88k/setjmp.S
++@HAVE_LIBC_MACHINE_MEP_TRUE@am__append_96 = libc/machine/mep/setjmp.S
++@HAVE_LIBC_MACHINE_MICROBLAZE_TRUE@am__append_97 = libc/machine/microblaze/strlen.c libc/machine/microblaze/strcmp.c libc/machine/microblaze/strcpy.c libc/machine/microblaze/setjmp.S libc/machine/microblaze/longjmp.S
++@HAVE_LIBC_MACHINE_MIPS_TRUE@am__append_98 = libc/machine/mips/setjmp.S libc/machine/mips/strlen.c libc/machine/mips/strcmp.S libc/machine/mips/strncpy.c libc/machine/mips/memset.c libc/machine/mips/memcpy.c
++@HAVE_LIBC_MACHINE_MN10200_TRUE@am__append_99 = libc/machine/mn10200/setjmp.S
++@HAVE_LIBC_MACHINE_MN10300_TRUE@am__append_100 = \
+ @HAVE_LIBC_MACHINE_MN10300_TRUE@	libc/machine/mn10300/setjmp.S libc/machine/mn10300/memchr.S libc/machine/mn10300/memcmp.S libc/machine/mn10300/memcpy.S libc/machine/mn10300/memset.S libc/machine/mn10300/strchr.S \
+ @HAVE_LIBC_MACHINE_MN10300_TRUE@	libc/machine/mn10300/strcmp.S libc/machine/mn10300/strcpy.S libc/machine/mn10300/strlen.S
+ 
+-@HAVE_LIBC_MACHINE_MOXIE_TRUE@am__append_100 = libc/machine/moxie/setjmp.S
+-@HAVE_LIBC_MACHINE_MSP430_TRUE@am__append_101 = libc/machine/msp430/setjmp.S
+-@HAVE_LIBC_MACHINE_MSP430_TRUE@@NEWLIB_NANO_FORMATTED_IO_TRUE@am__append_102 = libc/machine/msp430/tiny-puts.c libc/machine/msp430/tiny-printf.c
+-@HAVE_LIBC_MACHINE_MT_TRUE@am__append_103 = libc/machine/mt/setjmp.S
+-@HAVE_LIBC_MACHINE_NDS32_TRUE@am__append_104 = \
++@HAVE_LIBC_MACHINE_MOXIE_TRUE@am__append_101 = libc/machine/moxie/setjmp.S
++@HAVE_LIBC_MACHINE_MSP430_TRUE@am__append_102 = libc/machine/msp430/setjmp.S
++@HAVE_LIBC_MACHINE_MSP430_TRUE@@NEWLIB_NANO_FORMATTED_IO_TRUE@am__append_103 = libc/machine/msp430/tiny-puts.c libc/machine/msp430/tiny-printf.c
++@HAVE_LIBC_MACHINE_MT_TRUE@am__append_104 = libc/machine/mt/setjmp.S
++@HAVE_LIBC_MACHINE_NDS32_TRUE@am__append_105 = \
+ @HAVE_LIBC_MACHINE_NDS32_TRUE@	libc/machine/nds32/abort.c \
+ @HAVE_LIBC_MACHINE_NDS32_TRUE@	libc/machine/nds32/setjmp.S \
+ @HAVE_LIBC_MACHINE_NDS32_TRUE@	libc/machine/nds32/strcmp.S \
+ @HAVE_LIBC_MACHINE_NDS32_TRUE@	libc/machine/nds32/strcpy.S
+ 
+-@HAVE_LIBC_MACHINE_NDS32_TRUE@@IS_NDS32_ISA_V3M_FALSE@am__append_105 = libc/machine/nds32/memcpy.S libc/machine/nds32/memset.S
+-@HAVE_LIBC_MACHINE_NECV70_TRUE@am__append_106 = libc/machine/necv70/fastmath.S libc/machine/necv70/setjmp.S
+-@HAVE_LIBC_MACHINE_NIOS2_TRUE@am__append_107 = libc/machine/nios2/setjmp.s
+-@HAVE_LIBC_MACHINE_NVPTX_TRUE@am__append_108 = \
++@HAVE_LIBC_MACHINE_NDS32_TRUE@@IS_NDS32_ISA_V3M_FALSE@am__append_106 = libc/machine/nds32/memcpy.S libc/machine/nds32/memset.S
++@HAVE_LIBC_MACHINE_NECV70_TRUE@am__append_107 = libc/machine/necv70/fastmath.S libc/machine/necv70/setjmp.S
++@HAVE_LIBC_MACHINE_NIOS2_TRUE@am__append_108 = libc/machine/nios2/setjmp.s
++@HAVE_LIBC_MACHINE_NVPTX_TRUE@am__append_109 = \
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/_exit.c \
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/calloc.c libc/machine/nvptx/callocr.c libc/machine/nvptx/malloc.c libc/machine/nvptx/mallocr.c libc/machine/nvptx/realloc.c libc/machine/nvptx/reallocr.c \
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/free.c libc/machine/nvptx/write.c libc/machine/nvptx/assert.c libc/machine/nvptx/puts.c libc/machine/nvptx/putchar.c libc/machine/nvptx/printf.c libc/machine/nvptx/abort.c \
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/misc.c libc/machine/nvptx/clock.c
+ 
+-@HAVE_LIBC_MACHINE_OR1K_TRUE@am__append_109 = libc/machine/or1k/setjmp.S
+-@HAVE_LIBC_MACHINE_POWERPC_TRUE@am__append_110 = libc/machine/powerpc/setjmp.S
+-@HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@am__append_111 = \
++@HAVE_LIBC_MACHINE_OR1K_TRUE@am__append_110 = libc/machine/or1k/setjmp.S
++@HAVE_LIBC_MACHINE_POWERPC_TRUE@am__append_111 = libc/machine/powerpc/setjmp.S
++@HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@am__append_112 = \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/vfprintf.c \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/vfscanf.c \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/vec_malloc.c \
+@@ -836,7 +836,7 @@
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/vec_callocr.c \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/vec_reallocr.c
+ 
+-@HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@am__append_112 = \
++@HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@am__append_113 = \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/atosfix16.c \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/atosfix32.c \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/atosfix64.c \
+@@ -854,21 +854,22 @@
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/vfprintf.c \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/vfscanf.c
+ 
+-@HAVE_LIBC_MACHINE_PRU_TRUE@am__append_113 = libc/machine/pru/setjmp.s
+-@HAVE_LIBC_MACHINE_RISCV_TRUE@am__append_114 = \
++@HAVE_LIBC_MACHINE_PRU_TRUE@am__append_114 = libc/machine/pru/setjmp.s
++@HAVE_LIBC_MACHINE_R5900_TRUE@am__append_115 = libc/machine/r5900/setjmp.S
++@HAVE_LIBC_MACHINE_RISCV_TRUE@am__append_116 = \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/memmove-asm.S libc/machine/riscv/memmove.c libc/machine/riscv/memset.S libc/machine/riscv/memcpy-asm.S libc/machine/riscv/memcpy.c libc/machine/riscv/strlen.c \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/strcpy.c libc/machine/riscv/stpcpy.c libc/machine/riscv/strcmp.S libc/machine/riscv/memchr.c libc/machine/riscv/memrchr.c libc/machine/riscv/setjmp.S libc/machine/riscv/ieeefp.c libc/machine/riscv/ffs.c
+ 
+-@HAVE_LIBC_MACHINE_RL78_TRUE@am__append_115 = libc/machine/rl78/setjmp.S
+-@HAVE_LIBC_MACHINE_RX_TRUE@am__append_116 = \
++@HAVE_LIBC_MACHINE_RL78_TRUE@am__append_117 = libc/machine/rl78/setjmp.S
++@HAVE_LIBC_MACHINE_RX_TRUE@am__append_118 = \
+ @HAVE_LIBC_MACHINE_RX_TRUE@	libc/machine/rx/setjmp.S \
+ @HAVE_LIBC_MACHINE_RX_TRUE@	libc/machine/rx/strncmp.S libc/machine/rx/strcmp.S libc/machine/rx/strncpy.S libc/machine/rx/strcpy.S libc/machine/rx/strlen.S libc/machine/rx/strcat.S libc/machine/rx/strncat.S \
+ @HAVE_LIBC_MACHINE_RX_TRUE@	libc/machine/rx/memset.S libc/machine/rx/mempcpy.S libc/machine/rx/memcpy.S libc/machine/rx/memmove.S libc/machine/rx/memchr.S
+ 
+-@HAVE_LIBC_MACHINE_SH_TRUE@am__append_117 = libc/machine/sh/memcpy.S libc/machine/sh/memset.S libc/machine/sh/setjmp.S libc/machine/sh/strcpy.S libc/machine/sh/strlen.S libc/machine/sh/strcmp.S
+-@HAVE_LIBC_MACHINE_SH_TRUE@@SH64_TRUE@am__append_118 = libc/machine/sh/strncpy.S
+-@HAVE_LIBC_MACHINE_SPARC_TRUE@am__append_119 = libc/machine/sparc/scan.c libc/machine/sparc/shuffle.c libc/machine/sparc/setjmp.S
+-@HAVE_LIBC_MACHINE_SPU_TRUE@am__append_120 = \
++@HAVE_LIBC_MACHINE_SH_TRUE@am__append_119 = libc/machine/sh/memcpy.S libc/machine/sh/memset.S libc/machine/sh/setjmp.S libc/machine/sh/strcpy.S libc/machine/sh/strlen.S libc/machine/sh/strcmp.S
++@HAVE_LIBC_MACHINE_SH_TRUE@@SH64_TRUE@am__append_120 = libc/machine/sh/strncpy.S
++@HAVE_LIBC_MACHINE_SPARC_TRUE@am__append_121 = libc/machine/sparc/scan.c libc/machine/sparc/shuffle.c libc/machine/sparc/setjmp.S
++@HAVE_LIBC_MACHINE_SPU_TRUE@am__append_122 = \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/setjmp.S libc/machine/spu/assert.c libc/machine/spu/clearerr.c libc/machine/spu/creat.c libc/machine/spu/fclose.c libc/machine/spu/feof.c \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/ferror.c libc/machine/spu/fflush.c libc/machine/spu/fgetc.c libc/machine/spu/fgetpos.c libc/machine/spu/fgets.c libc/machine/spu/fileno.c libc/machine/spu/fiprintf.S \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/fiscanf.S libc/machine/spu/fopen.c libc/machine/spu/fprintf.S libc/machine/spu/fputc.c libc/machine/spu/fputs.c libc/machine/spu/fread.c libc/machine/spu/freopen.c \
+@@ -886,7 +887,7 @@
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/spu_timer_slih.c libc/machine/spu/spu_timer_slih_reg.c libc/machine/spu/spu_timer_svcs.c \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/spu_timer_stop.c libc/machine/spu/spu_timer_free.c libc/machine/spu/spu_timebase.c libc/machine/spu/fdopen.c
+ 
+-@HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@am__append_121 = \
++@HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@am__append_123 = \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/calloc_ea.c libc/machine/spu/free_ea.c libc/machine/spu/malloc_ea.c libc/machine/spu/memchr_ea.c libc/machine/spu/memcmp_ea.c \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/memcpy_ea.c libc/machine/spu/memmove_ea.c libc/machine/spu/memset_ea.c libc/machine/spu/mmap_ea.c libc/machine/spu/mremap_ea.c libc/machine/spu/msync_ea.c \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/munmap_ea.c libc/machine/spu/posix_memalign_ea.c libc/machine/spu/realloc_ea.c libc/machine/spu/strcat_ea.c libc/machine/spu/strchr_ea.c \
+@@ -895,18 +896,18 @@
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/pread_ea.c libc/machine/spu/readv_ea.c libc/machine/spu/write_ea.c libc/machine/spu/pwrite_ea.c libc/machine/spu/writev_ea.c libc/machine/spu/spu-mcount.S \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/spu-gmon.c
+ 
+-@HAVE_LIBC_MACHINE_TIC4X_TRUE@am__append_122 = libc/machine/tic4x/setjmp.S
+-@HAVE_LIBC_MACHINE_TIC6X_TRUE@am__append_123 = libc/machine/tic6x/setjmp.S
+-@HAVE_LIBC_MACHINE_TIC80_TRUE@am__append_124 = libc/machine/tic80/setjmp.S
+-@HAVE_LIBC_MACHINE_V850_TRUE@am__append_125 = libc/machine/v850/setjmp.S
+-@HAVE_LIBC_MACHINE_VISIUM_TRUE@am__append_126 = libc/machine/visium/memcpy.c libc/machine/visium/memset.c libc/machine/visium/memmove.c libc/machine/visium/setjmp.S
+-@HAVE_LIBC_MACHINE_W65_TRUE@am__append_127 = \
++@HAVE_LIBC_MACHINE_TIC4X_TRUE@am__append_124 = libc/machine/tic4x/setjmp.S
++@HAVE_LIBC_MACHINE_TIC6X_TRUE@am__append_125 = libc/machine/tic6x/setjmp.S
++@HAVE_LIBC_MACHINE_TIC80_TRUE@am__append_126 = libc/machine/tic80/setjmp.S
++@HAVE_LIBC_MACHINE_V850_TRUE@am__append_127 = libc/machine/v850/setjmp.S
++@HAVE_LIBC_MACHINE_VISIUM_TRUE@am__append_128 = libc/machine/visium/memcpy.c libc/machine/visium/memset.c libc/machine/visium/memmove.c libc/machine/visium/setjmp.S
++@HAVE_LIBC_MACHINE_W65_TRUE@am__append_129 = \
+ @HAVE_LIBC_MACHINE_W65_TRUE@	libc/machine/w65/udivhi3.S libc/machine/w65/umodhi3.S libc/machine/w65/smulhi3.S libc/machine/w65/lshrhi.S libc/machine/w65/sdivhi3.S libc/machine/w65/mulsi3.c \
+ @HAVE_LIBC_MACHINE_W65_TRUE@	libc/machine/w65/divsi3.c libc/machine/w65/cmpsi.c
+ 
+-@HAVE_LIBC_MACHINE_X86_64_TRUE@am__append_128 = libc/machine/x86_64/setjmp.S libc/machine/x86_64/memcpy.S libc/machine/x86_64/memset.S
+-@HAVE_LIBC_MACHINE_XC16X_TRUE@am__append_129 = libc/machine/xc16x/setjmp.S libc/machine/xc16x/puts.c libc/machine/xc16x/putchar.c
+-@HAVE_LIBC_MACHINE_XSTORMY16_TRUE@am__append_130 = \
++@HAVE_LIBC_MACHINE_X86_64_TRUE@am__append_130 = libc/machine/x86_64/setjmp.S libc/machine/x86_64/memcpy.S libc/machine/x86_64/memset.S
++@HAVE_LIBC_MACHINE_XC16X_TRUE@am__append_131 = libc/machine/xc16x/setjmp.S libc/machine/xc16x/puts.c libc/machine/xc16x/putchar.c
++@HAVE_LIBC_MACHINE_XSTORMY16_TRUE@am__append_132 = \
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/setjmp.S \
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/calloc.c \
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/callocr.c \
+@@ -921,13 +922,13 @@
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/reallocr.c \
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/valloc.c
+ 
+-@HAVE_LIBC_MACHINE_XTENSA_TRUE@am__append_131 = \
++@HAVE_LIBC_MACHINE_XTENSA_TRUE@am__append_133 = \
+ @HAVE_LIBC_MACHINE_XTENSA_TRUE@	libc/machine/xtensa/memcpy.S libc/machine/xtensa/memset.S libc/machine/xtensa/setjmp.S libc/machine/xtensa/strcmp.S libc/machine/xtensa/strcpy.S \
+ @HAVE_LIBC_MACHINE_XTENSA_TRUE@	libc/machine/xtensa/strlen.S libc/machine/xtensa/strncpy.S
+ 
+-@HAVE_LIBC_MACHINE_Z8K_TRUE@am__append_132 = libc/machine/z8k/setjmp.S libc/machine/z8k/memset.S libc/machine/z8k/memcpy.S libc/machine/z8k/memmove.S libc/machine/z8k/memcmp.S
+-@NEWLIB_HW_FP_TRUE@am__append_133 = $(libm_mathfp_src) $(libm_mathfp_fsrc)
+-@NEWLIB_HW_FP_TRUE@am__append_134 = \
++@HAVE_LIBC_MACHINE_Z8K_TRUE@am__append_134 = libc/machine/z8k/setjmp.S libc/machine/z8k/memset.S libc/machine/z8k/memcpy.S libc/machine/z8k/memmove.S libc/machine/z8k/memcmp.S
++@NEWLIB_HW_FP_TRUE@am__append_135 = $(libm_mathfp_src) $(libm_mathfp_fsrc)
++@NEWLIB_HW_FP_TRUE@am__append_136 = \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/e_acosh.def \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/e_atanh.def \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/e_hypot.def \
+@@ -957,9 +958,9 @@
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/s_tanh.def \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/w_jn.def
+ 
+-@NEWLIB_HW_FP_TRUE@am__append_135 = libm/mathfp/mathfp.tex
+-@NEWLIB_HW_FP_FALSE@am__append_136 = $(libm_math_src) $(libm_math_fsrc) $(libm_math_lsrc)
+-@NEWLIB_HW_FP_FALSE@am__append_137 = \
++@NEWLIB_HW_FP_TRUE@am__append_137 = libm/mathfp/mathfp.tex
++@NEWLIB_HW_FP_FALSE@am__append_138 = $(libm_math_src) $(libm_math_fsrc) $(libm_math_lsrc)
++@NEWLIB_HW_FP_FALSE@am__append_139 = \
+ @NEWLIB_HW_FP_FALSE@	libm/math/w_acos.def libm/math/w_acosh.def libm/math/w_asin.def libm/math/s_asinh.def \
+ @NEWLIB_HW_FP_FALSE@	libm/math/s_atan.def libm/math/w_atan2.def libm/math/w_atanh.def libm/math/w_j0.def \
+ @NEWLIB_HW_FP_FALSE@	libm/math/w_cosh.def libm/math/s_erf.def libm/math/w_exp.def libm/math/w_exp2.def \
+@@ -969,41 +970,41 @@
+ @NEWLIB_HW_FP_FALSE@	libm/math/w_pow.def libm/math/w_remainder.def libm/math/s_sin.def libm/math/w_sinh.def \
+ @NEWLIB_HW_FP_FALSE@	libm/math/w_sqrt.def libm/math/s_tan.def libm/math/s_tanh.def
+ 
+-@NEWLIB_HW_FP_FALSE@am__append_138 = libm/math/math.tex
+-@HAVE_LONG_DOUBLE_TRUE@am__append_139 = $(libm_common_lsrc)
+-@HAVE_FPMATH_H_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_140 = $(libm_ld_lsrc)
+-@HAVE_FPMATH_H_TRUE@am__append_141 = 
+-@HAVE_FPMATH_H_TRUE@am__append_142 = 
+-@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__append_143 = $(libm_machine_aarch64_src)
+-@HAVE_LIBM_MACHINE_AARCH64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_144 = $(libm_ld128_lsrc)
+-@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__append_145 = 
+-@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__append_146 = 
+-@HAVE_LIBM_MACHINE_AMDGCN_TRUE@am__append_147 = $(libm_machine_amdgcn_src)
+-@HAVE_LIBM_MACHINE_ARM_TRUE@am__append_148 = $(libm_machine_arm_src)
+-@HAVE_LIBM_MACHINE_I386_TRUE@am__append_149 = $(libm_machine_i386_src)
+-@HAVE_LIBM_MACHINE_I386_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_150 = $(libm_ld80_lsrc)
+-@HAVE_LIBM_MACHINE_I386_TRUE@am__append_151 = 
+-@HAVE_LIBM_MACHINE_I386_TRUE@am__append_152 = 
+-@HAVE_LIBM_MACHINE_MIPS_TRUE@am__append_153 = $(libm_machine_mips_src)
+-@HAS_NDS32_FPU_SP_TRUE@@HAVE_LIBM_MACHINE_NDS32_TRUE@am__append_154 = libm/machine/nds32/wf_sqrt.S
+-@HAS_NDS32_FPU_DP_TRUE@@HAVE_LIBM_MACHINE_NDS32_TRUE@am__append_155 = libm/machine/nds32/w_sqrt.S
+-@HAVE_LIBM_MACHINE_NDS32_TRUE@am__append_156 = $(libm_machine_nds32_src)
+-@HAVE_LIBM_MACHINE_POWERPC_TRUE@am__append_157 = $(libm_machine_powerpc_src)
+-@HAVE_LIBM_MACHINE_PRU_TRUE@am__append_158 = $(libm_machine_pru_src)
+-@HAVE_LIBM_MACHINE_SPARC_TRUE@am__append_159 = $(libm_machine_sparc_src)
+-@HAVE_LIBM_MACHINE_SPU_TRUE@am__append_160 = $(libm_machine_spu_src)
+-@HAVE_LIBM_MACHINE_RISCV_TRUE@am__append_161 = $(libm_machine_riscv_src)
+-@HAVE_LIBM_MACHINE_RISCV_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_162 = $(libm_ld128_lsrc)
+-@HAVE_LIBM_MACHINE_RISCV_TRUE@am__append_163 = 
+-@HAVE_LIBM_MACHINE_RISCV_TRUE@am__append_164 = 
+-@HAVE_LIBM_MACHINE_X86_64_TRUE@am__append_165 = $(libm_machine_x86_64_src)
+-@HAVE_LIBM_MACHINE_X86_64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_166 = $(libm_ld80_lsrc)
+-@HAVE_LIBM_MACHINE_X86_64_TRUE@am__append_167 = 
+-@HAVE_LIBM_MACHINE_X86_64_TRUE@am__append_168 = 
+-@HAVE_LIBM_MACHINE_XTENSA_TRUE@@XTENSA_XCHAL_HAVE_FP_SQRT_TRUE@am__append_169 = \
++@NEWLIB_HW_FP_FALSE@am__append_140 = libm/math/math.tex
++@HAVE_LONG_DOUBLE_TRUE@am__append_141 = $(libm_common_lsrc)
++@HAVE_FPMATH_H_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_142 = $(libm_ld_lsrc)
++@HAVE_FPMATH_H_TRUE@am__append_143 = 
++@HAVE_FPMATH_H_TRUE@am__append_144 = 
++@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__append_145 = $(libm_machine_aarch64_src)
++@HAVE_LIBM_MACHINE_AARCH64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_146 = $(libm_ld128_lsrc)
++@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__append_147 = 
++@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__append_148 = 
++@HAVE_LIBM_MACHINE_AMDGCN_TRUE@am__append_149 = $(libm_machine_amdgcn_src)
++@HAVE_LIBM_MACHINE_ARM_TRUE@am__append_150 = $(libm_machine_arm_src)
++@HAVE_LIBM_MACHINE_I386_TRUE@am__append_151 = $(libm_machine_i386_src)
++@HAVE_LIBM_MACHINE_I386_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_152 = $(libm_ld80_lsrc)
++@HAVE_LIBM_MACHINE_I386_TRUE@am__append_153 = 
++@HAVE_LIBM_MACHINE_I386_TRUE@am__append_154 = 
++@HAVE_LIBM_MACHINE_MIPS_TRUE@am__append_155 = $(libm_machine_mips_src)
++@HAS_NDS32_FPU_SP_TRUE@@HAVE_LIBM_MACHINE_NDS32_TRUE@am__append_156 = libm/machine/nds32/wf_sqrt.S
++@HAS_NDS32_FPU_DP_TRUE@@HAVE_LIBM_MACHINE_NDS32_TRUE@am__append_157 = libm/machine/nds32/w_sqrt.S
++@HAVE_LIBM_MACHINE_NDS32_TRUE@am__append_158 = $(libm_machine_nds32_src)
++@HAVE_LIBM_MACHINE_POWERPC_TRUE@am__append_159 = $(libm_machine_powerpc_src)
++@HAVE_LIBM_MACHINE_PRU_TRUE@am__append_160 = $(libm_machine_pru_src)
++@HAVE_LIBM_MACHINE_SPARC_TRUE@am__append_161 = $(libm_machine_sparc_src)
++@HAVE_LIBM_MACHINE_SPU_TRUE@am__append_162 = $(libm_machine_spu_src)
++@HAVE_LIBM_MACHINE_RISCV_TRUE@am__append_163 = $(libm_machine_riscv_src)
++@HAVE_LIBM_MACHINE_RISCV_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_164 = $(libm_ld128_lsrc)
++@HAVE_LIBM_MACHINE_RISCV_TRUE@am__append_165 = 
++@HAVE_LIBM_MACHINE_RISCV_TRUE@am__append_166 = 
++@HAVE_LIBM_MACHINE_X86_64_TRUE@am__append_167 = $(libm_machine_x86_64_src)
++@HAVE_LIBM_MACHINE_X86_64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_168 = $(libm_ld80_lsrc)
++@HAVE_LIBM_MACHINE_X86_64_TRUE@am__append_169 = 
++@HAVE_LIBM_MACHINE_X86_64_TRUE@am__append_170 = 
++@HAVE_LIBM_MACHINE_XTENSA_TRUE@@XTENSA_XCHAL_HAVE_FP_SQRT_TRUE@am__append_171 = \
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@@XTENSA_XCHAL_HAVE_FP_SQRT_TRUE@	libm/machine/xtensa/ef_sqrt.c
+ 
+-@HAVE_LIBM_MACHINE_XTENSA_TRUE@am__append_170 = $(libm_machine_xtensa_src)
++@HAVE_LIBM_MACHINE_XTENSA_TRUE@am__append_172 = $(libm_machine_xtensa_src)
+ subdir = .
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/../config/depstand.m4 \
+@@ -1731,7 +1732,7 @@
+ @HAVE_LIBC_SYS_NETWARE_DIR_TRUE@	libc/sys/netware/libc_a-link.$(OBJEXT)
+ @HAVE_LIBC_SYS_OR1K_DIR_TRUE@am__objects_64 = libc/sys/or1k/libc_a-getreent.$(OBJEXT) \
+ @HAVE_LIBC_SYS_OR1K_DIR_TRUE@	libc/sys/or1k/libc_a-mlock.$(OBJEXT)
+-@HAVE_LIBC_SYS_RDOS_DIR_TRUE@am__objects_65 = libc/sys/rdos/libc_a-chown.$(OBJEXT) \
++@HAVE_LIBC_SYS_RDOS_DIR_TRUE@am__objects_66 = libc/sys/rdos/libc_a-chown.$(OBJEXT) \
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/libc_a-close.$(OBJEXT) \
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/libc_a-execve.$(OBJEXT) \
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/libc_a-fork.$(OBJEXT) \
+@@ -1755,15 +1756,15 @@
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/libc_a-unlink.$(OBJEXT) \
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/libc_a-wait.$(OBJEXT) \
+ @HAVE_LIBC_SYS_RDOS_DIR_TRUE@	libc/sys/rdos/libc_a-write.$(OBJEXT)
+-@HAVE_LIBC_SYS_RTEMS_DIR_TRUE@am__objects_66 = libc/sys/rtems/libc_a-dummysys.$(OBJEXT) \
++@HAVE_LIBC_SYS_RTEMS_DIR_TRUE@am__objects_67 = libc/sys/rtems/libc_a-dummysys.$(OBJEXT) \
+ @HAVE_LIBC_SYS_RTEMS_DIR_TRUE@	libc/sys/rtems/libc_a-cpusetalloc.$(OBJEXT) \
+ @HAVE_LIBC_SYS_RTEMS_DIR_TRUE@	libc/sys/rtems/libc_a-cpusetfree.$(OBJEXT)
+-@HAVE_LIBC_SYS_SH_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@am__objects_67 = libc/sys/sh/libc_a-syscalls.$(OBJEXT) \
++@HAVE_LIBC_SYS_SH_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@am__objects_68 = libc/sys/sh/libc_a-syscalls.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SH_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sh/libc_a-trap.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SH_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sh/libc_a-creat.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SH_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sh/libc_a-ftruncate.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SH_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sh/libc_a-truncate.$(OBJEXT)
+-@HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@am__objects_68 = libc/sys/sysmec/libc_a-_exit.$(OBJEXT) \
++@HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@am__objects_69 = libc/sys/sysmec/libc_a-_exit.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/libc_a-access.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/libc_a-chmod.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/libc_a-chown.$(OBJEXT) \
+@@ -1791,11 +1792,11 @@
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/libc_a-write.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/libc_a-times.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSMEC_DIR_TRUE@	libc/sys/sysmec/libc_a-gettime.$(OBJEXT)
+-@HAVE_LIBC_SYS_SYSNEC810_DIR_TRUE@am__objects_69 = libc/sys/sysnec810/libc_a-io.$(OBJEXT) \
++@HAVE_LIBC_SYS_SYSNEC810_DIR_TRUE@am__objects_70 = libc/sys/sysnec810/libc_a-io.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSNEC810_DIR_TRUE@	libc/sys/sysnec810/libc_a-write.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSNEC810_DIR_TRUE@	libc/sys/sysnec810/libc_a-sbrk.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSNEC810_DIR_TRUE@	libc/sys/sysnec810/libc_a-misc.$(OBJEXT)
+-@HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@am__objects_70 = libc/sys/sysnecv850/libc_a-_exit.$(OBJEXT) \
++@HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@am__objects_71 = libc/sys/sysnecv850/libc_a-_exit.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/libc_a-access.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/libc_a-chmod.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/libc_a-chown.$(OBJEXT) \
+@@ -1825,7 +1826,7 @@
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/libc_a-times.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/libc_a-gettime.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSNECV850_DIR_TRUE@@MAY_SUPPLY_SYSCALLS_TRUE@	libc/sys/sysnecv850/libc_a-rename.$(OBJEXT)
+-@HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@am__objects_71 = libc/sys/sysvi386/libc_a-ioctl.$(OBJEXT) \
++@HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@am__objects_72 = libc/sys/sysvi386/libc_a-ioctl.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/libc_a-isatty.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/libc_a-read.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/libc_a-lseek.$(OBJEXT) \
+@@ -1888,7 +1889,7 @@
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/libc_a-access.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/libc_a-_longjmp.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVI386_DIR_TRUE@	libc/sys/sysvi386/libc_a-_setjmp.$(OBJEXT)
+-@HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@am__objects_72 = libc/sys/sysvnecv70/libc_a-ioctl.$(OBJEXT) \
++@HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@am__objects_73 = libc/sys/sysvnecv70/libc_a-ioctl.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@	libc/sys/sysvnecv70/libc_a-isatty.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@	libc/sys/sysvnecv70/libc_a-read.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@	libc/sys/sysvnecv70/libc_a-lseek.$(OBJEXT) \
+@@ -1902,11 +1903,11 @@
+ @HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@	libc/sys/sysvnecv70/libc_a-fpx.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@	libc/sys/sysvnecv70/libc_a-fps.$(OBJEXT) \
+ @HAVE_LIBC_SYS_SYSVNECV70_DIR_TRUE@	libc/sys/sysvnecv70/libc_a-open.$(OBJEXT)
+-@HAVE_LIBC_SYS_TIRTOS_DIR_TRUE@am__objects_73 = libc/sys/tirtos/libc_a-lock.$(OBJEXT)
+-@HAVE_LIBC_SYS_W65_DIR_TRUE@am__objects_74 = libc/sys/w65/libc_a-syscalls.$(OBJEXT) \
++@HAVE_LIBC_SYS_TIRTOS_DIR_TRUE@am__objects_74 = libc/sys/tirtos/libc_a-lock.$(OBJEXT)
++@HAVE_LIBC_SYS_W65_DIR_TRUE@am__objects_75 = libc/sys/w65/libc_a-syscalls.$(OBJEXT) \
+ @HAVE_LIBC_SYS_W65_DIR_TRUE@	libc/sys/w65/libc_a-trap.$(OBJEXT)
+-@HAVE_LIBC_SYS_Z8KSIM_DIR_TRUE@am__objects_75 = libc/sys/z8ksim/libc_a-glue.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_AARCH64_TRUE@am__objects_76 = libc/machine/aarch64/libc_a-memchr-stub.$(OBJEXT) \
++@HAVE_LIBC_SYS_Z8KSIM_DIR_TRUE@am__objects_76 = libc/sys/z8ksim/libc_a-glue.$(OBJEXT)
++@HAVE_LIBC_MACHINE_AARCH64_TRUE@am__objects_77 = libc/machine/aarch64/libc_a-memchr-stub.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/libc_a-memchr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/libc_a-memcmp-stub.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/libc_a-memcmp.$(OBJEXT) \
+@@ -1938,13 +1939,13 @@
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/libc_a-strnlen.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/libc_a-strrchr-stub.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AARCH64_TRUE@	libc/machine/aarch64/libc_a-strrchr.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_AMDGCN_TRUE@am__objects_77 = libc/machine/amdgcn/libc_a-_exit.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_AMDGCN_TRUE@am__objects_78 = libc/machine/amdgcn/libc_a-_exit.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/libc_a-abort.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/libc_a-atexit.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/libc_a-mlock.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/libc_a-getreent.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_AMDGCN_TRUE@	libc/machine/amdgcn/libc_a-signal.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_ARC_TRUE@am__objects_78 = libc/machine/arc/libc_a-memcmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_ARC_TRUE@am__objects_79 = libc/machine/arc/libc_a-memcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/libc_a-memcmp-bs-norm.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/libc_a-memcmp-stub.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/libc_a-memcpy.$(OBJEXT) \
+@@ -1974,7 +1975,7 @@
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/libc_a-strncpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/libc_a-strncpy-stub.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC_TRUE@	libc/machine/arc/libc_a-strncpy-bs.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_ARC64_TRUE@am__objects_79 = libc/machine/arc64/libc_a-memcmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_ARC64_TRUE@am__objects_80 = libc/machine/arc64/libc_a-memcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/libc_a-memcmp-stub.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/libc_a-memcpy-stub.$(OBJEXT) \
+@@ -1986,7 +1987,7 @@
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/libc_a-memmove.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARC64_TRUE@	libc/machine/arc64/libc_a-memchr.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_ARM_TRUE@am__objects_80 = libc/machine/arm/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_ARM_TRUE@am__objects_81 = libc/machine/arm/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/libc_a-strcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/libc_a-aeabi_memcpy.$(OBJEXT) \
+@@ -2002,44 +2003,44 @@
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/libc_a-strlen-stub.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_ARM_TRUE@	libc/machine/arm/libc_a-strlen.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_BFIN_TRUE@am__objects_81 = libc/machine/bfin/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_BFIN_TRUE@am__objects_82 = libc/machine/bfin/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_BFIN_TRUE@	libc/machine/bfin/libc_a-longjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_CR16_TRUE@am__objects_82 = libc/machine/cr16/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_CR16_TRUE@am__objects_83 = libc/machine/cr16/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_CR16_TRUE@	libc/machine/cr16/libc_a-getenv.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_CRIS_TRUE@am__objects_83 = libc/machine/cris/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_CRIS_TRUE@am__objects_84 = libc/machine/cris/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_CRIS_TRUE@	libc/machine/cris/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_CRIS_TRUE@	libc/machine/cris/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_CRIS_TRUE@	libc/machine/cris/libc_a-memmove.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_CRIS_TRUE@	libc/machine/cris/libc_a-libcdtor.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_CRX_TRUE@am__objects_84 = libc/machine/crx/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_CRX_TRUE@am__objects_85 = libc/machine/crx/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_CRX_TRUE@	libc/machine/crx/libc_a-getenv.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_CSKY_TRUE@am__objects_85 = libc/machine/csky/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_D10V_TRUE@am__objects_86 = libc/machine/d10v/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_D30V_TRUE@am__objects_87 = libc/machine/d30v/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_EPIPHANY_TRUE@am__objects_88 = libc/machine/epiphany/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_FR30_TRUE@am__objects_89 = libc/machine/fr30/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_FRV_TRUE@am__objects_90 = libc/machine/frv/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_FT32_TRUE@am__objects_91 = libc/machine/ft32/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_CSKY_TRUE@am__objects_86 = libc/machine/csky/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_D10V_TRUE@am__objects_87 = libc/machine/d10v/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_D30V_TRUE@am__objects_88 = libc/machine/d30v/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_EPIPHANY_TRUE@am__objects_89 = libc/machine/epiphany/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_FR30_TRUE@am__objects_90 = libc/machine/fr30/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_FRV_TRUE@am__objects_91 = libc/machine/frv/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_FT32_TRUE@am__objects_92 = libc/machine/ft32/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_FT32_TRUE@	libc/machine/ft32/libc_a-strlen.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_FT32_TRUE@	libc/machine/ft32/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_FT32_TRUE@	libc/machine/ft32/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_FT32_TRUE@	libc/machine/ft32/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_FT32_TRUE@	libc/machine/ft32/libc_a-strcpy.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_H8300_TRUE@am__objects_92 = libc/machine/h8300/libc_a-reg_memcpy.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_H8300_TRUE@am__objects_93 = libc/machine/h8300/libc_a-reg_memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8300_TRUE@	libc/machine/h8300/libc_a-reg_memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8300_TRUE@	libc/machine/h8300/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8300_TRUE@	libc/machine/h8300/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8300_TRUE@	libc/machine/h8300/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8300_TRUE@	libc/machine/h8300/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8300_TRUE@	libc/machine/h8300/libc_a-h8sx_strcpy.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_H8500_TRUE@am__objects_93 = libc/machine/h8500/libc_a-divsi3.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_H8500_TRUE@am__objects_94 = libc/machine/h8500/libc_a-divsi3.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8500_TRUE@	libc/machine/h8500/libc_a-mulsi3.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8500_TRUE@	libc/machine/h8500/libc_a-divhi3.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8500_TRUE@	libc/machine/h8500/libc_a-shifts.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8500_TRUE@	libc/machine/h8500/libc_a-cmpsi.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8500_TRUE@	libc/machine/h8500/libc_a-psi.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_H8500_TRUE@	libc/machine/h8500/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_HPPA_TRUE@am__objects_94 = libc/machine/hppa/libc_a-memchr.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_HPPA_TRUE@am__objects_95 = libc/machine/hppa/libc_a-memchr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/libc_a-memcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/libc_a-memset.$(OBJEXT) \
+@@ -2051,15 +2052,15 @@
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/libc_a-strncat.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/libc_a-strncmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_HPPA_TRUE@	libc/machine/hppa/libc_a-strncpy.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_I386_TRUE@@MACH_ADD_SETJMP_TRUE@am__objects_95 = libc/machine/i386/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_I386_TRUE@am__objects_96 = libc/machine/i386/libc_a-memchr.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_I386_TRUE@@MACH_ADD_SETJMP_TRUE@am__objects_96 = libc/machine/i386/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_I386_TRUE@am__objects_97 = libc/machine/i386/libc_a-memchr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I386_TRUE@	libc/machine/i386/libc_a-memcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I386_TRUE@	libc/machine/i386/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I386_TRUE@	libc/machine/i386/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I386_TRUE@	libc/machine/i386/libc_a-strchr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I386_TRUE@	libc/machine/i386/libc_a-memmove.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I386_TRUE@	libc/machine/i386/libc_a-strlen.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_I960_TRUE@am__objects_97 = libc/machine/i960/libc_a-memccpy_ca.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_I960_TRUE@am__objects_98 = libc/machine/i960/libc_a-memccpy_ca.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/libc_a-memccpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/libc_a-memchr_ca.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/libc_a-memchr.$(OBJEXT) \
+@@ -2087,31 +2088,31 @@
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/libc_a-strncpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/libc_a-strpbrk.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_I960_TRUE@	libc/machine/i960/libc_a-strrchr.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_IQ2000_TRUE@am__objects_98 = libc/machine/iq2000/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_LM32_TRUE@am__objects_99 = libc/machine/lm32/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_M32C_TRUE@am__objects_100 = libc/machine/m32c/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_M32R_TRUE@am__objects_101 = libc/machine/m32r/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_M68HC11_TRUE@am__objects_102 = libc/machine/m68hc11/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_M68K_TRUE@am__objects_103 = libc/machine/m68k/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_IQ2000_TRUE@am__objects_99 = libc/machine/iq2000/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_LM32_TRUE@am__objects_100 = libc/machine/lm32/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_M32C_TRUE@am__objects_101 = libc/machine/m32c/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_M32R_TRUE@am__objects_102 = libc/machine/m32r/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_M68HC11_TRUE@am__objects_103 = libc/machine/m68hc11/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_M68K_TRUE@am__objects_104 = libc/machine/m68k/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_M68K_TRUE@	libc/machine/m68k/libc_a-strcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_M68K_TRUE@	libc/machine/m68k/libc_a-strlen.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_M68K_TRUE@	libc/machine/m68k/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_M68K_TRUE@	libc/machine/m68k/libc_a-memset.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_M88K_TRUE@am__objects_104 = libc/machine/m88k/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_MEP_TRUE@am__objects_105 = libc/machine/mep/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_MICROBLAZE_TRUE@am__objects_106 = libc/machine/microblaze/libc_a-strlen.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_M88K_TRUE@am__objects_105 = libc/machine/m88k/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_MEP_TRUE@am__objects_106 = libc/machine/mep/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_MICROBLAZE_TRUE@am__objects_107 = libc/machine/microblaze/libc_a-strlen.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MICROBLAZE_TRUE@	libc/machine/microblaze/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MICROBLAZE_TRUE@	libc/machine/microblaze/libc_a-strcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MICROBLAZE_TRUE@	libc/machine/microblaze/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MICROBLAZE_TRUE@	libc/machine/microblaze/libc_a-longjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_MIPS_TRUE@am__objects_107 = libc/machine/mips/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_MIPS_TRUE@am__objects_108 = libc/machine/mips/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MIPS_TRUE@	libc/machine/mips/libc_a-strlen.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MIPS_TRUE@	libc/machine/mips/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MIPS_TRUE@	libc/machine/mips/libc_a-strncpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MIPS_TRUE@	libc/machine/mips/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MIPS_TRUE@	libc/machine/mips/libc_a-memcpy.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_MN10200_TRUE@am__objects_108 = libc/machine/mn10200/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_MN10300_TRUE@am__objects_109 = libc/machine/mn10300/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_MN10200_TRUE@am__objects_109 = libc/machine/mn10200/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_MN10300_TRUE@am__objects_110 = libc/machine/mn10300/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MN10300_TRUE@	libc/machine/mn10300/libc_a-memchr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MN10300_TRUE@	libc/machine/mn10300/libc_a-memcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MN10300_TRUE@	libc/machine/mn10300/libc_a-memcpy.$(OBJEXT) \
+@@ -2120,21 +2121,21 @@
+ @HAVE_LIBC_MACHINE_MN10300_TRUE@	libc/machine/mn10300/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MN10300_TRUE@	libc/machine/mn10300/libc_a-strcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MN10300_TRUE@	libc/machine/mn10300/libc_a-strlen.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_MOXIE_TRUE@am__objects_110 = libc/machine/moxie/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_MSP430_TRUE@am__objects_111 = libc/machine/msp430/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_MSP430_TRUE@@NEWLIB_NANO_FORMATTED_IO_TRUE@am__objects_112 = libc/machine/msp430/libc_a-tiny-puts.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_MOXIE_TRUE@am__objects_111 = libc/machine/moxie/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_MSP430_TRUE@am__objects_112 = libc/machine/msp430/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_MSP430_TRUE@@NEWLIB_NANO_FORMATTED_IO_TRUE@am__objects_113 = libc/machine/msp430/libc_a-tiny-puts.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_MSP430_TRUE@@NEWLIB_NANO_FORMATTED_IO_TRUE@	libc/machine/msp430/libc_a-tiny-printf.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_MT_TRUE@am__objects_113 = libc/machine/mt/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_NDS32_TRUE@am__objects_114 = libc/machine/nds32/libc_a-abort.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_MT_TRUE@am__objects_114 = libc/machine/mt/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_NDS32_TRUE@am__objects_115 = libc/machine/nds32/libc_a-abort.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NDS32_TRUE@	libc/machine/nds32/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NDS32_TRUE@	libc/machine/nds32/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NDS32_TRUE@	libc/machine/nds32/libc_a-strcpy.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_NDS32_TRUE@@IS_NDS32_ISA_V3M_FALSE@am__objects_115 = libc/machine/nds32/libc_a-memcpy.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_NDS32_TRUE@@IS_NDS32_ISA_V3M_FALSE@am__objects_116 = libc/machine/nds32/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NDS32_TRUE@@IS_NDS32_ISA_V3M_FALSE@	libc/machine/nds32/libc_a-memset.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_NECV70_TRUE@am__objects_116 = libc/machine/necv70/libc_a-fastmath.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_NECV70_TRUE@am__objects_117 = libc/machine/necv70/libc_a-fastmath.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NECV70_TRUE@	libc/machine/necv70/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_NIOS2_TRUE@am__objects_117 = libc/machine/nios2/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_NVPTX_TRUE@am__objects_118 = libc/machine/nvptx/libc_a-_exit.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_NIOS2_TRUE@am__objects_118 = libc/machine/nios2/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_NVPTX_TRUE@am__objects_119 = libc/machine/nvptx/libc_a-_exit.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/libc_a-calloc.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/libc_a-callocr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/libc_a-malloc.$(OBJEXT) \
+@@ -2150,9 +2151,9 @@
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/libc_a-abort.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/libc_a-misc.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_NVPTX_TRUE@	libc/machine/nvptx/libc_a-clock.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_OR1K_TRUE@am__objects_119 = libc/machine/or1k/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_POWERPC_TRUE@am__objects_120 = libc/machine/powerpc/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@am__objects_121 = libc/machine/powerpc/libc_a-vfprintf.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_OR1K_TRUE@am__objects_120 = libc/machine/or1k/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_POWERPC_TRUE@am__objects_121 = libc/machine/powerpc/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@am__objects_122 = libc/machine/powerpc/libc_a-vfprintf.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/libc_a-vfscanf.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/libc_a-vec_malloc.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/libc_a-vec_calloc.$(OBJEXT) \
+@@ -2161,7 +2162,7 @@
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/libc_a-vec_mallocr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/libc_a-vec_callocr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_ALTIVEC_TRUE@	libc/machine/powerpc/libc_a-vec_reallocr.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@am__objects_122 = libc/machine/powerpc/libc_a-atosfix16.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@am__objects_123 = libc/machine/powerpc/libc_a-atosfix16.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/libc_a-atosfix32.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/libc_a-atosfix64.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/libc_a-atoufix16.$(OBJEXT) \
+@@ -2177,8 +2178,9 @@
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/libc_a-ufix64toa.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/libc_a-vfprintf.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/libc_a-vfscanf.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_PRU_TRUE@am__objects_123 = libc/machine/pru/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_RISCV_TRUE@am__objects_124 = libc/machine/riscv/libc_a-memmove-asm.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_PRU_TRUE@am__objects_124 = libc/machine/pru/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_R5900_TRUE@am__objects_125 = libc/machine/r5900/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_RISCV_TRUE@am__objects_126 = libc/machine/riscv/libc_a-memmove-asm.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/libc_a-memmove.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/libc_a-memcpy-asm.$(OBJEXT) \
+@@ -2192,8 +2194,8 @@
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/libc_a-ieeefp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/libc_a-ffs.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_RL78_TRUE@am__objects_125 = libc/machine/rl78/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_RX_TRUE@am__objects_126 = libc/machine/rx/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_RL78_TRUE@am__objects_127 = libc/machine/rl78/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_RX_TRUE@am__objects_128 = libc/machine/rx/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RX_TRUE@	libc/machine/rx/libc_a-strncmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RX_TRUE@	libc/machine/rx/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RX_TRUE@	libc/machine/rx/libc_a-strncpy.$(OBJEXT) \
+@@ -2206,17 +2208,17 @@
+ @HAVE_LIBC_MACHINE_RX_TRUE@	libc/machine/rx/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RX_TRUE@	libc/machine/rx/libc_a-memmove.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RX_TRUE@	libc/machine/rx/libc_a-memchr.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_SH_TRUE@am__objects_127 = libc/machine/sh/libc_a-memcpy.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_SH_TRUE@am__objects_129 = libc/machine/sh/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SH_TRUE@	libc/machine/sh/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SH_TRUE@	libc/machine/sh/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SH_TRUE@	libc/machine/sh/libc_a-strcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SH_TRUE@	libc/machine/sh/libc_a-strlen.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SH_TRUE@	libc/machine/sh/libc_a-strcmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_SH_TRUE@@SH64_TRUE@am__objects_128 = libc/machine/sh/libc_a-strncpy.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_SPARC_TRUE@am__objects_129 = libc/machine/sparc/libc_a-scan.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_SH_TRUE@@SH64_TRUE@am__objects_130 = libc/machine/sh/libc_a-strncpy.$(OBJEXT)
++@HAVE_LIBC_MACHINE_SPARC_TRUE@am__objects_131 = libc/machine/sparc/libc_a-scan.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPARC_TRUE@	libc/machine/sparc/libc_a-shuffle.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPARC_TRUE@	libc/machine/sparc/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_SPU_TRUE@am__objects_130 = libc/machine/spu/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_SPU_TRUE@am__objects_132 = libc/machine/spu/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/libc_a-assert.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/libc_a-clearerr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/libc_a-creat.$(OBJEXT) \
+@@ -2311,7 +2313,7 @@
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/libc_a-spu_timer_free.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/libc_a-spu_timebase.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@	libc/machine/spu/libc_a-fdopen.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@am__objects_131 = libc/machine/spu/libc_a-calloc_ea.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@am__objects_133 = libc/machine/spu/libc_a-calloc_ea.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/libc_a-free_ea.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/libc_a-malloc_ea.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/libc_a-memchr_ea.$(OBJEXT) \
+@@ -2346,15 +2348,15 @@
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/libc_a-writev_ea.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/libc_a-spu-mcount.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_SPU_TRUE@@HAVE_SPU_EA_TRUE@	libc/machine/spu/libc_a-spu-gmon.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_TIC4X_TRUE@am__objects_132 = libc/machine/tic4x/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_TIC6X_TRUE@am__objects_133 = libc/machine/tic6x/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_TIC80_TRUE@am__objects_134 = libc/machine/tic80/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_V850_TRUE@am__objects_135 = libc/machine/v850/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_VISIUM_TRUE@am__objects_136 = libc/machine/visium/libc_a-memcpy.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_TIC4X_TRUE@am__objects_134 = libc/machine/tic4x/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_TIC6X_TRUE@am__objects_135 = libc/machine/tic6x/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_TIC80_TRUE@am__objects_136 = libc/machine/tic80/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_V850_TRUE@am__objects_137 = libc/machine/v850/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_VISIUM_TRUE@am__objects_138 = libc/machine/visium/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_VISIUM_TRUE@	libc/machine/visium/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_VISIUM_TRUE@	libc/machine/visium/libc_a-memmove.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_VISIUM_TRUE@	libc/machine/visium/libc_a-setjmp.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_W65_TRUE@am__objects_137 = libc/machine/w65/libc_a-udivhi3.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_W65_TRUE@am__objects_139 = libc/machine/w65/libc_a-udivhi3.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_W65_TRUE@	libc/machine/w65/libc_a-umodhi3.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_W65_TRUE@	libc/machine/w65/libc_a-smulhi3.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_W65_TRUE@	libc/machine/w65/libc_a-lshrhi.$(OBJEXT) \
+@@ -2362,13 +2364,13 @@
+ @HAVE_LIBC_MACHINE_W65_TRUE@	libc/machine/w65/libc_a-mulsi3.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_W65_TRUE@	libc/machine/w65/libc_a-divsi3.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_W65_TRUE@	libc/machine/w65/libc_a-cmpsi.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_X86_64_TRUE@am__objects_138 = libc/machine/x86_64/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_X86_64_TRUE@am__objects_140 = libc/machine/x86_64/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_X86_64_TRUE@	libc/machine/x86_64/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_X86_64_TRUE@	libc/machine/x86_64/libc_a-memset.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_XC16X_TRUE@am__objects_139 = libc/machine/xc16x/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_XC16X_TRUE@am__objects_141 = libc/machine/xc16x/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XC16X_TRUE@	libc/machine/xc16x/libc_a-puts.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XC16X_TRUE@	libc/machine/xc16x/libc_a-putchar.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_XSTORMY16_TRUE@am__objects_140 = libc/machine/xstormy16/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_XSTORMY16_TRUE@am__objects_142 = libc/machine/xstormy16/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/libc_a-calloc.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/libc_a-callocr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/libc_a-cfree.$(OBJEXT) \
+@@ -2381,14 +2383,14 @@
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/libc_a-realloc.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/libc_a-reallocr.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XSTORMY16_TRUE@	libc/machine/xstormy16/libc_a-valloc.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_XTENSA_TRUE@am__objects_141 = libc/machine/xtensa/libc_a-memcpy.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_XTENSA_TRUE@am__objects_143 = libc/machine/xtensa/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XTENSA_TRUE@	libc/machine/xtensa/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XTENSA_TRUE@	libc/machine/xtensa/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XTENSA_TRUE@	libc/machine/xtensa/libc_a-strcmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XTENSA_TRUE@	libc/machine/xtensa/libc_a-strcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XTENSA_TRUE@	libc/machine/xtensa/libc_a-strlen.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_XTENSA_TRUE@	libc/machine/xtensa/libc_a-strncpy.$(OBJEXT)
+-@HAVE_LIBC_MACHINE_Z8K_TRUE@am__objects_142 = libc/machine/z8k/libc_a-setjmp.$(OBJEXT) \
++@HAVE_LIBC_MACHINE_Z8K_TRUE@am__objects_144 = libc/machine/z8k/libc_a-setjmp.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_Z8K_TRUE@	libc/machine/z8k/libc_a-memset.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_Z8K_TRUE@	libc/machine/z8k/libc_a-memcpy.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_Z8K_TRUE@	libc/machine/z8k/libc_a-memmove.$(OBJEXT) \
+@@ -2657,33 +2659,33 @@
+ 	$(am__objects_54) $(am__objects_55) $(am__objects_56) \
+ 	$(am__objects_57) $(am__objects_58) $(am__objects_59) \
+ 	$(am__objects_60) $(am__objects_61) $(am__objects_62) \
+-	$(am__objects_63) $(am__objects_64) $(am__objects_65) \
+-	$(am__objects_66) $(am__objects_67) $(am__objects_68) \
+-	$(am__objects_69) $(am__objects_70) $(am__objects_71) \
+-	$(am__objects_72) $(am__objects_73) $(am__objects_74) \
+-	$(am__objects_75) $(am__objects_76) $(am__objects_77) \
+-	$(am__objects_78) $(am__objects_79) $(am__objects_80) \
+-	$(am__objects_81) $(am__objects_82) $(am__objects_83) \
+-	$(am__objects_84) $(am__objects_85) $(am__objects_86) \
+-	$(am__objects_87) $(am__objects_88) $(am__objects_89) \
+-	$(am__objects_90) $(am__objects_91) $(am__objects_92) \
+-	$(am__objects_93) $(am__objects_94) $(am__objects_95) \
+-	$(am__objects_96) $(am__objects_97) $(am__objects_98) \
+-	$(am__objects_99) $(am__objects_100) $(am__objects_101) \
+-	$(am__objects_102) $(am__objects_103) $(am__objects_104) \
+-	$(am__objects_105) $(am__objects_106) $(am__objects_107) \
+-	$(am__objects_108) $(am__objects_109) $(am__objects_110) \
+-	$(am__objects_111) $(am__objects_112) $(am__objects_113) \
+-	$(am__objects_114) $(am__objects_115) $(am__objects_116) \
+-	$(am__objects_117) $(am__objects_118) $(am__objects_119) \
+-	$(am__objects_120) $(am__objects_121) $(am__objects_122) \
+-	$(am__objects_123) $(am__objects_124) $(am__objects_125) \
+-	$(am__objects_126) $(am__objects_127) $(am__objects_128) \
+-	$(am__objects_129) $(am__objects_130) $(am__objects_131) \
+-	$(am__objects_132) $(am__objects_133) $(am__objects_134) \
+-	$(am__objects_135) $(am__objects_136) $(am__objects_137) \
+-	$(am__objects_138) $(am__objects_139) $(am__objects_140) \
+-	$(am__objects_141) $(am__objects_142)
++	$(am__objects_63) $(am__objects_64) $(am__objects_66) \
++	$(am__objects_67) $(am__objects_68) $(am__objects_69) \
++	$(am__objects_70) $(am__objects_71) $(am__objects_72) \
++	$(am__objects_73) $(am__objects_74) $(am__objects_75) \
++	$(am__objects_76) $(am__objects_77) $(am__objects_78) \
++	$(am__objects_79) $(am__objects_80) $(am__objects_81) \
++	$(am__objects_82) $(am__objects_83) $(am__objects_84) \
++	$(am__objects_85) $(am__objects_86) $(am__objects_87) \
++	$(am__objects_88) $(am__objects_89) $(am__objects_90) \
++	$(am__objects_91) $(am__objects_92) $(am__objects_93) \
++	$(am__objects_94) $(am__objects_95) $(am__objects_96) \
++	$(am__objects_97) $(am__objects_98) $(am__objects_99) \
++	$(am__objects_100) $(am__objects_101) $(am__objects_102) \
++	$(am__objects_103) $(am__objects_104) $(am__objects_105) \
++	$(am__objects_106) $(am__objects_107) $(am__objects_108) \
++	$(am__objects_109) $(am__objects_110) $(am__objects_111) \
++	$(am__objects_112) $(am__objects_113) $(am__objects_114) \
++	$(am__objects_115) $(am__objects_116) $(am__objects_117) \
++	$(am__objects_118) $(am__objects_119) $(am__objects_120) \
++	$(am__objects_121) $(am__objects_122) $(am__objects_123) \
++	$(am__objects_124) $(am__objects_125) $(am__objects_126) $(am__objects_127) \
++	$(am__objects_128) $(am__objects_129) $(am__objects_130) \
++	$(am__objects_131) $(am__objects_132) $(am__objects_133) \
++	$(am__objects_134) $(am__objects_135) $(am__objects_136) \
++	$(am__objects_137) $(am__objects_138) $(am__objects_139) \
++	$(am__objects_140) $(am__objects_141) $(am__objects_142) \
++	$(am__objects_143) $(am__objects_144)
+ libc_a_OBJECTS = $(am_libc_a_OBJECTS)
+ libc_machine_cris_libic_a_AR = $(AR) $(ARFLAGS)
+ @HAVE_LIBC_MACHINE_CRIS_TRUE@libc_machine_cris_libic_a_DEPENDENCIES = libc/machine/cris/libc_a-setjmp.o \
+@@ -2696,7 +2698,7 @@
+ 	$(am_libc_machine_cris_libic_a_OBJECTS)
+ libm_a_AR = $(AR) $(ARFLAGS)
+ libm_a_LIBADD =
+-@NEWLIB_HW_FP_TRUE@am__objects_143 =  \
++@NEWLIB_HW_FP_TRUE@am__objects_145 =  \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-s_acos.$(OBJEXT) \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-s_frexp.$(OBJEXT) \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-s_mathcnst.$(OBJEXT) \
+@@ -2744,7 +2746,7 @@
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-s_signif.$(OBJEXT) \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-s_exp2.$(OBJEXT) \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-s_tgamma.$(OBJEXT)
+-@NEWLIB_HW_FP_TRUE@am__objects_144 =  \
++@NEWLIB_HW_FP_TRUE@am__objects_146 =  \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-sf_ceil.$(OBJEXT) \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-sf_acos.$(OBJEXT) \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-sf_frexp.$(OBJEXT) \
+@@ -2792,9 +2794,9 @@
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-sf_signif.$(OBJEXT) \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-sf_exp2.$(OBJEXT) \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/libm_a-sf_tgamma.$(OBJEXT)
+-@NEWLIB_HW_FP_TRUE@am__objects_145 = $(am__objects_143) \
+-@NEWLIB_HW_FP_TRUE@	$(am__objects_144)
+-@NEWLIB_HW_FP_FALSE@am__objects_146 =  \
++@NEWLIB_HW_FP_TRUE@am__objects_147 = $(am__objects_145) \
++@NEWLIB_HW_FP_TRUE@	$(am__objects_146)
++@NEWLIB_HW_FP_FALSE@am__objects_148 =  \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-k_standard.$(OBJEXT) \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-k_rem_pio2.$(OBJEXT) \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-k_cos.$(OBJEXT) \
+@@ -2863,7 +2865,7 @@
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-s_tanh.$(OBJEXT) \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-w_exp2.$(OBJEXT) \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-w_tgamma.$(OBJEXT)
+-@NEWLIB_HW_FP_FALSE@am__objects_147 =  \
++@NEWLIB_HW_FP_FALSE@am__objects_149 =  \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-kf_rem_pio2.$(OBJEXT) \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-kf_cos.$(OBJEXT) \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-kf_sin.$(OBJEXT) \
+@@ -2931,11 +2933,11 @@
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-wf_exp2.$(OBJEXT) \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-wf_tgamma.$(OBJEXT) \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-wf_log2.$(OBJEXT)
+-@NEWLIB_HW_FP_FALSE@am__objects_148 =  \
++@NEWLIB_HW_FP_FALSE@am__objects_150 =  \
+ @NEWLIB_HW_FP_FALSE@	libm/math/libm_a-el_hypot.$(OBJEXT)
+-@NEWLIB_HW_FP_FALSE@am__objects_149 = $(am__objects_146) \
+-@NEWLIB_HW_FP_FALSE@	$(am__objects_147) $(am__objects_148)
+-am__objects_150 = libm/common/libm_a-s_finite.$(OBJEXT) \
++@NEWLIB_HW_FP_FALSE@am__objects_151 = $(am__objects_148) \
++@NEWLIB_HW_FP_FALSE@	$(am__objects_149) $(am__objects_150)
++am__objects_152 = libm/common/libm_a-s_finite.$(OBJEXT) \
+ 	libm/common/libm_a-s_copysign.$(OBJEXT) \
+ 	libm/common/libm_a-s_modf.$(OBJEXT) \
+ 	libm/common/libm_a-s_scalbn.$(OBJEXT) \
+@@ -2980,7 +2982,7 @@
+ 	libm/common/libm_a-log2_data.$(OBJEXT) \
+ 	libm/common/libm_a-pow.$(OBJEXT) \
+ 	libm/common/libm_a-pow_log_data.$(OBJEXT)
+-am__objects_151 = libm/common/libm_a-sf_finite.$(OBJEXT) \
++am__objects_153 = libm/common/libm_a-sf_finite.$(OBJEXT) \
+ 	libm/common/libm_a-sf_copysign.$(OBJEXT) \
+ 	libm/common/libm_a-sf_modf.$(OBJEXT) \
+ 	libm/common/libm_a-sf_scalbn.$(OBJEXT) \
+@@ -3027,7 +3029,7 @@
+ 	libm/common/libm_a-sincosf.$(OBJEXT) \
+ 	libm/common/libm_a-sincosf_data.$(OBJEXT) \
+ 	libm/common/libm_a-math_errf.$(OBJEXT)
+-am__objects_152 = libm/common/libm_a-atanl.$(OBJEXT) \
++am__objects_154 = libm/common/libm_a-atanl.$(OBJEXT) \
+ 	libm/common/libm_a-cosl.$(OBJEXT) \
+ 	libm/common/libm_a-sinl.$(OBJEXT) \
+ 	libm/common/libm_a-tanl.$(OBJEXT) \
+@@ -3087,8 +3089,8 @@
+ 	libm/common/libm_a-nexttowardl.$(OBJEXT) \
+ 	libm/common/libm_a-log2l.$(OBJEXT) \
+ 	libm/common/libm_a-sl_finite.$(OBJEXT)
+-@HAVE_LONG_DOUBLE_TRUE@am__objects_153 = $(am__objects_152)
+-@HAVE_FPMATH_H_TRUE@am__objects_154 =  \
++@HAVE_LONG_DOUBLE_TRUE@am__objects_155 = $(am__objects_154)
++@HAVE_FPMATH_H_TRUE@am__objects_156 =  \
+ @HAVE_FPMATH_H_TRUE@	libm/ld/libm_a-e_acoshl.$(OBJEXT) \
+ @HAVE_FPMATH_H_TRUE@	libm/ld/libm_a-e_acosl.$(OBJEXT) \
+ @HAVE_FPMATH_H_TRUE@	libm/ld/libm_a-e_asinl.$(OBJEXT) \
+@@ -3134,9 +3136,9 @@
+ @HAVE_FPMATH_H_TRUE@	libm/ld/libm_a-s_tanhl.$(OBJEXT) \
+ @HAVE_FPMATH_H_TRUE@	libm/ld/libm_a-s_tanl.$(OBJEXT) \
+ @HAVE_FPMATH_H_TRUE@	libm/ld/libm_a-s_truncl.$(OBJEXT)
+-@HAVE_FPMATH_H_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_155 =  \
+-@HAVE_FPMATH_H_TRUE@@HAVE_LONG_DOUBLE_TRUE@	$(am__objects_154)
+-am__objects_156 = libm/complex/libm_a-cabs.$(OBJEXT) \
++@HAVE_FPMATH_H_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_157 =  \
++@HAVE_FPMATH_H_TRUE@@HAVE_LONG_DOUBLE_TRUE@	$(am__objects_156)
++am__objects_158 = libm/complex/libm_a-cabs.$(OBJEXT) \
+ 	libm/complex/libm_a-cacos.$(OBJEXT) \
+ 	libm/complex/libm_a-cacosh.$(OBJEXT) \
+ 	libm/complex/libm_a-carg.$(OBJEXT) \
+@@ -3160,7 +3162,7 @@
+ 	libm/complex/libm_a-csqrt.$(OBJEXT) \
+ 	libm/complex/libm_a-ctan.$(OBJEXT) \
+ 	libm/complex/libm_a-ctanh.$(OBJEXT)
+-am__objects_157 = libm/complex/libm_a-cabsf.$(OBJEXT) \
++am__objects_159 = libm/complex/libm_a-cabsf.$(OBJEXT) \
+ 	libm/complex/libm_a-casinf.$(OBJEXT) \
+ 	libm/complex/libm_a-ccosf.$(OBJEXT) \
+ 	libm/complex/libm_a-cimagf.$(OBJEXT) \
+@@ -3184,7 +3186,7 @@
+ 	libm/complex/libm_a-cexpf.$(OBJEXT) \
+ 	libm/complex/libm_a-cpowf.$(OBJEXT) \
+ 	libm/complex/libm_a-csinhf.$(OBJEXT)
+-am__objects_158 = libm/complex/libm_a-cabsl.$(OBJEXT) \
++am__objects_160 = libm/complex/libm_a-cabsl.$(OBJEXT) \
+ 	libm/complex/libm_a-creall.$(OBJEXT) \
+ 	libm/complex/libm_a-cimagl.$(OBJEXT) \
+ 	libm/complex/libm_a-ccoshl.$(OBJEXT) \
+@@ -3207,7 +3209,7 @@
+ 	libm/complex/libm_a-csinhl.$(OBJEXT) \
+ 	libm/complex/libm_a-csinl.$(OBJEXT) \
+ 	libm/complex/libm_a-catanl.$(OBJEXT)
+-am__objects_159 = libm/fenv/libm_a-feclearexcept.$(OBJEXT) \
++am__objects_161 = libm/fenv/libm_a-feclearexcept.$(OBJEXT) \
+ 	libm/fenv/libm_a-fe_dfl_env.$(OBJEXT) \
+ 	libm/fenv/libm_a-fegetenv.$(OBJEXT) \
+ 	libm/fenv/libm_a-fegetexceptflag.$(OBJEXT) \
+@@ -3219,7 +3221,7 @@
+ 	libm/fenv/libm_a-fesetround.$(OBJEXT) \
+ 	libm/fenv/libm_a-fetestexcept.$(OBJEXT) \
+ 	libm/fenv/libm_a-feupdateenv.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__objects_160 = libm/machine/aarch64/libm_a-e_sqrt.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__objects_162 = libm/machine/aarch64/libm_a-e_sqrt.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/libm_a-ef_sqrt.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/libm_a-s_ceil.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/libm_a-s_fabs.$(OBJEXT) \
+@@ -3263,8 +3265,8 @@
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/libm_a-fesetround.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/libm_a-fetestexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/libm_a-feupdateenv.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__objects_161 = $(am__objects_160)
+-@HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@am__objects_162 = libm/ld128/libm_a-e_powl.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__objects_163 = $(am__objects_162)
++@HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@am__objects_164 = libm/ld128/libm_a-e_powl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_erfl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_exp2l.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_expl.$(OBJEXT) \
+@@ -3277,7 +3279,7 @@
+ @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-k_tanl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_sinpil.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_cospil.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__objects_162 = libm/ld128/libm_a-e_powl.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__objects_164 = libm/ld128/libm_a-e_powl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_erfl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_exp2l.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_expl.$(OBJEXT) \
+@@ -3290,8 +3292,8 @@
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-k_tanl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_sinpil.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_cospil.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_AARCH64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_163 = $(am__objects_162)
+-@HAVE_LIBM_MACHINE_AMDGCN_TRUE@am__objects_164 = libm/machine/amdgcn/libm_a-v64_mathcnst.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_AARCH64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_165 = $(am__objects_164)
++@HAVE_LIBM_MACHINE_AMDGCN_TRUE@am__objects_166 = libm/machine/amdgcn/libm_a-v64_mathcnst.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AMDGCN_TRUE@	libm/machine/amdgcn/libm_a-v64_reent.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AMDGCN_TRUE@	libm/machine/amdgcn/libm_a-v64df_acos.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AMDGCN_TRUE@	libm/machine/amdgcn/libm_a-v64df_acosh.$(OBJEXT) \
+@@ -3379,8 +3381,8 @@
+ @HAVE_LIBM_MACHINE_AMDGCN_TRUE@	libm/machine/amdgcn/libm_a-v64sf_tan.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AMDGCN_TRUE@	libm/machine/amdgcn/libm_a-v64sf_tanh.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_AMDGCN_TRUE@	libm/machine/amdgcn/libm_a-v64sf_tgamma.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_AMDGCN_TRUE@am__objects_165 = $(am__objects_164)
+-@HAVE_LIBM_MACHINE_ARM_TRUE@am__objects_166 = libm/machine/arm/libm_a-e_sqrt.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_AMDGCN_TRUE@am__objects_167 = $(am__objects_166)
++@HAVE_LIBM_MACHINE_ARM_TRUE@am__objects_168 = libm/machine/arm/libm_a-e_sqrt.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_ARM_TRUE@	libm/machine/arm/libm_a-ef_sqrt.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_ARM_TRUE@	libm/machine/arm/libm_a-s_ceil.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_ARM_TRUE@	libm/machine/arm/libm_a-s_floor.$(OBJEXT) \
+@@ -3411,8 +3413,8 @@
+ @HAVE_LIBM_MACHINE_ARM_TRUE@	libm/machine/arm/libm_a-feupdateenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_ARM_TRUE@	libm/machine/arm/libm_a-feenableexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_ARM_TRUE@	libm/machine/arm/libm_a-fedisableexcept.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_ARM_TRUE@am__objects_167 = $(am__objects_166)
+-@HAVE_LIBM_MACHINE_I386_TRUE@am__objects_168 = libm/machine/i386/libm_a-f_atan2.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_ARM_TRUE@am__objects_169 = $(am__objects_168)
++@HAVE_LIBM_MACHINE_I386_TRUE@am__objects_170 = libm/machine/i386/libm_a-f_atan2.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/machine/i386/libm_a-f_atan2f.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/machine/i386/libm_a-f_exp.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/machine/i386/libm_a-f_expf.$(OBJEXT) \
+@@ -3449,8 +3451,8 @@
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/machine/i386/libm_a-fesetround.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/machine/i386/libm_a-fetestexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/machine/i386/libm_a-feupdateenv.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_I386_TRUE@am__objects_169 = $(am__objects_168)
+-@HAVE_LIBM_MACHINE_I386_FALSE@@HAVE_LIBM_MACHINE_X86_64_TRUE@am__objects_170 = libm/ld80/libm_a-b_tgammal.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_I386_TRUE@am__objects_171 = $(am__objects_170)
++@HAVE_LIBM_MACHINE_I386_FALSE@@HAVE_LIBM_MACHINE_X86_64_TRUE@am__objects_172 = libm/ld80/libm_a-b_tgammal.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_FALSE@@HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/ld80/libm_a-e_powl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_FALSE@@HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/ld80/libm_a-s_erfl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_FALSE@@HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/ld80/libm_a-s_exp2l.$(OBJEXT) \
+@@ -3463,7 +3465,7 @@
+ @HAVE_LIBM_MACHINE_I386_FALSE@@HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/ld80/libm_a-k_cosl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_FALSE@@HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/ld80/libm_a-k_sinl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_FALSE@@HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/ld80/libm_a-k_tanl.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_I386_TRUE@am__objects_170 = libm/ld80/libm_a-b_tgammal.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_I386_TRUE@am__objects_172 = libm/ld80/libm_a-b_tgammal.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/ld80/libm_a-e_powl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/ld80/libm_a-s_erfl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/ld80/libm_a-s_exp2l.$(OBJEXT) \
+@@ -3476,8 +3478,8 @@
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/ld80/libm_a-k_cosl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/ld80/libm_a-k_sinl.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_I386_TRUE@	libm/ld80/libm_a-k_tanl.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_I386_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_171 = $(am__objects_170)
+-@HAVE_LIBM_MACHINE_MIPS_TRUE@am__objects_172 = libm/machine/mips/libm_a-feclearexcept.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_I386_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_173 = $(am__objects_172)
++@HAVE_LIBM_MACHINE_MIPS_TRUE@am__objects_174 = libm/machine/mips/libm_a-feclearexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_MIPS_TRUE@	libm/machine/mips/libm_a-fegetenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_MIPS_TRUE@	libm/machine/mips/libm_a-fegetexceptflag.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_MIPS_TRUE@	libm/machine/mips/libm_a-fegetround.$(OBJEXT) \
+@@ -3489,13 +3491,13 @@
+ @HAVE_LIBM_MACHINE_MIPS_TRUE@	libm/machine/mips/libm_a-fetestexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_MIPS_TRUE@	libm/machine/mips/libm_a-feupdateenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_MIPS_TRUE@	libm/machine/mips/libm_a-fenv.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_MIPS_TRUE@am__objects_173 = $(am__objects_172)
+-@HAS_NDS32_FPU_SP_TRUE@@HAVE_LIBM_MACHINE_NDS32_TRUE@am__objects_174 = libm/machine/nds32/libm_a-wf_sqrt.$(OBJEXT)
+-@HAS_NDS32_FPU_DP_TRUE@@HAVE_LIBM_MACHINE_NDS32_TRUE@am__objects_175 = libm/machine/nds32/libm_a-w_sqrt.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_NDS32_TRUE@am__objects_176 = $(am__objects_174) \
+-@HAVE_LIBM_MACHINE_NDS32_TRUE@	$(am__objects_175)
+-@HAVE_LIBM_MACHINE_NDS32_TRUE@am__objects_177 = $(am__objects_176)
+-@HAVE_LIBM_MACHINE_POWERPC_TRUE@am__objects_178 = libm/machine/powerpc/libm_a-feclearexcept.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_MIPS_TRUE@am__objects_175 = $(am__objects_174)
++@HAS_NDS32_FPU_SP_TRUE@@HAVE_LIBM_MACHINE_NDS32_TRUE@am__objects_176 = libm/machine/nds32/libm_a-wf_sqrt.$(OBJEXT)
++@HAS_NDS32_FPU_DP_TRUE@@HAVE_LIBM_MACHINE_NDS32_TRUE@am__objects_177 = libm/machine/nds32/libm_a-w_sqrt.$(OBJEXT)
++@HAVE_LIBM_MACHINE_NDS32_TRUE@am__objects_178 = $(am__objects_176) \
++@HAVE_LIBM_MACHINE_NDS32_TRUE@	$(am__objects_177)
++@HAVE_LIBM_MACHINE_NDS32_TRUE@am__objects_179 = $(am__objects_178)
++@HAVE_LIBM_MACHINE_POWERPC_TRUE@am__objects_180 = libm/machine/powerpc/libm_a-feclearexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_POWERPC_TRUE@	libm/machine/powerpc/libm_a-fegetenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_POWERPC_TRUE@	libm/machine/powerpc/libm_a-fegetexceptflag.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_POWERPC_TRUE@	libm/machine/powerpc/libm_a-fegetround.$(OBJEXT) \
+@@ -3507,8 +3509,8 @@
+ @HAVE_LIBM_MACHINE_POWERPC_TRUE@	libm/machine/powerpc/libm_a-fesetround.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_POWERPC_TRUE@	libm/machine/powerpc/libm_a-fetestexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_POWERPC_TRUE@	libm/machine/powerpc/libm_a-feupdateenv.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_POWERPC_TRUE@am__objects_179 = $(am__objects_178)
+-@HAVE_LIBM_MACHINE_PRU_TRUE@am__objects_180 = libm/machine/pru/libm_a-fpclassify.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_POWERPC_TRUE@am__objects_181 = $(am__objects_180)
++@HAVE_LIBM_MACHINE_PRU_TRUE@am__objects_182 = libm/machine/pru/libm_a-fpclassify.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_PRU_TRUE@	libm/machine/pru/libm_a-fpclassifyf.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_PRU_TRUE@	libm/machine/pru/libm_a-isfinite.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_PRU_TRUE@	libm/machine/pru/libm_a-isfinitef.$(OBJEXT) \
+@@ -3518,8 +3520,8 @@
+ @HAVE_LIBM_MACHINE_PRU_TRUE@	libm/machine/pru/libm_a-isnanf.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_PRU_TRUE@	libm/machine/pru/libm_a-isnormal.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_PRU_TRUE@	libm/machine/pru/libm_a-isnormalf.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_PRU_TRUE@am__objects_181 = $(am__objects_180)
+-@HAVE_LIBM_MACHINE_SPARC_TRUE@am__objects_182 = libm/machine/sparc/libm_a-feclearexcept.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_PRU_TRUE@am__objects_183 = $(am__objects_182)
++@HAVE_LIBM_MACHINE_SPARC_TRUE@am__objects_184 = libm/machine/sparc/libm_a-feclearexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPARC_TRUE@	libm/machine/sparc/libm_a-fegetenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPARC_TRUE@	libm/machine/sparc/libm_a-fegetexceptflag.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPARC_TRUE@	libm/machine/sparc/libm_a-fegetround.$(OBJEXT) \
+@@ -3531,8 +3533,8 @@
+ @HAVE_LIBM_MACHINE_SPARC_TRUE@	libm/machine/sparc/libm_a-fetestexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPARC_TRUE@	libm/machine/sparc/libm_a-feupdateenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPARC_TRUE@	libm/machine/sparc/libm_a-fenv.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_SPARC_TRUE@am__objects_183 = $(am__objects_182)
+-@HAVE_LIBM_MACHINE_SPU_TRUE@am__objects_184 = libm/machine/spu/libm_a-feclearexcept.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_SPARC_TRUE@am__objects_185 = $(am__objects_184)
++@HAVE_LIBM_MACHINE_SPU_TRUE@am__objects_186 = libm/machine/spu/libm_a-feclearexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPU_TRUE@	libm/machine/spu/libm_a-fe_dfl_env.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPU_TRUE@	libm/machine/spu/libm_a-fegetenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPU_TRUE@	libm/machine/spu/libm_a-fegetexceptflag.$(OBJEXT) \
+@@ -3657,8 +3659,8 @@
+ @HAVE_LIBM_MACHINE_SPU_TRUE@	libm/machine/spu/libm_a-w_sinh.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPU_TRUE@	libm/machine/spu/libm_a-w_sqrt.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_SPU_TRUE@	libm/machine/spu/libm_a-w_tgamma.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_SPU_TRUE@am__objects_185 = $(am__objects_184)
+-@HAVE_LIBM_MACHINE_RISCV_TRUE@am__objects_186 = libm/machine/riscv/libm_a-feclearexcept.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_SPU_TRUE@am__objects_187 = $(am__objects_186)
++@HAVE_LIBM_MACHINE_RISCV_TRUE@am__objects_188 = libm/machine/riscv/libm_a-feclearexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/machine/riscv/libm_a-fe_dfl_env.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/machine/riscv/libm_a-fegetenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/machine/riscv/libm_a-fegetexceptflag.$(OBJEXT) \
+@@ -3698,9 +3700,9 @@
+ @HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/machine/riscv/libm_a-sf_llrint.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/machine/riscv/libm_a-s_llround.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/machine/riscv/libm_a-sf_llround.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_RISCV_TRUE@am__objects_187 = $(am__objects_186)
+-@HAVE_LIBM_MACHINE_RISCV_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_188 = $(am__objects_162)
+-@HAVE_LIBM_MACHINE_X86_64_TRUE@am__objects_189 = libm/machine/x86_64/libm_a-feclearexcept.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_RISCV_TRUE@am__objects_189 = $(am__objects_188)
++@HAVE_LIBM_MACHINE_RISCV_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_190 = $(am__objects_164)
++@HAVE_LIBM_MACHINE_X86_64_TRUE@am__objects_191 = libm/machine/x86_64/libm_a-feclearexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/machine/x86_64/libm_a-fegetenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/machine/x86_64/libm_a-fegetexceptflag.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/machine/x86_64/libm_a-fegetround.$(OBJEXT) \
+@@ -3712,10 +3714,10 @@
+ @HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/machine/x86_64/libm_a-fesetround.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/machine/x86_64/libm_a-fetestexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_X86_64_TRUE@	libm/machine/x86_64/libm_a-feupdateenv.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_X86_64_TRUE@am__objects_190 = $(am__objects_189)
+-@HAVE_LIBM_MACHINE_X86_64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_191 = $(am__objects_170)
+-@HAVE_LIBM_MACHINE_XTENSA_TRUE@@XTENSA_XCHAL_HAVE_FP_SQRT_TRUE@am__objects_192 = libm/machine/xtensa/libm_a-ef_sqrt.$(OBJEXT)
+-@HAVE_LIBM_MACHINE_XTENSA_TRUE@am__objects_193 = libm/machine/xtensa/libm_a-feclearexcept.$(OBJEXT) \
++@HAVE_LIBM_MACHINE_X86_64_TRUE@am__objects_192 = $(am__objects_191)
++@HAVE_LIBM_MACHINE_X86_64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_193 = $(am__objects_172)
++@HAVE_LIBM_MACHINE_XTENSA_TRUE@@XTENSA_XCHAL_HAVE_FP_SQRT_TRUE@am__objects_194 = libm/machine/xtensa/libm_a-ef_sqrt.$(OBJEXT)
++@HAVE_LIBM_MACHINE_XTENSA_TRUE@am__objects_195 = libm/machine/xtensa/libm_a-feclearexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@	libm/machine/xtensa/libm_a-fegetenv.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@	libm/machine/xtensa/libm_a-fegetexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@	libm/machine/xtensa/libm_a-fegetexceptflag.$(OBJEXT) \
+@@ -3724,18 +3726,18 @@
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@	libm/machine/xtensa/libm_a-feraiseexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@	libm/machine/xtensa/libm_a-fetestexcept.$(OBJEXT) \
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@	libm/machine/xtensa/libm_a-feupdateenv.$(OBJEXT) \
+-@HAVE_LIBM_MACHINE_XTENSA_TRUE@	$(am__objects_192)
+-@HAVE_LIBM_MACHINE_XTENSA_TRUE@am__objects_194 = $(am__objects_193)
+-am_libm_a_OBJECTS = $(am__objects_145) $(am__objects_149) \
+-	$(am__objects_150) $(am__objects_151) $(am__objects_153) \
+-	$(am__objects_155) $(am__objects_156) $(am__objects_157) \
+-	$(am__objects_158) $(am__objects_159) $(am__objects_161) \
+-	$(am__objects_163) $(am__objects_165) $(am__objects_167) \
+-	$(am__objects_169) $(am__objects_171) $(am__objects_173) \
+-	$(am__objects_177) $(am__objects_179) $(am__objects_181) \
+-	$(am__objects_183) $(am__objects_185) $(am__objects_187) \
+-	$(am__objects_188) $(am__objects_190) $(am__objects_191) \
+-	$(am__objects_194)
++@HAVE_LIBM_MACHINE_XTENSA_TRUE@	$(am__objects_194)
++@HAVE_LIBM_MACHINE_XTENSA_TRUE@am__objects_196 = $(am__objects_195)
++am_libm_a_OBJECTS = $(am__objects_147) $(am__objects_151) \
++	$(am__objects_152) $(am__objects_153) $(am__objects_155) \
++	$(am__objects_157) $(am__objects_158) $(am__objects_159) \
++	$(am__objects_160) $(am__objects_161) $(am__objects_163) \
++	$(am__objects_165) $(am__objects_167) $(am__objects_169) \
++	$(am__objects_171) $(am__objects_173) $(am__objects_175) \
++	$(am__objects_179) $(am__objects_181) $(am__objects_183) \
++	$(am__objects_185) $(am__objects_187) $(am__objects_189) \
++	$(am__objects_190) $(am__objects_192) $(am__objects_193) \
++	$(am__objects_196)
+ libm_a_OBJECTS = $(am_libm_a_OBJECTS)
+ am_libm_test_test_OBJECTS = libm/test/test.$(OBJEXT) \
+ 	libm/test/string.$(OBJEXT) libm/test/convert.$(OBJEXT) \
+@@ -4089,7 +4091,7 @@
+ AM_CFLAGS = $(AM_CFLAGS_$(subst /,_,$(@D))) $(AM_CFLAGS_$(subst /,_,$(@D)_$(<F)))
+ AM_CCASFLAGS = $(AM_CCASFLAGS_$(subst /,_,$(@D))) $(AM_CCASFLAGS_$(subst /,_,$(@D)_$(<F)))
+ AM_CPPFLAGS = $(NEWLIB_CFLAGS) $(TARGET_CFLAGS) $(AM_CPPFLAGS_$(subst /,_,$(@D))) $(AM_CPPFLAGS_$(subst /,_,$(@D)_$(<F))) -idirafter $(srcroot)/include
+-toollib_LIBRARIES = libm.a libc.a $(am__append_73)
++toollib_LIBRARIES = libm.a libc.a $(am__append_74)
+ @HAVE_MULTISUBDIR_TRUE@BUILD_MULTISUBDIR = $(builddir)$(MULTISUBDIR)
+ toollib_DATA = $(CRT0) $(CRT1)
+ AWK_UNIQUE_OBJS = $(AWK) '{ \
+@@ -4254,47 +4256,47 @@
+ 	$(am__append_44) $(am__append_45) $(am__append_46) \
+ 	$(am__append_47) $(am__append_48) $(am__append_49) \
+ 	$(am__append_50) $(am__append_51) $(am__append_52) \
+-	$(am__append_53) $(am__append_54) $(am__append_55) \
+-	$(am__append_56) $(am__append_57) $(am__append_58) \
+-	$(am__append_59) $(am__append_60) $(am__append_61) \
+-	$(am__append_62) $(am__append_63) $(am__append_64) \
+-	$(am__append_65) $(am__append_66) $(am__append_67) \
+-	$(am__append_68) $(am__append_69) $(am__append_70) \
+-	$(am__append_71) $(am__append_72) $(am__append_74) \
+-	$(am__append_75) $(am__append_76) $(am__append_77) \
+-	$(am__append_78) $(am__append_79) $(am__append_80) \
+-	$(am__append_81) $(am__append_82) $(am__append_83) \
+-	$(am__append_84) $(am__append_85) $(am__append_86) \
+-	$(am__append_87) $(am__append_88) $(am__append_89) \
+-	$(am__append_90) $(am__append_91) $(am__append_92) \
+-	$(am__append_93) $(am__append_94) $(am__append_95) \
+-	$(am__append_96) $(am__append_97) $(am__append_98) \
+-	$(am__append_99) $(am__append_100) $(am__append_101) \
+-	$(am__append_102) $(am__append_103) $(am__append_104) \
+-	$(am__append_105) $(am__append_106) $(am__append_107) \
+-	$(am__append_108) $(am__append_109) $(am__append_110) \
+-	$(am__append_111) $(am__append_112) $(am__append_113) \
+-	$(am__append_114) $(am__append_115) $(am__append_116) \
+-	$(am__append_117) $(am__append_118) $(am__append_119) \
+-	$(am__append_120) $(am__append_121) $(am__append_122) \
+-	$(am__append_123) $(am__append_124) $(am__append_125) \
+-	$(am__append_126) $(am__append_127) $(am__append_128) \
+-	$(am__append_129) $(am__append_130) $(am__append_131) \
+-	$(am__append_132)
++	$(am__append_53) $(am__append_55) $(am__append_56) \
++	$(am__append_57) $(am__append_58) $(am__append_59) \
++	$(am__append_60) $(am__append_61) $(am__append_62) \
++	$(am__append_63) $(am__append_64) $(am__append_65) \
++	$(am__append_66) $(am__append_67) $(am__append_68) \
++	$(am__append_69) $(am__append_70) $(am__append_71) \
++	$(am__append_72) $(am__append_73) $(am__append_75) \
++	$(am__append_76) $(am__append_77) $(am__append_78) \
++	$(am__append_79) $(am__append_80) $(am__append_81) \
++	$(am__append_82) $(am__append_83) $(am__append_84) \
++	$(am__append_85) $(am__append_86) $(am__append_87) \
++	$(am__append_88) $(am__append_89) $(am__append_90) \
++	$(am__append_91) $(am__append_92) $(am__append_93) \
++	$(am__append_94) $(am__append_95) $(am__append_96) \
++	$(am__append_97) $(am__append_98) $(am__append_99) \
++	$(am__append_100) $(am__append_101) $(am__append_102) \
++	$(am__append_103) $(am__append_104) $(am__append_105) \
++	$(am__append_106) $(am__append_107) $(am__append_108) \
++	$(am__append_109) $(am__append_110) $(am__append_111) \
++	$(am__append_112) $(am__append_113) $(am__append_114) $(am__append_115) \
++	$(am__append_116) $(am__append_117) $(am__append_118) \
++	$(am__append_119) $(am__append_120) $(am__append_121) \
++	$(am__append_122) $(am__append_123) $(am__append_124) \
++	$(am__append_125) $(am__append_126) $(am__append_127) \
++	$(am__append_128) $(am__append_129) $(am__append_130) \
++	$(am__append_131) $(am__append_132) $(am__append_133) \
++	$(am__append_134)
+ libc_a_CFLAGS = $(AM_CFLAGS) $(libc_a_CFLAGS_$(subst /,_,$(@D))) $(libc_a_CFLAGS_$(subst /,_,$(@D)_$(<F)))
+ libc_a_CCASFLAGS = $(AM_CCASFLAGS) $(libc_a_CCASFLAGS_$(subst /,_,$(@D))) $(libc_a_CCASFLAGS_$(subst /,_,$(@D)_$(<F)))
+ libc_a_CPPFLAGS = $(AM_CPPFLAGS) $(libc_a_CPPFLAGS_$(subst /,_,$(@D))) $(libc_a_CPPFLAGS_$(subst /,_,$(@D)_$(<F)))
+ libc_a_DEPENDENCIES = stamp-libc-math-objects
+-libm_a_SOURCES = $(am__append_133) $(am__append_136) \
+-	$(libm_common_src) $(libm_common_fsrc) $(am__append_139) \
+-	$(am__append_140) $(libm_complex_src) $(libm_complex_fsrc) \
+-	$(libm_complex_lsrc) $(libm_fenv_src) $(am__append_143) \
+-	$(am__append_144) $(am__append_147) $(am__append_148) \
+-	$(am__append_149) $(am__append_150) $(am__append_153) \
+-	$(am__append_156) $(am__append_157) $(am__append_158) \
+-	$(am__append_159) $(am__append_160) $(am__append_161) \
+-	$(am__append_162) $(am__append_165) $(am__append_166) \
+-	$(am__append_170)
++libm_a_SOURCES = $(am__append_135) $(am__append_138) \
++	$(libm_common_src) $(libm_common_fsrc) $(am__append_141) \
++	$(am__append_142) $(libm_complex_src) $(libm_complex_fsrc) \
++	$(libm_complex_lsrc) $(libm_fenv_src) $(am__append_145) \
++	$(am__append_146) $(am__append_149) $(am__append_150) \
++	$(am__append_151) $(am__append_152) $(am__append_155) \
++	$(am__append_158) $(am__append_159) $(am__append_160) \
++	$(am__append_161) $(am__append_162) $(am__append_163) \
++	$(am__append_164) $(am__append_167) $(am__append_168) \
++	$(am__append_172)
+ libm_a_CFLAGS = $(AM_CFLAGS) $(libm_a_CFLAGS_$(subst /,_,$(@D))) $(libm_a_CFLAGS_$(subst /,_,$(@D)_$(<F)))
+ libm_a_CCASFLAGS = $(AM_CCASFLAGS) $(libm_a_CCASFLAGS_$(subst /,_,$(@D))) $(libm_a_CCASFLAGS_$(subst /,_,$(@D)_$(<F)))
+ libm_a_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/libm/common $(libm_a_CPPFLAGS_$(subst /,_,$(@D))) $(libm_a_CPPFLAGS_$(subst /,_,$(@D)_$(<F)))
+@@ -4697,7 +4699,7 @@
+ @HAVE_LIBC_MACHINE_XTENSA_TRUE@@XTENSA_ESP32_PSRAM_CACHE_FIX_TRUE@	-DXTENSA_ESP32_PSRAM_CACHE_FIX
+ 
+ libm_libm_TEXINFOS = libm/targetdep.tex $(LIBM_CHEWOUT_FILES)
+-LIBM_CHEWOUT_FILES = $(am__append_134) $(am__append_137) \
++LIBM_CHEWOUT_FILES = $(am__append_136) $(am__append_139) \
+ 	libm/common/s_cbrt.def libm/common/s_copysign.def \
+ 	libm/common/s_exp10.def libm/common/s_expm1.def \
+ 	libm/common/s_ilogb.def libm/common/s_infinity.def \
+@@ -4712,7 +4714,7 @@
+ 	libm/common/s_remquo.def libm/common/s_rint.def \
+ 	libm/common/s_round.def libm/common/s_signbit.def \
+ 	libm/common/s_trunc.def libm/common/isgreater.def \
+-	$(am__append_141) libm/complex/cabs.def libm/complex/cacos.def \
++	$(am__append_143) libm/complex/cabs.def libm/complex/cacos.def \
+ 	libm/complex/cacosh.def libm/complex/carg.def \
+ 	libm/complex/casin.def libm/complex/casinh.def \
+ 	libm/complex/catan.def libm/complex/catanh.def \
+@@ -4729,11 +4731,11 @@
+ 	libm/fenv/feraiseexcept.def libm/fenv/fesetenv.def \
+ 	libm/fenv/fesetexceptflag.def libm/fenv/fesetround.def \
+ 	libm/fenv/fetestexcept.def libm/fenv/feupdateenv.def \
+-	$(am__append_145) $(am__append_151) $(am__append_163) \
+-	$(am__append_167)
+-LIBM_CHAPTERS = $(am__append_135) $(am__append_138) $(am__append_142) \
+-	libm/complex/complex.tex libm/fenv/fenv.tex $(am__append_146) \
+-	$(am__append_152) $(am__append_164) $(am__append_168)
++	$(am__append_147) $(am__append_153) $(am__append_165) \
++	$(am__append_169)
++LIBM_CHAPTERS = $(am__append_137) $(am__append_140) $(am__append_144) \
++	libm/complex/complex.tex libm/fenv/fenv.tex $(am__append_148) \
++	$(am__append_154) $(am__append_166) $(am__append_170)
+ LIBM_DOCBOOK_OUT_FILES = $(LIBM_CHEWOUT_FILES:.def=.xml)
+ @NEWLIB_HW_FP_TRUE@libm_mathfp_src = \
+ @NEWLIB_HW_FP_TRUE@	libm/mathfp/s_acos.c libm/mathfp/s_frexp.c libm/mathfp/s_mathcnst.c \
+@@ -5273,8 +5275,8 @@
+ # fenv.c cannot be compiled as mips16 since it uses the cfc1 instruction.
+ @HAVE_LIBM_MACHINE_MIPS_TRUE@libm_a_CFLAGS_libm_machine_mips_fenv.c = -mno-mips16
+ @HAVE_LIBM_MACHINE_NDS32_TRUE@libm_machine_nds32_src =  \
+-@HAVE_LIBM_MACHINE_NDS32_TRUE@	$(am__append_154) \
+-@HAVE_LIBM_MACHINE_NDS32_TRUE@	$(am__append_155)
++@HAVE_LIBM_MACHINE_NDS32_TRUE@	$(am__append_156) \
++@HAVE_LIBM_MACHINE_NDS32_TRUE@	$(am__append_157)
+ @HAVE_LIBM_MACHINE_POWERPC_TRUE@libm_machine_powerpc_src = \
+ @HAVE_LIBM_MACHINE_POWERPC_TRUE@	libm/machine/powerpc/feclearexcept.c libm/machine/powerpc/fegetenv.c libm/machine/powerpc/fegetexceptflag.c \
+ @HAVE_LIBM_MACHINE_POWERPC_TRUE@	libm/machine/powerpc/fegetround.c libm/machine/powerpc/feholdexcept.c libm/machine/powerpc/fenv.c libm/machine/powerpc/feraiseexcept.c libm/machine/powerpc/fesetenv.c \
+@@ -5345,7 +5347,7 @@
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@	libm/machine/xtensa/feraiseexcept.c \
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@	libm/machine/xtensa/fetestexcept.c \
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@	libm/machine/xtensa/feupdateenv.c \
+-@HAVE_LIBM_MACHINE_XTENSA_TRUE@	$(am__append_169)
++@HAVE_LIBM_MACHINE_XTENSA_TRUE@	$(am__append_171)
+ @HAVE_LIBM_MACHINE_XTENSA_TRUE@libm_a_CFLAGS_libm_machine_xtensa = -D_LIBM
+ all: newlib.h _newlib_version.h
+ 	$(MAKE) $(AM_MAKEFLAGS) all-am
+@@ -9161,6 +9163,15 @@
+ libc/machine/pru/libc_a-setjmp.$(OBJEXT):  \
+ 	libc/machine/pru/$(am__dirstamp) \
+ 	libc/machine/pru/$(DEPDIR)/$(am__dirstamp)
++libc/machine/r5900/$(am__dirstamp):
++	@$(MKDIR_P) libc/machine/r5900
++	@: > libc/machine/r5900/$(am__dirstamp)
++libc/machine/r5900/$(DEPDIR)/$(am__dirstamp):
++	@$(MKDIR_P) libc/machine/r5900/$(DEPDIR)
++	@: > libc/machine/r5900/$(DEPDIR)/$(am__dirstamp)
++libc/machine/r5900/libc_a-setjmp.$(OBJEXT):  \
++	libc/machine/r5900/$(am__dirstamp) \
++	libc/machine/r5900/$(DEPDIR)/$(am__dirstamp)
+ libc/machine/riscv/$(am__dirstamp):
+ 	@$(MKDIR_P) libc/machine/riscv
+ 	@: > libc/machine/riscv/$(am__dirstamp)
+@@ -13158,6 +13169,7 @@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/powerpc/$(DEPDIR)/libc_a-vec_reallocr.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/powerpc/$(DEPDIR)/libc_a-vfprintf.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/powerpc/$(DEPDIR)/libc_a-vfscanf.Po@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/riscv/$(DEPDIR)/libc_a-ffs.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/riscv/$(DEPDIR)/libc_a-ieeefp.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/riscv/$(DEPDIR)/libc_a-memchr.Po@am__quote@
+@@ -19163,6 +19175,21 @@
+ @AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+ @am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -c -o libc/machine/powerpc/libc_a-setjmp.obj `if test -f 'libc/machine/powerpc/setjmp.S'; then $(CYGPATH_W) 'libc/machine/powerpc/setjmp.S'; else $(CYGPATH_W) '$(srcdir)/libc/machine/powerpc/setjmp.S'; fi`
+ 
++
++libc/machine/r5900/libc_a-setjmp.o: libc/machine/r5900/setjmp.S
++@am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -MT libc/machine/r5900/libc_a-setjmp.o -MD -MP -MF libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Tpo -c -o libc/machine/r5900/libc_a-setjmp.o `test -f 'libc/machine/r5900/setjmp.S' || echo '$(srcdir)/'`libc/machine/r5900/setjmp.S
++@am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Tpo libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Po
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS)source='libc/machine/r5900/setjmp.S' object='libc/machine/r5900/libc_a-setjmp.o' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -c -o libc/machine/r5900/libc_a-setjmp.o `test -f 'libc/machine/r5900/setjmp.S' || echo '$(srcdir)/'`libc/machine/r5900/setjmp.S
++
++libc/machine/r5900/libc_a-setjmp.obj: libc/machine/r5900/setjmp.S
++@am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -MT libc/machine/r5900/libc_a-setjmp.obj -MD -MP -MF libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Tpo -c -o libc/machine/r5900/libc_a-setjmp.obj `if test -f 'libc/machine/r5900/setjmp.S'; then $(CYGPATH_W) 'libc/machine/r5900/setjmp.S'; else $(CYGPATH_W) '$(srcdir)/libc/machine/r5900/setjmp.S'; fi`
++@am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Tpo libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Po
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS)source='libc/machine/r5900/setjmp.S' object='libc/machine/r5900/libc_a-setjmp.obj' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -c -o libc/machine/r5900/libc_a-setjmp.obj `if test -f 'libc/machine/r5900/setjmp.S'; then $(CYGPATH_W) 'libc/machine/r5900/setjmp.S'; else $(CYGPATH_W) '$(srcdir)/libc/machine/r5900/setjmp.S'; fi`
++
+ libc/machine/riscv/libc_a-memmove-asm.o: libc/machine/riscv/memmove-asm.S
+ @am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -MT libc/machine/riscv/libc_a-memmove-asm.o -MD -MP -MF libc/machine/riscv/$(DEPDIR)/libc_a-memmove-asm.Tpo -c -o libc/machine/riscv/libc_a-memmove-asm.o `test -f 'libc/machine/riscv/memmove-asm.S' || echo '$(srcdir)/'`libc/machine/riscv/memmove-asm.S
+ @am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) libc/machine/riscv/$(DEPDIR)/libc_a-memmove-asm.Tpo libc/machine/riscv/$(DEPDIR)/libc_a-memmove-asm.Po
+@@ -31835,6 +31862,7 @@
+ @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+ @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CFLAGS) $(CFLAGS) -c -o libc/sys/or1k/libc_a-mlock.obj `if test -f 'libc/sys/or1k/mlock.c'; then $(CYGPATH_W) 'libc/sys/or1k/mlock.c'; else $(CYGPATH_W) '$(srcdir)/libc/sys/or1k/mlock.c'; fi`
+ 
++
+ libc/sys/rdos/libc_a-chown.o: libc/sys/rdos/chown.c
+ @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CFLAGS) $(CFLAGS) -MT libc/sys/rdos/libc_a-chown.o -MD -MP -MF libc/sys/rdos/$(DEPDIR)/libc_a-chown.Tpo -c -o libc/sys/rdos/libc_a-chown.o `test -f 'libc/sys/rdos/chown.c' || echo '$(srcdir)/'`libc/sys/rdos/chown.c
+ @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) libc/sys/rdos/$(DEPDIR)/libc_a-chown.Tpo libc/sys/rdos/$(DEPDIR)/libc_a-chown.Po
+@@ -50614,6 +50642,8 @@
+ 	-rm -f libc/machine/powerpc/$(am__dirstamp)
+ 	-rm -f libc/machine/pru/$(DEPDIR)/$(am__dirstamp)
+ 	-rm -f libc/machine/pru/$(am__dirstamp)
++	-rm -f libc/machine/r5900/$(DEPDIR)/$(am__dirstamp)
++	-rm -f libc/machine/r5900/$(am__dirstamp)
+ 	-rm -f libc/machine/riscv/$(DEPDIR)/$(am__dirstamp)
+ 	-rm -f libc/machine/riscv/$(am__dirstamp)
+ 	-rm -f libc/machine/rl78/$(DEPDIR)/$(am__dirstamp)
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/configure newlib-4.6.0.20260123-kos/newlib/configure
+--- newlib-4.6.0.20260123/newlib/configure	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/configure	2026-07-02 12:52:38
+@@ -673,6 +673,8 @@
+ HAVE_LIBC_MACHINE_RL78_TRUE
+ HAVE_LIBC_MACHINE_RISCV_FALSE
+ HAVE_LIBC_MACHINE_RISCV_TRUE
++HAVE_LIBC_MACHINE_R5900_FALSE
++HAVE_LIBC_MACHINE_R5900_TRUE
+ HAVE_LIBC_MACHINE_PRU_FALSE
+ HAVE_LIBC_MACHINE_PRU_TRUE
+ HAVE_LIBC_MACHINE_POWERPC_FALSE
+@@ -6065,6 +6067,13 @@
+   HAVE_LIBC_MACHINE_PRU_TRUE='#'
+   HAVE_LIBC_MACHINE_PRU_FALSE=
+ fi
++ if test "${machine_dir}" = r5900; then
++  HAVE_LIBC_MACHINE_R5900_TRUE=
++  HAVE_LIBC_MACHINE_R5900_FALSE='#'
++else
++  HAVE_LIBC_MACHINE_R5900_TRUE='#'
++  HAVE_LIBC_MACHINE_R5900_FALSE=
++fi
+  if test "${machine_dir}" = riscv; then
+   HAVE_LIBC_MACHINE_RISCV_TRUE=
+   HAVE_LIBC_MACHINE_RISCV_FALSE='#'
+@@ -7975,6 +7984,10 @@
+ fi
+ if test -z "${HAVE_LIBC_MACHINE_PRU_TRUE}" && test -z "${HAVE_LIBC_MACHINE_PRU_FALSE}"; then
+   as_fn_error $? "conditional \"HAVE_LIBC_MACHINE_PRU\" was never defined.
++Usually this means the macro was only invoked conditionally." "$LINENO" 5
++fi
++if test -z "${HAVE_LIBC_MACHINE_R5900_TRUE}" && test -z "${HAVE_LIBC_MACHINE_R5900_FALSE}"; then
++  as_fn_error $? "conditional \"HAVE_LIBC_MACHINE_R5900\" was never defined.
+ Usually this means the macro was only invoked conditionally." "$LINENO" 5
+ fi
+ if test -z "${HAVE_LIBC_MACHINE_RISCV_TRUE}" && test -z "${HAVE_LIBC_MACHINE_RISCV_FALSE}"; then
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/configure.host newlib-4.6.0.20260123-kos/newlib/configure.host
+--- newlib-4.6.0.20260123/newlib/configure.host	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/configure.host	2026-07-02 12:52:38
 @@ -130,8 +130,7 @@
  	machine_dir=arc64
  	;;
@@ -11,7 +1490,17 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/configure.host newlib-4.6.0.20260
  	;;
    avr*)
  	newlib_cflags="${newlib_cflags} -DPREFER_SIZE_OVER_SPEED -mcall-prologues"
-@@ -326,6 +325,7 @@
+@@ -249,6 +248,9 @@
+   mep)
+ 	machine_dir=mep
+ 	;;
++  mips64r5900*)
++	machine_dir=r5900
++	;;
+   mips*)
+ 	machine_dir=mips
+ 	libm_machine_dir=mips
+@@ -326,6 +328,7 @@
  	;;
    sh | sh64)
  	machine_dir=sh
@@ -19,7 +1508,28 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/configure.host newlib-4.6.0.20260
  	;;
    sparc*)
  	libm_machine_dir=sparc
-@@ -823,7 +823,11 @@
+@@ -540,6 +543,9 @@
+   microblaze*-*-*)
+ 	machine_dir=microblaze
+ 	;;
++  mips*-ps2-*)
++	newlib_cflags="${newlib_cflags} -G0 -DREENTRANT_SYSCALLS_PROVIDED -DMALLOC_PROVIDED -DABORT_PROVIDED -DHAVE_FCNTL -ffunction-sections -fdata-sections"
++	;;
+   mmix-knuth-mmixware)
+ 	sys_dir=mmixware
+ 	;;
+@@ -783,6 +789,10 @@
+ 	default_newlib_io_long_long="yes"
+ 	newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
+ 	;;
++  mips*-ps2-elf*)
++	syscall_dir=syscalls
++	default_newlib_io_long_long="yes"
++	;;
+   mips*-*-elf*)
+ 	default_newlib_io_long_long="yes"
+ 	newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
+@@ -823,7 +833,11 @@
  	default_newlib_io_long_long="yes"
  	newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
  	;;
@@ -32,9 +1542,21 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/configure.host newlib-4.6.0.20260
    powerpc*-*-elf* | \
    powerpc*-*-linux* | \
    powerpc*-*-rtem* | \
-diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/assert.h newlib-4.6.0.20260123-kos/newlib/libc/include/assert.h
---- newlib-4.6.0.20260123/newlib/libc/include/assert.h	2024-02-10 09:30:58.781247667 -0600
-+++ newlib-4.6.0.20260123-kos/newlib/libc/include/assert.h	2024-02-10 09:31:16.329331366 -0600
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/acinclude.m4 newlib-4.6.0.20260123-kos/newlib/libc/acinclude.m4
+--- newlib-4.6.0.20260123/newlib/libc/acinclude.m4	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/acinclude.m4	2026-07-02 12:52:38
+@@ -54,7 +54,7 @@
+   nds32 necv70 nios2 nvptx
+   or1k
+   powerpc pru
+-  riscv rl78 rx
++  r5900 riscv rl78 rx
+   sh sparc spu
+   tic4x tic6x tic80
+   v850 visium
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/include/assert.h newlib-4.6.0.20260123-kos/newlib/libc/include/assert.h
+--- newlib-4.6.0.20260123/newlib/libc/include/assert.h	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/include/assert.h	2026-05-13 05:01:13
 @@ -13,8 +13,8 @@
  #ifdef NDEBUG           /* required by ANSI standard */
  # define assert(__e) ((void)0)
@@ -61,9 +1583,31 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/assert.h newlib-4.6.
  
  #if __STDC_VERSION__ >= 201112L && !defined __cplusplus
  # define static_assert _Static_assert
-diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/sys/_pthreadtypes.h newlib-4.6.0.20260123-kos/newlib/libc/include/sys/_pthreadtypes.h
---- newlib-4.6.0.20260123/newlib/libc/include/sys/_pthreadtypes.h	2024-02-10 09:30:58.783247676 -0600
-+++ newlib-4.6.0.20260123-kos/newlib/libc/include/sys/_pthreadtypes.h	2024-02-10 09:31:16.329331366 -0600
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/include/machine/setjmp.h newlib-4.6.0.20260123-kos/newlib/libc/include/machine/setjmp.h
+--- newlib-4.6.0.20260123/newlib/libc/include/machine/setjmp.h	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/include/machine/setjmp.h	2026-05-13 05:01:13
+@@ -138,10 +138,17 @@
+ 
+ #ifdef __mips__
+ # if defined(__mips64)
+-#  define _JBTYPE long long
++#  if defined(_MIPS_ARCH_R5900)
++    typedef unsigned int jbtype128 __attribute__((mode(TI))) __attribute__((aligned(16)));
++#   define _JBTYPE jbtype128
++#  else
++#   define _JBTYPE long long
++#  endif
+ # endif
+ # ifdef __mips_soft_float
+ #  define _JBLEN 11
++# elif defined(_MIPS_ARCH_R5900)
++#  define _JBLEN 14
+ # else
+ #  define _JBLEN 23
+ # endif
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/include/sys/_pthreadtypes.h newlib-4.6.0.20260123-kos/newlib/libc/include/sys/_pthreadtypes.h
+--- newlib-4.6.0.20260123/newlib/libc/include/sys/_pthreadtypes.h	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/include/sys/_pthreadtypes.h	2026-05-13 05:01:13
 @@ -22,16 +22,6 @@
  
  #include <sys/sched.h>
@@ -175,7 +1719,7 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/sys/_pthreadtypes.h 
 -
 -#define _PTHREAD_ONCE_INIT  { 1, 0 }  /* is initialized and not run */
  #endif /* defined(_POSIX_THREADS) || __POSIX_VISIBLE >= 199506 */
- 
+-
 -/* POSIX Barrier Types */
 -
 -#if defined(_POSIX_BARRIERS)
@@ -208,51 +1752,176 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/sys/_pthreadtypes.h 
 -#endif
 -} pthread_rwlockattr_t;
 -#endif /* defined(_POSIX_READER_WRITER_LOCKS) */
--
+ 
  #endif /* ! _SYS__PTHREADTYPES_H_ */
-diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/sys/signal.h newlib-4.6.0.20260123-kos/newlib/libc/include/sys/signal.h
---- newlib-4.6.0.20260123/newlib/libc/include/sys/signal.h	2024-02-10 09:30:58.783247676 -0600
-+++ newlib-4.6.0.20260123-kos/newlib/libc/include/sys/signal.h	2024-02-10 09:31:16.329331366 -0600
-@@ -223,9 +223,11 @@
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/include/sys/_types.h newlib-4.6.0.20260123-kos/newlib/libc/include/sys/_types.h
+--- newlib-4.6.0.20260123/newlib/libc/include/sys/_types.h	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/include/sys/_types.h	2026-05-13 05:01:13
+@@ -69,7 +69,7 @@
+ 
+ #ifndef __machine_ino_t_defined
+ #if (defined(__i386__) && (defined(GO32) || defined(__MSDOS__))) || \
+-    defined(__sparc__) || defined(__SPU__)
++    defined(__sparc__) || defined(__SPU__) || defined(__sh__) || defined(__PPC__) || defined(__ARMEL__) || defined(__mips__)
+ typedef unsigned long __ino_t;
+ #else
+ typedef unsigned short __ino_t;
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/include/sys/signal.h newlib-4.6.0.20260123-kos/newlib/libc/include/sys/signal.h
+--- newlib-4.6.0.20260123/newlib/libc/include/sys/signal.h	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/include/sys/signal.h	2026-05-13 05:01:13
+@@ -223,8 +223,10 @@
  int sigaltstack (const stack_t *__restrict, stack_t *__restrict);
  #endif
  
 +#if 0
  #if __POSIX_VISIBLE >= 199506
  int pthread_kill (pthread_t, int);
- #endif
 +#endif
+ #endif
  
  #if __POSIX_VISIBLE >= 199309
-
-diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/sys/stat.h newlib-4.6.0.20260123-kos/newlib/libc/include/sys/stat.h
---- newlib-4.6.0.20260123/newlib/libc/include/sys/stat.h	2025-03-18 17:54:52.217013623 -0500
-+++ newlib-4.6.0.20260123-kos/newlib/libc/include/sys/stat.h	2025-03-18 17:54:59.003048247 -0500
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/include/sys/stat.h newlib-4.6.0.20260123-kos/newlib/libc/include/sys/stat.h
+--- newlib-4.6.0.20260123/newlib/libc/include/sys/stat.h	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/include/sys/stat.h	2026-05-13 05:01:13
 @@ -157,8 +157,8 @@
  int	stat (const char *__restrict __path, struct stat *__restrict __sbuf );
  mode_t	umask (mode_t __mask );
-
+ 
 -#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__)
  int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
 +#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__)
  int	mknod (const char *__path, mode_t __mode, dev_t __dev );
  #endif
-
-diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/sys/_types.h newlib-4.6.0.20260123-kos/newlib/libc/include/sys/_types.h
---- newlib-4.6.0.20260123/newlib/libc/include/sys/_types.h	2024-02-10 09:30:58.783247676 -0600
-+++ newlib-4.6.0.20260123-kos/newlib/libc/include/sys/_types.h	2024-02-10 09:31:16.329331366 -0600
-@@ -69,7 +69,7 @@
  
- #ifndef __machine_ino_t_defined
- #if (defined(__i386__) && (defined(GO32) || defined(__MSDOS__))) || \
--    defined(__sparc__) || defined(__SPU__)
-+    defined(__sparc__) || defined(__SPU__) || defined(__sh__) || defined(__PPC__) || defined(__ARMEL__)
- typedef unsigned long __ino_t;
- #else
- typedef unsigned short __ino_t;
-diff --color -ruN newlib-4.6.0.20260123/newlib/libc/ssp/stack_protector.c newlib-4.6.0.20260123-kos/newlib/libc/ssp/stack_protector.c
---- newlib-4.6.0.20260123/newlib/libc/ssp/stack_protector.c	2024-02-10 09:30:58.832247910 -0600
-+++ newlib-4.6.0.20260123-kos/newlib/libc/ssp/stack_protector.c	2024-02-10 09:31:16.329331366 -0600
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/machine/Makefile.inc newlib-4.6.0.20260123-kos/newlib/libc/machine/Makefile.inc
+--- newlib-4.6.0.20260123/newlib/libc/machine/Makefile.inc	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/machine/Makefile.inc	2026-05-13 05:01:13
+@@ -127,6 +127,9 @@
+ if HAVE_LIBC_MACHINE_PRU
+ include %D%/pru/Makefile.inc
+ endif
++if HAVE_LIBC_MACHINE_R5900
++include %D%/r5900/Makefile.inc
++endif
+ if HAVE_LIBC_MACHINE_RISCV
+ include %D%/riscv/Makefile.inc
+ endif
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/machine/r5900/Makefile.inc newlib-4.6.0.20260123-kos/newlib/libc/machine/r5900/Makefile.inc
+--- newlib-4.6.0.20260123/newlib/libc/machine/r5900/Makefile.inc	1969-12-31 16:00:00
++++ newlib-4.6.0.20260123-kos/newlib/libc/machine/r5900/Makefile.inc	2026-05-13 05:01:13
+@@ -0,0 +1 @@
++libc_a_SOURCES += %D%/setjmp.S
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/machine/r5900/setjmp.S newlib-4.6.0.20260123-kos/newlib/libc/machine/r5900/setjmp.S
+--- newlib-4.6.0.20260123/newlib/libc/machine/r5900/setjmp.S	1969-12-31 16:00:00
++++ newlib-4.6.0.20260123-kos/newlib/libc/machine/r5900/setjmp.S	2026-05-13 05:01:13
+@@ -0,0 +1,104 @@
++/* This is a simple version of setjmp and longjmp.
++ * Floating point support in. */
++
++#define O_S0	0x00
++#define O_S1	0x10
++#define O_S2	0x20
++#define O_S3	0x30
++#define O_S4	0x40
++#define O_S5	0x50
++#define O_S6	0x60
++#define O_S7	0x70
++#define O_FP	0x80
++#define O_SP	0x90
++#define O_RA	0xa0
++#define O_F20   0xb0
++#define O_F21   0xb4
++#define O_F22   0xb8
++#define O_F23   0xbc
++#define O_F24   0xc0
++#define O_F25   0xc4
++#define O_F26   0xc8
++#define O_F27   0xcc
++#define O_F28   0xd0
++#define O_F29   0xd4
++#define O_F30   0xd8
++#define O_F31   0xdc
++
++/* int setjmp (jmp_buf);  */
++	.globl	setjmp
++	.ent	setjmp
++setjmp:
++	.frame	$sp,0,$31
++
++	sq	$s0, O_S0($a0)
++	sq	$s1, O_S1($a0)
++	sq	$s2, O_S2($a0)
++	sq	$s3, O_S3($a0)
++	sq	$s4, O_S4($a0)
++	sq	$s5, O_S5($a0)
++	sq	$s6, O_S6($a0)
++	sq	$s7, O_S7($a0)
++	sq	$fp, O_FP($a0)
++	sq	$sp, O_SP($a0)
++	sq	$ra, O_RA($a0)
++
++	swc1    $f20, O_F20($a0)
++	swc1    $f21, O_F21($a0)
++	swc1    $f22, O_F22($a0)
++	swc1    $f23, O_F23($a0)
++	swc1    $f24, O_F24($a0)
++	swc1    $f25, O_F25($a0)
++	swc1    $f26, O_F26($a0)
++	swc1    $f27, O_F27($a0)
++	swc1    $f28, O_F28($a0)
++	swc1    $f29, O_F29($a0)
++	swc1    $f30, O_F30($a0)
++	swc1    $f31, O_F31($a0)
++
++
++	move	$v0, $0
++
++	jr	$ra
++
++	.end	setjmp
++
++/* volatile void longjmp (jmp_buf, int);  */
++	.globl	longjmp
++	.ent	longjmp
++longjmp:
++	.frame	$sp,0,$31
++
++	lq	$s0, O_S0($a0)
++	lq	$s1, O_S1($a0)
++	lq	$s2, O_S2($a0)
++	lq	$s3, O_S3($a0)
++	lq	$s4, O_S4($a0)
++	lq	$s5, O_S5($a0)
++	lq	$s6, O_S6($a0)
++	lq	$s7, O_S7($a0)
++	lq	$fp, O_FP($a0)
++	lq	$sp, O_SP($a0)
++	lq	$ra, O_RA($a0)
++
++	lwc1    $f20, O_F20($a0)
++	lwc1    $f21, O_F21($a0)
++	lwc1    $f22, O_F22($a0)
++	lwc1    $f23, O_F23($a0)
++	lwc1    $f24, O_F24($a0)
++	lwc1    $f25, O_F25($a0)
++	lwc1    $f26, O_F26($a0)
++	lwc1    $f27, O_F27($a0)
++	lwc1    $f28, O_F28($a0)
++	lwc1    $f29, O_F29($a0)
++	lwc1    $f30, O_F30($a0)
++	lwc1    $f31, O_F31($a0)
++
++	bne	$a1, $0, 1f
++	li	$a1, 1
++1:
++	move	$v0, $a1
++
++	jr	$ra
++
++	.end longjmp
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/ssp/stack_protector.c newlib-4.6.0.20260123-kos/newlib/libc/ssp/stack_protector.c
+--- newlib-4.6.0.20260123/newlib/libc/ssp/stack_protector.c	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/ssp/stack_protector.c	2026-05-13 05:01:13
 @@ -32,12 +32,11 @@
  #endif
  
@@ -267,9 +1936,9 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/libc/ssp/stack_protector.c newlib
    _exit (127);
  }
  
-diff --color -ruN newlib-4.6.0.20260123/newlib/libc/stdlib/assert.c newlib-4.6.0.20260123-kos/newlib/libc/stdlib/assert.c
---- newlib-4.6.0.20260123/newlib/libc/stdlib/assert.c	2024-02-10 09:30:58.811247810 -0600
-+++ newlib-4.6.0.20260123-kos/newlib/libc/stdlib/assert.c	2024-02-10 09:31:16.329331366 -0600
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/stdlib/assert.c newlib-4.6.0.20260123-kos/newlib/libc/stdlib/assert.c
+--- newlib-4.6.0.20260123/newlib/libc/stdlib/assert.c	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/stdlib/assert.c	2026-05-13 05:01:13
 @@ -47,6 +47,8 @@
  #include <stdlib.h>
  #include <stdio.h>

--- a/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
+++ b/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
@@ -11,7 +11,17 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/configure.host newlib-4.6.0.20260
  	;;
    avr*)
  	newlib_cflags="${newlib_cflags} -DPREFER_SIZE_OVER_SPEED -mcall-prologues"
-@@ -326,6 +325,7 @@
+@@ -249,6 +248,9 @@
+   mep)
+ 	machine_dir=mep
+ 	;;
++  mips64r5900*)
++	machine_dir=r5900
++	;;
+   mips*)
+ 	machine_dir=mips
+ 	libm_machine_dir=mips
+@@ -326,6 +328,7 @@
  	;;
    sh | sh64)
  	machine_dir=sh
@@ -19,7 +29,28 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/configure.host newlib-4.6.0.20260
  	;;
    sparc*)
  	libm_machine_dir=sparc
-@@ -823,7 +823,11 @@
+@@ -540,6 +543,9 @@
+   microblaze*-*-*)
+ 	machine_dir=microblaze
+ 	;;
++  mips*-ps2-*)
++	newlib_cflags="${newlib_cflags} -G0 -DREENTRANT_SYSCALLS_PROVIDED -DMALLOC_PROVIDED -DABORT_PROVIDED -DHAVE_FCNTL -ffunction-sections -fdata-sections"
++	;;
+   mmix-knuth-mmixware)
+ 	sys_dir=mmixware
+ 	;;
+@@ -783,6 +789,10 @@
+ 	default_newlib_io_long_long="yes"
+ 	newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
+ 	;;
++  mips*-ps2-elf*)
++	syscall_dir=syscalls
++	default_newlib_io_long_long="yes"
++	;;
+   mips*-*-elf*)
+ 	default_newlib_io_long_long="yes"
+ 	newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
+@@ -823,7 +833,11 @@
  	default_newlib_io_long_long="yes"
  	newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
  	;;
@@ -246,7 +277,7 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/libc/include/sys/_types.h newlib-
  #ifndef __machine_ino_t_defined
  #if (defined(__i386__) && (defined(GO32) || defined(__MSDOS__))) || \
 -    defined(__sparc__) || defined(__SPU__)
-+    defined(__sparc__) || defined(__SPU__) || defined(__sh__) || defined(__PPC__) || defined(__ARMEL__)
++    defined(__sparc__) || defined(__SPU__) || defined(__sh__) || defined(__PPC__) || defined(__ARMEL__) || defined(__mips__)
  typedef unsigned long __ino_t;
  #else
  typedef unsigned short __ino_t;
@@ -287,3 +318,308 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/libc/stdlib/assert.c newlib-4.6.0
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
 +
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/configure newlib-4.6.0.20260123-kos/configure
+--- newlib-4.6.0.20260123/configure	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/configure	2026-07-14 09:36:41
+@@ -3985,6 +3985,9 @@
+   | mips*-*-irix* | mips*-*-lnews* | mips*-*-riscos*)
+     noconfigdirs="$noconfigdirs ld gas gprof"
+     ;;
++  mips*-ps2-*)
++    noconfigdirs="$noconfigdirs target-libgloss"
++    ;;
+   mips*-*-*)
+     noconfigdirs="$noconfigdirs gprof"
+     ;;
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/configure.ac newlib-4.6.0.20260123-kos/configure.ac
+--- newlib-4.6.0.20260123/configure.ac	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/configure.ac	2026-07-14 09:36:41
+@@ -1269,6 +1269,9 @@
+   | mips*-*-irix* | mips*-*-lnews* | mips*-*-riscos*)
+     noconfigdirs="$noconfigdirs ld gas gprof"
+     ;;
++  mips*-ps2-*)
++    noconfigdirs="$noconfigdirs target-libgloss"
++    ;;
+   mips*-*-*)
+     noconfigdirs="$noconfigdirs gprof"
+     ;;
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/Makefile.in newlib-4.6.0.20260123-kos/newlib/Makefile.in
+--- newlib-4.6.0.20260123/newlib/Makefile.in	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/Makefile.in	2026-07-14 09:36:52
+@@ -855,6 +855,7 @@
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/vfscanf.c
+ 
+ @HAVE_LIBC_MACHINE_PRU_TRUE@am__append_113 = libc/machine/pru/setjmp.s
++@HAVE_LIBC_MACHINE_R5900_TRUE@am__append_171 = libc/machine/r5900/setjmp.S
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@am__append_114 = \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/memmove-asm.S libc/machine/riscv/memmove.c libc/machine/riscv/memset.S libc/machine/riscv/memcpy-asm.S libc/machine/riscv/memcpy.c libc/machine/riscv/strlen.c \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/strcpy.c libc/machine/riscv/stpcpy.c libc/machine/riscv/strcmp.S libc/machine/riscv/memchr.c libc/machine/riscv/memrchr.c libc/machine/riscv/setjmp.S libc/machine/riscv/ieeefp.c libc/machine/riscv/ffs.c
+@@ -2178,6 +2179,7 @@
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/libc_a-vfprintf.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_POWERPC_TRUE@@HAVE_POWERPC_SPE_TRUE@	libc/machine/powerpc/libc_a-vfscanf.$(OBJEXT)
+ @HAVE_LIBC_MACHINE_PRU_TRUE@am__objects_123 = libc/machine/pru/libc_a-setjmp.$(OBJEXT)
++@HAVE_LIBC_MACHINE_R5900_TRUE@am__objects_195 = libc/machine/r5900/libc_a-setjmp.$(OBJEXT)
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@am__objects_124 = libc/machine/riscv/libc_a-memmove-asm.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/libc_a-memmove.$(OBJEXT) \
+ @HAVE_LIBC_MACHINE_RISCV_TRUE@	libc/machine/riscv/libc_a-memset.$(OBJEXT) \
+@@ -2677,7 +2679,7 @@
+ 	$(am__objects_114) $(am__objects_115) $(am__objects_116) \
+ 	$(am__objects_117) $(am__objects_118) $(am__objects_119) \
+ 	$(am__objects_120) $(am__objects_121) $(am__objects_122) \
+-	$(am__objects_123) $(am__objects_124) $(am__objects_125) \
++	$(am__objects_123) $(am__objects_195) $(am__objects_124) $(am__objects_125) \
+ 	$(am__objects_126) $(am__objects_127) $(am__objects_128) \
+ 	$(am__objects_129) $(am__objects_130) $(am__objects_131) \
+ 	$(am__objects_132) $(am__objects_133) $(am__objects_134) \
+@@ -4273,7 +4275,7 @@
+ 	$(am__append_102) $(am__append_103) $(am__append_104) \
+ 	$(am__append_105) $(am__append_106) $(am__append_107) \
+ 	$(am__append_108) $(am__append_109) $(am__append_110) \
+-	$(am__append_111) $(am__append_112) $(am__append_113) \
++	$(am__append_111) $(am__append_112) $(am__append_113) $(am__append_171) \
+ 	$(am__append_114) $(am__append_115) $(am__append_116) \
+ 	$(am__append_117) $(am__append_118) $(am__append_119) \
+ 	$(am__append_120) $(am__append_121) $(am__append_122) \
+@@ -9161,6 +9163,15 @@
+ libc/machine/pru/libc_a-setjmp.$(OBJEXT):  \
+ 	libc/machine/pru/$(am__dirstamp) \
+ 	libc/machine/pru/$(DEPDIR)/$(am__dirstamp)
++libc/machine/r5900/$(am__dirstamp):
++	@$(MKDIR_P) libc/machine/r5900
++	@: > libc/machine/r5900/$(am__dirstamp)
++libc/machine/r5900/$(DEPDIR)/$(am__dirstamp):
++	@$(MKDIR_P) libc/machine/r5900/$(DEPDIR)
++	@: > libc/machine/r5900/$(DEPDIR)/$(am__dirstamp)
++libc/machine/r5900/libc_a-setjmp.$(OBJEXT):  \
++	libc/machine/r5900/$(am__dirstamp) \
++	libc/machine/r5900/$(DEPDIR)/$(am__dirstamp)
+ libc/machine/riscv/$(am__dirstamp):
+ 	@$(MKDIR_P) libc/machine/riscv
+ 	@: > libc/machine/riscv/$(am__dirstamp)
+@@ -13158,6 +13169,7 @@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/powerpc/$(DEPDIR)/libc_a-vec_reallocr.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/powerpc/$(DEPDIR)/libc_a-vfprintf.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/powerpc/$(DEPDIR)/libc_a-vfscanf.Po@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/riscv/$(DEPDIR)/libc_a-ffs.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/riscv/$(DEPDIR)/libc_a-ieeefp.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@libc/machine/riscv/$(DEPDIR)/libc_a-memchr.Po@am__quote@
+@@ -19163,6 +19175,21 @@
+ @AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+ @am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -c -o libc/machine/powerpc/libc_a-setjmp.obj `if test -f 'libc/machine/powerpc/setjmp.S'; then $(CYGPATH_W) 'libc/machine/powerpc/setjmp.S'; else $(CYGPATH_W) '$(srcdir)/libc/machine/powerpc/setjmp.S'; fi`
+ 
++
++libc/machine/r5900/libc_a-setjmp.o: libc/machine/r5900/setjmp.S
++@am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -MT libc/machine/r5900/libc_a-setjmp.o -MD -MP -MF libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Tpo -c -o libc/machine/r5900/libc_a-setjmp.o `test -f 'libc/machine/r5900/setjmp.S' || echo '$(srcdir)/'`libc/machine/r5900/setjmp.S
++@am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Tpo libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Po
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS)source='libc/machine/r5900/setjmp.S' object='libc/machine/r5900/libc_a-setjmp.o' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -c -o libc/machine/r5900/libc_a-setjmp.o `test -f 'libc/machine/r5900/setjmp.S' || echo '$(srcdir)/'`libc/machine/r5900/setjmp.S
++
++libc/machine/r5900/libc_a-setjmp.obj: libc/machine/r5900/setjmp.S
++@am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -MT libc/machine/r5900/libc_a-setjmp.obj -MD -MP -MF libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Tpo -c -o libc/machine/r5900/libc_a-setjmp.obj `if test -f 'libc/machine/r5900/setjmp.S'; then $(CYGPATH_W) 'libc/machine/r5900/setjmp.S'; else $(CYGPATH_W) '$(srcdir)/libc/machine/r5900/setjmp.S'; fi`
++@am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Tpo libc/machine/r5900/$(DEPDIR)/libc_a-setjmp.Po
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS)source='libc/machine/r5900/setjmp.S' object='libc/machine/r5900/libc_a-setjmp.obj' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -c -o libc/machine/r5900/libc_a-setjmp.obj `if test -f 'libc/machine/r5900/setjmp.S'; then $(CYGPATH_W) 'libc/machine/r5900/setjmp.S'; else $(CYGPATH_W) '$(srcdir)/libc/machine/r5900/setjmp.S'; fi`
++
+ libc/machine/riscv/libc_a-memmove-asm.o: libc/machine/riscv/memmove-asm.S
+ @am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libc_a_CPPFLAGS) $(CPPFLAGS) $(libc_a_CCASFLAGS) $(CCASFLAGS) -MT libc/machine/riscv/libc_a-memmove-asm.o -MD -MP -MF libc/machine/riscv/$(DEPDIR)/libc_a-memmove-asm.Tpo -c -o libc/machine/riscv/libc_a-memmove-asm.o `test -f 'libc/machine/riscv/memmove-asm.S' || echo '$(srcdir)/'`libc/machine/riscv/memmove-asm.S
+ @am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) libc/machine/riscv/$(DEPDIR)/libc_a-memmove-asm.Tpo libc/machine/riscv/$(DEPDIR)/libc_a-memmove-asm.Po
+@@ -50614,6 +50641,8 @@
+ 	-rm -f libc/machine/powerpc/$(am__dirstamp)
+ 	-rm -f libc/machine/pru/$(DEPDIR)/$(am__dirstamp)
+ 	-rm -f libc/machine/pru/$(am__dirstamp)
++	-rm -f libc/machine/r5900/$(DEPDIR)/$(am__dirstamp)
++	-rm -f libc/machine/r5900/$(am__dirstamp)
+ 	-rm -f libc/machine/riscv/$(DEPDIR)/$(am__dirstamp)
+ 	-rm -f libc/machine/riscv/$(am__dirstamp)
+ 	-rm -f libc/machine/rl78/$(DEPDIR)/$(am__dirstamp)
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/configure newlib-4.6.0.20260123-kos/newlib/configure
+--- newlib-4.6.0.20260123/newlib/configure	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/configure	2026-07-14 09:36:41
+@@ -673,6 +673,8 @@
+ HAVE_LIBC_MACHINE_RL78_TRUE
+ HAVE_LIBC_MACHINE_RISCV_FALSE
+ HAVE_LIBC_MACHINE_RISCV_TRUE
++HAVE_LIBC_MACHINE_R5900_FALSE
++HAVE_LIBC_MACHINE_R5900_TRUE
+ HAVE_LIBC_MACHINE_PRU_FALSE
+ HAVE_LIBC_MACHINE_PRU_TRUE
+ HAVE_LIBC_MACHINE_POWERPC_FALSE
+@@ -6065,6 +6067,13 @@
+   HAVE_LIBC_MACHINE_PRU_TRUE='#'
+   HAVE_LIBC_MACHINE_PRU_FALSE=
+ fi
++ if test "${machine_dir}" = r5900; then
++  HAVE_LIBC_MACHINE_R5900_TRUE=
++  HAVE_LIBC_MACHINE_R5900_FALSE='#'
++else
++  HAVE_LIBC_MACHINE_R5900_TRUE='#'
++  HAVE_LIBC_MACHINE_R5900_FALSE=
++fi
+  if test "${machine_dir}" = riscv; then
+   HAVE_LIBC_MACHINE_RISCV_TRUE=
+   HAVE_LIBC_MACHINE_RISCV_FALSE='#'
+@@ -7975,6 +7984,10 @@
+ fi
+ if test -z "${HAVE_LIBC_MACHINE_PRU_TRUE}" && test -z "${HAVE_LIBC_MACHINE_PRU_FALSE}"; then
+   as_fn_error $? "conditional \"HAVE_LIBC_MACHINE_PRU\" was never defined.
++Usually this means the macro was only invoked conditionally." "$LINENO" 5
++fi
++if test -z "${HAVE_LIBC_MACHINE_R5900_TRUE}" && test -z "${HAVE_LIBC_MACHINE_R5900_FALSE}"; then
++  as_fn_error $? "conditional \"HAVE_LIBC_MACHINE_R5900\" was never defined.
+ Usually this means the macro was only invoked conditionally." "$LINENO" 5
+ fi
+ if test -z "${HAVE_LIBC_MACHINE_RISCV_TRUE}" && test -z "${HAVE_LIBC_MACHINE_RISCV_FALSE}"; then
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/acinclude.m4 newlib-4.6.0.20260123-kos/newlib/libc/acinclude.m4
+--- newlib-4.6.0.20260123/newlib/libc/acinclude.m4	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/acinclude.m4	2026-07-14 09:36:41
+@@ -54,7 +54,7 @@
+   nds32 necv70 nios2 nvptx
+   or1k
+   powerpc pru
+-  riscv rl78 rx
++  r5900 riscv rl78 rx
+   sh sparc spu
+   tic4x tic6x tic80
+   v850 visium
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/include/machine/setjmp.h newlib-4.6.0.20260123-kos/newlib/libc/include/machine/setjmp.h
+--- newlib-4.6.0.20260123/newlib/libc/include/machine/setjmp.h	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/include/machine/setjmp.h	2026-07-14 09:36:41
+@@ -138,10 +138,17 @@
+ 
+ #ifdef __mips__
+ # if defined(__mips64)
+-#  define _JBTYPE long long
++#  if defined(_MIPS_ARCH_R5900)
++    typedef unsigned int jbtype128 __attribute__((mode(TI))) __attribute__((aligned(16)));
++#   define _JBTYPE jbtype128
++#  else
++#   define _JBTYPE long long
++#  endif
+ # endif
+ # ifdef __mips_soft_float
+ #  define _JBLEN 11
++# elif defined(_MIPS_ARCH_R5900)
++#  define _JBLEN 14
+ # else
+ #  define _JBLEN 23
+ # endif
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/machine/Makefile.inc newlib-4.6.0.20260123-kos/newlib/libc/machine/Makefile.inc
+--- newlib-4.6.0.20260123/newlib/libc/machine/Makefile.inc	2026-01-23 14:12:49
++++ newlib-4.6.0.20260123-kos/newlib/libc/machine/Makefile.inc	2026-07-14 09:36:41
+@@ -127,6 +127,9 @@
+ if HAVE_LIBC_MACHINE_PRU
+ include %D%/pru/Makefile.inc
+ endif
++if HAVE_LIBC_MACHINE_R5900
++include %D%/r5900/Makefile.inc
++endif
+ if HAVE_LIBC_MACHINE_RISCV
+ include %D%/riscv/Makefile.inc
+ endif
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/machine/r5900/Makefile.inc newlib-4.6.0.20260123-kos/newlib/libc/machine/r5900/Makefile.inc
+--- newlib-4.6.0.20260123/newlib/libc/machine/r5900/Makefile.inc	1969-12-31 16:00:00
++++ newlib-4.6.0.20260123-kos/newlib/libc/machine/r5900/Makefile.inc	2026-07-14 09:36:41
+@@ -0,0 +1 @@
++libc_a_SOURCES += %D%/setjmp.S
+diff -ruN -x .DS_Store newlib-4.6.0.20260123/newlib/libc/machine/r5900/setjmp.S newlib-4.6.0.20260123-kos/newlib/libc/machine/r5900/setjmp.S
+--- newlib-4.6.0.20260123/newlib/libc/machine/r5900/setjmp.S	1969-12-31 16:00:00
++++ newlib-4.6.0.20260123-kos/newlib/libc/machine/r5900/setjmp.S	2026-07-14 09:36:41
+@@ -0,0 +1,94 @@
++/* setjmp/longjmp for the PlayStation 2 Emotion Engine (MIPS R5900).
++ *
++ * Clean-room implementation written from the MIPS n32 calling convention and
++ * the public R5900 architecture; not derived from any third-party source.
++ *
++ * The R5900 has 128-bit general registers (the upper 64 bits hold MMI data),
++ * so callee-saved GPRs are preserved with the R5900 sq/lq (store/load
++ * quadword) instructions to keep the full width across a longjmp. Floating
++ * point is single precision only, so the callee-saved FP registers are saved
++ * as 32-bit words with swc1/lwc1.
++ *
++ * jmp_buf layout (matches machine/setjmp.h: _JBLEN = 14 128-bit slots):
++ *   0x00..0xa0  eleven 128-bit GPR slots: s0-s7, sp, fp, ra
++ *   0xb0..0xdc  twelve 32-bit FP words:   f20-f31
++ * Total 224 bytes.
++ */
++
++	.set	noreorder
++	.set	noat
++
++	.text
++	.globl	setjmp
++	.ent	setjmp
++	.type	setjmp, @function
++setjmp:
++	sq	$16, 0x00($4)		/* s0 */
++	sq	$17, 0x10($4)		/* s1 */
++	sq	$18, 0x20($4)		/* s2 */
++	sq	$19, 0x30($4)		/* s3 */
++	sq	$20, 0x40($4)		/* s4 */
++	sq	$21, 0x50($4)		/* s5 */
++	sq	$22, 0x60($4)		/* s6 */
++	sq	$23, 0x70($4)		/* s7 */
++	sq	$29, 0x80($4)		/* sp */
++	sq	$30, 0x90($4)		/* fp */
++	sq	$31, 0xa0($4)		/* ra */
++
++	swc1	$f20, 0xb0($4)
++	swc1	$f21, 0xb4($4)
++	swc1	$f22, 0xb8($4)
++	swc1	$f23, 0xbc($4)
++	swc1	$f24, 0xc0($4)
++	swc1	$f25, 0xc4($4)
++	swc1	$f26, 0xc8($4)
++	swc1	$f27, 0xcc($4)
++	swc1	$f28, 0xd0($4)
++	swc1	$f29, 0xd4($4)
++	swc1	$f30, 0xd8($4)
++	swc1	$f31, 0xdc($4)
++
++	jr	$31			/* setjmp returns 0 */
++	move	$2, $0
++	.end	setjmp
++	.size	setjmp, .-setjmp
++
++	.globl	longjmp
++	.ent	longjmp
++	.type	longjmp, @function
++longjmp:
++	lq	$16, 0x00($4)		/* s0 */
++	lq	$17, 0x10($4)		/* s1 */
++	lq	$18, 0x20($4)		/* s2 */
++	lq	$19, 0x30($4)		/* s3 */
++	lq	$20, 0x40($4)		/* s4 */
++	lq	$21, 0x50($4)		/* s5 */
++	lq	$22, 0x60($4)		/* s6 */
++	lq	$23, 0x70($4)		/* s7 */
++	lq	$29, 0x80($4)		/* sp */
++	lq	$30, 0x90($4)		/* fp */
++	lq	$31, 0xa0($4)		/* ra */
++
++	lwc1	$f20, 0xb0($4)
++	lwc1	$f21, 0xb4($4)
++	lwc1	$f22, 0xb8($4)
++	lwc1	$f23, 0xbc($4)
++	lwc1	$f24, 0xc0($4)
++	lwc1	$f25, 0xc4($4)
++	lwc1	$f26, 0xc8($4)
++	lwc1	$f27, 0xcc($4)
++	lwc1	$f28, 0xd0($4)
++	lwc1	$f29, 0xd4($4)
++	lwc1	$f30, 0xd8($4)
++	lwc1	$f31, 0xdc($4)
++
++	/* return value: the second argument, forced to 1 if it was 0 */
++	move	$2, $5
++	bne	$5, $0, 1f
++	nop
++	li	$2, 1
++1:
++	jr	$31
++	nop
++	.end	longjmp
++	.size	longjmp, .-longjmp

--- a/utils/kos-chain/profiles/dvp/stable.mk
+++ b/utils/kos-chain/profiles/dvp/stable.mk
@@ -1,0 +1,11 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=dvp-elf
+
+# DVP is binutils-only (assembler and linker for VU microcode)
+build_final_target=build-binutils
+
+binutils_extra_configure_args += --disable-nls --disable-build-warnings
+
+# Toolchain versions for PS2 DVP
+binutils_ver=2.46.1

--- a/utils/kos-chain/profiles/dvp/stable.mk
+++ b/utils/kos-chain/profiles/dvp/stable.mk
@@ -1,0 +1,23 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=dvp-elf
+
+# Binutils only: the VU has no C compiler or library.
+build_final_target=build-binutils
+
+# Toolchain versions for the PlayStation 2 DVP
+binutils_ver=2.47
+
+# The KOS Binutils patch is mandatory: stock config.sub rejects dvp-elf.
+#
+#   --enable-binutils    objdump decodes VU/VIF/DMA/GIF tags; also installs
+#                        ar, nm, strip.
+#   --disable-gprof(ng)  Profilers, irrelevant to an assembler.
+#   --disable-ld         No dvp-elf ld emulation exists, and none is wanted: the
+#                        EE linker places the objcopy'd blob.  Configure fails
+#                        without this flag.
+binutils_extra_configure_args = \
+  --enable-binutils \
+  --disable-gprof \
+  --disable-gprofng \
+  --disable-ld

--- a/utils/kos-chain/profiles/iop/17.0.0-dev.mk
+++ b/utils/kos-chain/profiles/iop/17.0.0-dev.mk
@@ -1,0 +1,44 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=mipsel-elf
+
+cpu_configure_args=--with-arch=mips2 --with-float=soft --disable-multilib
+
+# Build without newlib - the IOP gets its C library from KOS, not newlib.
+build_final_target=build-gcc-pass1
+
+# Toolchain versions for PS2 IOP
+binutils_ver=2.46.1
+gcc_ver=17.0.0
+
+# Override toolchain download type
+gcc_download_type=git
+gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+gcc_git_branch=master
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24
+
+gcc_pass1_configure_args = \
+  --disable-shared \
+  --disable-threads \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --disable-tls \
+  --disable-libgomp \
+  --disable-libquadmath \
+  --disable-libstdcxx \
+  --disable-fixincludes

--- a/utils/kos-chain/profiles/iop/17.0.0-dev.mk
+++ b/utils/kos-chain/profiles/iop/17.0.0-dev.mk
@@ -1,0 +1,51 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=mipsel-elf
+
+# Preserve the existing MIPS II choice while making the remaining clean-room
+# target controls explicit. MIPS I/r3000 can replace this only after IOP tests.
+cpu_configure_args = \
+  --with-arch=mips2 \
+  --with-abi=32 \
+  --with-float=soft \
+  --with-endian=little \
+  --disable-multilib
+
+# Build without newlib - the IOP gets its C library from KOS, not newlib.
+build_final_target=build-gcc-pass1
+
+# Toolchain versions for PS2 IOP
+binutils_ver=2.47
+gcc_ver=17.0.0
+
+# Override toolchain download type
+gcc_download_type=git
+gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+gcc_git_branch=master
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24
+
+gcc_pass1_configure_args = \
+  --disable-shared \
+  --disable-threads \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --disable-tls \
+  --disable-libgomp \
+  --disable-libquadmath \
+  --disable-libstdcxx \
+  --disable-fixincludes

--- a/utils/kos-chain/profiles/iop/stable.mk
+++ b/utils/kos-chain/profiles/iop/stable.mk
@@ -1,0 +1,39 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=mipsel-elf
+
+cpu_configure_args=--with-arch=mips2 --with-float=soft --disable-multilib
+
+# Build without newlib - the IOP gets its C library from KOS, not newlib.
+build_final_target=build-gcc-pass1
+
+# Toolchain versions for PS2 IOP
+binutils_ver=2.46.1
+gcc_ver=16.1.0
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24
+
+gcc_pass1_configure_args = \
+  --disable-shared \
+  --disable-threads \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --disable-tls \
+  --disable-libgomp \
+  --disable-libquadmath \
+  --disable-libstdcxx \
+  --disable-fixincludes

--- a/utils/kos-chain/profiles/iop/stable.mk
+++ b/utils/kos-chain/profiles/iop/stable.mk
@@ -1,0 +1,46 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=mipsel-elf
+
+# Preserve the existing MIPS II choice while making the remaining clean-room
+# target controls explicit. MIPS I/r3000 can replace this only after IOP tests.
+cpu_configure_args = \
+  --with-arch=mips2 \
+  --with-abi=32 \
+  --with-float=soft \
+  --with-endian=little \
+  --disable-multilib
+
+# Build without newlib - the IOP gets its C library from KOS, not newlib.
+build_final_target=build-gcc-pass1
+
+# Toolchain versions for PS2 IOP
+binutils_ver=2.47
+gcc_ver=16.2.0
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24
+
+gcc_pass1_configure_args = \
+  --disable-shared \
+  --disable-threads \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --disable-tls \
+  --disable-libgomp \
+  --disable-libquadmath \
+  --disable-libstdcxx \
+  --disable-fixincludes

--- a/utils/kos-chain/profiles/playstation2/17.0.0-dev.mk
+++ b/utils/kos-chain/profiles/playstation2/17.0.0-dev.mk
@@ -1,0 +1,48 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=mips64r5900el-ps2-elf
+
+cpu_configure_args=--with-float=hard
+
+# Toolchain versions for PS2 EE
+binutils_ver=2.46.1
+gcc_ver=17.0.0
+
+# Override toolchain download type
+gcc_download_type=git
+gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+gcc_git_branch=master
+newlib_ver=4.6.0.20260123
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24
+
+gcc_pass1_configure_args = \
+  --disable-libgcc \
+  --disable-shared \
+  --disable-threads \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --disable-tls \
+  --disable-libgomp \
+  --disable-libquadmath
+
+gcc_pass2_configure_args = \
+  --enable-cxx-flags=-G0 \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --enable-tls

--- a/utils/kos-chain/profiles/playstation2/17.0.0-dev.mk
+++ b/utils/kos-chain/profiles/playstation2/17.0.0-dev.mk
@@ -1,0 +1,55 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=mips64r5900el-ps2-elf
+
+# Keep the working EE ABI explicit. These are the upstream target controls used
+# by the clean-room builder, with n32/hard-float retained for KOS compatibility.
+cpu_configure_args = \
+  --with-arch=r5900 \
+  --with-abi=n32 \
+  --with-float=hard \
+  --with-endian=little \
+  --disable-multilib
+
+# Toolchain versions for PS2 EE
+binutils_ver=2.47
+gcc_ver=17.0.0
+
+# Override toolchain download type
+gcc_download_type=git
+gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+gcc_git_branch=master
+newlib_ver=4.6.0.20260123
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24
+
+gcc_pass1_configure_args = \
+  --disable-libgcc \
+  --disable-shared \
+  --disable-threads \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --disable-tls \
+  --disable-libgomp \
+  --disable-libquadmath
+
+gcc_pass2_configure_args = \
+  --enable-cxx-flags=-G0 \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --enable-tls

--- a/utils/kos-chain/profiles/playstation2/stable.mk
+++ b/utils/kos-chain/profiles/playstation2/stable.mk
@@ -1,0 +1,43 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=mips64r5900el-ps2-elf
+
+cpu_configure_args=--with-float=hard
+
+# Toolchain versions for PS2 EE
+binutils_ver=2.46.1
+gcc_ver=16.1.0
+newlib_ver=4.6.0.20260123
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24
+
+gcc_pass1_configure_args = \
+  --disable-libgcc \
+  --disable-shared \
+  --disable-threads \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --disable-tls \
+  --disable-libgomp \
+  --disable-libquadmath
+
+gcc_pass2_configure_args = \
+  --enable-cxx-flags=-G0 \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --enable-tls

--- a/utils/kos-chain/profiles/playstation2/stable.mk
+++ b/utils/kos-chain/profiles/playstation2/stable.mk
@@ -1,0 +1,50 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=mips64r5900el-ps2-elf
+
+# Keep the working EE ABI explicit. These are the upstream target controls used
+# by the clean-room builder, with n32/hard-float retained for KOS compatibility.
+cpu_configure_args = \
+  --with-arch=r5900 \
+  --with-abi=n32 \
+  --with-float=hard \
+  --with-endian=little \
+  --disable-multilib
+
+# Toolchain versions for PS2 EE
+binutils_ver=2.47
+gcc_ver=16.2.0
+newlib_ver=4.6.0.20260123
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24
+
+gcc_pass1_configure_args = \
+  --disable-libgcc \
+  --disable-shared \
+  --disable-threads \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --disable-tls \
+  --disable-libgomp \
+  --disable-libquadmath
+
+gcc_pass2_configure_args = \
+  --enable-cxx-flags=-G0 \
+  --disable-multilib \
+  --disable-libatomic \
+  --disable-nls \
+  --enable-tls

--- a/utils/kos-chain/scripts/build.mk
+++ b/utils/kos-chain/scripts/build.mk
@@ -1,6 +1,7 @@
 # KallistiOS Toolchain Builder (kos-chain)
 
-build: build-done
+# Profiles may stop the build early (dvp: binutils only; iop: no newlib).
+build: $(or $(build_final_target),build-done)
 build-gcc: build-gcc-pass2
 build-newlib: build-newlib-only fixup-newlib
 

--- a/utils/kos-chain/scripts/init.mk
+++ b/utils/kos-chain/scripts/init.mk
@@ -52,6 +52,19 @@ CXX_FOR_TARGET = $(target)-$(GXX)
 
 # Handle macOS
 ifdef MACOS
+  # GCC needs GNU sed and GNU m4; prefer Homebrew's over the BSD versions.
+  ifeq ($(shell command -v brew >/dev/null 2>&1 && echo yes),yes)
+    PATH := $(shell brew --prefix gnu-sed)/libexec/gnubin:$(PATH)
+    PATH := $(shell brew --prefix m4)/bin:$(PATH)
+  endif
+  # gawk 5.4.0 has a regex bug that breaks GCC's option parsing; probe for
+  # it and fall back to the system awk.
+  cparen := )
+  ifneq (,$(shell command -v gawk 2>/dev/null))
+    ifneq (a,$(shell gawk 'BEGIN{s="a$(cparen)b"; sub("\\$(cparen).*", "", s); print s}' 2>/dev/null))
+      export AWK := /usr/bin/awk
+    endif
+  endif
   ifdef MACOS_MOJAVE_AND_UP
     # Starting from macOS Mojave (10.14+)
     sdkroot = $(shell xcrun --sdk macosx --show-sdk-path)

--- a/utils/kos-chain/scripts/patch.mk
+++ b/utils/kos-chain/scripts/patch.mk
@@ -50,15 +50,20 @@ endef
 # This function is used to replace the config.guess & config.sub that come
 # bundled with the sources with updated versions from GNU. This fixes issues
 # when trying to compile older versions of the toolchain software on newer
-# hardware.
+# hardware. If a KOS patch modifies the file (e.g. config.sub gaining a new
+# target like dvp-elf), keep the patched copy: the GNU version would undo it.
 define update_configs
-	@echo "+++ Updating $(1) files in $(src_dir)"; \
-	files=$$(find $(src_dir) -name $(1)); \
-	echo "$${files}" | while I= read -r line; do \
-		echo "    $${line}"; \
-		cp $(1) $${line} > /dev/null; \
-	done; \
-	echo ""
+	@if grep -q '^+++ .*/$(1)' /dev/null $(diff_patches); then \
+		echo "+++ Keeping patched $(1) in $(src_dir)"; \
+	else \
+		echo "+++ Updating $(1) files in $(src_dir)"; \
+		files=$$(find $(src_dir) -name $(1)); \
+		echo "$${files}" | while I= read -r line; do \
+			echo "    $${line}"; \
+			cp $(1) $${line} > /dev/null; \
+		done; \
+		echo ""; \
+	fi
 endef
 
 define update_config_guess_sub


### PR DESCRIPTION
Add toolchains for the three PlayStation 2 processors:

- playstation2: mips64r5900el-ps2-elf for the Emotion Engine.
- iop: mipsel-elf for the I/O Processor.
- dvp: dvp-elf, a binutils-only assembler/linker for the VUs.