### PR TITLE
feat(kos-chain): add optional GDB support to Docker image

### DIFF
--- a/utils/kos-chain/docker/Dockerfile
+++ b/utils/kos-chain/docker/Dockerfile
@@ -9,8 +9,8 @@
 #       docker run -it --name containername dcchain:stable /bin/bash
 
 # Stage 1
-FROM alpine:latest as build
-MAINTAINER KallistiOS <cadcdev-kallistios@lists.sourceforge.net>
+FROM alpine:latest AS build
+LABEL maintainer="KallistiOS <cadcdev-kallistios@lists.sourceforge.net>"
 
 # Installing prerequisites
 RUN apk --update add --no-cache \
@@ -38,12 +38,17 @@ RUN apk --update add --no-cache \
 # You may adapt the KallistiOS repository URL if needed
 ARG platform=dreamcast
 ARG profile=stable
+ARG include_gdb=0
 
 RUN mkdir -p /opt/toolchains/dc
 COPY . /opt/toolchains/dc/kos
 
 RUN cd /opt/toolchains/dc/kos/utils/kos-chain \
-	&& make build platform=$platform toolchain_profile=$profile \
+        && if [ "$include_gdb" = "1" ]; then \
+                make all platform=$platform toolchain_profile=$profile; \
+        else \
+                make build platform=$platform toolchain_profile=$profile; \
+        fi \
 	&& rm -rf /opt/toolchains/dc/kos
 
 # Stage 2

--- a/utils/kos-chain/docker/README.md
+++ b/utils/kos-chain/docker/README.md
@@ -26,3 +26,6 @@ This Dockerfile builds the `stable` toolchain by default, but can be used to
 build the other toolchains like `9.5.0-winxp`, `15.2.1-dev`, etc., as long as
 you pass the `dc_chain` argument in the docker command line (see the Dockerfile
 for an example of the syntax).
+
+GDB is not built by default. To include it in the image, pass the
+`include_gdb=1` build argument when invoking `docker build`.


### PR DESCRIPTION
This change updates the kos-chain Docker image so GDB can be included when requested without changing the default build behavior.

By default, the Dockerfile still builds the standard toolchain with make build. When include_gdb=1 is passed as a Docker build argument, it switches to make all, which includes sh-elf-gdb in the resulting image. The Docker documentation was updated to describe this new build option.

The Dockerfile was also cleaned up by replacing the deprecated MAINTAINER instruction with LABEL and normalizing the FROM ... AS syntax.

### Validation:

Built the Docker image with --build-arg include_gdb=1
Verified sh-elf-gdb is present and runnable in the image
Confirmed reported version: GNU gdb (GDB) 17.1