### PR TITLE
Header cleanups

### DIFF
--- a/addons/include/kos/img.h
+++ b/addons/include/kos/img.h
@@ -77,7 +77,7 @@ typedef struct kos_img {
     of the value, which contains the platform-independent half of the format.
 
     \param  x           An image format (fmt field of a kos_img_t).
-    
+
     \return             The platform-independent half of the format.
 */
 #define KOS_IMG_FMT_I(x) ((x) & 0xffff)
@@ -88,7 +88,7 @@ typedef struct kos_img {
     of the value, which contains the platform-specific half of the format.
 
     \param  x           An image format (fmt field of a kos_img_t).
-    
+
     \return             The platform-specific half of the format.
 */
 #define KOS_IMG_FMT_D(x) (((x) >> 16) & 0xffff)
@@ -103,7 +103,7 @@ typedef struct kos_img {
     \param  i           The platform-independent half of the format.
     \param  d           The platform-specific half of the format. This should
                         not be pre-shifted.
-    
+
     \return             A complete image format value, suitable for placing in
                         the fmt variable of a kos_img_t.
 */

--- a/addons/include/kos/netcfg.h
+++ b/addons/include/kos/netcfg.h
@@ -111,7 +111,7 @@ typedef struct netcfg {
 
     \param  fn          The file to read the configuration from.
     \param  out         Buffer to store the parsed configuration.
-    
+
     \return             0 on success, <0 on failure.
 */
 int netcfg_load_from(const char *fn, netcfg_t *out);
@@ -126,7 +126,7 @@ int netcfg_load_from(const char *fn, netcfg_t *out);
                         the PlanetWeb browser at all.
 
     \param  out         Buffer to store the parsed configuration.
-    
+
     \return             0 on success, <0 on failure.
 */
 int netcfg_load_flash(netcfg_t *out);
@@ -136,12 +136,12 @@ int netcfg_load_flash(netcfg_t *out);
 
     This function loads the network configuration data, searching in multiple
     locations to attempt to find a file with a stored configuration. This
-    function will attempt to read the configuration from each VMU first (from 
+    function will attempt to read the configuration from each VMU first (from
     a file named net.cfg), then it will try the flashrom, followed by the
     current working directory, and lastly the root of the CD.
 
     \param  out         Buffer to store the parsed configuration.
-    
+
     \return             0 on success, <0 on failure.
 */
 int netcfg_load(netcfg_t *out);
@@ -155,7 +155,7 @@ int netcfg_load(netcfg_t *out);
 
     \param  fn          The file to save to.
     \param  cfg         The configuration to save.
-    
+
     \return             0 on success, <0 on failure.
 */
 int netcfg_save_to(const char *fn, const netcfg_t *cfg);
@@ -167,7 +167,7 @@ int netcfg_save_to(const char *fn, const netcfg_t *cfg);
     will not retry if the first VMU doesn't have enough space to hold the file.
 
     \param  cfg         The configuration to save.
-    
+
     \return             0 on success, <0 on failure.
 */
 int netcfg_save(const netcfg_t *cfg);

--- a/include/kos/barrier.h
+++ b/include/kos/barrier.h
@@ -33,7 +33,7 @@ __BEGIN_DECLS
 
     Barriers are a type of synchronization method which halt execution
     for group of threads until a certain number of them have reached
-    the barrier. 
+    the barrier.
 
     @{
 */

--- a/include/kos/elf.h
+++ b/include/kos/elf.h
@@ -247,7 +247,7 @@ switch (sh_type) {
 
 /** \brief   Symbol table entry
     \ingroup elf
-    
+
     This structure represents a single entry in a symbol table in an ELF file.
 
     \headerfile kos/elf.h

--- a/include/kos/fs.h
+++ b/include/kos/fs.h
@@ -254,7 +254,7 @@ extern struct fs_hnd *fd_table[FD_SETSIZE];
                             etc), as well as values from the \ref vfs_fopen_modes
                             "File Open Modes" list. Multiple values can be ORed
                             together.
-    
+
     \return                 The new file descriptor on success, FILEHND_INVALID on error.
 */
 file_t fs_open(const char *fn, int mode);
@@ -265,7 +265,7 @@ file_t fs_open(const char *fn, int mode);
     associated with the descriptor.
 
     \param  hnd             The file descriptor to close.
-    
+
     \return                 0 for success, -1 for error
 */
 int fs_close(file_t hnd);
@@ -279,7 +279,7 @@ int fs_close(file_t hnd);
     \param  buffer          The buffer to read into.
     \param  cnt             The size of the buffer (or the number of bytes
                             requested).
-    
+
     \return                 The number of bytes read, or -1 on error. Note that
                             this may not be the full number of bytes requested.
 */
@@ -293,7 +293,7 @@ ssize_t fs_read(file_t hnd, void *buffer, size_t cnt);
     \param  hnd             The file descriptor to write into.
     \param  buffer          The data to write into the file.
     \param  cnt             The size of the buffer, in bytes.
-    
+
     \return                 The number of bytes written, or -1 on failure. Note
                             that the number of bytes written may be less than
                             what was requested.
@@ -309,7 +309,7 @@ ssize_t fs_write(file_t hnd, const void *buffer, size_t cnt);
     \param  offset          The offset in bytes from the specified base.
     \param  whence          The base of the pointer move. This should be one of
                             the \ref vfs_seek_modes "Seek Modes" values.
-    
+
     \return                 The new position of the file pointer.
 */
 off_t fs_seek(file_t hnd, off_t offset, int whence);
@@ -323,7 +323,7 @@ off_t fs_seek(file_t hnd, off_t offset, int whence);
     \param  offset          The offset in bytes from the specified base.
     \param  whence          The base of the pointer move. This should be one of
                             the \ref vfs_seek_modes "Seek Modes" values.
-    
+
     \return                 The new position of the file pointer.
 */
 _off64_t fs_seek64(file_t hnd, _off64_t offset, int whence);
@@ -334,7 +334,7 @@ _off64_t fs_seek64(file_t hnd, _off64_t offset, int whence);
     opened file. This is an offset in bytes from the start of the file.
 
     \param  hnd             The file descriptor to retrieve the pointer from.
-    
+
     \return                 The offset within the file for the pointer.
 */
 off_t fs_tell(file_t hnd);
@@ -345,7 +345,7 @@ off_t fs_tell(file_t hnd);
     opened file. This is an offset in bytes from the start of the file.
 
     \param  hnd             The file descriptor to retrieve the pointer from.
-    
+
     \return                 The offset within the file for the pointer.
 */
 _off64_t fs_tell64(file_t hnd);
@@ -359,7 +359,7 @@ _off64_t fs_tell64(file_t hnd);
                             less than 0.
 
     \param  hnd             The file descriptor to retrieve the size from.
-    
+
     \return                 The length of the file on success, -1 on failure.
 */
 ssize_t fs_total(file_t hnd);
@@ -373,7 +373,7 @@ ssize_t fs_total(file_t hnd);
                             not less than 0.
 
     \param  hnd             The file descriptor to retrieve the size from.
-    
+
     \return                 The length of the file on success, -1 on failure.
 */
 int64_t fs_total64(file_t hnd);
@@ -385,7 +385,7 @@ int64_t fs_total64(file_t hnd);
     file descriptor.
 
     \param  hnd             The opened directory's file descriptor.
-    
+
     \return                 The next entry, or NULL on failure.
 */
 const dirent_t *fs_readdir(file_t hnd);
@@ -399,7 +399,7 @@ const dirent_t *fs_readdir(file_t hnd);
     \param  hnd             The file descriptor to use.
     \param  cmd             The command to run.
     \param  ...             Arguments for the command specified.
-    
+
     \return                 -1 on error.
 */
 int fs_ioctl(file_t hnd, int cmd, ...);
@@ -411,7 +411,7 @@ int fs_ioctl(file_t hnd, int cmd, ...);
 
     \param  fn1             The existing file to rename.
     \param  fn2             The new filename to rename to.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_rename(const char *fn1, const char *fn2);
@@ -423,7 +423,7 @@ int fs_rename(const char *fn1, const char *fn2);
     instead of this function.
 
     \param  fn              The path to remove.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_unlink(const char *fn);
@@ -435,7 +435,7 @@ int fs_unlink(const char *fn);
     the path that is changed to.
 
     \param  fn              The path to set as the current working directory.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_chdir(const char *fn);
@@ -454,7 +454,7 @@ int fs_chdir(const char *fn);
                             function will return NULL and set errno to EINVAL.
 
     \param  hnd             The descriptor to memory map.
-    
+
     \return                 The memory mapped buffer, or NULL on failure.
 */
 void *fs_mmap(file_t hnd);
@@ -471,7 +471,7 @@ void *fs_mmap(file_t hnd);
 
     \param  fd              The descriptor to complete I/O on.
     \param  rv              A buffer to store the size of the I/O in.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_complete(file_t fd, ssize_t *rv);
@@ -491,7 +491,7 @@ int fs_mkdir(const char *fn);
     removed if it is empty.
 
     \param  fn              The path of the directory to remove.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_rmdir(const char *fn);
@@ -503,7 +503,7 @@ int fs_rmdir(const char *fn);
     \param  fd              The file descriptor to use.
     \param  cmd             The command to run.
     \param  ...             Arguments for the command specified.
-    
+
     \return                 -1 on error (generally).
 */
 int fs_fcntl(file_t fd, int cmd, ...);
@@ -520,7 +520,7 @@ int fs_fcntl(file_t fd, int cmd, ...);
 
     \param  path1           An existing file to create a new link to.
     \param  path2           The pathname of the new link to be created.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_link(const char *path1, const char *path2);
@@ -539,7 +539,7 @@ int fs_link(const char *path1, const char *path2);
 
     \param  path1           The content of the link (i.e, what to point at).
     \param  path2           The pathname of the new link to be created.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_symlink(const char *path1, const char *path2);
@@ -558,7 +558,7 @@ int fs_symlink(const char *path1, const char *path2);
     \param  path            The symbolic link to read.
     \param  buf             The buffer to place the link's contents in.
     \param  bufsize         The number of bytes allocated to buf.
-    
+
     \return                 -1 on failure, the number of bytes placed into buf
                             on success. If the return value is equal to bufsize,
                             you may not have the whole link -- provide a larger
@@ -579,7 +579,7 @@ ssize_t fs_readlink(const char *path, char *buf, size_t bufsize);
                             If you don't want to resolve any symbolic links at
                             the end of the path, pass AT_SYMLINK_NOFOLLOW,
                             otherwise pass 0.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_stat(const char *path, struct stat *buf, int flag);
@@ -594,7 +594,7 @@ int fs_stat(const char *path, struct stat *buf, int flag);
                             ENOSYS and -1 will be returned.
 
     \param  hnd             The opened directory's file descriptor.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_rewinddir(file_t hnd);
@@ -610,7 +610,7 @@ int fs_rewinddir(file_t hnd);
 
     \param  hnd             The file descriptor to retrieve information about.
     \param  buf             The buffer to store stat information in.
-    
+
     \return                 0 on success, -1 on failure.
 */
 int fs_fstat(file_t hnd, struct stat *buf);
@@ -622,7 +622,7 @@ int fs_fstat(file_t hnd, struct stat *buf);
     standard POSIX function dup().
 
     \param  oldfd           The old file descriptor to duplicate.
-    
+
     \return                 The new file descriptor on success, FILEHND_INVALID on failure.
 */
 file_t fs_dup(file_t oldfd);
@@ -636,7 +636,7 @@ file_t fs_dup(file_t oldfd);
 
     \param  oldfd           The old file descriptor to duplicate.
     \param  newfd           The descriptor to copy into.
-    
+
     \return                 The new file descriptor on success, FILEHND_INVALID on failure.
 */
 file_t fs_dup2(file_t oldfd, file_t newfd);
@@ -651,7 +651,7 @@ file_t fs_dup2(file_t oldfd, file_t newfd);
 
     \param  vfs             The VFS handler structure to use for the file.
     \param  hnd             Internal handle data for the file.
-    
+
     \return                 The opened descriptor on success, FILEHND_INVALID on failure.
 */
 file_t fs_open_handle(vfs_handler_t *vfs, void *hnd);
@@ -663,7 +663,7 @@ file_t fs_open_handle(vfs_handler_t *vfs, void *hnd);
     code, as it is meant for use internally.
 
     \param  fd              The file descriptor to retrieve the handler for.
-    
+
     \return                 The VFS' handler structure.
 */
 vfs_handler_t *fs_get_handler(file_t fd);
@@ -675,7 +675,7 @@ vfs_handler_t *fs_get_handler(file_t fd);
     as it is meant for use internally.
 
     \param  fd              The file descriptor to retrieve the handler for.
-    
+
     \return                 The internal handle for the file descriptor.
 */
 void *fs_get_handle(file_t fd);
@@ -694,7 +694,7 @@ const char *fs_getwd(void);
 
     \param  src             The filename to copy from.
     \param  dst             The filename to copy to.
-    
+
     \return                 The number of bytes copied successfully.
 */
 ssize_t fs_copy(const char *src, const char *dst);
@@ -707,7 +707,7 @@ ssize_t fs_copy(const char *src, const char *dst);
 
     \param  src             The filename to open and read.
     \param  out_ptr         A pointer to the buffer on success, NULL otherwise.
-    
+
     \return                 The size of the file on success, -1 otherwise.
 */
 ssize_t fs_load(const char *src, void **out_ptr);
@@ -724,7 +724,7 @@ ssize_t fs_load(const char *src, void **out_ptr);
     \param  dst             The string to modify.
     \param  src             The path component to append.
     \param  len             The length allocated for dst.
-    
+
     \return                 The length of the new string (including the NUL
                             terminator) on success, -1 otherwise.
 
@@ -735,16 +735,16 @@ ssize_t fs_load(const char *src, void **out_ptr);
 */
 ssize_t fs_path_append(char *dst, const char *src, size_t len);
 
-/** \brief   Normalize the specified path. 
+/** \brief   Normalize the specified path.
     This function acts mostly like the function realpath() but it only simplifies
-    a path by resolving . and .. components and removing redundant slashes.  It 
+    a path by resolving . and .. components and removing redundant slashes.  It
     doesn't check if the path exists or resolve symbolic links.
     \param  path            The path to normalize.
-    \param  resolved        The buffer to store resolved normalized path. It has 
+    \param  resolved        The buffer to store resolved normalized path. It has
                             to be PATH_MAX bytes in size.
-    
-    \return                 A pointer to the normalized path on success, 
-                            or NULL on failure, in which case the path which 
+
+    \return                 A pointer to the normalized path on success,
+                            or NULL on failure, in which case the path which
                             caused trouble is left in resolved.
     \par    Error Conditions:
     \em     EINVAL - path or resolved is a NULL pointer \n

--- a/include/kos/fs_dev.h
+++ b/include/kos/fs_dev.h
@@ -9,8 +9,8 @@
     \brief   Container for /dev.
     \ingroup vfs_dev
 
-    This is a thin filesystem that allows the /dev folder 
-    and its contents to be read/listed as well new devices 
+    This is a thin filesystem that allows the /dev folder
+    and its contents to be read/listed as well new devices
     to be added under it.
 
     \author Donald Haase

--- a/include/kos/fs_null.h
+++ b/include/kos/fs_null.h
@@ -9,7 +9,7 @@
     \brief   /dev/null, a black hole.
     \ingroup vfs_dev
 
-    This is a IEEE Std 1003.1-2017 POSIX standard 
+    This is a IEEE Std 1003.1-2017 POSIX standard
     'empty data source and infinite data sink'
 
     \author Donald Haase

--- a/include/kos/fs_romdisk.h
+++ b/include/kos/fs_romdisk.h
@@ -22,24 +22,24 @@
     \warning
     An embedded romdisk image is linked to your executable and cannot be evicted from
     system RAM!
-    
+
     Mounting additional images that you load from some other sources (such as a modified BIOS)
     on whatever mountpoint you want, is also possible. Using fs_romdisk_mount() and passing a
     pointer to the location of a romdisk image will mount it.
 
-    \remark 
+    \remark
     Mounted images will reside in system RAM for as long as your program is running
     or until you unmount them with fs_romdisk_unmount(). The size of your generated
-    ROMFS image must be kept below 16MB, with 14MB being the maximum recommended size, 
+    ROMFS image must be kept below 16MB, with 14MB being the maximum recommended size,
     as your binary will also reside in RAM and you need to leave some memory available
     for it. Generating files larger than the available RAM will lead to system crashes.
-    
+
     A romdisk filesystem image can be created by adding "KOS_ROMDISK_DIR=" to your Makefile
     and pointing it to the directory contaning all the resources you wish to have embeded in
     filesystem image. A rule to create the image is provided in the rules provided in Makefile.rules,
-    the created object file must be linked with your binary file by adding romdisk.o to your 
+    the created object file must be linked with your binary file by adding romdisk.o to your
     list of objects.
-    
+
     \see INIT_FS_ROMDISK
     \see KOS_INIT_FLAGS()
 

--- a/include/kos/fs_socket.h
+++ b/include/kos/fs_socket.h
@@ -335,7 +335,7 @@ typedef struct fs_socket_proto {
     */
     int (*getsockname)(net_socket_t *s, struct sockaddr *name, socklen_t *name_len);
 
-        /** \brief  Get the name of the peer connected to a socket created with the 
+        /** \brief  Get the name of the peer connected to a socket created with the
                     protocol.
 
         This function should implement the ::getpeername() system call for the
@@ -379,7 +379,7 @@ typedef struct fs_socket_proto {
     short (*poll)(net_socket_t *s, short events);
 } fs_socket_proto_t;
 
-/** \brief   Initializer for the entry field in the fs_socket_proto_t struct. 
+/** \brief   Initializer for the entry field in the fs_socket_proto_t struct.
     \ingroup vfs_sockets
 */
 #define FS_SOCKET_PROTO_ENTRY { NULL, NULL }
@@ -461,7 +461,7 @@ int fs_socket_input(netif_t *src, int domain, int protocol, const void *hdr,
     This function is NOT safe to call inside an interrupt.
 
     \param  proto       The new protocol handler to register
-    
+
     \retval 0           On success (no error conditions are currently defined)
 */
 int fs_socket_proto_add(fs_socket_proto_t *proto);
@@ -470,7 +470,7 @@ int fs_socket_proto_add(fs_socket_proto_t *proto);
     \ingroup vfs_sockets
 
     This function does the exact opposite of fs_socket_proto_add, and removes
-    a protocol from use with fs_socket. 
+    a protocol from use with fs_socket.
 
     \note
     It is the programmer's responsibility to make sure that no sockets are
@@ -478,7 +478,7 @@ int fs_socket_proto_add(fs_socket_proto_t *proto);
     they will not work properly once the handler has been removed).
 
     \param  proto       The protocol handler to remove
-    
+
     \retval -1          On error (This function does not directly change errno)
     \retval 0           On success
 */

--- a/include/kos/genwait.h
+++ b/include/kos/genwait.h
@@ -95,9 +95,9 @@ void genwait_wake_one(const void *obj);
 void genwait_wake_all_err(const void *obj, int err);
 
 /** \brief  Wake up one thread sleeping on an object, with an error.
- 
+
     This function simply calls genwait_wake_cnt(obj, 1, err).
- 
+
     \param  obj             The object to wake threads that are sleeping on it
     \param  err             The value to set in the threads' errno values
     \see    genwait_wake_cnt()

--- a/include/kos/net.h
+++ b/include/kos/net.h
@@ -285,7 +285,7 @@ typedef struct ipv6_hdr_s {
 */
 int net_arp_init(void);
 
-/** \brief   Shutdown ARP. 
+/** \brief   Shutdown ARP.
     \ingroup networking_arp
  */
 void net_arp_shutdown(void);

--- a/include/kos/nmmgr.h
+++ b/include/kos/nmmgr.h
@@ -70,8 +70,8 @@ typedef struct nmmgr_handler {
 /** \brief   Alias handler interface.
     \ingroup system_namemgr
 
-    The smallest possible extension of name handler, it has its own name 
-    but holds a pointer to a full handler of the appropriate type. This 
+    The smallest possible extension of name handler, it has its own name
+    but holds a pointer to a full handler of the appropriate type. This
     prevents the need to duplicate large vfs structures.
 
 */
@@ -88,7 +88,7 @@ typedef struct alias_handler {
    mostly-compatible but newer/older revisions of the implementing code. */
 
 /* Flag bits */
-/** \brief  This structure must be freed when removed. 
+/** \brief  This structure must be freed when removed.
     \ingroup system_namemgr
 */
 #define NMMGR_FLAGS_NEEDSFREE   0x00000001
@@ -132,14 +132,14 @@ typedef struct alias_handler {
     This function will retrieve a name handler by its pathname.
 
     \param  name            The handler to look up
-    
+
     \return                 The handler, or NULL on failure.
 */
 nmmgr_handler_t * nmmgr_lookup(const char *name);
 
 /** \brief   Get the head element of the name list.
     \ingroup system_namemgr
-    
+
     \warning
     DO NOT MODIFY THE VALUE RETURNED BY THIS FUNCTION! In fact, don't ever call
     this function.
@@ -154,7 +154,7 @@ nmmgr_list_t * nmmgr_get_list(void);
     This function adds a new name handler to the list in the kernel.
 
     \param  hnd             The handler to add
-    
+
     \retval 0               On success
 */
 int nmmgr_handler_add(nmmgr_handler_t *hnd);
@@ -165,7 +165,7 @@ int nmmgr_handler_add(nmmgr_handler_t *hnd);
     This function removes a name handler from the list in the kernel.
 
     \param  hnd             The handler to remove
-    
+
     \retval 0               On success
     \retval -1              If the handler wasn't found
 */

--- a/include/kos/opts.h
+++ b/include/kos/opts.h
@@ -37,7 +37,7 @@ __BEGIN_DECLS
     \ingroup                    debugging
 
    Various debug options. Uncomment the `#define` line to enable the specific
-   option described. 
+   option described.
 
    @{
 */
@@ -110,7 +110,7 @@ __BEGIN_DECLS
    malloc, as well as everything in level 2. */
 /* #define KOS_DEBUG 3 */
 
-#ifndef KOS_DEBUG 
+#ifndef KOS_DEBUG
 #define KOS_DEBUG 0
 #endif
 

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -771,7 +771,7 @@ int thd_detach(kthread_t *thd);
 /** \brief       Iterate all threads and call the passed callback for each
     \relatesalso kthread_t
 
-    \param cb               The callback to call for each thread. 
+    \param cb               The callback to call for each thread.
                             If a nonzero value is returned, iteration
                             ceases immediately.
     \param data             User data to be passed to the callback
@@ -813,7 +813,7 @@ int thd_pslist_queue(int (*pf)(const char *fmt, ...)) __nonnull_all;
 /** \cond INTERNAL */
 
 /** \brief  Initialize the threading system.
-    
+
     This is normally done for you by default when KOS starts. This will also
     initialize all the various synchronization primitives.
     \retval -1              If threads are already initialized.
@@ -823,10 +823,10 @@ int thd_pslist_queue(int (*pf)(const char *fmt, ...)) __nonnull_all;
 int thd_init(void);
 
 /** \brief   Shutdown the threading system.
- 
+
     This is done for you by the normal shutdown procedure of KOS. This will
     also shutdown all the various synchronization primitives.
- 
+
     \sa thd_init
 */
 void thd_shutdown(void);

--- a/include/poll.h
+++ b/include/poll.h
@@ -33,7 +33,7 @@ __BEGIN_DECLS
     @{
 */
 
-/** \brief   Type representing a number of file descriptors. 
+/** \brief   Type representing a number of file descriptors.
     \ingroup threading_polling
  */
 typedef __uint32_t nfds_t;
@@ -86,11 +86,11 @@ struct pollfd {
     \param  timeout     Maximum amount of time to block, in milliseconds. Pass
                         0 to ensure the function does not block and -1 to block
                         for an "infinite" amount of time, until an event occurs.
-    
+
     \return             -1 on error (sets errno as appropriate), or the number
                         of file descriptors that matched the event flags before
                         the function returns.
-    
+
     \sa     poll_events
 */
 int poll(struct pollfd fds[], nfds_t nfds, int timeout);

--- a/include/sys/ioctl.h
+++ b/include/sys/ioctl.h
@@ -27,7 +27,7 @@ __BEGIN_DECLS
 #include <kos/fs.h>
 
 #ifndef IOCTL_FS_ROOTBUS_DMA_READY
-/** \brief This operation can determine that file system 
+/** \brief This operation can determine that file system
  * can read data directly into SPU and PVR RAM's thought the Root Bus
  * and are all the conditions for this met like file position
  * on sector boundary at first reading and DMA aligning for others,

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -16,6 +16,7 @@
 #ifndef __SYS_RESOURCE_H
 #define __SYS_RESOURCE_H
 
+#include <sys/cdefs.h>
 __BEGIN_DECLS
 
 #include <limits.h>

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -222,7 +222,7 @@ struct sockaddr_storage {
     \param  address_len A pointer to a socklen_t which specifies the amount of
                         space in address on input, and the amount used of the
                         space on output.
-    
+
     \return             On success, the non-negative file descriptor of the
                         new connection, otherwise -1 and errno will be set to
                         the appropriate error value.
@@ -237,7 +237,7 @@ int accept(int socket, struct sockaddr *address, socklen_t *address_len);
     \param  address     A pointer to a sockaddr structure where the name to be
                         assigned to the socket resides.
     \param  address_len The length of the address structure.
-    
+
     \retval 0           On success.
     \retval -1          On error, sets errno as appropriate.
 */
@@ -252,7 +252,7 @@ int bind(int socket, const struct sockaddr *address, socklen_t address_len);
     \param  address     A pointer to a sockaddr structure where the name of the
                         peer resides.
     \param  address_len The length of the address structure.
-    
+
     \retval 0           On success.
     \retval -1          On error, sets errno as appropriate.
 */
@@ -264,7 +264,7 @@ int connect(int socket, const struct sockaddr *address, socklen_t address_len);
 
     \param  socket      A connection-mode socket to listen on.
     \param  backlog     The number of queue entries.
-    
+
     \retval 0           On success.
     \retval -1          On error, sets errno as appropriate.
 */
@@ -278,7 +278,7 @@ int listen(int socket, int backlog);
     \param  buffer      A pointer to a buffer to store the message in.
     \param  length      The length of the buffer.
     \param  flags       The type of message reception. Set to 0 for now.
-    
+
     \return             On success, the length of the message in bytes. If no
                         messages are available, and the socket has been shut
                         down, 0. On error, -1, and sets errno as appropriate.
@@ -298,7 +298,7 @@ ssize_t recv(int socket, void *buffer, size_t length, int flags);
                         name in.
     \param  address_len A pointer to the length of the address structure on
                         input, the number of bytes used on output.
-    
+
     \return             On success, the length of the message in bytes. If no
                         messages are available, and the socket has been shut
                         down, 0. On error, -1, and sets errno as appropriate.
@@ -314,7 +314,7 @@ ssize_t recvfrom(int socket, void *buffer, size_t length, int flags,
     \param  message     A pointer to a buffer with the message to send.
     \param  length      The length of the message.
     \param  flags       The type of message transmission. Set to 0 for now.
-    
+
     \return             On success, the number of bytes sent. On error, -1,
                         and sets errno as appropriate.
 */
@@ -332,7 +332,7 @@ ssize_t send(int socket, const void *message, size_t length, int flags);
     \param  flags       The type of message transmission. Set to 0 for now.
     \param  dest_addr   A pointer to a sockaddr structure with the peer's name.
     \param  dest_len    The length of dest_addr, in bytes.
-    
+
     \return             On success, the number of bytes sent. On error, -1,
                         and sets errno as appropriate.
 */
@@ -345,10 +345,10 @@ ssize_t sendto(int socket, const void *message, size_t length, int flags,
 
     \param  socket      The socket to shutdown.
     \param  how         The type of shutdown.
-    
+
     \retval 0           On success.
     \retval -1          On error, sets errno as appropriate.
-    
+
     \see                SHUT_RD
     \see                SHUT_WR
     \see                SHUT_RDWR
@@ -364,7 +364,7 @@ int shutdown(int socket, int how);
     \param  type        The type of socket to be created (i.e, SOCK_DGRAM).
     \param  protocol    The protocol to use with the socket. May be 0 to allow
                         a default to be used.
-    
+
     \return             A non-negative file descriptor on success. -1 on error,
                         and sets errno as appropriate.
 */
@@ -381,7 +381,7 @@ int socket(int domain, int type, int protocol);
     \param  name_len        The amount of space pointed to by name, in bytes.
                             On return, this is set to the actual size of the
                             returned address information.
-    
+
     \retval -1              On error, sets errno as appropriate.
     \retval 0               On success.
 */
@@ -396,27 +396,27 @@ int getsockname(int socket, struct sockaddr *name, socklen_t *name_len);
     returned in the name_len parameter.
 
     \param  socket          A socket that is already connected to a peer.
-    \param  name            A pointer to a sockaddr structure where the peer 
+    \param  name            A pointer to a sockaddr structure where the peer
                             address will be stored.
-    \param  name_len        A pointer to a socklen_t variable that specifies the 
+    \param  name_len        A pointer to a socklen_t variable that specifies the
                             length of the address structure.
-                            On return, it will contain the actual size of the 
+                            On return, it will contain the actual size of the
                             address returned.
 
     \retval 0               On success.
     \retval -1              On error, sets errno as appropriate, such as:
-                            - EBADF: The socket argument is not a valid file 
+                            - EBADF: The socket argument is not a valid file
                                      descriptor.
-                            - EFAULT: The addr argument points to memory not in a 
+                            - EFAULT: The addr argument points to memory not in a
                                       valid part of the process address space.
-                            - ENOBUFS: Insufficient resources were available in the 
+                            - ENOBUFS: Insufficient resources were available in the
                                        system to perform the operation.
                             - ENOTCONN: The socket is not connected.
-                            - ENOTSOCK: The socket argument does not refer to a 
+                            - ENOTSOCK: The socket argument does not refer to a
                                         socket.
                             - EOPNOTSUPP: The socket does not support getpeername.
 */
-int getpeername(int socket, struct sockaddr *__RESTRICT name, 
+int getpeername(int socket, struct sockaddr *__RESTRICT name,
                 socklen_t *__RESTRICT name_len);
 
 /** \brief  Get socket options.
@@ -432,7 +432,7 @@ int getpeername(int socket, struct sockaddr *__RESTRICT name,
     \param  option_len      The length of option_value on call, and the real
                             option length (if less than the original value)
                             on return.
-    
+
     \return                 Zero on success. -1 on error, and sets errno as
                             appropriate.
 
@@ -455,7 +455,7 @@ int getsockopt(int socket, int level, int option_name, void *option_value,
     \param  option_name     The option to set.
     \param  option_value    The value to set for the option.
     \param  option_len      The length of option_value in bytes.
-    
+
     \return                 Zero on success. -1 on error, and sets errno as
                             appropriate.
 

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -244,10 +244,10 @@ void hardware_shutdown(void);
     \ingroup  arch
 
     These are the various region codes that can be returned by the
-    hardware_sys_mode() function. 
+    hardware_sys_mode() function.
 
     \note
-    A retail Dreamcast will always return 0 for the region code. 
+    A retail Dreamcast will always return 0 for the region code.
     You must read the region of a retail device from the flashrom.
 
     \see    fr_region

--- a/kernel/arch/dreamcast/include/dc/cdrom.h
+++ b/kernel/arch/dreamcast/include/dc/cdrom.h
@@ -30,7 +30,7 @@ __BEGIN_DECLS
     CD, it will automatically detect and react to disc changes for you.
 
     This file only facilitates reading raw sectors and doing other fairly low-
-    level things with CDs. If you're looking for higher-level stuff, like 
+    level things with CDs. If you're looking for higher-level stuff, like
     normal file reading, consult with the stuff for the fs and for fs_iso9660.
 
     If you're looking for *even lower* level things with CDs, see the gdrom
@@ -46,7 +46,7 @@ __BEGIN_DECLS
     \see    dc/g1ata.h
 */
 
-/** \defgroup gdrom     GD-ROM 
+/** \defgroup gdrom     GD-ROM
     \brief              Driver for the Dreamcast's GD-ROM drive
     \ingroup            vfs
 */
@@ -229,9 +229,9 @@ int cdrom_get_status(int *status, int *disc_type);
 /** \brief    Change the datatype of disc.
     \ingroup  gdrom
 
-    This function will take in all parameters to pass to the change_datatype 
-    syscall. This allows these parameters to be modified without a reinit. 
-    Each parameter allows -1 as a default, which is tied to the former static 
+    This function will take in all parameters to pass to the change_datatype
+    syscall. This allows these parameters to be modified without a reinit.
+    Each parameter allows -1 as a default, which is tied to the former static
     values provided by cdrom_reinit and cdrom_set_sector_size.
 
     \param sector_part      How much of each sector to return.
@@ -257,8 +257,8 @@ int cdrom_reinit(void);
 /** \brief    Re-initialize the GD-ROM drive with custom parameters.
     \ingroup  gdrom
 
-    At the end of each cdrom_reinit(), cdrom_change_datatype is called. 
-    This passes in the requested values to that function after 
+    At the end of each cdrom_reinit(), cdrom_change_datatype is called.
+    This passes in the requested values to that function after
     reinitialization, as opposed to defaults.
 
     \param sector_part      How much of each sector to return.
@@ -381,8 +381,8 @@ void cdrom_stream_set_callback(cdrom_stream_callback_t callback, void *param);
 /** \brief    Read subcode data from the most recently read sectors.
     \ingroup  gdrom
 
-    After reading sectors, this can pull subcode data regarding the sectors 
-    read. If reading all subcode data with CD_SUB_CURRENT_POSITION, this needs 
+    After reading sectors, this can pull subcode data regarding the sectors
+    read. If reading all subcode data with CD_SUB_CURRENT_POSITION, this needs
     to be performed one sector at a time.
 
     \param  buffer          Space to store the read subcode data.

--- a/kernel/arch/dreamcast/include/dc/g2bus.h
+++ b/kernel/arch/dreamcast/include/dc/g2bus.h
@@ -48,18 +48,18 @@ __BEGIN_DECLS
 */
 
 /** \name       List of G2 Bus channels
- 
-    AICA (SPU) is channel 0, BBA uses channel 1. CH2_DMA_G2CHN and 
+
+    AICA (SPU) is channel 0, BBA uses channel 1. CH2_DMA_G2CHN and
     CH3_DMA_G2CHN are not currently tied to any specific device.
 
-    \note 
-      A change in the implementation has rendered *_DMA_MODE and *_DMA_SHCHN 
+    \note
+      A change in the implementation has rendered *_DMA_MODE and *_DMA_SHCHN
       obsolete.
 
-      In the current implementation, *_DMA_MODE should always be set to zero 
+      In the current implementation, *_DMA_MODE should always be set to zero
       (representing CPU_TRIGGER). There is also no involvement of SH4-DMA with
       G2-DMA; therefore, the *_DMA_SHCHN values have been deprecated.
-      
+
     @{
 */
 #define G2_DMA_CHAN_SPU  0 /**< \brief AICA: G2 channel 0 */
@@ -89,8 +89,8 @@ typedef void (*g2_dma_callback_t)(void *data);
 
 /** \brief  Perform a DMA transfer between SH-4 RAM and G2 Bus
 
-    This function copies a block of data between SH-4 RAM and G2 Bus via DMA. 
-    You specify the direction of the copy (SH4TOG2BUS/G2BUSTOSH4). There are all 
+    This function copies a block of data between SH-4 RAM and G2 Bus via DMA.
+    You specify the direction of the copy (SH4TOG2BUS/G2BUSTOSH4). There are all
     kinds of constraints that must be fulfilled to actually do this, so
     make sure to read all the fine print with the parameter list.
 
@@ -139,13 +139,13 @@ void g2_dma_shutdown(void);
     A G2 context containing the states of IRQs and G2 DMA. This struct
     is used in with g2_lock() and g2_unlock().
 */
-typedef struct { 
+typedef struct {
     irq_mask_t irq_state;    /** \brief IRQ state when entering a G2 critical block */
 } g2_ctx_t;
 
 /* Internal constants to access suspend registers for G2 DMA. They are not meant for
    user-code use. */
-/** \cond */ 
+/** \cond */
 #define G2_DMA_SUSPEND_SPU     (*((volatile uint32_t *)0xa05f781C))
 #define G2_DMA_SUSPEND_BBA     (*((volatile uint32_t *)0xa05f783C))
 #define G2_DMA_SUSPEND_CH2     (*((volatile uint32_t *)0xa05f785C))
@@ -153,8 +153,8 @@ typedef struct {
 
 /** \brief  Disable IRQs and G2 DMA
 
-    This function makes the following g2_read_*()/g2_write_*() functions atomic 
-    by disabling IRQs and G2 DMA and storing their states. Pass the context 
+    This function makes the following g2_read_*()/g2_write_*() functions atomic
+    by disabling IRQs and G2 DMA and storing their states. Pass the context
     created by this function to g2_unlock() to re-enable IRQs and G2 DMA.
 
     \return                 The context containing the IRQ and G2 DMA states.

--- a/kernel/arch/dreamcast/include/dc/maple/controller.h
+++ b/kernel/arch/dreamcast/include/dc/maple/controller.h
@@ -57,7 +57,7 @@ __BEGIN_DECLS
                             \/      |        \/
                                Start button
 
-   You can grab a pointer to a connected controller by 
+   You can grab a pointer to a connected controller by
    using the following:
 
         maple_device_t *device = maple_enum_type(N, MAPLE_FUNC_CONTROLLER);
@@ -65,7 +65,7 @@ __BEGIN_DECLS
         if(device) printf("Controller found!\n");
         else printf("Controller not found!\n");
 
-    where N is the controller number. 0 would be the first 
+    where N is the controller number. 0 would be the first
     controller found, which may not necessarily be on port A.
 */
 
@@ -94,7 +94,7 @@ __BEGIN_DECLS
 /** \defgroup controller_input_masks Inputs
     \brief    Collection of all status masks for checking input
     \ingroup  controller_inputs
-  
+
     A set of bitmasks representing each input source on a controller, used to
     check its status.
 
@@ -120,7 +120,7 @@ __BEGIN_DECLS
 
 /** \brief   Controller buttons for standard reset action
     \ingroup controller_inputs
-    
+
     Convenience macro providing the standard button combination
     used as a reset mechanism by most retail games.
 */
@@ -200,16 +200,16 @@ typedef void (*cont_btn_callback_t)(uint8_t addr, uint32_t btns);
     This function sets a callback function to be called when the specified
     controller has the set of buttons given pressed.
 
-    \note 
+    \note
     The callback gets invoked for the given maple port; however, providing
-    an address of '0' will cause it to be invoked for any port with a 
-    device pressing the given buttons. Since you are passed back the address 
+    an address of '0' will cause it to be invoked for any port with a
+    device pressing the given buttons. Since you are passed back the address
     of this device, You are free to implement your own filtering logic within
     your callback. Any callback with addr==0 will be installed to the end of
     the list of callbacks and will run after callbacks with the same btns but
     a specified address.
 
-    \param  addr            The controller to listen on (or 0 for all ports). 
+    \param  addr            The controller to listen on (or 0 for all ports).
                             This value can be obtained by using maple_addr().
     \param  btns            The buttons bitmask to match.
     \param  cb              The callback to call when the buttons are pressed.
@@ -221,9 +221,9 @@ int cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb);
 /** \defgroup controller_query_caps Querying Capabilities
     \brief    API used to query for a controller's capabilities
     \ingroup  controller
-    
-    The following API is used to query for the support of individual 
-    or groups of capabilities by a particular device.  
+
+    The following API is used to query for the support of individual
+    or groups of capabilities by a particular device.
 */
 
 /** \defgroup controller_caps Capabilities
@@ -234,7 +234,7 @@ int cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb);
     if the controller supports the corresponding button/axis capability.
 
     \note
-    The ordering here is so that they match the order found in 
+    The ordering here is so that they match the order found in
     \ref controller_input_masks.
 
     @{
@@ -267,7 +267,7 @@ int cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb);
     \brief    Bit masks representing common groups of capabilities
     \ingroup  controller_query_caps
 
-    These are a sets of capabilities providing a 
+    These are a sets of capabilities providing a
     convenient way to test for high-level features,
     such as dual-analog sticks or extra buttons.
 
@@ -288,7 +288,7 @@ int cont_btn_callback(uint8_t addr, uint32_t btns, cont_btn_callback_t cb);
 
 /** \brief Analog stick (X, Y axes) controller capabilities */
 #define CONT_CAPABILITIES_ANALOG              (CONT_CAPABILITY_ANALOG_X | \
-                                               CONT_CAPABILITY_ANALOG_Y) 
+                                               CONT_CAPABILITY_ANALOG_Y)
 
 /** \brief Trigger (L, R lever) controller capabilities */
 #define CONT_CAPABILITIES_TRIGGERS            (CONT_CAPABILITY_LTRIG | \
@@ -322,24 +322,24 @@ struct maple_device;
 /** \brief   Check for controller capabilities
     \ingroup controller_query_caps
 
-    Checks whether or not a controller implements the capabilities 
-    associated with the given type. 
+    Checks whether or not a controller implements the capabilities
+    associated with the given type.
 
     \note
-    Controller capability reporting is an extremely generic mechanism, 
-    such that many peripherals may implement the same capability in 
-    completely different ways. For example, the Samba De Amigo maraca 
+    Controller capability reporting is an extremely generic mechanism,
+    such that many peripherals may implement the same capability in
+    completely different ways. For example, the Samba De Amigo maraca
     controller will advertise itself as a dual-analog device, with each
-    maraca being an analog stick. 
+    maraca being an analog stick.
 
     \param cont            Pointer to a Maple device structure which
-                           implements the CONTROLLER function.   
-    \param capabilities    Capability mask the controller is expected 
+                           implements the CONTROLLER function.
+    \param capabilities    Capability mask the controller is expected
                            to implement
 
     \retval 1              The controller supports the given capabilities.
     \retval 0              The controller doesn't support the given capabilities.
-    \retval -1             Invalid controller. 
+    \retval -1             Invalid controller.
 
     \sa cont_is_type
 */
@@ -353,22 +353,22 @@ int __pure cont_has_capabilities(const struct maple_device *cont, uint32_t capab
     The following API is for detecting between different types
     of standard controllers. These controllers are not identified
     by specific model but are instead identified solely by capabilities,
-    so that homebrew software can remain generic and future-proof to later 
+    so that homebrew software can remain generic and future-proof to later
     homebrew controllers or exotic, untested 3rd party peripherals.
 
     \warning
-    Usually you want to check if a controller <i>supports the 
-    capabilities</i> of another controller, not whether it is has 
-    the <i>exact</i> same capabilities of a controller. For example, 
-    a controller that happens to come along supporting a dual analog 
-    stick but is otherwise the same layout as a standard controller 
-    would not match the standard controller type; however, it would 
-    implement its capabilities. There exist 3rd party adapters for 
-    connecting dual-analog PS2 controllers to DC which operate 
+    Usually you want to check if a controller <i>supports the
+    capabilities</i> of another controller, not whether it is has
+    the <i>exact</i> same capabilities of a controller. For example,
+    a controller that happens to come along supporting a dual analog
+    stick but is otherwise the same layout as a standard controller
+    would not match the standard controller type; however, it would
+    implement its capabilities. There exist 3rd party adapters for
+    connecting dual-analog PS2 controllers to DC which operate
     like this today.
 
     \note
-    If you really want to hard-code the detection of a certain 
+    If you really want to hard-code the detection of a certain
     exact model or brand of controller, instead of basing your
     detection upon capabilities, check for its product_name
     or license within the maple_devinfo structure.
@@ -380,7 +380,7 @@ int __pure cont_has_capabilities(const struct maple_device *cont, uint32_t capab
     \brief    Preconfigured capabilities for standard controllers
     \ingroup  controller_query_types
 
-    Aggregate capability mask containing all capabilities 
+    Aggregate capability mask containing all capabilities
     which are implemented for a particular controller type.
     For example, the standard controller type is simply a
     combination of the following capabilities:
@@ -388,10 +388,10 @@ int __pure cont_has_capabilities(const struct maple_device *cont, uint32_t capab
         - Triggers
         - Dpad
         - Analog
-    
+
     \note
     Because these are technically just capability masks,
-    a type may also be passed to cont_has_capabilities() 
+    a type may also be passed to cont_has_capabilities()
     for detecting whether something has <i>at least</i>
     the capabilities of a type.
 
@@ -488,26 +488,26 @@ int __pure cont_has_capabilities(const struct maple_device *cont, uint32_t capab
 /** \brief   Check for controller type
     \ingroup controller_query_types
 
-    Checks whether or not a controller has the <i>exact</i> 
-    capabilities associated with the given type. 
+    Checks whether or not a controller has the <i>exact</i>
+    capabilities associated with the given type.
 
     \warning
-    Just because a controller has all of the same capabilities of a 
+    Just because a controller has all of the same capabilities of a
     type does not mean that it's that exact type. For example, the
     ASCII Pad and Arcade Stick both implement the same capabilities,
-    although they are not the same controllers. They would be 
-    indistinguishable here, by design, so that you are able to 
-    generalize to a collection of 1st or 3rd party controllers 
+    although they are not the same controllers. They would be
+    indistinguishable here, by design, so that you are able to
+    generalize to a collection of 1st or 3rd party controllers
     easily.
 
     \param cont            Pointer to a Maple device structure which
-                           implements the CONTROLLER function.   
+                           implements the CONTROLLER function.
     \param type            Type identifier or capability mask the
                            controller is expected to match
 
     \retval 1              The controller matches the given type.
     \retval 0              The controller doesn't match the given type.
-    \retval -1             Invalid controller. 
+    \retval -1             Invalid controller.
 
     \sa cont_has_capabilities
 */

--- a/kernel/arch/dreamcast/include/dc/modem/mconst.h
+++ b/kernel/arch/dreamcast/include/dc/modem/mconst.h
@@ -117,7 +117,7 @@
 */
 #define MODEM_MAKE_SPEED(p, s)      ((modem_speed_t)((((p) & 0xF) << 4) | ((s) & 0xF)))
 
-/** \brief   Modem speed/protocol value type. 
+/** \brief   Modem speed/protocol value type.
     \ingroup modem
  */
 typedef unsigned char modem_speed_t;

--- a/kernel/arch/dreamcast/include/dc/modem/modem.h
+++ b/kernel/arch/dreamcast/include/dc/modem/modem.h
@@ -60,7 +60,7 @@
 
 /** \defgroup   modem_v22       V.22 Modes
     \brief                      Modem V.22 Modes
-    \ingroup    modem 
+    \ingroup    modem
     @{
 */
 /** \brief  1200bps, V.22 */
@@ -171,7 +171,7 @@ typedef enum {
     MODEM_EVENT_TX_EMPTY
 } modemEvent_t;
 
-/** \brief   Type of a modem event handling function. 
+/** \brief   Type of a modem event handling function.
     \ingroup modem
  */
 typedef void (*MODEMEVENTHANDLERPROC)(modemEvent_t event);

--- a/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
+++ b/kernel/arch/dreamcast/include/dc/net/broadband_adapter.h
@@ -38,8 +38,8 @@ __BEGIN_DECLS
 /** \defgroup bba_regs_locs Locations
     \brief    Locations for various broadband adapter registers.
 
-    The default assumption is that these are all RW at any aligned size unless 
-    otherwise noted. ex (RW 32bit, RO 16/8) indicates read/write at 32bit and 
+    The default assumption is that these are all RW at any aligned size unless
+    otherwise noted. ex (RW 32bit, RO 16/8) indicates read/write at 32bit and
     read-only at 16 or 8bits.
 
     @{

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_dma.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_dma.h
@@ -176,12 +176,12 @@ int pvr_dma_yuv_conv(const void *src, size_t count, bool block,
 */
 bool pvr_dma_ready(void);
 
-/** \brief   Initialize TA/PVR DMA. 
+/** \brief   Initialize TA/PVR DMA.
     \ingroup pvr_dma
  */
 void pvr_dma_init(void);
 
-/** \brief   Shut down TA/PVR DMA. 
+/** \brief   Shut down TA/PVR DMA.
     \ingroup pvr_dma
  */
 void pvr_dma_shutdown(void);
@@ -195,8 +195,8 @@ void pvr_dma_shutdown(void);
     \warning
     This function cannot be used at the same time as a PVR DMA transfer.
 
-    The dest pointer must be at least 32-byte aligned and reside 
-    in video memory, the src pointer must be at least 8-byte aligned, 
+    The dest pointer must be at least 32-byte aligned and reside
+    in video memory, the src pointer must be at least 8-byte aligned,
     and n must be a multiple of 32.
 
     \param  dest            The address to copy to (32-byte aligned).
@@ -218,9 +218,9 @@ void *pvr_sq_load(void *dest, const void *src,
 
     \warning
     This function cannot be used at the same time as a PVR DMA transfer.
-    
-    The dest pointer must be at least 32-byte aligned and reside in video 
-    memory, n must be a multiple of 32 and only the low 16-bits are used 
+
+    The dest pointer must be at least 32-byte aligned and reside in video
+    memory, n must be a multiple of 32 and only the low 16-bits are used
     from c.
 
     \param  dest            The address to begin setting at (32-byte aligned).
@@ -242,7 +242,7 @@ void *pvr_sq_set16(void *dest, uint32_t c, size_t n, pvr_dma_type_t type);
     \warning
     This function cannot be used at the same time as a PVR DMA transfer.
 
-    The dest pointer must be at least 32-byte aligned and reside in video 
+    The dest pointer must be at least 32-byte aligned and reside in video
     memory, n must be a multiple of 32.
 
     \param  dest            The address to begin setting at (32-byte aligned).

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_fog.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_fog.h
@@ -32,7 +32,7 @@ __BEGIN_DECLS
 
     \todo Explain fog modes + equations
 
-    \note 
+    \note
     Thanks to Paul Boese for figuring this stuff out
 
     @{
@@ -52,11 +52,11 @@ void pvr_fog_table_color(float a, float r, float g, float b);
 /** Set the vertex fog color.
 
     This function sets the fog color for vertex fog. `0-1` range for all colors.
-    
+
     \todo
     This function is currently not implemented, as vertex fog is not supported
-    by KOS. 
-    
+    by KOS.
+
     \warning
     Calling this function will cause an assertion failure.
 

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_mem.h
@@ -40,7 +40,7 @@ __BEGIN_DECLS
     Unlike the old "TA" system, PVR pointers in the new system are actually SH-4
     compatible pointers and can be used directly in place of ta_txr_map().
 
-    Not that anyone probably even remembers the old TA system anymore... 
+    Not that anyone probably even remembers the old TA system anymore...
 */
 typedef void *pvr_ptr_t;
 
@@ -49,7 +49,7 @@ typedef void *pvr_ptr_t;
     \ingroup                 pvr_vram
 
     PVR memory management in KOS uses a modified dlmalloc; see the
-    source file pvr_mem_core.c for more info. 
+    source file pvr_mem_core.c for more info.
 */
 
 /** \brief   Allocate a chunk of memory from texture space.
@@ -61,7 +61,7 @@ typedef void *pvr_ptr_t;
     allocations will be aligned to a 32-byte boundary.
 
     \param  size            The amount of memory to allocate
-    
+
     \return                 A pointer to the memory on success, NULL on error
 */
 pvr_ptr_t pvr_mem_malloc(size_t size);

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_pal.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_pal.h
@@ -34,12 +34,12 @@ __BEGIN_DECLS
     \ingroup                pvr_global
 
     In addition to its 16-bit truecolor modes, the PVR also supports some
-    nice paletted modes. 
+    nice paletted modes.
 
     \remark
     These aren't useful for super high quality images most of the time,
     but they can be useful for doing some interesting special effects,
-    like the old cheap "worm hole". 
+    like the old cheap "worm hole".
 */
 
 /** \brief   Color palette formats of the PowerVR
@@ -86,6 +86,6 @@ static inline void pvr_set_pal_entry(uint32_t idx, uint32_t value) {
     PVR_SET(PVR_PALETTE_TABLE_BASE + 4 * idx, value);
 }
 
-__END_DECLS 
+__END_DECLS
 
 #endif  /* __DC_PVR_PVR_PALETTE_H */

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
@@ -46,7 +46,7 @@ __BEGIN_DECLS
 /** \brief   Retrieve a PVR register value
 
     \param   REG             The register to fetch. See \ref pvr_regs.
-    
+
     \return                  The value of that register (32-bits)
 */
 #define PVR_GET(REG) (* ( (volatile uint32_t *)( 0xa05f8000 + (REG) ) ) )
@@ -68,7 +68,7 @@ __BEGIN_DECLS
 
     \note
     2D specific registers have been excluded for now (like
-    vsync, hsync, v/h size, etc) 
+    vsync, hsync, v/h size, etc)
 
     @{
 */

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_txr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_txr.h
@@ -36,7 +36,7 @@ __BEGIN_DECLS
 /** \defgroup pvr_txr_mgmt      Texturing
     \brief                      API for managing PowerVR textures
     \ingroup                    pvr
-    
+
     Helper functions for handling texture tasks of various kinds.
 */
 
@@ -83,7 +83,7 @@ void pvr_txr_set_stride(size_t texture_width);
 size_t pvr_txr_get_stride(void);
 
 /** \brief   Load raw texture data from an SH-4 buffer into PVR RAM.
-    \ingroup pvr_txr_mgmt 
+    \ingroup pvr_txr_mgmt
 
     This essentially just acts as a memcpy() from main RAM to PVR RAM, using
     the Store Queues and 64-bit TA bus.

--- a/kernel/arch/dreamcast/include/dc/sound/aica_comm.h
+++ b/kernel/arch/dreamcast/include/dc/sound/aica_comm.h
@@ -36,7 +36,7 @@ typedef unsigned long uint32;
     AICA, and another for the other direction. If a command is written
     to the queue and it is longer than the amount of space between the
     head point and the queue size, the command will wrap around to
-    the beginning (i.e., queue commands _can_ be split up). 
+    the beginning (i.e., queue commands _can_ be split up).
 */
 typedef struct aica_queue {
     uint32      head;       /**< \brief Insertion point offset (in bytes) */
@@ -63,7 +63,7 @@ typedef struct aica_cmd {
 /** \brief AICA command payload data for AICA_CMD_CHAN
 
     This is the aica_cmd_t::cmd_data for AICA_CMD_CHAN.
-    Make this 16 dwords long for two aica bus queues. 
+    Make this 16 dwords long for two aica bus queues.
 */
 typedef struct aica_channel {
     uint32      cmd;        /**< \brief Command ID */
@@ -83,7 +83,7 @@ typedef struct aica_channel {
 /** \brief Macro for declaring an aica channel command
 
     Declare an aica_cmd_t big enough to hold an aica_channel_t
-    using temp name T, aica_cmd_t name CMDR, and aica_channel_t name CHANR 
+    using temp name T, aica_cmd_t name CMDR, and aica_channel_t name CHANR
 
     \param T        Buffer name
     \param CMDR     aica_cmd_t pointer name
@@ -117,7 +117,7 @@ typedef struct aica_channel {
 /** @} */
 
 /** \defgroup audio_aica_ch_cmd Channel Commands
-    \brief Command values (for aica_channel_t commands) 
+    \brief Command values (for aica_channel_t commands)
     @{
 */
 #define AICA_CH_CMD_MASK    0x0000000f /**< \brief Mask for commands */
@@ -128,7 +128,7 @@ typedef struct aica_channel {
 #define AICA_CH_CMD_UPDATE  0x00000003 /**< \brief Update command */
 /** @} */
 
-/** \defgroup audio_aica_ch_start Channel Start Values 
+/** \defgroup audio_aica_ch_start Channel Start Values
     \brief                        Start values for AICA channels
     @{
 */
@@ -138,7 +138,7 @@ typedef struct aica_channel {
 #define AICA_CH_START_SYNC  0x00200000 /**< \brief Set key-on for all selected channels */
 /** @} */
 
-/** \defgroup audio_aica_ch_update Channel Update Values 
+/** \defgroup audio_aica_ch_update Channel Update Values
     \brief                         Update values for AICA channels
     @{
 */
@@ -149,7 +149,7 @@ typedef struct aica_channel {
 #define AICA_CH_UPDATE_SET_PAN  0x00004000 /**< \brief panning */
 /** @} */
 
-/** \defgroup audio_aica_samples Sample Types 
+/** \defgroup audio_aica_samples Sample Types
     \brief                       Types of samples used by the AICA
     @{
 */

--- a/kernel/arch/dreamcast/include/dc/sq.h
+++ b/kernel/arch/dreamcast/include/dc/sq.h
@@ -27,12 +27,12 @@
     destinations must be 32-byte aligned.
 
     \note
-    Mastery over knowing when and how to utilize the store queues is 
+    Mastery over knowing when and how to utilize the store queues is
     important when trying to push the limits of the Dreamcast, specifically
     when transferring chunks of data between regions of memory. It is often
-    the case that the DMA is faster for transactions which are consistently 
-    large; however, the store queues tend to have better performance and 
-    have less configuration overhead when bursting smaller chunks of data. 
+    the case that the DMA is faster for transactions which are consistently
+    large; however, the store queues tend to have better performance and
+    have less configuration overhead when bursting smaller chunks of data.
 */
 
 #ifndef __DC_SQ_H
@@ -59,13 +59,13 @@ __BEGIN_DECLS
 /** \brief  Lock Store Queues
     \ingroup store_queues
 
-    Locks the store queues so that they cannot be used from another thread 
-    until unlocked. 
+    Locks the store queues so that they cannot be used from another thread
+    until unlocked.
 
     \warning
-    This function is called automatically by the store queue API provided by KOS; 
-    however, it must be called manually when driving the SQs directly from outside 
-    of this API. 
+    This function is called automatically by the store queue API provided by KOS;
+    however, it must be called manually when driving the SQs directly from outside
+    of this API.
 
     \param  dest            The destination address.
     \return                 The translated address that can be directly written to.
@@ -77,24 +77,24 @@ uint32_t *sq_lock(void *dest);
 /** \brief  Unlock Store Queues
     \ingroup store_queues
 
-    Unlocks the store queues so that they can be used from any thread. 
+    Unlocks the store queues so that they can be used from any thread.
 
-    \note 
+    \note
     sq_lock() should've already been called previously.
 
     \warning
-    sq_lock() and sq_unlock() are called automatically by the store queue API provided 
-    by KOS; however, they must be called manually when driving the SQs directly from 
+    sq_lock() and sq_unlock() are called automatically by the store queue API provided
+    by KOS; however, they must be called manually when driving the SQs directly from
     outside this API.
 
     \sa sq_lock()
 */
 void sq_unlock(void);
 
-/** \brief  Wait for both Store Queues to complete 
+/** \brief  Wait for both Store Queues to complete
     \ingroup store_queues
 
-    Wait for both store queues to complete by writing to SQ area. 
+    Wait for both store queues to complete by writing to SQ area.
 
     \sa sq_lock()
 */
@@ -125,7 +125,7 @@ static inline void sq_flush(void *src) {
 
     \warning
     The dest pointer must be at least 32-byte aligned, the src pointer
-    must be at least 4-byte aligned (8-byte aligned uses fast path), 
+    must be at least 4-byte aligned (8-byte aligned uses fast path),
     and n must be a multiple of 32!
 
     \param  dest            The address to copy to (32-byte aligned).
@@ -145,8 +145,8 @@ void *sq_cpy(void *dest, const void *src, size_t n);
     for the params.
 
     \warning
-    The dest pointer must be at least 32-byte aligned that already has been 
-    masked by SQ_MASK_DEST(), the src pointer must be at least 8-byte aligned, 
+    The dest pointer must be at least 32-byte aligned that already has been
+    masked by SQ_MASK_DEST(), the src pointer must be at least 8-byte aligned,
     and n must be the number of 32-byte blocks you want to copy.
 
     \param  dest            The store queue address to copy to (32-byte aligned).
@@ -165,7 +165,7 @@ void *sq_fast_cpy(void *dest, const void *src, size_t n);
     do its work.
 
     \warning
-    The dest pointer must be a 32-byte aligned with n being a multiple of 32, 
+    The dest pointer must be a 32-byte aligned with n being a multiple of 32,
     and only the low 8-bits are used from c.
 
     \param  dest            The address to begin setting at (32-byte aligned).
@@ -184,7 +184,7 @@ void *sq_set(void *dest, uint32_t c, size_t n);
     do its work.
 
     \warning
-    The dest pointer must be a 32-byte aligned with n being a multiple of 32, 
+    The dest pointer must be a 32-byte aligned with n being a multiple of 32,
     and only the low 16-bits are used from c.
 
     \param  dest            The address to begin setting at (32-byte aligned).

--- a/kernel/arch/dreamcast/include/dc/ubc.h
+++ b/kernel/arch/dreamcast/include/dc/ubc.h
@@ -5,10 +5,10 @@
 */
 
 /** \file    dc/ubc.h
-    \brief   User Break Controller Driver 
+    \brief   User Break Controller Driver
     \ingroup ubc
 
-    This file provides a driver and API around the SH4's UBC. 
+    This file provides a driver and API around the SH4's UBC.
 
     \sa arch/gdb.h
 
@@ -294,7 +294,7 @@ typedef struct ubc_breakpoint {
 
     \sa ubc_add_breakpoint()
 */
-typedef bool (*ubc_break_func_t)(const ubc_breakpoint_t   *bp, 
+typedef bool (*ubc_break_func_t)(const ubc_breakpoint_t   *bp,
                                  const irq_context_t *ctx,
                                  void                     *user_data);
 

--- a/kernel/arch/dreamcast/include/dc/vblank.h
+++ b/kernel/arch/dreamcast/include/dc/vblank.h
@@ -39,7 +39,7 @@ __BEGIN_DECLS
 
     \param  hnd             The handler to add.
     \param  data            A user pointer that will be passed to the callback.
-    
+
     \return                 The handle id on success, or <0 on failure.
 */
 int vblank_handler_add(asic_evt_handler hnd, void *data);
@@ -50,7 +50,7 @@ int vblank_handler_add(asic_evt_handler hnd, void *data);
 
     \param  handle          The handle id to remove (returned by
                             vblank_handler_add() when the handler was added).
-    
+
     \retval 0               On success.
     \retval -1              On failure.
 */

--- a/kernel/arch/dreamcast/include/dc/video.h
+++ b/kernel/arch/dreamcast/include/dc/video.h
@@ -116,7 +116,7 @@ typedef enum vid_display_mode_generic {
 /* ------------------------------------------------------------------------- */
 /* More specific modes (and actual indices into the mode table) */
 
-/** \brief   Specific Display Modes 
+/** \brief   Specific Display Modes
     \ingroup video_modes_display
 */
 typedef enum vid_display_mode {
@@ -186,13 +186,13 @@ typedef struct vid_mode {
     size_t  fb_size;      /**< \brief Size of each framebuffer */
 } vid_mode_t;
 
-/** \brief   The list of builtin video modes. Do not modify these! 
+/** \brief   The list of builtin video modes. Do not modify these!
     \ingroup video_modes
 */
 extern vid_mode_t vid_builtin[DM_MODE_COUNT];
 
-/** \brief   The current video mode. Do not modify directly! 
-    \ingroup video_modes 
+/** \brief   The current video mode. Do not modify directly!
+    \ingroup video_modes
 */
 extern vid_mode_t *vid_mode;
 
@@ -209,12 +209,12 @@ extern vid_mode_t *vid_mode;
     \ingroup           video_display
 */
 
-/** \brief   16-bit size pointer to the current drawing area. 
+/** \brief   16-bit size pointer to the current drawing area.
     \ingroup video_fb
 */
 extern uint16_t *vram_s;
 
-/** \brief   32-bit size pointer to the current drawing area. 
+/** \brief   32-bit size pointer to the current drawing area.
     \ingroup video_fb
 */
 extern uint32_t *vram_l;
@@ -292,7 +292,7 @@ void vid_flip(int32_t fb);
 /** \brief   Set the border color of the display.
     \ingroup video_display
 
-    This sets the color of the border area of the display. 
+    This sets the color of the border area of the display.
 
     \note
     On some screens, the border area may not be shown at all,
@@ -301,7 +301,7 @@ void vid_flip(int32_t fb);
     \param  r               The red value of the color (0-255).
     \param  g               The green value of the color (0-255).
     \param  b               The blue value of the color (0-255).
-    
+
     \return                 Old border color value (RGB888)
 */
 uint32_t vid_border_color(uint8_t r, uint8_t g, uint8_t b);
@@ -313,7 +313,7 @@ uint32_t vid_border_color(uint8_t r, uint8_t g, uint8_t b);
     this uses the store queues to actually clear the display entirely.
 
     \note
-    This operates via the vram convenience pointers. In multibuffered mode, 
+    This operates via the vram convenience pointers. In multibuffered mode,
     by default it will clear the framebuffer you are currently writing to
     rather than the one being displayed.
 
@@ -430,7 +430,7 @@ int vid_screen_shot(const char *destfn);
     \ingroup video_fb
 
     This function takes the current framebuffer (/vram_l) and converts it into
-    24bpp image data. The function allocates memory for the image data, which 
+    24bpp image data. The function allocates memory for the image data, which
     the caller is responsible for freeing.
 
     \param  buffer          A pointer to a uint8_t* that will be allocated and


### PR DESCRIPTION
A newer version of curl was yelling at me because they have `-Wtrailing-whitespace` set. While nitpicky, we do already try to avoid this so figured I'd go ahead and do a pass clearing them out.

Additionally add a missing include of `<sys/cdefs.h>`