### PR TITLE
genexports: Add stack protector symbols.

### DIFF
--- a/examples/dreamcast/library/Makefile
+++ b/examples/dreamcast/library/Makefile
@@ -21,7 +21,7 @@ KOS_CFLAGS += -I./loadable-dependence
 all: rm-elf $(TARGET_LIB) loadable $(TARGET)
 
 clean: rm-elf
-	-rm -f $(OBJS)
+	-rm -f $(OBJS) exports.c exports_stubs.*
 	-rm -rf ./romdisk
 	cd loadable-dependence && make clean
 	cd loadable-dependent && make clean

--- a/kernel/exports.txt
+++ b/kernel/exports.txt
@@ -57,6 +57,8 @@ strlen
 
 # Misc
 abs
+__stack_chk_fail
+__stack_chk_guard
 # __error
 
 ######################################

--- a/utils/genexports/genexports.sh
+++ b/utils/genexports/genexports.sh
@@ -30,6 +30,11 @@ echo '#ifdef __STRICT_ANSI__' >> $outpfile
 echo '#undef __STRICT_ANSI__' >> $outpfile
 echo '#endif' >> $outpfile
 
+#Provide prototypes for stack protector to work
+echo '#include <stdint.h>' >> $outpfile
+echo 'extern uintptr_t __stack_chk_guard;' >> $outpfile
+echo 'void __stack_chk_fail(void);' >> $outpfile
+
 for i in $includes; do
 	echo "#include <$i>" >> $outpfile
 done


### PR DESCRIPTION
This allows the building of loadable libraries with gcc's stack protector. These symbols are added unconditionally, but should cause no issue if stack protector isn't enabled, and there is no simple way to dynamically test if the stack protector is enabled or not.

Additionally update the library example's makefile to clean up the generated export files, which I noticed during testing.