### PR TITLE
kos-chain: Fix parallel libgcc build race in SH GCC patches

### DIFF
--- a/utils/kos-chain/patches/targets/gcc-13.2.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-13.2.0-kos.diff
@@ -145,3 +145,15 @@ diff --color -ruN gcc-13.2.0/libstdc++-v3/configure gcc-13.2.0-kos/libstdc++-v3/
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+diff -ruN gcc-13.2.0/libgcc/config/sh/t-sh gcc-13.2.0-kos/libgcc/config/sh/t-sh
+--- gcc-13.2.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-13.2.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-13.4.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-13.4.0-kos.diff
@@ -145,3 +145,15 @@ diff --color -ruN gcc-13.4.0/libstdc++-v3/configure gcc-13.4.0-kos/libstdc++-v3/
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+diff -ruN gcc-13.4.0/libgcc/config/sh/t-sh gcc-13.4.0-kos/libgcc/config/sh/t-sh
+--- gcc-13.4.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-13.4.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-13.4.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-13.4.1-kos.diff
@@ -145,3 +145,15 @@ diff --color -ruN gcc-13.4.1/libstdc++-v3/configure gcc-13.4.1-kos/libstdc++-v3/
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+diff -ruN gcc-13.4.1/libgcc/config/sh/t-sh gcc-13.4.1-kos/libgcc/config/sh/t-sh
+--- gcc-13.4.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-13.4.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-14.4.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-14.4.0-kos.diff
@@ -145,3 +145,15 @@ diff -ruN gcc-14.4.0/libstdc++-v3/configure gcc-14.4.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+diff -ruN gcc-14.4.0/libgcc/config/sh/t-sh gcc-14.4.0-kos/libgcc/config/sh/t-sh
+--- gcc-14.4.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-14.4.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-14.4.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-14.4.1-kos.diff
@@ -145,3 +145,15 @@ diff -ruN gcc-14.4.1/libstdc++-v3/configure gcc-14.4.1-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+diff -ruN gcc-14.4.1/libgcc/config/sh/t-sh gcc-14.4.1-kos/libgcc/config/sh/t-sh
+--- gcc-14.4.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-14.4.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-15.2.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-15.2.0-kos.diff
@@ -145,3 +145,15 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+diff -ruN gcc-15.2.0/libgcc/config/sh/t-sh gcc-15.2.0-kos/libgcc/config/sh/t-sh
+--- gcc-15.2.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-15.2.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-15.3.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-15.3.0-kos.diff
@@ -145,3 +145,15 @@ diff -ruN gcc-15.3.0/libstdc++-v3/configure gcc-15.3.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+diff -ruN gcc-15.3.0/libgcc/config/sh/t-sh gcc-15.3.0-kos/libgcc/config/sh/t-sh
+--- gcc-15.3.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-15.3.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-15.3.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-15.3.1-kos.diff
@@ -145,3 +145,15 @@ diff -ruN gcc-15.3.1/libstdc++-v3/configure gcc-15.3.1-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+diff -ruN gcc-15.3.1/libgcc/config/sh/t-sh gcc-15.3.1-kos/libgcc/config/sh/t-sh
+--- gcc-15.3.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-15.3.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-16.1.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.1.0-kos.diff
@@ -145,3 +145,15 @@ diff -ruN gcc-16.1.0/libstdc++-v3/configure gcc-16.1.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
+diff -ruN gcc-16.1.0/libgcc/config/sh/t-sh gcc-16.1.0-kos/libgcc/config/sh/t-sh
+--- gcc-16.1.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-16.1.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-16.1.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.1.1-kos.diff
@@ -146,3 +146,15 @@ diff -ruN gcc-16.1.1/libstdc++-v3/configure gcc-16.1.1-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
+diff -ruN gcc-16.1.1/libgcc/config/sh/t-sh gcc-16.1.1-kos/libgcc/config/sh/t-sh
+--- gcc-16.1.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-16.1.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o

--- a/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
@@ -146,3 +146,15 @@ diff -ruN gcc-17.0.0/libstdc++-v3/configure gcc-17.0.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
+diff -ruN gcc-17.0.0/libgcc/config/sh/t-sh gcc-17.0.0-kos/libgcc/config/sh/t-sh
+--- gcc-17.0.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-17.0.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+@@ -45,7 +45,7 @@
+ 	$(gcc_compile) -c -DL_sdivsi3_i4i $<
+ udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S
+ 	$(gcc_compile) -c -DL_udivsi3_i4i $<
+-unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS)
++unwind-dw2-Os-4-200.o: $(srcdir)/unwind-dw2.c $(LIBGCC_LINKS) libgcc_tm.h
+ 	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
+ 
+ OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o


### PR DESCRIPTION
On macOS it is easy to get compile errors when trying to build any GCC version when makejobs is not 1. 

The reason is the SH-specific unwind-dw2-Os-4-200.o rule in libgcc/config/sh/t-sh compiles unwind-dw2.c, which #includes the generated libgcc_tm.h, but does not list it as a prerequisite. Under a parallel build (-j) the object can be compiled before mkheader.sh has generated the header, failing with "libgcc_tm.h: No such file or directory".

Add libgcc_tm.h as a prerequisite to that rule, matching the dependency the generic libgcc Makefile.in already applies to every other object. Applied to the GCC 13.2.0 through 17.0.0 target patches.