### PR TITLE
examples: Fix non-building examples, overall warnings reduction, and loadable cleanup.

### DIFF
--- a/examples/dreamcast/basic/exec/exec.c
+++ b/examples/dreamcast/basic/exec/exec.c
@@ -9,8 +9,7 @@
 
 int main(int argc, char **argv) {
     file_t f;
-    size_t s;
-    ssize_t rv;
+    ssize_t s, rv;
     void *subbin;
 
     /* Print a hello */
@@ -25,7 +24,7 @@ int main(int argc, char **argv) {
 
     /* Get the size of sub.bin */
     s = fs_total(f);
-    assert(s);
+    assert(s > 0);
 
     /* Allocate space for it */
     subbin = malloc(s);

--- a/examples/dreamcast/basic/mmu/nullptr/nullptr.c
+++ b/examples/dreamcast/basic/mmu/nullptr/nullptr.c
@@ -14,7 +14,8 @@
 
 KOS_INIT_FLAGS(INIT_DEFAULT | INIT_MALLOCSTATS);
 
-mmupage_t * catchnull(mmucontext_t *, int vp) {
+mmupage_t * catchnull(mmucontext_t *unused, int vp) {
+    (void)unused;
     printf("Caught us trying to use a bad pointer!\n");
     printf("The pointer page was %08x\n", vp << PAGESIZE_BITS);
     printf("The address of the attempt was %08lx\n",

--- a/examples/dreamcast/basic/posix_resource/resource.c
+++ b/examples/dreamcast/basic/posix_resource/resource.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
 
     printf("First testing out getpriority()\n");
 
-    for(int i = 0; i < __array_size(gp_samples); i++) {
+    for(size_t i = 0; i < __array_size(gp_samples); i++) {
         int rv = gp_samples[i].rv;
         int which = gp_samples[i].which;
         id_t who = gp_samples[i].who;
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
 
     printf("Next testing out setpriority()\n");
 
-    for(int i = 0; i < __array_size(sp_samples); i++) {
+    for(size_t i = 0; i < __array_size(sp_samples); i++) {
         int rv = sp_samples[i].rv;
         int which = sp_samples[i].which;
         id_t who = sp_samples[i].who;

--- a/examples/dreamcast/filesystem/browse/browse.c
+++ b/examples/dreamcast/filesystem/browse/browse.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <dirent.h>
+#include <langinfo.h>
 #include <libgen.h>
 #include <sys/stat.h>
 
@@ -351,7 +352,6 @@ static void draw_directory_selector(int index) {
 static void draw_directory_contents(directory_file_t *directory_contents, int num) {
     int x = 20 + BFONT_HEIGHT, y = BFONT_HEIGHT;
     int color = 1;
-    int count = 0;
     char str[80];
 
     bfont_set_foreground_color(0xFFFFFFFF);
@@ -364,7 +364,6 @@ static void draw_directory_contents(directory_file_t *directory_contents, int nu
         else {
             bfont_draw_str(vram_s + y*SCREEN_WIDTH+x, SCREEN_WIDTH, color, directory_contents[i].filename);
         }
-        count++;
         y += BFONT_HEIGHT;
 
         if(y >= (SCREEN_HEIGHT - BFONT_HEIGHT))
@@ -375,16 +374,18 @@ static void draw_directory_contents(directory_file_t *directory_contents, int nu
 static bool draw_stat(const char *path) {
     int x = 20 + BFONT_HEIGHT, y = 350;
     struct stat path_stat;
+    char timestring[64];
 
     /* If stat fails */
     if(stat(path, &path_stat) < 0)
         return false;
 
     /* We got a stat, so lets draw it */
+    strftime(timestring, 64, nl_langinfo(D_T_FMT), localtime(&path_stat.st_mtime));
     bfont_draw_str_fmt(vram_s + y*SCREEN_WIDTH+x, SCREEN_WIDTH, true,
     "Stat succeeded:\n\tFile size: %lu\n\tLast Modified: %s\n",
     S_ISDIR(path_stat.st_mode) ? 0 : path_stat.st_size,
-    asctime(gmtime(&path_stat.st_mtime)));
+    timestring);
 
     return true;
 }

--- a/examples/dreamcast/library/loadable-dependence/Makefile
+++ b/examples/dreamcast/library/loadable-dependence/Makefile
@@ -10,7 +10,7 @@ TARGET_LIB = lib$(TARGET_NAME).a
 OBJS = $(TARGET_NAME).o
 
 # For exporting kos_md5
-LIBS = -lkosutils -fno-lto
+LIBS = -lkosutils
 
 # library-test exported stub for link test
 DBG_LIBS = -llibrary-test

--- a/examples/dreamcast/library/loadable-dependent/Makefile
+++ b/examples/dreamcast/library/loadable-dependent/Makefile
@@ -13,6 +13,6 @@ DBG_LIBS = -llibrary-dependence -llibrary-test
 KOS_LIB_PATHS += -L../loadable-dependence -L../
 
 # Dependence include
-KOS_CFLAGS += -fno-lto -I../loadable-dependence
+KOS_CFLAGS += -I../loadable-dependence
 
 include $(KOS_BASE)/loadable/Makefile.prefab

--- a/examples/dreamcast/mruby/mrbtris/dckos.c
+++ b/examples/dreamcast/mruby/mrbtris/dckos.c
@@ -52,7 +52,8 @@ struct InputBuf {
 static mrb_value btn_mrb_buffer;
 
 // buf has to be BUFSIZE elements at least
-void *read_buttons(void*) {
+void *read_buttons(void *unused) {
+  (void)unused;
   while(1) {
     input_buf.index = (input_buf.index + 1) % BUFSIZE;
     //printf("index: %" PRIu32 "\n", buf_index);

--- a/examples/dreamcast/network/ntp/ntp.c
+++ b/examples/dreamcast/network/ntp/ntp.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <langinfo.h>
 
 #include <netdb.h>
 
@@ -54,6 +55,7 @@ int main(int argc, char **argv) {
     int sockfd;
     struct addrinfo *ai;
     time_t ntp_time, dc_time;
+    char timestring[64];
 
     /* Set the framebuffer as the output device for dbgio. */
     dbgio_dev_select("fb");
@@ -100,17 +102,20 @@ int main(int argc, char **argv) {
     /* Grab time from the structure, and subtract 70 years to convert
        from NTP's 1900 epoch to Unix time's 1970 epoch */
     ntp_time = (ntohl(packet.trns_time_s) - NTP_DELTA);
-    printf("The current NTP time is...\n %s\n", ctime(&ntp_time));
+    strftime(timestring, 64, nl_langinfo(D_T_FMT), localtime(&ntp_time));
+    printf("The current NTP time is...\n %s\n", timestring);
 
     /* Print the current system time */
     dc_time = rtc_unix_secs();
-    printf("Dreamcast system time is...\n %s\n", ctime(&dc_time));
+    strftime(timestring, 64, nl_langinfo(D_T_FMT), localtime(&dc_time));
+    printf("Dreamcast system time is...\n %s\n", timestring);
 
     /* Set the system time to the NTP time and read it back */
     printf("Setting Dreamcast clock's time to NTP time...\n\n");
     rtc_set_unix_secs(ntp_time);
     dc_time = rtc_unix_secs();
-    printf("Dreamcast system time is now...\n %s\n", ctime(&dc_time));
+    strftime(timestring, 64, nl_langinfo(D_T_FMT), localtime(&dc_time));
+    printf("Dreamcast system time is now...\n %s\n", timestring);
 
     /* Wait 10 seconds for the user to see what's on the screen before we clear
        it during the exit back to the loader */

--- a/examples/dreamcast/network/speedtest/handle_request.c
+++ b/examples/dreamcast/network/speedtest/handle_request.c
@@ -39,6 +39,7 @@ void *handle_request(void *p) {
     char *path_end;
     ssize_t total_bytes = 0;
     http_state_t *hr = (http_state_t *)p;
+    char response_buf[BUFSIZE];
 
     /* Read the max we expect the request line to be */
     total_bytes = recv(hr->socket, request_line, REQUEST_LINE_SIZE-1, MSG_NONE);
@@ -168,7 +169,6 @@ refresh_buffer:
     }
 
 done_parsing:
-    char response_buf[BUFSIZE];
     if(hr->method == METHOD_GET) {
         file_t file = FILEHND_INVALID;
         uint32_t offset;

--- a/examples/dreamcast/pvr/fb_tex/fb_tex.c
+++ b/examples/dreamcast/pvr/fb_tex/fb_tex.c
@@ -20,14 +20,18 @@ static bool done;
 
 static uint32_t fbuf_color = 0xffffffff;
 
-static void change_color(uint8_t, uint32_t btns) {
+static void change_color(uint8_t unused, uint32_t btns) {
+    (void)unused;
+
     if(btns & CONT_A)
         fbuf_color = 0xfff8f8f8;
     else
         fbuf_color = 0xffffffff;
 }
 
-static void do_exit(uint8_t, uint32_t) {
+static void do_exit(uint8_t unused1, uint32_t unused2) {
+    (void)unused1;
+    (void)unused2;
     done = 1;
 }
 

--- a/examples/dreamcast/pvr/modifier_volume_zclip/pvr_zclip.c
+++ b/examples/dreamcast/pvr/modifier_volume_zclip/pvr_zclip.c
@@ -348,6 +348,7 @@ int pvr_vertex_commit_zclip(pvr_vertex_t *src, int size)
             case 3: /* 0 and 1 inside, 2 outside */
                 inter_vert_commit(dest++, &src[-2], src, 0);
                 vert_commit(dest++, &src[-1], 0);
+                __fallthrough;
             case 2: /* 0 outside, 1 inside, 2 outside */
                 inter_vert_commit(dest++, &src[-1], src, eos);
                 break;
@@ -368,6 +369,7 @@ int pvr_vertex_commit_zclip(pvr_vertex_t *src, int size)
                 vert_commit(dest++, src, eos);
                 break;
             default:
+                break;
             }
         }
     }
@@ -446,6 +448,7 @@ int pvr_vertex_commit_zclip_intensity(pvr_vertex_t *src, int size)
             case 3: /* 0 and 1 inside, 2 outside */
                 inter_vert_commit_intensity(dest++, &src[-2], src, 0);
                 vert_commit(dest++, &src[-1], 0);
+                __fallthrough;
             case 2: /* 0 outside, 1 inside, 2 outside */
                 inter_vert_commit_intensity(dest++, &src[-1], src, eos);
                 break;
@@ -466,6 +469,7 @@ int pvr_vertex_commit_zclip_intensity(pvr_vertex_t *src, int size)
                 vert_commit(dest++, src, eos);
                 break;
             default:
+                break;
             }
         }
     }

--- a/examples/dreamcast/pvr/texture_render/texture_render.c
+++ b/examples/dreamcast/pvr/texture_render/texture_render.c
@@ -127,7 +127,7 @@ void draw_frame(void) {
     if(!to_texture)
         pvr_scene_begin();
     else
-        pvr_scene_begin_txr(d_texture, &tx_x, &tx_y);
+        pvr_scene_begin_rtt(d_texture, 640, 480, tx_x);
 
     /* Start opaque poly list */
     pvr_list_begin(PVR_LIST_OP_POLY);

--- a/examples/dreamcast/sdl/sound/Makefile
+++ b/examples/dreamcast/sdl/sound/Makefile
@@ -12,7 +12,7 @@ rm-elf:
 	-rm -f $(TARGET)
 
 $(TARGET): $(OBJS)
-	kos-cc -o $(TARGET) $(OBJS) -lSDL
+	kos-cc -o $(TARGET) $(OBJS) -lSDL -lGL
 
 run: $(TARGET)
 	$(KOS_LOADER) $(TARGET)

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -355,9 +355,6 @@ _off64_t fs_tell64(file_t hnd);
     This file retrieves the length of the file associated with the given file
     descriptor.
 
-    \note                   size_t is unsigned, so the error return value is not
-                            less than 0.
-
     \param  hnd             The file descriptor to retrieve the size from.
     
     \return                 The length of the file on success, -1 on failure.

--- a/loadable/Makefile.prefab
+++ b/loadable/Makefile.prefab
@@ -22,7 +22,7 @@ endif
 # First one checks for missing symbols (and fully links with an offset
 # of zero so we can do tracebacks later), second one makes the real file.
 $(TARGET): $(OBJS)
-	$(KOS_CC) $(KOS_CFLAGS) -Wl,-Ttext=0x00000000 -e _start -nostartfiles -nodefaultlibs -o dbg-$(TARGET) $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) $(DBG_LIBS) -lgcc -Wl,--end-group
+	$(KOS_CC) $(KOS_CFLAGS) -Wl,-Ttext=0x00000000 -e 0x00000000 -nostartfiles -nodefaultlibs -o dbg-$(TARGET) $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) $(DBG_LIBS) -lgcc -Wl,--end-group
 	$(KOS_CC) $(KOS_CFLAGS) -Wl,-d -Wl,-r -Wl,-S -Wl,-x -nostartfiles -nodefaultlibs -o $(TARGET) -Wl,-T $(KOS_BASE)/loadable/shlelf_dc.xr $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) -lgcc -Wl,--end-group
 	$(KOS_SIZE) $(TARGET)
 

--- a/loadable/Makefile.prefab
+++ b/loadable/Makefile.prefab
@@ -22,8 +22,8 @@ endif
 # First one checks for missing symbols (and fully links with an offset
 # of zero so we can do tracebacks later), second one makes the real file.
 $(TARGET): $(OBJS)
-	$(KOS_CC) $(KOS_CFLAGS) -Wl,-Ttext=0x00000000 -e 0x00000000 -nostartfiles -nodefaultlibs -o dbg-$(TARGET) $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) $(DBG_LIBS) -lgcc -Wl,--end-group
-	$(KOS_CC) $(KOS_CFLAGS) -Wl,-d -Wl,-r -Wl,-S -Wl,-x -nostartfiles -nodefaultlibs -o $(TARGET) -Wl,-T $(KOS_BASE)/loadable/shlelf_dc.xr $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) -lgcc -Wl,--end-group
+	$(KOS_CC) $(KOS_CFLAGS) -fno-lto -Wl,-Ttext=0x00000000 -e 0x00000000 -nostartfiles -nodefaultlibs -o dbg-$(TARGET) $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) $(DBG_LIBS) -lgcc -Wl,--end-group
+	$(KOS_CC) $(KOS_CFLAGS) -fno-lto -Wl,-d -Wl,-r -Wl,-S -Wl,-x -nostartfiles -nodefaultlibs -o $(TARGET) -Wl,-T $(KOS_BASE)/loadable/shlelf_dc.xr $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) -lgcc -Wl,--end-group
 	$(KOS_SIZE) $(TARGET)
 
 clean:

--- a/loadable/Makefile.prefab
+++ b/loadable/Makefile.prefab
@@ -22,8 +22,8 @@ endif
 # First one checks for missing symbols (and fully links with an offset
 # of zero so we can do tracebacks later), second one makes the real file.
 $(TARGET): $(OBJS)
-	$(KOS_CC) -g -ml $(KOS_SH4_PRECISION) -O2 -g -Wl,-Ttext=0x00000000 -e _start -nostartfiles -nodefaultlibs -o dbg-$(TARGET) $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) $(DBG_LIBS) -lgcc -Wl,--end-group
-	$(KOS_CC) -g -ml $(KOS_SH4_PRECISION) -O2 -Wl,-d -Wl,-r -Wl,-S -Wl,-x -nostartfiles -nodefaultlibs -o $(TARGET) -Wl,-T $(KOS_BASE)/loadable/shlelf_dc.xr $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) -lgcc -Wl,--end-group
+	$(KOS_CC) $(KOS_CFLAGS) -Wl,-Ttext=0x00000000 -e _start -nostartfiles -nodefaultlibs -o dbg-$(TARGET) $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) $(DBG_LIBS) -lgcc -Wl,--end-group
+	$(KOS_CC) $(KOS_CFLAGS) -Wl,-d -Wl,-r -Wl,-S -Wl,-x -nostartfiles -nodefaultlibs -o $(TARGET) -Wl,-T $(KOS_BASE)/loadable/shlelf_dc.xr $(OBJS) $(KOS_LIB_PATHS) -Wl,--start-group $(LIBS) -lgcc -Wl,--end-group
 	$(KOS_SIZE) $(TARGET)
 
 clean:


### PR DESCRIPTION
A collection of changes for the examples, with some going a few steps deeper:
- Broken GCC 9.5 examples. These didn't have anything necessary that was preventing them from being built in GCC 9.5 (and so were never marked with a min GCC version) but had either anonymous parameters or issues with labels that weren't supported back then and have been updated to work. When we drop support we can go ahead and clean up all the void casts at once.
- The SDL sound example was not building due to a new default dependence on libGL upstream.
- Use `pvr_scene_begin_rtt()` and `strftime()` rather than the deprecated `pvr_scene_begin_txr()` and `ctime()`.
- Clean up unnecessarily mismatched sign comparison warnings.
- Clean up the loadable example and prefab makefile
  - Provide explicit start address during test first run, preventing a warning about the symbol not being found.
  - Apply `-fno-lto` in the prefab rather than the example (which as added in #1127 to prevent build failure). It's expected this be the case for any use and not unique to the example.
  - Use standard kos cflags rather than an explicitly enumerated set of our defaults.
