### PR TITLE
[v2.2.x backport] kos-chain: Force C++14 to build GCC

### DIFF
--- a/utils/dc-chain/scripts/gcc-pass1.mk
+++ b/utils/dc-chain/scripts/gcc-pass1.mk
@@ -26,9 +26,8 @@ $(build_gcc_pass1): logdir
 	      $(gcc_pass1_configure_args) \
 	      $(macos_gcc_configure_args) \
 	      MAKEINFO=missing \
-	      CC="$(CC)" \
-	      CXX="$(CXX)" \
-	      CFLAGS="$(CFLAGS) -std=gnu17" \
+	      CC="$(CC) -std=gnu17" \
+	      CXX="$(CXX) -std=gnu++14" \
 	      $(static_flag) \
 	      $(to_log)
 	$(MAKE) $(jobs_arg) -C $(build) DESTDIR=$(DESTDIR) $(to_log)

--- a/utils/dc-chain/scripts/gcc-pass2.mk
+++ b/utils/dc-chain/scripts/gcc-pass2.mk
@@ -21,9 +21,8 @@ $(build_gcc_pass2): logdir
           $(gcc_pass2_configure_args) \
           $(macos_gcc_configure_args) \
           MAKEINFO=missing \
-          CC="$(CC)" \
-          CXX="$(CXX)" \
-          CFLAGS="$(CFLAGS) -std=gnu17" \
+          CC="$(CC) -std=gnu17" \
+          CXX="$(CXX) -std=gnu++14" \
           $(static_flag) \
           $(to_log)
 	$(MAKE) $(jobs_arg) -C $(build) DESTDIR=$(DESTDIR) $(to_log)


### PR DESCRIPTION
Newer host compiler default to C++23, which cannot compile some versions of GCC properly. Force C++14 to fix that.

Note that the -std= argument is passed to the CC/CXX variables. This means that CFLAGS/CXXFLAGS are not overriden, which caused problems when building libcody.