### PR TITLE
c11: Use correct return values.

### DIFF
--- a/kernel/libc/c11/cnd_broadcast.c
+++ b/kernel/libc/c11/cnd_broadcast.c
@@ -7,5 +7,5 @@
 #include <threads.h>
 
 int cnd_broadcast(cnd_t *cond) {
-    return cond_broadcast(cond);
+    return cond_broadcast(cond) ? thrd_error : thrd_success;
 }

--- a/kernel/libc/c11/cnd_init.c
+++ b/kernel/libc/c11/cnd_init.c
@@ -7,5 +7,5 @@
 #include <threads.h>
 
 int cnd_init(cnd_t *cond) {
-    return cond_init(cond);
+    return cond_init(cond) ? thrd_error : thrd_success;
 }

--- a/kernel/libc/c11/cnd_signal.c
+++ b/kernel/libc/c11/cnd_signal.c
@@ -7,5 +7,5 @@
 #include <threads.h>
 
 int cnd_signal(cnd_t *cond) {
-    return cond_signal(cond);
+    return cond_signal(cond) ? thrd_error : thrd_success;
 }

--- a/kernel/libc/c11/cnd_wait.c
+++ b/kernel/libc/c11/cnd_wait.c
@@ -7,5 +7,5 @@
 #include <threads.h>
 
 int cnd_wait(cnd_t *cond, mtx_t *mtx) {
-    return cond_wait(cond, mtx);
+    return cond_wait(cond, mtx) ? thrd_error : thrd_success;
 }

--- a/kernel/libc/c11/mtx_init.c
+++ b/kernel/libc/c11/mtx_init.c
@@ -8,7 +8,7 @@
 
 int mtx_init(mtx_t *mtx, int type) {
     if(type & mtx_recursive)
-        return mutex_init(mtx, MUTEX_TYPE_RECURSIVE);
+        return mutex_init(mtx, MUTEX_TYPE_RECURSIVE) ? thrd_error : thrd_success;
 
-    return mutex_init(mtx, MUTEX_TYPE_NORMAL);
+    return mutex_init(mtx, MUTEX_TYPE_NORMAL) ? thrd_error : thrd_success;
 }

--- a/kernel/libc/c11/mtx_lock.c
+++ b/kernel/libc/c11/mtx_lock.c
@@ -10,8 +10,8 @@
 int mtx_lock(mtx_t *mtx) {
     if(mtx->type > MUTEX_TYPE_RECURSIVE) {
         errno = EINVAL;
-        return -1;
+        return thrd_error;
     }
 
-    return mutex_lock(mtx);
+    return mutex_lock(mtx) ? thrd_error : thrd_success;
 }

--- a/kernel/libc/c11/mtx_timedlock.c
+++ b/kernel/libc/c11/mtx_timedlock.c
@@ -12,7 +12,7 @@ int mtx_timedlock(mtx_t *restrict mtx, const struct timespec *restrict ts) {
 
     if(mtx->type > MUTEX_TYPE_RECURSIVE) {
         errno = EINVAL;
-        return -1;
+        return thrd_error;
     }
 
     /* Calculate the number of milliseconds to sleep for. No, you don't get

--- a/kernel/libc/c11/mtx_trylock.c
+++ b/kernel/libc/c11/mtx_trylock.c
@@ -10,7 +10,7 @@
 int mtx_trylock(mtx_t *mtx) {
     if(mtx->type > MUTEX_TYPE_RECURSIVE) {
         errno = EINVAL;
-        return -1;
+        return thrd_error;
     }
 
     if(mutex_trylock(mtx)) {

--- a/kernel/libc/c11/mtx_unlock.c
+++ b/kernel/libc/c11/mtx_unlock.c
@@ -7,5 +7,5 @@
 #include <threads.h>
 
 int mtx_unlock(mtx_t *mtx) {
-    return mutex_unlock(mtx);
+    return mutex_unlock(mtx) ? thrd_error : thrd_success;
 }

--- a/kernel/libc/c11/tss_create.c
+++ b/kernel/libc/c11/tss_create.c
@@ -7,5 +7,5 @@
 #include <threads.h>
 
 int tss_create(tss_t *key, tss_dtor_t dtor) {
-    return kthread_key_create(key, dtor);
+    return kthread_key_create(key, dtor) ? thrd_error : thrd_success;
 }

--- a/kernel/libc/c11/tss_set.c
+++ b/kernel/libc/c11/tss_set.c
@@ -7,5 +7,5 @@
 #include <threads.h>
 
 int tss_set(tss_t key, void *val) {
-    return kthread_setspecific(key, val);
+    return kthread_setspecific(key, val) ? thrd_error : thrd_success;
 }


### PR DESCRIPTION
We had been passing through the return values of various functions straight out through the c11 layer. However, this layer specifies blind defines `thrd_error` and `thrd_success` to be used. This used to be fine when we were defining our own `<threads.h>` but since #1270 where that was delegated to newlib we can't guarantee the values will match our returns.

Pulled out from #1493 to go in immediately as it corrects what would otherwise be a regression in v2.3.0 (Thanks @cypressru !)