### PR TITLE
gdb: Add missing 'b' prefix to binary memory read replies

### DIFF
--- a/kernel/arch/dreamcast/gdb/gdb_mem.c
+++ b/kernel/arch/dreamcast/gdb/gdb_mem.c
@@ -202,6 +202,10 @@ void gdb_handle_read_mem_binary(char *ptr) {
     }
 
     src = (const unsigned char *)addr;
+
+    /* 'x' reply must begin with a literal 'b' before the binary payload */
+    *out++ = 'b';
+
     for(uint32_t i = 0; i < len; ++i) {
         if((size_t)(out - remcom_out_buffer) > BUFMAX - 3u) {
             gdb_error_with_code_str(GDB_EMEM_SIZE, "x: response too large");


### PR DESCRIPTION
Adding the modern 'x' endpoint during the gdb refactor replaced the working legacy 'm' endpoint. This screwed up backtracing in GDB. The 'x' packet must begin with a literal 'b' before the payload. This should restore backtraces.

Fixes this issue: https://github.com/KallistiOS/KallistiOS/issues/1514