### PR TITLE
kos-chain: Add XBox toolchain support

### DIFF
--- a/utils/kos-chain/Makefile.aica.cfg
+++ b/utils/kos-chain/Makefile.aica.cfg
@@ -8,6 +8,7 @@
 # - dreamcast:    Build a toolchain for the SEGA Dreamcast
 # - aica:         Build a toolchain for the Dreamcast's AICA co-processor
 # - gamecube:     Build a toolchain for the Nintendo GameCube
+# - xbox:         Build a toolchain for the original Microsoft Xbox
 platform=aica
 
 # Choose a toolchain profile from the following available options:

--- a/utils/kos-chain/Makefile.dreamcast.cfg
+++ b/utils/kos-chain/Makefile.dreamcast.cfg
@@ -8,6 +8,7 @@
 # - dreamcast:    Build a toolchain for the SEGA Dreamcast
 # - aica:         Build a toolchain for the Dreamcast's AICA co-processor
 # - gamecube:     Build a toolchain for the Nintendo GameCube
+# - xbox:         Build a toolchain for the original Microsoft Xbox
 platform=dreamcast
 
 # Choose a toolchain profile from the following available options:

--- a/utils/kos-chain/Makefile.gamecube.cfg
+++ b/utils/kos-chain/Makefile.gamecube.cfg
@@ -8,6 +8,7 @@
 # - dreamcast:    Build a toolchain for the SEGA Dreamcast
 # - aica:         Build a toolchain for the Dreamcast's AICA co-processor
 # - gamecube:     Build a toolchain for the Nintendo GameCube
+# - xbox:         Build a toolchain for the original Microsoft Xbox
 platform=gamecube
 
 # Choose a toolchain profile from the following available options:

--- a/utils/kos-chain/Makefile.xbox.cfg
+++ b/utils/kos-chain/Makefile.xbox.cfg
@@ -1,0 +1,199 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+#########################
+### TOOLCHAIN PROFILE ###
+#########################
+
+# One of the supported platforms:
+# - dreamcast:    Build a toolchain for the SEGA Dreamcast
+# - aica:         Build a toolchain for the Dreamcast's AICA co-processor
+# - gamecube:     Build a toolchain for the Nintendo GameCube
+# - xbox:         Build a toolchain for the original Microsoft Xbox
+platform=xbox
+
+# Choose a toolchain profile from the following available options:
+# Release toolchains:
+# - stable:       Stable: based on GCC 16.2.0, Binutils 2.47, and Newlib 4.6.0.
+# Development toolchains:
+# - 17.0.0-dev    Bleeding edge GCC 17 series from git.
+# If unsure, select stable. See README.md for more detailed descriptions.
+toolchain_profile=stable
+
+########################
+### DOWNLOAD OPTIONS ###
+########################
+
+### Download protocol (http|https|ftp)
+# Specify the protocol you want to use for downloading package files.
+download_protocol=https
+
+### Force downloader (curl|wget)
+# Specify here if you'd prefer to use 'wget' or 'curl'. If neither is specified,
+# a web downloader tool will be auto-detected in the following order: cURL, Wget
+# You must have either Wget or cURL installed to use kos-chain.
+#force_downloader=wget
+
+### Specify GNU mirror override
+# The default mirror for GNU sources is 'ftpmirror.gnu.org'
+# This setting overrides the default mirror with a preferred mirror.
+#gnu_mirror=mirrors.kernel.org
+
+#####################
+### BUILD OPTIONS ###
+#####################
+
+### Toolchains install path
+# Specify the directory where the toolchains will be installed. This setting
+# must match the KOS_CC_BASE setting in your KOS "environ.sh" configuration.
+toolchain_path=/opt/toolchains/xbox/i686-pc-xbox
+
+### Make jobs (n|<empty>)
+# Set this value to the number of parallel jobs you want to run with make.
+# Leave it empty to use a number of parallel jobs that corresponds to the
+# number of CPU threads available.
+# Using multiple jobs may cause issues in certain environments and may be
+# automatically disabled. If you encounter errors building your toolchain,
+# reduce the number of jobs to 1 to avoid issues and ease troubleshooting.
+makejobs=
+
+### Verbose (1|0)
+# Choose whether to actively display compilation messages on the screen.
+# Messages are saved to the build log files regardless of this setting.
+verbose=1
+
+### Erase (1|0)
+# Erase build directories as toolchain components are installed to save space.
+erase=1
+
+### Install toolchain debug symbols (1|0)
+# Choose whether to keep the debugging symbols for the toolchain.
+# This is only useful if you wish to debug the toolchain itself.
+#toolchain_debug=1
+
+########################
+### LANGUAGE OPTIONS ###
+########################
+
+### Enable C++
+# Builds C++ support, including the C++ compiler and its standard library. The
+# vast majority of language features are supported, with C++23 and early C++26
+# support included. KallistiOS provides several examples with C++ support, so it
+# is enabled by default. Adding C++ support requires extra disk space and
+# compilation time, so you may disable it here if you do not plan on using C++.
+enable_cpp=1
+
+### Enable Objective-C
+# Builds Objective-C support. There is no Xbox arch port in KallistiOS yet, so
+# the Obj-C runtime has nothing to build against and is disabled here.
+enable_objc=0
+
+### Enable Objective C++
+# Builds Objective C++ support. Disabled along with Objective-C above.
+enable_objcpp=0
+
+### Enable D
+# Builds D support. This will build the D compiler, but does not build the
+# Phobos Runtime Library. D support may only be enabled on POSIX platforms which
+# have its external dependencies provided through a host DMD, GDC, or LDC
+# compiler installation.
+#enable_d=1
+
+### Enable Ada
+# Builds Ada support. This will build the GNAT Ada compiler and tools but does
+# not build the libada runtime library. In order for this build to succeed, the
+# host's GCC version must match the target version, plus the same version of
+# GNAT and its tools must be preinstalled (and in your path).
+#enable_ada=1
+
+### Enable Rust
+# Builds the work-in-progress GCCRS Rust compiler frontend for GCC.
+# Requires a development version of GCC.
+#enable_rust=1
+
+### Enable libgccjit
+# Enables the libgccjit just-in-time embeddable GCC library. This can also be
+# used to generate code ahead of time, e.g. with rustc_codegen_gcc project.
+#enable_libgccjit=1
+
+###################
+### GCC OPTIONS ###
+###################
+
+### GCC threading model (single|kos)
+# KallistiOS patches to GCC provide a 'kos' thread model, which should be used.
+# If you want to disable threading support for C++, Objective-C, and so forth,
+# you can set this option to 'single'.
+thread_model=kos
+
+### Automatic patching for KallistiOS (1|0)
+# Uncomment this option if you want to disable applying KallistiOS patches to
+# toolchain source files before building. This will disable usage of the 'kos'
+# thread model. Only do this if you understand what you are doing.
+#use_kos_patches=0
+
+### Disable GCC Native Language Support (1|0)
+# By default, NLS allows GCC to output diagnostics in non-English languages.
+# Uncomment this option to disable NLS and force GCC to output in English.
+#disable_nls=1
+
+######################
+### NEWLIB OPTIONS ###
+######################
+
+### Automatic patching for Newlib (1|0)
+# Uncomment this option if you want to disable the automatic patching of Newlib
+# needed by KallistiOS. This will keep the generated toolchain completely raw.
+# This will also disable the 'kos' thread model. Only do this if you understand
+# what you are doing.
+#auto_fixup_newlib=0
+
+### C99 format specifier support (1|0)
+# Define this to build Newlib with additional support for the C99 format
+# specifiers, used by printf and friends. These include support for size_t,
+# ptrdiff_t, intmax_t, and sized integral types.
+newlib_c99_formats=1
+
+### Multibyte character set support (1|0)
+# Define this to build Newlib with additional multibyte support. This enables
+# three special locales: "C-JIS", "C-SJIS", and "C-EUCJP". The multibyte
+# support extends to the mb and wc functions in stdlib as well as format
+# characters for the printf and scanf family of routines.
+#newlib_multibyte=1
+
+### iconv() character encoding conversions support (encoding list)
+# Define a list here to enable support for the iconv() function and <iconv.h>
+# header file. The given comma separated list defines for which encoding types
+# to include bidirectional conversion support. For the full list of available
+# encodings, see the Newlib configuration documentation.
+#newlib_iconv_encodings=us_ascii,utf8,utf16,ucs_2_internal,ucs_4_internal
+
+### Optimize Newlib for space (1|0)
+# Uncomment this option to optimize for space when building Newlib. This will
+# build Newlib with compiler flags which favor smaller code sizes over faster
+# performance.
+#newlib_opt_space=1
+
+###################
+### C++ OPTIONS ###
+###################
+
+### Timezone database support (1|0|path)
+# Uncomment this option to enable building support for C++'s std::chrono::tzdb
+# into your C++ standard library by using a combination of the system's local
+# timezone DB and one dynamically fetched from the "IANA Time Zone Database."
+# Without support enabled, only the "UTC" and "GMT" timezones will be defined.
+# You can optionally provide the path to a directory with a custom "tzdata.zi"
+# database file. NOTE: Enabling this will result in larger C++ binaries!
+#libstdcxx_tzdb=1
+
+#######################
+### WINDOWS OPTIONS ###
+#######################
+
+### MinGW/MSYS
+# Standalone binaries (1|0)
+# Uncomment this option if you want static binaries that are standalone and
+# require no dependencies. When this option is used, binaries can be run outside
+# the MinGW/MSYS environment. This is NOT recommended; only do this if you know
+# what you are doing.
+#standalone_binary=1

--- a/utils/kos-chain/README.md
+++ b/utils/kos-chain/README.md
@@ -28,6 +28,10 @@ toolchain is optional and only necessary for compiling custom AICA drivers.
 - **GameCube**: `powerpc-eabi` toolchain, the cross-compiler toolchain targeting
 the **IBM Gekko PowerPC (PPC) CPU** in the Nintendo GameCube. GameCube support
 is coming soon to KallistiOS.
+- **Xbox**: `i686-pc-xbox` toolchain, the cross-compiler toolchain targeting
+the **Intel Pentium III-class CPU** in the original Microsoft Xbox. It emits
+32-bit ELF objects, which a converter turns into an XBE. Xbox support is coming
+soon to KallistiOS.
 
 ## Getting started
 

--- a/utils/kos-chain/doc/CHANGELOG.md
+++ b/utils/kos-chain/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Date<br/>_____________ | Author(s)<br/>_____________ | Changes<br/>_____________ |
 |:-----------------------|:----------------------------|---------------------------|
+| 2026-08-19 | Andy Barajas | Add support for the original Xbox toolchain and add xbox profiles |
 | 2026-08-07 | Eric Fradella | Update GCC 16 series to 16.2.0, update binutils to 2.47 for most profiles |
 | 2026-06-30 | Eric Fradella | Bump GCC series 14/15/16/17 profiles to latest available versions, update LRA testing toolchain |
 | 2026-06-30 | Eric Fradella | Update binutils to 2.46.1 for most profiles |

--- a/utils/kos-chain/patches/targets/binutils-2.47-kos.diff
+++ b/utils/kos-chain/patches/targets/binutils-2.47-kos.diff
@@ -1,0 +1,53 @@
+--- binutils-2.47/bfd/config.bfd
++++ binutils-2.47-kos/bfd/config.bfd
+@@ -562,6 +562,12 @@
+     targ_defvec=i386_elf32_vec
+     targ_selvecs="i386_coff_vec"
+     ;;
++  i[3-7]86-*-xbox*)
++    # ELF by default: the i386 TLS relocations and .tdata/.tbss need it.
++    # PE/COFF stays selectable for XBE conversion.
++    targ_defvec=i386_elf32_vec
++    targ_selvecs="i386_coff_vec i386_pe_vec i386_pe_big_vec i386_pei_vec pdb_vec"
++    ;;
+   i[3-7]86-*-solaris2*)
+     targ_defvec=i386_elf32_sol2_vec
+     # Include 64-bit support to match GCC.
+
+--- binutils-2.47/ld/configure.tgt
++++ binutils-2.47-kos/ld/configure.tgt
+@@ -381,6 +381,12 @@
+ 			;;
+ i[3-7]86-*-elf* | i[3-7]86-*-rtems* | i[3-7]86-*-genode*)
+ 			targ_emul=elf_i386
++			;;
++i[3-7]86-*-xbox*)	targ_emul=elf_i386
++			targ_extra_emuls=i386pe
++			# The ELF emulation still needs the default ldelf.o/ldelfgen.o;
++			# the rest are what i386pe pulls in.
++			targ_extra_ofiles="ldelf.o ldelfgen.o deffilep.o pdb.o pe-dll.o"
+ 			;;
+ i[3-7]86-*-dragonfly*)	targ_emul=elf_i386
+ 			targ_extra_emuls="i386bsd"
+
+--- binutils-2.47/gas/configure.tgt
++++ binutils-2.47-kos/gas/configure.tgt
+@@ -229,6 +229,7 @@
+   i386-*-beos*)				fmt=elf ;;
+   i386-*-elfiamcu)			fmt=elf arch=iamcu ;;
+   i386-*-elf*)				fmt=elf ;;
++  i386-*-xbox*)				fmt=elf ;;
+   i386-*-fuchsia*)			fmt=elf ;;
+   i386-*-haiku*)			fmt=elf em=haiku ;;
+   i386-*-genode*)			fmt=elf ;;
+
+--- binutils-2.47/config.sub
++++ binutils-2.47-kos/config.sub
+@@ -2152,6 +2152,7 @@
+ 	| windiss* \
+ 	| windows* \
+ 	| winnt* \
++	| xbox* \
+ 	| xenix* \
+ 	| xray* \
+ 	| zephyr* \

--- a/utils/kos-chain/patches/targets/gcc-16.2.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.2.0-kos.diff
@@ -1,13 +1,12 @@
 diff -ruN gcc-16.2.0/gcc/config/elfos.h gcc-16.2.0-kos/gcc/config/elfos.h
 --- gcc-16.2.0/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
 +++ gcc-16.2.0-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
-@@ -486,3 +486,6 @@
+@@ -486,3 +486,5 @@
  
  #undef TARGET_LIBC_HAS_FUNCTION
  #define TARGET_LIBC_HAS_FUNCTION no_c99_libc_has_function
 +
 +#define TARGET_OS_CPP_BUILTINS()			\
-+  builtin_define ("__KOS_GCC_PATCHLEVEL__=2025062800")
 diff -ruN gcc-16.2.0/gcc/configure gcc-16.2.0-kos/gcc/configure
 --- gcc-16.2.0/gcc/configure	2025-04-18 16:01:33.801051764 -0600
 +++ gcc-16.2.0-kos/gcc/configure	2025-04-18 16:01:42.913094480 -0600
@@ -35,7 +34,7 @@ diff --color -ruN gcc-16.2.0/libgcc/config.host gcc-16.2.0-kos/libgcc/config.hos
 diff -ruN /dev/null gcc-16.2.0-kos/libgcc/config/t-kos
 --- /dev/null	2025-04-27 14:45:09.695053718 -0600
 +++ gcc-16.2.0-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
-@@ -0,0 +1 @@
+@@ -0,0 +1,1 @@
 +LIB2ADD = $(srcdir)/config/fake-kos.c
 diff -ruN gcc-16.2.0/libgcc/configure gcc-16.2.0-kos/libgcc/configure
 --- gcc-16.2.0/libgcc/configure	2025-04-18 16:01:37.139067412 -0600
@@ -157,3 +156,89 @@ diff -ruN gcc-16.2.0/libgcc/config/sh/t-sh gcc-16.2.0-kos/libgcc/config/sh/t-sh
  	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
  
  OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o
+
+--- gcc-16.2.0/gcc/config.gcc
++++ gcc-16.2.0-kos/gcc/config.gcc
+@@ -2233,6 +2233,15 @@
+ 	    ;;
+ 	esac
+ 	;;
++i[34567]86-*-xbox*)
++	# elfos.h emits .tdata/.tbss, giving native %gs TLS instead of libgcc's emutls.
++	tm_file="${tm_file} i386/unix.h i386/att.h elfos.h newlib-stdint.h"
++	tm_file="${tm_file} i386/i386elf.h i386/xbox.h"
++	gas=yes
++	gnu_ld=yes
++	default_use_cxa_atexit=yes
++	use_gcc_stdint=wrap
++	;;
+ i[34567]86-*-cygwin*)
+ 	tm_file="${tm_file} i386/unix.h i386/bsd.h i386/gas.h i386/cygming.h i386/cygwin.h i386/cygwin-stdint.h"
+ 	tm_file="${tm_file} mingw/winnt.h"
+--- gcc-16.2.0/gcc/config/i386/xbox.h
++++ gcc-16.2.0-kos/gcc/config/i386/xbox.h
+@@ -0,0 +1,40 @@
++/* Target definitions for the original Microsoft Xbox running KallistiOS.  */
++
++#undef TARGET_OS_CPP_BUILTINS
++#define TARGET_OS_CPP_BUILTINS()				\
++  do								\
++    {								\
++      builtin_define ("__XBOX__");				\
++      builtin_assert ("system=xbox");				\
++    }								\
++  while (0)
++
++/* KOS maps the whole %gs segment flat (4 GB limit), the way Linux does with
++   %fs, so a thread-local can be reached with one segment-prefixed
++   instruction -- movl %gs:x@ntpoff, %eax -- instead of loading the thread
++   pointer from %gs:0 first. i386 is TLS variant II, so @ntpoff is negative
++   and the effective address relies on the segment offset wrapping modulo
++   2^32; that is only valid while the descriptor really does span 4 GB. Build
++   with -mno-tls-direct-seg-refs if %gs is ever given a bounded limit.  */
++#undef TARGET_TLS_DIRECT_SEG_REFS_DEFAULT
++#define TARGET_TLS_DIRECT_SEG_REFS_DEFAULT MASK_TLS_DIRECT_SEG_REFS
++
++/* newlib-stdint.h already resolves to the correct i386 types: the fast types
++   are int-sized because INT_TYPE_SIZE is 32, and the pointer types follow
++   PTRDIFF_TYPE / SIZE_TYPE. No Xbox-specific override is required.  */
++
++/* crti.o/crtn.o bracket crtbegin.o's .init and .fini fragments, forming
++   the _init()/_fini() pair arch_main() calls, as on the Dreamcast.  */
++#undef STARTFILE_SPEC
++#define STARTFILE_SPEC "crti.o%s crtbegin.o%s"
++
++#undef ENDFILE_SPEC
++#define ENDFILE_SPEC "crtend.o%s crtn.o%s"
++
++#undef LIB_SPEC
++#define LIB_SPEC "%{!nostdlib:%{!nodefaultlibs:-lc}}"
++
++/* The KOS linker script names the entry point too; pass it explicitly so a
++   link that does not use the script still starts in the right place.  */
++#undef LINK_SPEC
++#define LINK_SPEC "%{!r:%{!nostdlib:%{!e*:-e _start}}}"
+--- gcc-16.2.0/libgcc/config.host
++++ gcc-16.2.0-kos/libgcc/config.host
+@@ -843,6 +843,10 @@
+ 	;;
+ i[4567]86-wrs-vxworks*|x86_64-wrs-vxworks*)
+ 	;;
++i[34567]86-*-xbox*)
++	tmake_file="$tmake_file i386/t-crtstuff t-crtfm t-dfprules"
++	extra_parts="$extra_parts crti.o crtn.o crtbegin.o crtend.o crtfastmath.o"
++	;;
+ i[34567]86-*-cygwin*)
+ 	extra_parts="crtbegin.o crtbeginS.o crtend.o crtfastmath.o"
+ 	if test x$enable_vtable_verify = xyes; then
+
+--- gcc-16.2.0/config.sub
++++ gcc-16.2.0-kos/config.sub
+@@ -1734,6 +1734,7 @@
+ 	     | ekkobsd* | freebsd* | riscix* | lynxos* | os400* \
+ 	     | bosx* | nextstep* | cxux* | aout* | elf* | oabi* \
+ 	     | ptx* | coff* | ecoff* | winnt* | domain* | vsta* \
++	     | xbox* \
+ 	     | udi* | lites* | ieee* | go32* | aux* | hcos* \
+ 	     | chorusrdb* | cegcc* | glidix* | serenity* \
+ 	     | cygwin* | msys* | pe* | moss* | proelf* | rtems* \

--- a/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
@@ -1,13 +1,12 @@
 diff -ruN gcc-17.0.0/gcc/config/elfos.h gcc-17.0.0-kos/gcc/config/elfos.h
 --- gcc-17.0.0/gcc/config/elfos.h	2025-04-17 16:01:33.790051712 -0600
 +++ gcc-17.0.0-kos/gcc/config/elfos.h	2025-04-17 16:01:42.910094466 -0600
-@@ -486,3 +486,6 @@
+@@ -486,3 +486,5 @@
  
  #undef TARGET_LIBC_HAS_FUNCTION
  #define TARGET_LIBC_HAS_FUNCTION no_c99_libc_has_function
 +
 +#define TARGET_OS_CPP_BUILTINS()			\
-+  builtin_define ("__KOS_GCC_PATCHLEVEL__=2025062800")
 diff -ruN gcc-17.0.0/gcc/configure gcc-17.0.0-kos/gcc/configure
 --- gcc-17.0.0/gcc/configure	2025-04-17 16:01:33.801051764 -0600
 +++ gcc-17.0.0-kos/gcc/configure	2025-04-17 16:01:42.913094480 -0600
@@ -33,10 +32,9 @@ diff --color -ruN gcc-17.0.0/libgcc/config.host gcc-17.0.0-kos/libgcc/config.hos
  tm_define=
  md_unwind_def_header=no-unwind.h
 diff -ruN /dev/null gcc-17.0.0-kos/libgcc/config/t-kos
-+++ b/libgcc/config/t-kos
 --- /dev/null	2025-04-27 14:45:09.695053718 -0600
 +++ gcc-17.0.0-kos/libgcc/config/t-kos	2025-04-27 15:10:10.267714917 -0600
-@@ -0,0 +1 @@
+@@ -0,0 +1,1 @@
 +LIB2ADD = $(srcdir)/config/fake-kos.c
 diff -ruN gcc-17.0.0/libgcc/configure gcc-17.0.0-kos/libgcc/configure
 --- gcc-17.0.0/libgcc/configure	2026-01-28 00:56:02.311489006 -0600
@@ -158,3 +156,89 @@ diff -ruN gcc-17.0.0/libgcc/config/sh/t-sh gcc-17.0.0-kos/libgcc/config/sh/t-sh
  	$(gcc_compile) $(LIBGCC2_CFLAGS) $(vis_hide) -fexceptions -Os -c $<
  
  OBJS_Os_4_200=sdivsi3_i4i-Os-4-200.o udivsi3_i4i-Os-4-200.o unwind-dw2-Os-4-200.o
+
+--- gcc-17.0.0/gcc/config.gcc
++++ gcc-17.0.0-kos/gcc/config.gcc
+@@ -2207,6 +2207,15 @@
+ 	    ;;
+ 	esac
+ 	;;
++i[34567]86-*-xbox*)
++	# elfos.h emits .tdata/.tbss, giving native %gs TLS instead of libgcc's emutls.
++	tm_file="${tm_file} i386/unix.h i386/att.h elfos.h newlib-stdint.h"
++	tm_file="${tm_file} i386/i386elf.h i386/xbox.h"
++	gas=yes
++	gnu_ld=yes
++	default_use_cxa_atexit=yes
++	use_gcc_stdint=wrap
++	;;
+ i[34567]86-*-cygwin*)
+ 	tm_file="${tm_file} i386/unix.h i386/bsd.h i386/gas.h i386/cygming.h i386/cygwin.h i386/cygwin-stdint.h"
+ 	tm_file="${tm_file} mingw/winnt.h"
+--- gcc-17.0.0/gcc/config/i386/xbox.h
++++ gcc-17.0.0-kos/gcc/config/i386/xbox.h
+@@ -0,0 +1,40 @@
++/* Target definitions for the original Microsoft Xbox running KallistiOS.  */
++
++#undef TARGET_OS_CPP_BUILTINS
++#define TARGET_OS_CPP_BUILTINS()				\
++  do								\
++    {								\
++      builtin_define ("__XBOX__");				\
++      builtin_assert ("system=xbox");				\
++    }								\
++  while (0)
++
++/* KOS maps the whole %gs segment flat (4 GB limit), the way Linux does with
++   %fs, so a thread-local can be reached with one segment-prefixed
++   instruction -- movl %gs:x@ntpoff, %eax -- instead of loading the thread
++   pointer from %gs:0 first. i386 is TLS variant II, so @ntpoff is negative
++   and the effective address relies on the segment offset wrapping modulo
++   2^32; that is only valid while the descriptor really does span 4 GB. Build
++   with -mno-tls-direct-seg-refs if %gs is ever given a bounded limit.  */
++#undef TARGET_TLS_DIRECT_SEG_REFS_DEFAULT
++#define TARGET_TLS_DIRECT_SEG_REFS_DEFAULT MASK_TLS_DIRECT_SEG_REFS
++
++/* newlib-stdint.h already resolves to the correct i386 types: the fast types
++   are int-sized because INT_TYPE_SIZE is 32, and the pointer types follow
++   PTRDIFF_TYPE / SIZE_TYPE. No Xbox-specific override is required.  */
++
++/* crti.o/crtn.o bracket crtbegin.o's .init and .fini fragments, forming
++   the _init()/_fini() pair arch_main() calls, as on the Dreamcast.  */
++#undef STARTFILE_SPEC
++#define STARTFILE_SPEC "crti.o%s crtbegin.o%s"
++
++#undef ENDFILE_SPEC
++#define ENDFILE_SPEC "crtend.o%s crtn.o%s"
++
++#undef LIB_SPEC
++#define LIB_SPEC "%{!nostdlib:%{!nodefaultlibs:-lc}}"
++
++/* The KOS linker script names the entry point too; pass it explicitly so a
++   link that does not use the script still starts in the right place.  */
++#undef LINK_SPEC
++#define LINK_SPEC "%{!r:%{!nostdlib:%{!e*:-e _start}}}"
+--- gcc-17.0.0/libgcc/config.host
++++ gcc-17.0.0-kos/libgcc/config.host
+@@ -843,6 +843,10 @@
+ 	;;
+ i[4567]86-wrs-vxworks*|x86_64-wrs-vxworks*)
+ 	;;
++i[34567]86-*-xbox*)
++	tmake_file="$tmake_file i386/t-crtstuff t-crtfm t-dfprules"
++	extra_parts="$extra_parts crti.o crtn.o crtbegin.o crtend.o crtfastmath.o"
++	;;
+ i[34567]86-*-cygwin*)
+ 	extra_parts="crtbegin.o crtbeginS.o crtend.o crtfastmath.o"
+ 	if test x$enable_vtable_verify = xyes; then
+
+--- gcc-17.0.0/config.sub
++++ gcc-17.0.0-kos/config.sub
+@@ -1734,6 +1734,7 @@
+ 	     | ekkobsd* | freebsd* | riscix* | lynxos* | os400* \
+ 	     | bosx* | nextstep* | cxux* | aout* | elf* | oabi* \
+ 	     | ptx* | coff* | ecoff* | winnt* | domain* | vsta* \
++	     | xbox* \
+ 	     | udi* | lites* | ieee* | go32* | aux* | hcos* \
+ 	     | chorusrdb* | cegcc* | glidix* | serenity* \
+ 	     | cygwin* | msys* | pe* | moss* | proelf* | rtems* \

--- a/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
+++ b/utils/kos-chain/patches/targets/newlib-4.6.0.20260123-kos.diff
@@ -287,3 +287,31 @@ diff --color -ruN newlib-4.6.0.20260123/newlib/libc/stdlib/assert.c newlib-4.6.0
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
 +
+
+--- newlib-4.6.0.20260123/newlib/configure.host
++++ newlib-4.6.0.20260123-kos/newlib/configure.host
+@@ -726,6 +726,13 @@
+ 	syscall_dir=syscalls	
+ 	newlib_cflags="${newlib_cflags} -DSMALL_DTOA -DSMALL_MEMORY"
+ 	;;	
++  i[34567]86-*-xbox*)
++	default_newlib_io_long_long="yes"
++	syscall_dir=syscalls
++	newlib_cflags="${newlib_cflags} -DREENTRANT_SYSCALLS_PROVIDED -DMALLOC_PROVIDED -DABORT_PROVIDED -DHAVE_FCNTL"
++	newlib_cflags="${newlib_cflags} -ffunction-sections -fdata-sections"
++	newlib_cv_initfinit_array=yes
++	;;
+   i[34567]86-*-sco*)
+ 	newlib_cflags="${newlib_cflags} -DSIGNAL_PROVIDED -DHAVE_FCNTL"
+ 	;;
+
+--- newlib-4.6.0.20260123/config.sub
++++ newlib-4.6.0.20260123-kos/config.sub
+@@ -1734,6 +1734,7 @@
+ 	     | ekkobsd* | freebsd* | riscix* | lynxos* | os400* \
+ 	     | bosx* | nextstep* | cxux* | aout* | elf* | oabi* \
+ 	     | ptx* | coff* | ecoff* | winnt* | domain* | vsta* \
++	     | xbox* \
+ 	     | udi* | lites* | ieee* | go32* | aux* | hcos* \
+ 	     | chorusrdb* | cegcc* | glidix* | serenity* \
+ 	     | cygwin* | msys* | pe* | moss* | proelf* | rtems* \

--- a/utils/kos-chain/profiles/xbox/17.0.0-dev.mk
+++ b/utils/kos-chain/profiles/xbox/17.0.0-dev.mk
@@ -1,0 +1,36 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=i686-pc-xbox
+
+cpu_configure_args=--with-arch=pentium3 --with-tune=pentium3 --disable-multilib
+newlib_extra_configure_args += --disable-libgloss
+
+# The original Xbox target uses ELF output for a later XBE conversion
+# stage, but it does not provide the hosted runtime libraries expected by
+# GCC's generic x86 runtime packages.
+gcc_xbox_runtime_configure_args= \
+  --disable-libquadmath \
+  --disable-libgomp \
+  --disable-libatomic \
+  --disable-libitm \
+  --disable-libsanitizer \
+  --disable-libvtv
+
+gcc_pass1_configure_args += $(gcc_xbox_runtime_configure_args)
+gcc_pass2_configure_args += $(gcc_xbox_runtime_configure_args)
+
+# Toolchain versions for original Xbox
+binutils_ver=2.47
+gcc_ver=17.0.0
+
+# Override toolchain download type
+gcc_download_type=git
+gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+gcc_git_branch=master
+newlib_ver=4.6.0.20260123
+
+# GCC dependencies for original Xbox
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24

--- a/utils/kos-chain/profiles/xbox/stable.mk
+++ b/utils/kos-chain/profiles/xbox/stable.mk
@@ -1,0 +1,31 @@
+# KallistiOS Toolchain Builder (kos-chain)
+
+target=i686-pc-xbox
+
+cpu_configure_args=--with-arch=pentium3 --with-tune=pentium3 --disable-multilib
+newlib_extra_configure_args += --disable-libgloss
+
+# The original Xbox target uses ELF output for a later XBE conversion
+# stage, but it does not provide the hosted runtime libraries expected by
+# GCC's generic x86 runtime packages.
+gcc_xbox_runtime_configure_args= \
+  --disable-libquadmath \
+  --disable-libgomp \
+  --disable-libatomic \
+  --disable-libitm \
+  --disable-libsanitizer \
+  --disable-libvtv
+
+gcc_pass1_configure_args += $(gcc_xbox_runtime_configure_args)
+gcc_pass2_configure_args += $(gcc_xbox_runtime_configure_args)
+
+# Toolchain versions for original Xbox
+binutils_ver=2.47
+gcc_ver=16.2.0
+newlib_ver=4.6.0.20260123
+
+# GCC dependencies for original Xbox
+gmp_ver=6.2.1
+mpfr_ver=4.1.0
+mpc_ver=1.2.1
+isl_ver=0.24

--- a/utils/kos-chain/scripts/patch.mk
+++ b/utils/kos-chain/scripts/patch.mk
@@ -50,15 +50,20 @@ endef
 # This function is used to replace the config.guess & config.sub that come
 # bundled with the sources with updated versions from GNU. This fixes issues
 # when trying to compile older versions of the toolchain software on newer
-# hardware.
+# hardware. If a KOS patch modifies the file (e.g. config.sub gaining a new
+# target triple), keep the patched copy: the GNU version would undo it.
 define update_configs
-	@echo "+++ Updating $(1) files in $(src_dir)"; \
-	files=$$(find $(src_dir) -name $(1)); \
-	echo "$${files}" | while I= read -r line; do \
-		echo "    $${line}"; \
-		cp $(1) $${line} > /dev/null; \
-	done; \
-	echo ""
+	@if grep -q '^+++ .*/$(1)' /dev/null $(diff_patches); then \
+		echo "+++ Keeping patched $(1) in $(src_dir)"; \
+	else \
+		echo "+++ Updating $(1) files in $(src_dir)"; \
+		files=$$(find $(src_dir) -name $(1)); \
+		echo "$${files}" | while I= read -r line; do \
+			echo "    $${line}"; \
+			cp $(1) $${line} > /dev/null; \
+		done; \
+		echo ""; \
+	fi
 endef
 
 define update_config_guess_sub


### PR DESCRIPTION
Add a toolchain for the original Xbox:
- xbox: i686-pc-xbox for building Xbox programs.