### PR TITLE
kos-chain: Add GCC 16.2.0, update binutils to 2.47

### DIFF
--- a/utils/kos-chain/Makefile.dreamcast.cfg
+++ b/utils/kos-chain/Makefile.dreamcast.cfg
@@ -18,12 +18,12 @@ platform=dreamcast
 # - 13.4.0:       Testing: Latest release in the GCC 13 series, released 2025-06-05.
 # - 14.4.0:       Testing: Latest release in the GCC 14 series, released 2026-06-19.
 # - 15.3.0:       Testing: Latest release in the GCC 15 series, released 2026-06-12.
-# - 16.1.0:       Testing: Latest release in the GCC 16 series, released 2026-04-22.
+# - 16.2.0:       Testing: Latest release in the GCC 16 series, released 2026-08-07.
 # Development toolchains:
 # - 13.4.1-dev    Bleeding edge GCC 13 series from git.
 # - 14.4.1-dev    Bleeding edge GCC 14 series from git.
 # - 15.3.1-dev    Bleeding edge GCC 15 series from git.
-# - 16.1.1-dev    Bleeding edge GCC 16 series from git.
+# - 16.2.1-dev    Bleeding edge GCC 16 series from git.
 # - 17.0.0-dev    Bleeding edge GCC 17 series from git.
 # - 17.0.0-exp    GCC 17 branch containing experimental SuperH improvements.
 # If unsure, select stable. See README.md for more detailed descriptions.

--- a/utils/kos-chain/Makefile.gamecube.cfg
+++ b/utils/kos-chain/Makefile.gamecube.cfg
@@ -11,7 +11,7 @@
 platform=gamecube
 
 # Choose a toolchain profile from the following available options:
-# - stable:       Stable: Well-tested; based on GCC 15.2.0, released 2025-08-08.
+# - stable:       Stable: Well-tested; based on GCC 16.2.0, released 2026-08-07.
 # If unsure, select stable. See README.md for more detailed descriptions.
 toolchain_profile=stable
 

--- a/utils/kos-chain/doc/CHANGELOG.md
+++ b/utils/kos-chain/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Date<br/>_____________ | Author(s)<br/>_____________ | Changes<br/>_____________ |
 |:-----------------------|:----------------------------|---------------------------|
+| 2026-08-07 | Eric Fradella | Update GCC 16 series to 16.2.0, update binutils to 2.47 for most profiles |
 | 2026-06-30 | Eric Fradella | Bump GCC series 14/15/16/17 profiles to latest available versions, update LRA testing toolchain |
 | 2026-06-30 | Eric Fradella | Update binutils to 2.46.1 for most profiles |
 | 2026-02-07 | Eric Fradella | Rename to KallistiOS Toolchain Builder, move to utils/kos-chain, stabilize GCC 15.2.0, various bug fixes |

--- a/utils/kos-chain/patches/targets/gcc-16.2.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.2.0-kos.diff
@@ -1,6 +1,6 @@
-diff -ruN gcc-16.1.1/gcc/config/elfos.h gcc-16.1.1-kos/gcc/config/elfos.h
---- gcc-16.1.1/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
-+++ gcc-16.1.1-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
+diff -ruN gcc-16.2.0/gcc/config/elfos.h gcc-16.2.0-kos/gcc/config/elfos.h
+--- gcc-16.2.0/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
++++ gcc-16.2.0-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
 @@ -486,3 +486,6 @@
  
  #undef TARGET_LIBC_HAS_FUNCTION
@@ -8,9 +8,9 @@ diff -ruN gcc-16.1.1/gcc/config/elfos.h gcc-16.1.1-kos/gcc/config/elfos.h
 +
 +#define TARGET_OS_CPP_BUILTINS()			\
 +  builtin_define ("__KOS_GCC_PATCHLEVEL__=2025062800")
-diff -ruN gcc-16.1.1/gcc/configure gcc-16.1.1-kos/gcc/configure
---- gcc-16.1.1/gcc/configure	2025-04-17 16:01:33.801051764 -0600
-+++ gcc-16.1.1-kos/gcc/configure	2025-04-17 16:01:42.913094480 -0600
+diff -ruN gcc-16.2.0/gcc/configure gcc-16.2.0-kos/gcc/configure
+--- gcc-16.2.0/gcc/configure	2025-04-18 16:01:33.801051764 -0600
++++ gcc-16.2.0-kos/gcc/configure	2025-04-18 16:01:42.913094480 -0600
 @@ -13220,7 +13220,7 @@
      target_thread_file='single'
      ;;
@@ -20,9 +20,9 @@ diff -ruN gcc-16.1.1/gcc/configure gcc-16.1.1-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff --color -ruN gcc-16.1.1/libgcc/config.host gcc-16.1.1-kos/libgcc/config.host
---- gcc-16.1.1/libgcc/config.host	2025-04-27 14:45:09.695053718 -0600
-+++ gcc-16.1.1-kos/libgcc/config.host	2025-04-27 15:10:10.267714917 -0600
+diff --color -ruN gcc-16.2.0/libgcc/config.host gcc-16.2.0-kos/libgcc/config.host
+--- gcc-16.2.0/libgcc/config.host	2025-04-27 14:45:09.695053718 -0600
++++ gcc-16.2.0-kos/libgcc/config.host	2025-04-27 15:10:10.267714917 -0600
 @@ -71,7 +71,7 @@
  asm_hidden_op=.hidden
  enable_execute_stack=
@@ -32,15 +32,14 @@ diff --color -ruN gcc-16.1.1/libgcc/config.host gcc-16.1.1-kos/libgcc/config.hos
  tm_file=
  tm_define=
  md_unwind_def_header=no-unwind.h
-diff -ruN /dev/null gcc-16.1.1-kos/libgcc/config/t-kos
-+++ b/libgcc/config/t-kos
+diff -ruN /dev/null gcc-16.2.0-kos/libgcc/config/t-kos
 --- /dev/null	2025-04-27 14:45:09.695053718 -0600
-+++ gcc-16.1.1-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
++++ gcc-16.2.0-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
 @@ -0,0 +1 @@
 +LIB2ADD = $(srcdir)/config/fake-kos.c
-diff -ruN gcc-16.1.1/libgcc/configure gcc-16.1.1-kos/libgcc/configure
---- gcc-16.1.1/libgcc/configure	2026-01-28 00:56:02.311489006 -0600
-+++ gcc-16.1.1-kos/libgcc/configure	2026-01-28 00:56:08.161520414 -0600
+diff -ruN gcc-16.2.0/libgcc/configure gcc-16.2.0-kos/libgcc/configure
+--- gcc-16.2.0/libgcc/configure	2025-04-18 16:01:37.139067412 -0600
++++ gcc-16.2.0-kos/libgcc/configure	2025-04-18 16:01:42.914094485 -0600
 @@ -5826,6 +5826,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -49,9 +48,9 @@ diff -ruN gcc-16.1.1/libgcc/configure gcc-16.1.1-kos/libgcc/configure
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
-diff -ruN gcc-16.1.1/libobjc/Makefile.in gcc-16.1.1-kos/libobjc/Makefile.in
---- gcc-16.1.1/libobjc/Makefile.in	2025-04-17 16:01:37.499069099 -0600
-+++ gcc-16.1.1-kos/libobjc/Makefile.in	2025-04-17 16:01:42.915094489 -0600
+diff -ruN gcc-16.2.0/libobjc/Makefile.in gcc-16.2.0-kos/libobjc/Makefile.in
+--- gcc-16.2.0/libobjc/Makefile.in	2025-04-18 16:01:37.499069099 -0600
++++ gcc-16.2.0-kos/libobjc/Makefile.in	2025-04-18 16:01:42.915094489 -0600
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -82,9 +81,9 @@ diff -ruN gcc-16.1.1/libobjc/Makefile.in gcc-16.1.1-kos/libobjc/Makefile.in
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff -ruN gcc-16.1.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-16.1.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-16.1.1/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-17 16:01:37.608069611 -0600
-+++ gcc-16.1.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-17 16:01:42.916094494 -0600
+diff -ruN gcc-16.2.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-16.2.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-16.2.0/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:37.608069611 -0600
++++ gcc-16.2.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:42.916094494 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -135,9 +134,9 @@ diff -ruN gcc-16.1.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-16.1.1-kos/libst
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-16.1.1/libstdc++-v3/configure gcc-16.1.1-kos/libstdc++-v3/configure
---- gcc-16.1.1/libstdc++-v3/configure	2026-01-28 00:56:03.034826223 -0600
-+++ gcc-16.1.1-kos/libstdc++-v3/configure	2026-01-28 00:56:08.168187116 -0600
+diff -ruN gcc-16.2.0/libstdc++-v3/configure gcc-16.2.0-kos/libstdc++-v3/configure
+--- gcc-16.2.0/libstdc++-v3/configure	2025-04-18 16:01:37.616069648 -0600
++++ gcc-16.2.0-kos/libstdc++-v3/configure	2025-04-18 16:01:42.919094508 -0600
 @@ -16391,6 +16391,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -146,9 +145,9 @@ diff -ruN gcc-16.1.1/libstdc++-v3/configure gcc-16.1.1-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
-diff -ruN gcc-16.1.1/libgcc/config/sh/t-sh gcc-16.1.1-kos/libgcc/config/sh/t-sh
---- gcc-16.1.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
-+++ gcc-16.1.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+diff -ruN gcc-16.2.0/libgcc/config/sh/t-sh gcc-16.2.0-kos/libgcc/config/sh/t-sh
+--- gcc-16.2.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-16.2.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 @@ -45,7 +45,7 @@
  	$(gcc_compile) -c -DL_sdivsi3_i4i $<
  udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S

--- a/utils/kos-chain/patches/targets/gcc-16.2.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.2.1-kos.diff
@@ -1,6 +1,6 @@
-diff -ruN gcc-16.1.0/gcc/config/elfos.h gcc-16.1.0-kos/gcc/config/elfos.h
---- gcc-16.1.0/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
-+++ gcc-16.1.0-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
+diff -ruN gcc-16.2.1/gcc/config/elfos.h gcc-16.2.1-kos/gcc/config/elfos.h
+--- gcc-16.2.1/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
++++ gcc-16.2.1-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
 @@ -486,3 +486,6 @@
  
  #undef TARGET_LIBC_HAS_FUNCTION
@@ -8,9 +8,9 @@ diff -ruN gcc-16.1.0/gcc/config/elfos.h gcc-16.1.0-kos/gcc/config/elfos.h
 +
 +#define TARGET_OS_CPP_BUILTINS()			\
 +  builtin_define ("__KOS_GCC_PATCHLEVEL__=2025062800")
-diff -ruN gcc-16.1.0/gcc/configure gcc-16.1.0-kos/gcc/configure
---- gcc-16.1.0/gcc/configure	2025-04-18 16:01:33.801051764 -0600
-+++ gcc-16.1.0-kos/gcc/configure	2025-04-18 16:01:42.913094480 -0600
+diff -ruN gcc-16.2.1/gcc/configure gcc-16.2.1-kos/gcc/configure
+--- gcc-16.2.1/gcc/configure	2025-04-17 16:01:33.801051764 -0600
++++ gcc-16.2.1-kos/gcc/configure	2025-04-17 16:01:42.913094480 -0600
 @@ -13220,7 +13220,7 @@
      target_thread_file='single'
      ;;
@@ -20,9 +20,9 @@ diff -ruN gcc-16.1.0/gcc/configure gcc-16.1.0-kos/gcc/configure
      target_thread_file=${enable_threads}
      ;;
    *)
-diff --color -ruN gcc-16.1.0/libgcc/config.host gcc-16.1.0-kos/libgcc/config.host
---- gcc-16.1.0/libgcc/config.host	2025-04-27 14:45:09.695053718 -0600
-+++ gcc-16.1.0-kos/libgcc/config.host	2025-04-27 15:10:10.267714917 -0600
+diff --color -ruN gcc-16.2.1/libgcc/config.host gcc-16.2.1-kos/libgcc/config.host
+--- gcc-16.2.1/libgcc/config.host	2025-04-27 14:45:09.695053718 -0600
++++ gcc-16.2.1-kos/libgcc/config.host	2025-04-27 15:10:10.267714917 -0600
 @@ -71,7 +71,7 @@
  asm_hidden_op=.hidden
  enable_execute_stack=
@@ -32,14 +32,15 @@ diff --color -ruN gcc-16.1.0/libgcc/config.host gcc-16.1.0-kos/libgcc/config.hos
  tm_file=
  tm_define=
  md_unwind_def_header=no-unwind.h
-diff -ruN /dev/null gcc-16.1.0-kos/libgcc/config/t-kos
+diff -ruN /dev/null gcc-16.2.1-kos/libgcc/config/t-kos
++++ b/libgcc/config/t-kos
 --- /dev/null	2025-04-27 14:45:09.695053718 -0600
-+++ gcc-16.1.0-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
++++ gcc-16.2.1-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
 @@ -0,0 +1 @@
 +LIB2ADD = $(srcdir)/config/fake-kos.c
-diff -ruN gcc-16.1.0/libgcc/configure gcc-16.1.0-kos/libgcc/configure
---- gcc-16.1.0/libgcc/configure	2025-04-18 16:01:37.139067412 -0600
-+++ gcc-16.1.0-kos/libgcc/configure	2025-04-18 16:01:42.914094485 -0600
+diff -ruN gcc-16.2.1/libgcc/configure gcc-16.2.1-kos/libgcc/configure
+--- gcc-16.2.1/libgcc/configure	2026-01-28 00:56:02.311489006 -0600
++++ gcc-16.2.1-kos/libgcc/configure	2026-01-28 00:56:08.161520414 -0600
 @@ -5826,6 +5826,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -48,9 +49,9 @@ diff -ruN gcc-16.1.0/libgcc/configure gcc-16.1.0-kos/libgcc/configure
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
-diff -ruN gcc-16.1.0/libobjc/Makefile.in gcc-16.1.0-kos/libobjc/Makefile.in
---- gcc-16.1.0/libobjc/Makefile.in	2025-04-18 16:01:37.499069099 -0600
-+++ gcc-16.1.0-kos/libobjc/Makefile.in	2025-04-18 16:01:42.915094489 -0600
+diff -ruN gcc-16.2.1/libobjc/Makefile.in gcc-16.2.1-kos/libobjc/Makefile.in
+--- gcc-16.2.1/libobjc/Makefile.in	2025-04-17 16:01:37.499069099 -0600
++++ gcc-16.2.1-kos/libobjc/Makefile.in	2025-04-17 16:01:42.915094489 -0600
 @@ -308,14 +308,16 @@
  $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
  	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
@@ -81,9 +82,9 @@ diff -ruN gcc-16.1.0/libobjc/Makefile.in gcc-16.1.0-kos/libobjc/Makefile.in
  
  mostlyclean:
  	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo
-diff -ruN gcc-16.1.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-16.1.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h
---- gcc-16.1.0/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:37.608069611 -0600
-+++ gcc-16.1.0-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-18 16:01:42.916094494 -0600
+diff -ruN gcc-16.2.1/libstdc++-v3/config/cpu/sh/atomicity.h gcc-16.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h
+--- gcc-16.2.1/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-17 16:01:37.608069611 -0600
++++ gcc-16.2.1-kos/libstdc++-v3/config/cpu/sh/atomicity.h	2025-04-17 16:01:42.916094494 -0600
 @@ -22,14 +22,40 @@
  // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  // <http://www.gnu.org/licenses/>.
@@ -134,9 +135,9 @@ diff -ruN gcc-16.1.0/libstdc++-v3/config/cpu/sh/atomicity.h gcc-16.1.0-kos/libst
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-16.1.0/libstdc++-v3/configure gcc-16.1.0-kos/libstdc++-v3/configure
---- gcc-16.1.0/libstdc++-v3/configure	2025-04-18 16:01:37.616069648 -0600
-+++ gcc-16.1.0-kos/libstdc++-v3/configure	2025-04-18 16:01:42.919094508 -0600
+diff -ruN gcc-16.2.1/libstdc++-v3/configure gcc-16.2.1-kos/libstdc++-v3/configure
+--- gcc-16.2.1/libstdc++-v3/configure	2026-01-28 00:56:03.034826223 -0600
++++ gcc-16.2.1-kos/libstdc++-v3/configure	2026-01-28 00:56:08.168187116 -0600
 @@ -16391,6 +16391,7 @@
      tpf)	thread_header=config/s390/gthr-tpf.h ;;
      vxworks)	thread_header=config/gthr-vxworks.h ;;
@@ -145,9 +146,9 @@ diff -ruN gcc-16.1.0/libstdc++-v3/configure gcc-16.1.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
-diff -ruN gcc-16.1.0/libgcc/config/sh/t-sh gcc-16.1.0-kos/libgcc/config/sh/t-sh
---- gcc-16.1.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
-+++ gcc-16.1.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
+diff -ruN gcc-16.2.1/libgcc/config/sh/t-sh gcc-16.2.1-kos/libgcc/config/sh/t-sh
+--- gcc-16.2.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
++++ gcc-16.2.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 @@ -45,7 +45,7 @@
  	$(gcc_compile) -c -DL_sdivsi3_i4i $<
  udivsi3_i4i-Os-4-200.o: $(srcdir)/config/sh/lib1funcs-Os-4-200.S

--- a/utils/kos-chain/profiles/aica/stable.mk
+++ b/utils/kos-chain/profiles/aica/stable.mk
@@ -5,7 +5,7 @@ target=arm-eabi
 cpu_configure_args=--with-arch=armv4 --with-mode=arm --disable-multilib
 
 # Toolchain versions
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=8.5.0
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/13.4.0.mk
+++ b/utils/kos-chain/profiles/dreamcast/13.4.0.mk
@@ -5,7 +5,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=13.4.0
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/13.4.1-dev.mk
+++ b/utils/kos-chain/profiles/dreamcast/13.4.1-dev.mk
@@ -12,7 +12,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=13.4.1
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/14.4.0.mk
+++ b/utils/kos-chain/profiles/dreamcast/14.4.0.mk
@@ -5,7 +5,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=14.4.0
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/14.4.1-dev.mk
+++ b/utils/kos-chain/profiles/dreamcast/14.4.1-dev.mk
@@ -12,7 +12,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=14.4.1
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/15.3.0.mk
+++ b/utils/kos-chain/profiles/dreamcast/15.3.0.mk
@@ -5,7 +5,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=15.3.0
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/15.3.1-dev.mk
+++ b/utils/kos-chain/profiles/dreamcast/15.3.1-dev.mk
@@ -12,7 +12,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=15.3.1
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/16.2.0.mk
+++ b/utils/kos-chain/profiles/dreamcast/16.2.0.mk
@@ -6,7 +6,7 @@ cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little 
 
 # Toolchain versions for SH
 binutils_ver=2.46.1
-gcc_ver=16.1.0
+gcc_ver=16.2.0
 newlib_ver=4.6.0.20260123
 
 # GCC custom dependencies

--- a/utils/kos-chain/profiles/dreamcast/16.2.0.mk
+++ b/utils/kos-chain/profiles/dreamcast/16.2.0.mk
@@ -5,7 +5,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=16.2.0
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/16.2.1-dev.mk
+++ b/utils/kos-chain/profiles/dreamcast/16.2.1-dev.mk
@@ -12,7 +12,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=16.2.1
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/16.2.1-dev.mk
+++ b/utils/kos-chain/profiles/dreamcast/16.2.1-dev.mk
@@ -1,0 +1,37 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+###############################################################################
+###############################################################################
+### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2026-06-30.
+###############################################################################
+###############################################################################
+
+target=sh-elf
+
+cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
+
+# Toolchain versions for SH
+binutils_ver=2.46.1
+gcc_ver=16.2.1
+newlib_ver=4.6.0.20260123
+
+# Overide SH toolchain download type
+gcc_download_type=git
+gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+gcc_git_branch=releases/gcc-16
+
+# GCC custom dependencies
+# Specify here if you want to use custom GMP, MPFR and MPC libraries when
+# building GCC. It is recommended that you leave this variable commented, in
+# which case these dependencies will be automatically downloaded by using the
+# '/contrib/download_prerequisites' shell script provided within the GCC packages.
+# The ISL dependency isn't mandatory; if desired, you may comment the version
+# numbers (i.e. 'isl_ver') to disable the ISL library.
+#use_custom_dependencies=1
+
+# GCC dependencies for SH
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24

--- a/utils/kos-chain/profiles/dreamcast/17.0.0-dev.mk
+++ b/utils/kos-chain/profiles/dreamcast/17.0.0-dev.mk
@@ -12,7 +12,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=17.0.0
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/dreamcast/17.0.0-exp.mk
+++ b/utils/kos-chain/profiles/dreamcast/17.0.0-exp.mk
@@ -12,7 +12,7 @@ target=sh-elf
 cpu_configure_args=--with-multilib-list=$(precision_modes) --with-endian=little --with-cpu=$(default_precision)
 
 # Toolchain versions for SH
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=17.0.0
 newlib_ver=4.6.0.20260123
 

--- a/utils/kos-chain/profiles/gamecube/stable.mk
+++ b/utils/kos-chain/profiles/gamecube/stable.mk
@@ -7,7 +7,7 @@ newlib_extra_configure_args += --disable-libgloss
 
 # Toolchain versions for PowerPC
 binutils_ver=2.46.1
-gcc_ver=15.2.0
+gcc_ver=16.2.0
 newlib_ver=4.6.0.20260123
 
 # GCC custom dependencies

--- a/utils/kos-chain/profiles/gamecube/stable.mk
+++ b/utils/kos-chain/profiles/gamecube/stable.mk
@@ -6,7 +6,7 @@ cpu_configure_args=--with-endian=big --with-cpu=750 --disable-multilib --disable
 newlib_extra_configure_args += --disable-libgloss
 
 # Toolchain versions for PowerPC
-binutils_ver=2.46.1
+binutils_ver=2.47
 gcc_ver=16.2.0
 newlib_ver=4.6.0.20260123
 


### PR DESCRIPTION
Draft until GCC 16.2.0 is released on August 7.

To test earlier, run:

```
wget https://gcc.gnu.org/pub/gcc/snapshots/16.2.0-RC-20260731/gcc-16.2.0-RC-20260731.tar.xz
mv gcc-16.2.0-RC-20260731.tar.xz gcc-16.2.0.tar.xz
tar xvf gcc-16.2.0.tar.xz
mv gcc-16.2.0-RC-20260731 gcc-16.2.0
touch gcc-16.2.0/gcc_download.stamp
```

then `make` as usual.