### PR TITLE
dc: Report call sites in Dreamcast stack traces

### DIFF
--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -163,7 +163,8 @@ void irq_dump_regs(int code, irq_t evt) {
                 dbglog(DBG_DEAD, " %08lx", irq_srt_addr->pr);
 
             while(arch_stk_unwind_step(sp, &ret_addr, &next_sp)) {
-                dbglog(DBG_DEAD, " %08x", ret_addr);
+                /* Log the call site (the BSR/BSRF/JSR itself) */
+                dbglog(DBG_DEAD, " %08x", ret_addr - 4);
                 sp = next_sp;
             }
         }

--- a/kernel/arch/dreamcast/kernel/stack.c
+++ b/kernel/arch/dreamcast/kernel/stack.c
@@ -150,7 +150,8 @@ void arch_stk_trace_at(uintptr_t sp, size_t n) {
             continue;
         }
 
-        dbgio_printf("   %08lx\n", (unsigned long)ret_addr);
+        /* Log the call site (the BSR/BSRF/JSR itself) */
+        dbgio_printf("   %08lx\n", (unsigned long)(ret_addr - 4));
         ++printed;
 
         if(printed >= max_frames) {


### PR DESCRIPTION
SH-4 call instructions save the address following the delay slot as the return address. Subtract four bytes so traces point to the call instruction.

@pcercuei Here you go.