### PR TITLE
workqueue: Race fix

### DIFF
--- a/kernel/thread/workqueue.c
+++ b/kernel/thread/workqueue.c
@@ -115,9 +115,18 @@ void workqueue_enqueue(workqueue_t *wq, workqueue_job_t *job) {
 }
 
 void workqueue_cancel(workqueue_t *wq, workqueue_job_t *job) {
+    workqueue_job_t *cur;
+
     mutex_lock_scoped(&wq->lock);
 
-    STAILQ_REMOVE(&wq->jobs, job, workqueue_job, entry);
+    /* Only unlink it if it is actually queued: a job in flight is no longer
+       on the list, and STAILQ_REMOVE() of a non-member walks off the end. */
+    STAILQ_FOREACH(cur, &wq->jobs, entry) {
+        if(cur == job) {
+            STAILQ_REMOVE(&wq->jobs, job, workqueue_job, entry);
+            break;
+        }
+    }
 
     if(wq->curr_job == job) {
         /* The job's callback is being executed. Wait until it's done. */

--- a/kernel/thread/workqueue.c
+++ b/kernel/thread/workqueue.c
@@ -128,8 +128,9 @@ void workqueue_cancel(workqueue_t *wq, workqueue_job_t *job) {
         }
     }
 
-    if(wq->curr_job == job) {
-        /* The job's callback is being executed. Wait until it's done. */
+    if(wq->curr_job == job && !wq->quit) {
+        /* The job's callback is being executed. Wait until it's done, unless
+           we are shutting down: do not block on a queue that is going away. */
         cond_wait(&wq->cond, &wq->lock);
     }
 
@@ -139,11 +140,19 @@ void workqueue_cancel(workqueue_t *wq, workqueue_job_t *job) {
 }
 
 void workqueue_kill(workqueue_t *wq) {
-    if(!wq->quit) {
-        wq->quit = true;
-        cond_signal(&wq->cond);
-        thd_join(wq->thd, NULL);
+    mutex_lock(&wq->lock);
+
+    if(wq->quit) {
+        /* Already killed */
+        mutex_unlock(&wq->lock);
+        return;
     }
+
+    wq->quit = true;
+    cond_signal(&wq->cond);
+    mutex_unlock(&wq->lock);
+
+    thd_join(wq->thd, NULL);
 }
 
 void workqueue_destroy(workqueue_t *wq) {


### PR DESCRIPTION
@QuzarDC reported a hang on shutdown with dcload-ip + net. Tracking it down turned up these race conditions; fixing them clears the hang.

**Only unlink a cancelled job when it is queued** — the worker dequeues a job
before running it, so an in-flight job is no longer on `wq->jobs`, and
`STAILQ_REMOVE()` of a non-member walks off the end of the list. Now checks
membership first.

**Release blocked cancellers when the thread exits** — during shutdown the
thread could exit without clearing `curr_job` or signalling, leaving a caller
blocked forever on a condvar that `workqueue_destroy()` then frees. The thread
now broadcasts on its way out.