### PR TITLE
libc: Treat C11 timeouts as absolute deadlines

### DIFF
--- a/kernel/libc/c11/cnd_timedwait.c
+++ b/kernel/libc/c11/cnd_timedwait.c
@@ -7,20 +7,29 @@
 #include <threads.h>
 #include <errno.h>
 
+#include "threads_timeout.h"
+
 int cnd_timedwait(cnd_t *restrict cond, mtx_t *restrict mtx,
                   const struct timespec *restrict ts) {
-    int ms = 0;
+    unsigned int timeout;
 
-    /* Calculate the number of milliseconds to sleep for. No, you don't get
-       anywhere near nanosecond precision here. */
-    ms = ts->tv_sec * 1000 + ts->tv_nsec / 1000000;
+    /* Convert deadline to relative milliseconds. */
+    int deadline_status = c11_timeout_ms(ts, &timeout);
 
-    /* The standard wording implies that we must wait at least the time period
-       specified, so if we have an uneven number of milliseconds, round up. */
-    if(ts->tv_nsec % 1000000)
-        ++ms;
+    /* Negative means a bad deadline or an unusable clock. */
+    if(deadline_status < 0)
+        return thrd_error;
 
-    if(cond_wait_timed(cond, mtx, ms)) {
+    /* Deadline has already expired. C11 still requires the mutex to be
+       released and reacquired, but there is nothing left to wait for. */
+    if(!deadline_status) {
+        mutex_unlock(mtx);
+        mutex_lock(mtx);
+        return thrd_timedout;
+    }
+
+    /* Wait for a signal or the deadline, whichever comes first. */
+    if(cond_wait_timed(cond, mtx, timeout)) {
         if(errno == ETIMEDOUT)
             return thrd_timedout;
 

--- a/kernel/libc/c11/mtx_timedlock.c
+++ b/kernel/libc/c11/mtx_timedlock.c
@@ -7,27 +7,38 @@
 #include <threads.h>
 #include <errno.h>
 
+#include "threads_timeout.h"
+
 int mtx_timedlock(mtx_t *restrict mtx, const struct timespec *restrict ts) {
-    int ms = 0;
+    unsigned int timeout;
+    int deadline_status;
 
     if(mtx->type > MUTEX_TYPE_RECURSIVE) {
         errno = EINVAL;
         return thrd_error;
     }
 
-    /* Calculate the number of milliseconds to sleep for. No, you don't get
-       anywhere near nanosecond precision here. */
-    ms = ts->tv_sec * 1000 + ts->tv_nsec / 1000000;
+    /* Uncontended locks succeed even on an expired deadline. */
+    if(!mutex_trylock(mtx))
+        return thrd_success;
 
-    /* The standard wording implies that we must wait at least the time period
-       specified, so if we have an uneven number of milliseconds, round up. */
-    if(ts->tv_nsec % 1000000)
-        ++ms;
+    /* Anything but EBUSY is a real failure. */
+    if(errno != EBUSY)
+        return thrd_error;
 
-    if(ms < 0)
+    /* Convert deadline to relative milliseconds. */
+    deadline_status = c11_timeout_ms(ts, &timeout);
+
+    /* Negative means a bad deadline or an unusable clock. */
+    if(deadline_status < 0)
+        return thrd_error;
+
+    /* Deadline has already expired. */
+    if(!deadline_status)
         return thrd_timedout;
 
-    if(mutex_lock_timed(mtx, ms)) {
+    /* Block until we own the mutex or the deadline arrives. */
+    if(mutex_lock_timed(mtx, timeout)) {
         if(errno == ETIMEDOUT)
             return thrd_timedout;
 

--- a/kernel/libc/c11/threads_timeout.h
+++ b/kernel/libc/c11/threads_timeout.h
@@ -1,0 +1,57 @@
+/* KallistiOS ##version##
+
+   threads_timeout.h
+   Copyright (C) 2026 Cypress
+
+*/
+
+#ifndef __LOCAL_C11_THREADS_TIMEOUT_H
+#define __LOCAL_C11_THREADS_TIMEOUT_H
+
+#include <stdint.h>
+#include <threads.h>
+
+/* Convert the absolute TIME_UTC deadline required by the C threads API to the
+   relative millisecond timeout used by KOS synchronization primitives.
+
+   Returns:
+      1  the deadline is in the future, with *timeout set to the wait
+      0  the deadline has already expired
+     -1  a null argument, or the clock could not be read
+*/
+static inline int
+c11_timeout_ms(const struct timespec *deadline, unsigned int *timeout) {
+    struct timespec now;
+    uint32_t seconds;
+    uint32_t milliseconds;
+    long nanoseconds;
+
+    /* Make sure we have valid inputs. */
+    if(!deadline || !timeout || timespec_get(&now, TIME_UTC) != TIME_UTC)
+        return -1;
+
+    /* The deadline has passed, so there is no time left to wait. */
+    if(deadline->tv_sec < now.tv_sec ||
+      (deadline->tv_sec == now.tv_sec &&
+       deadline->tv_nsec <= now.tv_nsec))
+        return 0;
+
+    /* Calculate the time difference between the deadline and current time. */
+    seconds = (uint32_t)deadline->tv_sec - (uint32_t)now.tv_sec;
+    nanoseconds = deadline->tv_nsec - now.tv_nsec;
+    if(nanoseconds < 0) {
+        --seconds;
+        nanoseconds += 1000000000;
+    }
+
+    /* Calculate the number of milliseconds to sleep for (Rounding up to at
+       least 1 ms). */
+    milliseconds = seconds * 1000;
+    milliseconds += ((uint32_t)nanoseconds + 999999) / 1000000;
+
+    *timeout = milliseconds;
+
+    return 1;
+}
+
+#endif /* __LOCAL_C11_THREADS_TIMEOUT_H */

--- a/kernel/thread/cond.c
+++ b/kernel/thread/cond.c
@@ -15,6 +15,7 @@
 
 #include <kos/thread.h>
 #include <kos/cond.h>
+#include <kos/errno.h>
 #include <kos/genwait.h>
 
 #include <kos/dbglog.h>
@@ -59,6 +60,9 @@ int cond_wait_timed(condvar_t *cv, mutex_t *m, int timeout) {
 
     if(rv < 0 && errno == EAGAIN)
         errno = ETIMEDOUT;
+
+    /* Caching errno since a contended mutex sets EBUSY. */
+    errno_save_scoped();
 
     /* Re-lock our mutex */
     mutex_lock(m);


### PR DESCRIPTION
These fixes were initially made by @cypressru. I cleaned them up and made them PR ready.

C11 says these functions take a *deadline* (a point in time), but KOS read it as a *duration*.

A new `c11_timeout_ms()` subtracts the current time to get the duration KOS actually wants. Following the spec:

- [`mtx_timedlock()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/mtx_timedlock.html) tries the lock before checking the clock. A free lock is yours even if the deadline passed — C11 §7.26.4.4 only reports a timeout if you *didn't* get the lock.
- [`cnd_timedwait()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/cnd_timedwait.html) still unlocks and relocks your mutex when the deadline has passed, as §7.26.3.5 requires.

Also, `cond_wait_timed()` relocks your mutex after timing out. If another thread held it, that overwrote `ETIMEDOUT` with `EBUSY`, hiding real timeouts.