### PR TITLE
build: Fix build system issues

### DIFF
--- a/addons/Makefile.prefab
+++ b/addons/Makefile.prefab
@@ -19,6 +19,7 @@
 defaultall: $(OBJS) subdirs linklib
 
 linklib: $(OBJS) $(LIB_OBJS)
+	@mkdir -p $(KOS_BASE)/addons/lib/$(KOS_ARCH)
 	rm -f $(KOS_BASE)/addons/lib/$(KOS_ARCH)/$(TARGET)
 	$(KOS_AR) rcs $(KOS_BASE)/addons/lib/$(KOS_ARCH)/$(TARGET) $(OBJS) $(LIB_OBJS)
 

--- a/environ_base.sh
+++ b/environ_base.sh
@@ -25,7 +25,7 @@ if ! expr ":$PATH:" : ".*:${KOS_BASE}/utils/build_wrappers:.*" > /dev/null ; the
 fi
 
 # Our includes.
-export KOS_INC_PATHS="${KOS_INC_PATHS} -isystem ${KOS_BASE}/include \
+export KOS_INC_PATHS="-isystem ${KOS_BASE}/include \
 -isystem ${KOS_BASE}/kernel/arch/${KOS_ARCH}/include -isystem ${KOS_BASE}/addons/include/ \
 -isystem ${KOS_PORTS}/include"
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -15,6 +15,8 @@ KOS_CFLAGS += $(KOS_CSTD)
 all: banner.h defaultall $(STUBS)
 	@mkdir -p $(KOS_BASE)/lib/$(KOS_ARCH)
 	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a
+	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti_exports.a
+	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libromdiskbase.a
 	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libromdiskbase.a romdisk/*.o
 	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a build/*.o
 	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti_exports.a stubs/*.o

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -13,6 +13,7 @@ STUBS = stubs/kernel_export_stubs.o stubs/arch_export_stubs.o stubs/subarch_expo
 KOS_CFLAGS += $(KOS_CSTD)
 
 all: banner.h defaultall $(STUBS)
+	@mkdir -p $(KOS_BASE)/lib/$(KOS_ARCH)
 	rm -f $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a
 	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libromdiskbase.a romdisk/*.o
 	kos-ar rcs $(KOS_BASE)/lib/$(KOS_ARCH)/libkallisti.a build/*.o

--- a/kernel/arch/dreamcast/kernel/Makefile
+++ b/kernel/arch/dreamcast/kernel/Makefile
@@ -18,7 +18,8 @@ SUBDIRS =
 
 myall: $(OBJS)
 	-cp $(COPYOBJS) $(KOS_BASE)/kernel/build/
-	-cp startup.o $(KOS_BASE)/lib/$(KOS_ARCH)/_kos_startup.o
+	@mkdir -p $(KOS_BASE)/lib/$(KOS_ARCH)
+	cp startup.o $(KOS_BASE)/lib/$(KOS_ARCH)/_kos_startup.o
 
 include $(KOS_BASE)/Makefile.prefab
 


### PR DESCRIPTION
While working on porting KOS to other consoles there are a few places that can be made more sturdy or better handle multiple archs. These have no behavioral/negative-effects on our current one arch build system. They show up when a library output directory does not exist yet, which is what adding a new arch looks like, when an archive keeps a member nothing builds anymore, and when a second environ.sh is sourced in a shell that already has one.

I plan to do a follow up branch next week. After I experiment with building for multiple archs without having to clean the kernel in between, and that builds on these.