### PR TITLE
Disable flicker filter for progressive modes.

### DIFF
--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -103,8 +103,14 @@ int pvr_init(const pvr_init_params_t *params) {
     if(vid_mode->cable_type == CT_VGA) {
         dbglog(DBG_KDEBUG, "pvr: disabling vertical scaling for VGA\n");
     } else {
-        dbglog(DBG_KDEBUG, "pvr: enabling vertical scaling for non-VGA\n");
-        vscale++;
+        /* If using an interlaced video mode, enable vertical smoothing ("flicker filter"),
+           otherwise disable it */
+        if(vid_mode->flags & VID_INTERLACE) {
+            dbglog(DBG_KDEBUG, "pvr: enabling vertical scaling for interlaced non-VGA\n");
+            vscale++;
+        } else {
+            dbglog(DBG_KDEBUG, "pvr: disabling vertical scaling for progressive non-VGA\n");
+        }
     }
 
     /* Set horizontal / vertical scale factors */


### PR DESCRIPTION
KOS currently enables the flicker filter for all non-VGA video modes, including non-interlaced modes (320x240 NTSC and PAL). This makes the progressive modes look awful, very blurry. This fixes that.

Some before and after examples of 240P captured via s-video:

Sonic Mania 2d gameplay

<img width="946" height="773" alt="Screenshot 2026-08-14 at 1 49 56 PM" src="https://github.com/user-attachments/assets/1c1aa459-60ef-4249-9eb4-1d1460bd898c" />
<img width="946" height="773" alt="Screenshot 2026-08-14 at 1 49 47 PM" src="https://github.com/user-attachments/assets/95f33d94-05f0-4d1a-b48e-3a73d5199e98" />

Sonic Mania 3d gameplay
<img width="946" height="773" alt="Screenshot 2026-08-14 at 5 12 41 PM" src="https://github.com/user-attachments/assets/1a2cec1f-c4fc-4716-a6f8-cfa1b6726464" />
<img width="946" height="773" alt="Screenshot 2026-08-14 at 5 13 39 PM" src="https://github.com/user-attachments/assets/ccbf5f14-c5b9-48f5-9852-cb69cc0851a8" />
