### PR TITLE
GLdc fixes

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -52,7 +52,7 @@ __BEGIN_DECLS
 /** \endcond */
 
 #ifdef NDEBUG
-#   define assert(e) ((void)(0 ? (e) : 0))
+#   define assert(e) ((void)0)
 #   define assert_msg(e, m) assert(e)
 #else
 

--- a/kernel/libc/newlib/newlib_getentropy.c
+++ b/kernel/libc/newlib/newlib_getentropy.c
@@ -6,23 +6,18 @@
 */
 
 #include <errno.h>
+#include <reent.h>
 #include <stdint.h>
 #include <unistd.h>
 #include <sys/time.h>
 
 #include <arch/arch.h>
 
-/* We provide getentropy() if using Newlib < 4.4.0 */
-#if __NEWLIB__ < 4 || (__NEWLIB__ == 4 && __NEWLIB_MINOR__ < 4)
-int getentropy(void *ptr, size_t len) {
-#else
-
-#include <reent.h>
 /* getentropy() is provided by Newlib >= 4.4.0,
    but we must provide _getentropy_r() */
 int _getentropy_r(struct _reent *re, void *ptr, size_t len) {
     (void)re;
-#endif
+
     const int block_size = 128;
     struct timeval tv;
     uint8_t *src = ((uint8_t *)_arch_mem_top);
@@ -49,3 +44,10 @@ int _getentropy_r(struct _reent *re, void *ptr, size_t len) {
 
     return 0;
 }
+
+/* We provide getentropy() if using Newlib < 4.4.0 */
+#if __NEWLIB__ < 4 || (__NEWLIB__ == 4 && __NEWLIB_MINOR__ < 4)
+int getentropy(void *ptr, size_t len) {
+    return _getentropy_r(NULL, ptr, len);
+}
+#endif


### PR DESCRIPTION
Two small fixes for GLdc building (and generally):

- https://github.com/KallistiOS/KallistiOS/pull/1486/commits/6b270bbc19af78dda249a331db1980205fcb98e3 unfortunately broke expected standards behavior which was being leveraged by GLdc in only defining variables being asserted if `NDEBUG` isn't set. Unfortunately we'll have to keep getting those unused variable warnings.
- GLdc (and cmake-based kos-ports generally) had the possibility of being unable to find `_getentropy_r()` when built with lto. So instead of conditionally defining our function as one or a different, always provide `_getentropy_r()` and have `getentropy()` be a wrapper around it if we need to provide it.

```
-- Check for working C compiler: /home/quzar/dcdev/KallistiOS/utils/build_wrappers/kos-cc - broken
CMake Error at /usr/share/cmake-3.31/Modules/CMakeTestCCompiler.cmake:67 (message):
  The C compiler

    "/home/quzar/dcdev/KallistiOS/utils/build_wrappers/kos-cc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: '/home/quzar/dcdev/kos-ports/libvldmail/build-dreamcast/1.2.1/libvldmail-1.2.1/build/CMakeFiles/CMakeScratch/TryCompile-67mPmt'

    Run Build Command(s): /usr/bin/cmake -E env VERBOSE=1 /usr/bin/gmake -f Makefile cmTC_e6645/fast
    gmake[2]: Entering directory '/home/quzar/dcdev/kos-ports/libvldmail/build-dreamcast/1.2.1/libvldmail-1.2.1/build/CMakeFiles/CMakeScratch/TryCompile-67mPmt'
    /usr/bin/gmake  -f CMakeFiles/cmTC_e6645.dir/build.make CMakeFiles/cmTC_e6645.dir/build
    gmake[3]: Entering directory '/home/quzar/dcdev/kos-ports/libvldmail/build-dreamcast/1.2.1/libvldmail-1.2.1/build/CMakeFiles/CMakeScratch/TryCompile-67mPmt'
    Building C object CMakeFiles/cmTC_e6645.dir/testCCompiler.c.obj
    /home/quzar/dcdev/KallistiOS/utils/build_wrappers/kos-cc --sysroot=/home/quzar/dcdev/KallistiOS/sysroot/dreamcast   -g -DFRAME_POINTERS -fno-omit-frame-pointer -o CMakeFiles/cmTC_e6645.dir/testCCompiler.c.obj -c /home/quzar/dcdev/kos-ports/libvldmail/build-dreamcast/1.2.1/libvldmail-1.2.1/build/CMakeFiles/CMakeScratch/TryCompile-67mPmt/testCCompiler.c
    Linking C executable cmTC_e6645.elf
    /usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_e6645.dir/link.txt --verbose=1
    /opt/toolchains/dc-16.0.1-dev/sh-elf/lib/gcc/sh-elf/17.0.0/../../../../sh-elf/bin/ld: /opt/toolchains/dc-16.0.1-dev/sh-elf/lib/gcc/sh-elf/17.0.0/../../../../sh-elf/lib/libc.a(libc_a-sysgetentropy.o): in function `getentropy':
    /home/quzar/dcdev/KallistiOS/utils/kos-chain/build-newlib-sh-elf-4.6.0.20260123/sh-elf/newlib/../../../newlib-4.6.0.20260123/newlib/libc/syscalls/sysgetentropy.c:11:(.text.getentropy+0x10): undefined reference to `_getentropy_r'
    collect2: error: ld returned 1 exit status
    /home/quzar/dcdev/KallistiOS/utils/build_wrappers/kos-cc --sysroot=/home/quzar/dcdev/KallistiOS/sysroot/dreamcast -g -fno-lto CMakeFiles/cmTC_e6645.dir/testCCompiler.c.obj -o cmTC_e6645.elf
    gmake[3]: *** [CMakeFiles/cmTC_e6645.dir/build.make:102: cmTC_e6645.elf] Error 1
    gmake[3]: Leaving directory '/home/quzar/dcdev/kos-ports/libvldmail/build-dreamcast/1.2.1/libvldmail-1.2.1/build/CMakeFiles/CMakeScratch/TryCompile-67mPmt'
    gmake[2]: *** [Makefile:134: cmTC_e6645/fast] Error 2
    gmake[2]: Leaving directory '/home/quzar/dcdev/kos-ports/libvldmail/build-dreamcast/1.2.1/libvldmail-1.2.1/build/CMakeFiles/CMakeScratch/TryCompile-67mPmt'
    ```