### PR TITLE
    browse: Correct screen blanking on open fails.

### DIFF
--- a/examples/dreamcast/filesystem/browse/browse.c
+++ b/examples/dreamcast/filesystem/browse/browse.c
@@ -9,7 +9,8 @@
    file operations like copying and deleting files.
 */
 
-#include <stdio.h> 
+#include <string.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <dirent.h>
@@ -19,7 +20,6 @@
 
 #include <dc/video.h>
 #include <fat/fs_fat.h>
-#include <kos/string.h>
 
 #include <kos/fs_romdisk.h>
 #include <kos/fs_ramdisk.h>

--- a/examples/dreamcast/filesystem/browse/browse.c
+++ b/examples/dreamcast/filesystem/browse/browse.c
@@ -129,8 +129,9 @@ int main(int argc, char **argv) {
 
                     memset(directory_temp2, 0, BUFFER_LENGTH);
                     fs_normalize_path(directory_temp, directory_temp2);
-                    content_count = browse_directory(directory_temp2, directory_contents);
-                    if(content_count > 0) {
+                    int tmp_content_count = browse_directory(directory_temp2, directory_contents);
+                    if(tmp_content_count > 0) {
+                        content_count = tmp_content_count;
                         realpath(directory_temp2, current_directory);
                         changed_directory = true;
                         selector_index = 0;
@@ -157,8 +158,9 @@ int main(int argc, char **argv) {
                     int copy_count = strrchr(current_directory, '/') - current_directory;
                     strncat(directory_temp, current_directory, (copy_count==0) ? 1 : copy_count );
                     /* Go the previous directory and get the directory contents */
-                    content_count = browse_directory(directory_temp, directory_contents);
-                    if(content_count > 0) {
+                    int tmp_content_count = browse_directory(directory_temp, directory_contents);
+                    if(tmp_content_count > 0) {
+                        content_count = tmp_content_count;
                         strcpy(current_directory, directory_temp);
                         changed_directory = true;
                         selector_index = 0;


### PR DESCRIPTION
Don't override the content count if opening the new dir fails.
Without this, on the next redraw, the content count may have stayed
overwritten with 0 from the failure and blank the screen.

Additionally cleaned up an include.