### PR TITLE
Misc pvr updates

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_fog.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_fog.c
@@ -230,13 +230,8 @@ void pvr_fog_table_color(float a, float r, float g, float b) {
 }
 
 /* Set the fog vertex color */
-void pvr_fog_vertex_color(float a, float r, float g, float b) {
-    (void)a;
-    (void)r;
-    (void)g;
-    (void)b;
-    assert_msg(0, "not implemented");
-    /*  PVR_SET(PVR_FOG_VERTEX_COLOR, PVR_PACK_COLOR(a, r, g, b)); */
+void pvr_fog_vertex_color(float r, float g, float b) {
+    PVR_SET(PVR_FOG_VERTEX_COLOR, PVR_PACK_COLOR(0, r, g, b));
 }
 
 /* Set the fog far depth */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -182,7 +182,7 @@ int pvr_init(const pvr_init_params_t *params) {
     PVR_SET(PVR_TEXTURE_CLIP, 0x00000000);      /* texture clip distance */
     PVR_SET(PVR_SPANSORT_CFG, 0x00000101);      /* M */
     PVR_SET(PVR_FOG_TABLE_COLOR, 0x007f7f7f);   /* Fog table color */
-    PVR_SET(PVR_FOG_VERTEX_COLOR, 0x007f7f7f);  /* Fog vertex color */
+    pvr_fog_vertex_color(0.5f, 0.5f, 0.5f);     /* Fog vertex color */
     PVR_SET(PVR_COLOR_CLAMP_MIN, 0x00000000);   /* color clamp min */
     PVR_SET(PVR_COLOR_CLAMP_MAX, 0xffffffff);   /* color clamp max */
     PVR_SET(PVR_UNK_0080, 0x00000007);      /* M */

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -26,30 +26,7 @@
    and translucent lists, and 0's for everything else; 512k of vertex
    buffer. This is equivalent to the old ta_init_defaults() for now. */
 int pvr_init_defaults(void) {
-    const pvr_init_params_t params = {
-        /* Enable opaque and translucent polygons with size 16 */
-        { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0 },
-
-        /* Vertex buffer size 512K */
-        512 * 1024,
-
-        /* No DMA */
-        0,
-
-        /* No FSAA */
-        0,
-
-        /* Translucent Autosort enabled. */
-        0,
-
-        /* Extra OPBs */
-        3,
-
-        /* Vertex buffer double-buffering enabled */
-        0
-    };
-
-    return pvr_init(&params);
+    return pvr_init(&pvr_default_params);
 }
 
 /* Initialize the PVR chip to ready status, enabling the specified lists

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -73,7 +73,7 @@ int pvr_init(const pvr_init_params_t *params) {
     assert(vid_mode->width != 0 && vid_mode->height != 0);
 
     /* Check for compatibility with 3D stuff */
-    if((vid_mode->width % 32) != 0) {
+    if(!__is_aligned(vid_mode->width, 32)) {
         dbglog(DBG_WARNING, "pvr: mode %dx%d isn't usable for 3D (width not multiples of 32)\n",
                vid_mode->width, vid_mode->height);
         return -1;
@@ -89,10 +89,10 @@ int pvr_init(const pvr_init_params_t *params) {
     /* Start off with a nice empty structure */
     memset((void *)&pvr_state, 0, sizeof(pvr_state));
 
-    // Enable DMA if the user wants that.
+    /* Enable DMA if the user wants that. */
     pvr_state.dma_mode = params->dma_enabled;
 
-    // Copy over FSAA setting.
+    /* Copy over FSAA setting. */
     pvr_state.fsaa = params->fsaa_enabled;
 
     pvr_state.vbuf_doublebuf = !params->vbuf_doublebuf_disabled;
@@ -100,22 +100,16 @@ int pvr_init(const pvr_init_params_t *params) {
     /* Everything's clear, do the initial buffer pointer setup */
     pvr_allocate_buffers(params);
 
-    // Initialize tile matrices
+    /* Initialize tile matrices */
     pvr_init_tile_matrices(!!params->autosort_disabled);
-
-    // Setup all pipeline targets. Yes, this is redundant. :) I just
-    // like to have it explicit.
-    pvr_state.ram_target = 0;
-    pvr_state.ta_target = 0;
-    pvr_state.view_target = 0;
 
     pvr_state.list_reg_open = PVR_LIST_NONE;
 
-    // Sync all the hardware registers with our pipeline state.
+    /* Sync all the hardware registers with our pipeline state. */
     pvr_sync_view();
     pvr_sync_reg_buffer();
 
-    // Clear out our stats
+    /* Clear out our stats */
     pvr_state.vbl_count = 0;
     pvr_state.frame_last_time = 0;
     pvr_state.buf_start_time = 0;
@@ -143,7 +137,7 @@ int pvr_init(const pvr_init_params_t *params) {
 
     /* Hook the PVR interrupt events on G2 */
     pvr_state.vbl_handle = vblank_handler_add(pvr_vblank_handler, NULL);
-    
+
     asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEDONE, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_OPAQUEDONE, ASIC_IRQ_DEFAULT);
     asic_evt_set_handler(ASIC_EVT_PVR_OPAQUEMODDONE, pvr_int_handler, NULL);
@@ -157,8 +151,8 @@ int pvr_init(const pvr_init_params_t *params) {
     asic_evt_set_handler(ASIC_EVT_PVR_RENDERDONE_TSP, pvr_int_handler, NULL);
     asic_evt_enable(ASIC_EVT_PVR_RENDERDONE_TSP, ASIC_IRQ_DEFAULT);
 
+    /* Hook up interrupt handlers for error events */
     if(__is_defined(PVR_RENDER_DBG)) {
-        /* Hook up interrupt handlers for error events */
         asic_evt_set_handler(ASIC_EVT_PVR_ISP_OUTOFMEM, pvr_int_handler, NULL);
         asic_evt_enable(ASIC_EVT_PVR_ISP_OUTOFMEM, ASIC_IRQ_DEFAULT);
         asic_evt_set_handler(ASIC_EVT_PVR_STRIP_HALT, pvr_int_handler, NULL);
@@ -174,23 +168,23 @@ int pvr_init(const pvr_init_params_t *params) {
     /* 3d-specific parameters; these are all about rendering and
        nothing to do with setting up the video; some stuff in here
        is still unknown. */
-    PVR_SET(PVR_UNK_00A8, 0x15d1c951);      /* M (Unknown magic value) */
-    PVR_SET(PVR_UNK_00A0, 0x00000020);      /* M */
+    PVR_SET(PVR_UNK_00A8, 0x15d1c951);          /* M (Unknown magic value) */
+    PVR_SET(PVR_UNK_00A0, 0x00000020);          /* M */
     /* PVR_FB_CFG_2 is configured in vid_set_mode() */
-    PVR_SET(PVR_UNK_0110, 0x00093f39);      /* M */
-    PVR_SET(PVR_UNK_0098, 0x00800408);      /* M */
+    PVR_SET(PVR_UNK_0110, 0x00093f39);          /* M */
+    PVR_SET(PVR_UNK_0098, 0x00800408);          /* M */
     PVR_SET(PVR_TEXTURE_CLIP, 0x00000000);      /* texture clip distance */
     PVR_SET(PVR_SPANSORT_CFG, 0x00000101);      /* M */
-    PVR_SET(PVR_FOG_TABLE_COLOR, 0x007f7f7f);   /* Fog table color */
+    pvr_fog_table_color(0.0f, 0.5f, 0.5f, 0.5f);/* Fog table color */
     pvr_fog_vertex_color(0.5f, 0.5f, 0.5f);     /* Fog vertex color */
-    PVR_SET(PVR_COLOR_CLAMP_MIN, 0x00000000);   /* color clamp min */
-    PVR_SET(PVR_COLOR_CLAMP_MAX, 0xffffffff);   /* color clamp max */
-    PVR_SET(PVR_UNK_0080, 0x00000007);      /* M */
+    PVR_SET(PVR_COLOR_CLAMP_MIN, PVR_PACK_COLOR(0, 0, 0, 0));   /* color clamp min */
+    PVR_SET(PVR_COLOR_CLAMP_MAX, PVR_PACK_COLOR(1, 1, 1, 1));   /* color clamp max */
+    PVR_SET(PVR_UNK_0080, 0x00000007);          /* M */
     PVR_SET(PVR_CHEAP_SHADOW, 0x00000001);      /* cheap shadow */
-    PVR_SET(PVR_UNK_007C, 0x0027df77);      /* M */
+    PVR_SET(PVR_UNK_007C, 0x0027df77);          /* M */
     PVR_SET(PVR_TEXTURE_MODULO, 0x00000000);    /* stride width */
     PVR_SET(PVR_FOG_DENSITY, 0x0000ff07);       /* fog density */
-    PVR_SET(PVR_UNK_0118, 0x00008040);      /* M */
+    PVR_SET(PVR_UNK_0118, 0x00008040);          /* M */
 
     /* Initialize PVR DMA */
     sem_init((semaphore_t *)&pvr_state.dma_lock, 1);
@@ -202,11 +196,6 @@ int pvr_init(const pvr_init_params_t *params) {
     /* Validate our memory pool */
     pvr_mem_initialize((pvr_ptr_t)(PVR_RAM_INT_BASE + pvr_state.texture_base), PVR_RAM_SIZE - pvr_state.texture_base);
     pvr_mem_reset();
-    /* This doesn't work right now... */
-    /*#ifndef NDEBUG
-        dbglog(DBG_KDEBUG, "pvr: free memory is %08lx bytes\n",
-            pvr_mem_available());
-    #endif*//* !NDEBUG */
 
     return 0;
 }

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_texture.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_texture.c
@@ -211,7 +211,7 @@ void pvr_txr_load_kimg(const kos_img_t *img, pvr_ptr_t dst, uint32_t flags) {
             if(flags & PVR_TXRLOAD_DMA) {
                 sem_wait((semaphore_t *)&pvr_state.dma_lock);
                 pvr_txr_load_dma(img->data, dst, img->byte_count,
-                                 (flags & PVR_TXRLOAD_NONBLOCK) ? 1 : 0, NULL, 0);
+                                 !(flags & PVR_TXRLOAD_NONBLOCK), NULL, 0);
                 sem_signal((semaphore_t *)&pvr_state.dma_lock);
             }
             else if(flags & PVR_TXRLOAD_SQ) {

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -659,6 +659,7 @@ Striplength set to 2 */
     You essentially fill one of these in, and pass it to pvr_init().
 
     \headerfile dc/pvr.h
+    \sa pvr_default_params
 */
 typedef struct {
     /** \brief  Bin sizes.
@@ -714,6 +715,19 @@ typedef struct {
 
 } pvr_init_params_t;
 
+/** \brief   PVR initialization structure defaults
+    \ingroup pvr_init
+
+    These are the default values for pvr_init_params_t used by pvr_init_defaults().
+
+    \sa pvr_init_defaults()
+*/
+static const pvr_init_params_t pvr_default_params = {
+    .opb_sizes = { PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_16, PVR_BINSIZE_0, PVR_BINSIZE_0 },
+    .vertex_buf_size = 512 * 1024,
+    .opb_overflow_count = 3
+};
+
 /** \brief   Initialize the PVR chip to ready status.
     \ingroup pvr_init
 
@@ -732,13 +746,14 @@ int pvr_init(const pvr_init_params_t *params);
 /** \brief   Simple PVR initialization.
     \ingroup pvr_init
 
-    This simpler function initializes the PVR using 16/16 for the opaque
-    and translucent lists' bin sizes, and 0's for everything else. It sets 512KB
-    of vertex buffer. This is equivalent to the old ta_init_defaults() for now.
+    This simpler function initializes the PVR using the default parameters defined in
+    pvr_default_params.
 
     \retval 0               On success
     \retval -1              If the PVR has already been initialized or the video
                             mode active is not suitable for 3D
+
+    \sa pvr_default_params
 */
 int pvr_init_defaults(void);
 

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_fog.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_fog.h
@@ -53,19 +53,11 @@ void pvr_fog_table_color(float a, float r, float g, float b);
 
     This function sets the fog color for vertex fog. `0-1` range for all colors.
 
-    \todo
-    This function is currently not implemented, as vertex fog is not supported
-    by KOS.
-
-    \warning
-    Calling this function will cause an assertion failure.
-
-    \param  a               Alpha value of the fog
     \param  r               Red value of the fog
     \param  g               Green value of the fog
     \param  b               Blue value of the fog
 */
-void pvr_fog_vertex_color(float a, float r, float g, float b);
+void pvr_fog_vertex_color(float r, float g, float b);
 
 /** Set the fog far depth.
 

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
@@ -137,6 +137,8 @@ __BEGIN_DECLS
 #define PVR_UNK_0114            0x0114  /**< \brief ?? -- write 0x200000 for now */
 #define PVR_UNK_0118            0x0118  /**< \brief ?? -- write 0x8040 for now */
 
+#define PVR_PT_ALPHA_REF        0x011c  /**< \brief Only pixels with alpha >= this value are drawn for Punch Through polygons */
+
 #define PVR_TA_OPB_START        0x0124  /**< \brief Object Pointer Buffer start for TA usage */
 #define PVR_TA_VERTBUF_START    0x0128  /**< \brief Vertex buffer start for TA usage */
 #define PVR_TA_OPB_END          0x012c  /**< \brief OPB end for TA usage */


### PR DESCRIPTION
A collection of small updates based on reports from users in the simulant discord:
- Enable vertex fog color setting. This has been part of the API forever but always set to assert. Repeated reports from users to one another are 'just remove the assert and it works fine'. So doing that and cleaning it up as the alpha value isn't used. This changes the API, but considering the original function would do nothing but assert that seems reasonable.
- Correct `pvr_txr_load_kimg` dma blocking. It was inverted, as reported by @DC-SWAT .
- Add `PVR_PT_ALPHA_REF` . As reported by @jnmartin84 
- Make `pvr_init_defaults()` params public. Since this was private and not well documented, users would have to look into `pvr_init_shutdown.c` in order to see what the defaults were. By moving it to `pvr.h` now they're documented publicly as well as being available to do something like: `memcpy(&my_params, &pvr_default_params, sizeof(my_params)); myparams.fsaa_enabled = 1; pvr_init(&my_params);` where only a single setting is changed and the rest are ensured to be default.
- Minor cleanups in pvr_init_shutdown. Dropped some commented out debug code, some pointless init, de-magic'd some values, and cleaned up some comments.