### PR TITLE
examples: Add alternative header locations for kos-ports includes.

### DIFF
--- a/examples/dreamcast/cpp/modplug_test/example.cpp
+++ b/examples/dreamcast/cpp/modplug_test/example.cpp
@@ -1,6 +1,13 @@
 #include <kos.h>
+
+/* Allow both old kos-ports location and standard */
+#if __has_include("modplug/stdafx.h")
 #include <modplug/stdafx.h>
 #include <modplug/sndfile.h>
+#else
+#include <libmodplug/stdafx.h>
+#include <libmodplug/sndfile.h>
+#endif
 
 uint16_t sound_buffer[65536] = {0};
 CSoundFile *soundfile;

--- a/examples/dreamcast/lua/basic/lua.c
+++ b/examples/dreamcast/lua/basic/lua.c
@@ -17,10 +17,18 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Allow both old kos-ports location and standard */
+#if __has_include("lua.h")
 #include "lua.h"
 #include "llimits.h"
 #include "lauxlib.h"
 #include "lualib.h"
+#else
+#include <lua/lua.h>
+#include <lua/llimits.h>
+#include <lua/lauxlib.h>
+#include <lua/lualib.h>
+#endif
 
 /* KOS-specific stuff. */
 #include <kos/dbgio.h>

--- a/examples/dreamcast/micropython/example.c
+++ b/examples/dreamcast/micropython/example.c
@@ -12,6 +12,8 @@
 
 #include <kos.h>
 
+/* Allow both old kos-ports location and standard */
+#if __has_include("micropython/py/runtime.h")
 #include <micropython/py/parse.h>
 #include <micropython/py/lexer.h>
 #include <micropython/py/gc.h>
@@ -21,6 +23,17 @@
 #include <micropython/py/stackctrl.h>
 #include <micropython/py/qstr.h>
 #include <micropython/py/obj.h>
+#else
+#include <py/parse.h>
+#include <py/lexer.h>
+#include <py/gc.h>
+#include <py/nlr.h>
+#include <py/compile.h>
+#include <py/runtime.h>
+#include <py/stackctrl.h>
+#include <py/qstr.h>
+#include <py/obj.h>
+#endif
 
 static char mp_heap[8 * 1024];
 

--- a/examples/dreamcast/mruby/dreampresent/dckos.c
+++ b/examples/dreamcast/mruby/dreampresent/dckos.c
@@ -26,17 +26,30 @@
    SOFTWARE.
 */
 
+#include <stdio.h>
+#include <inttypes.h>
 #include <assert.h>
 #include <kos.h>
 #include <kos/img.h>
+
+/* Allow both old kos-ports location and standard */
+#if __has_include("mruby/mruby.h")
 #include <mruby/mruby.h>
+#include <mruby/mruby/array.h>
 #include <mruby/mruby/internal.h>
-#include <mruby/mruby/data.h>
 #include <mruby/mruby/string.h>
-#include <mruby/mruby/error.h>
-#include <stdio.h>
-#include <inttypes.h>
+#else
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/internal.h>
+#include <mruby/string.h>
+#endif
+
+#if __has_include("png/png.h")
 #include <png/png.h>
+#else
+#include <png.h>
+#endif
 
 // Convert ARGB1555 to RGB565 - drops the A bit and G is exapanded to 6 bits
 #define CONV1555TO565(colour) ( (((colour) & 0x7C00) << 1) | (((colour) & 0x03E0) << 1) | ((colour) & 0x001F) )

--- a/examples/dreamcast/mruby/dreampresent/main.c
+++ b/examples/dreamcast/mruby/dreampresent/main.c
@@ -27,8 +27,16 @@
 */
 
 #include <kos.h>
+
+/* Allow both old kos-ports location and standard */
+#if __has_include("mruby/mruby.h")
 #include <mruby/mruby.h>
 #include <mruby/mruby/irep.h>
+#else
+#include <mruby.h>
+#include <mruby/irep.h>
+#endif
+
 #include "dckos.h"
 
 /* These macros tell KOS how to initialize itself. All of this initialization

--- a/examples/dreamcast/mruby/mrbtris/dckos.c
+++ b/examples/dreamcast/mruby/mrbtris/dckos.c
@@ -27,12 +27,20 @@
 */
 
 #include <kos.h>
+
+/* Allow both old kos-ports location and standard */
+#if __has_include("mruby/mruby.h")
 #include <mruby/mruby.h>
-#include <mruby/mruby/internal.h>
-#include <mruby/mruby/data.h>
-#include <mruby/mruby/string.h>
-#include <mruby/mruby/error.h>
 #include <mruby/mruby/array.h>
+#include <mruby/mruby/internal.h>
+#include <mruby/mruby/string.h>
+#else
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/internal.h>
+#include <mruby/string.h>
+#endif
+
 #include <stdio.h>
 #include <inttypes.h>
 

--- a/examples/dreamcast/mruby/mrbtris/main.c
+++ b/examples/dreamcast/mruby/mrbtris/main.c
@@ -27,8 +27,16 @@
 */
 
 #include <kos.h>
+
+/* Allow both old kos-ports location and standard */
+#if __has_include("mruby/mruby.h")
 #include <mruby/mruby.h>
 #include <mruby/mruby/irep.h>
+#else
+#include <mruby.h>
+#include <mruby/irep.h>
+#endif
+
 #include "dckos.h"
 
 /* These macros tell KOS how to initialize itself. All of this initialization

--- a/examples/dreamcast/network/lftpd/lftpd.c
+++ b/examples/dreamcast/network/lftpd/lftpd.c
@@ -26,7 +26,12 @@
 #include <dc/sd.h>
 #include <fat/fs_fat.h>
 
+/* Allow both old kos-ports location and standard */
+#if __has_include("lftpd/lftpd.h")
 #include <lftpd/lftpd.h>
+#else
+#include <lftpd.h>
+#endif
 
 KOS_INIT_FLAGS(INIT_DEFAULT | INIT_NET);
 

--- a/examples/dreamcast/parallax/raster_melt/raster_melt.c
+++ b/examples/dreamcast/parallax/raster_melt/raster_melt.c
@@ -5,7 +5,14 @@
 */
 
 #include <kos.h>
+
+/* Allow both old kos-ports location and standard */
+#if __has_include("png/png.h")
 #include <png/png.h>
+#else
+#include <png.h>
+#endif
+
 #include <plx/texture.h>
 #include <plx/context.h>
 #include <plx/prim.h>

--- a/examples/dreamcast/png/example.c
+++ b/examples/dreamcast/png/example.c
@@ -8,8 +8,18 @@
  */
 
 #include <kos.h>
+
+/* Allow both old kos-ports location and standard */
+#if __has_include("png/png.h")
 #include <png/png.h>
+#else
+#include <png.h>
+#endif
+#if __has_include("zlib/zlib.h")
 #include <zlib/zlib.h>
+#else
+#include <zlib.h>
+#endif
 
 /* font data */
 extern char wfont[];

--- a/examples/dreamcast/pvr/modifier_volume_zclip/example.c
+++ b/examples/dreamcast/pvr/modifier_volume_zclip/example.c
@@ -9,8 +9,19 @@
  * by Twada
  */
 #include <kos.h>
+
+/* Allow both old kos-ports location and standard */
+#if __has_include("png/png.h")
 #include <png/png.h>
+#else
+#include <png.h>
+#endif
+#if __has_include("zlib/zlib.h")
 #include <zlib/zlib.h>
+#else
+#include <zlib.h>
+#endif
+
 #include "pvr_zclip.h"
 
 /* textures */

--- a/examples/dreamcast/sound/hello-opus/opustest.c
+++ b/examples/dreamcast/sound/hello-opus/opustest.c
@@ -17,7 +17,12 @@
 #include <kos/init.h>
 #include <kos/thread.h>
 
+/* Allow both old kos-ports location and standard */
+#if __has_include("opusplay/opusplay.h")
 #include <opusplay/opusplay.h>
+#else
+#include <opus/opusplay.h>
+#endif
 
 int main(int argc, char **argv) {
     maple_device_t *cont;


### PR DESCRIPTION
In the new kos-ports scheme (ref KallistiOS/kos-ports#165 ) headers will be available in their intended top-level locations rather than the traditional portname subfolder that had. This set of changes tests if the headers exist in their old location and if not uses the new (more correct) locations.

This should reduce issues related to the kos-ports update rather than just changing the headers by not requiring as many changes to be hard-cutovers.