### PR TITLE
libc: Give std::chrono its full 80ns resolution

### DIFF
--- a/examples/dreamcast/cpp/clock/Makefile
+++ b/examples/dreamcast/cpp/clock/Makefile
@@ -1,18 +1,22 @@
 #
 # DC Clock App
 # Based on Peter Hatch's Font Test
-# (c)2002 Megan Potter
-#   
+#
+# Copyright (C) 2002 Megan Potter
+# Copyright (C) 2026 Falco Girgis
+#
 
 TARGET = clock.elf
 OBJS = clock.o romdisk.o
 KOS_ROMDISK_DIR = romdisk
-
-KOS_CPPFLAGS += -std=gnu++17
-
-all: rm-elf $(TARGET)
+KOS_CPPFLAGS += -std=gnu++23
+KOS_GCCVER_MIN = 14.1.0
 
 include $(KOS_BASE)/Makefile.rules
+
+ifeq ($(call KOS_GCCVER_MIN_CHECK,$(KOS_GCCVER_MIN)),1)
+
+all: rm-elf $(TARGET)
 
 clean: rm-elf
 	-rm -f $(OBJS) 
@@ -30,3 +34,7 @@ dist: $(TARGET)
 	-rm -f $(OBJS) romdisk.img
 	$(KOS_STRIP) $(TARGET)
 
+else
+  all $(TARGET) clean rm-elf run dist:
+	$(KOS_GCCVER_MIN_WARNING)
+endif

--- a/examples/dreamcast/cpp/clock/clock.cc
+++ b/examples/dreamcast/cpp/clock/clock.cc
@@ -1,76 +1,85 @@
-// Originally from plib_examples
-// Ported to Dreamcast/KOS by Peter Hatch
-// read_input () code from KOS examples
-// Converted to a clock by Megan Potter
-// Resolution enhanced by Falco Girgis
+/* KallistiOS ##version##
+
+   examples/dreamcast/cpp/clock/clock.cc
+
+   Copyright (C) Peter Hatch
+   Copyright (C) Megan Potter
+   Copyright (C) 2023, 2026 Falco Girgis
+
+*/
+
+/*
+    This example displays the following information, updating in real-time:
+        - Current Unix timestamp
+        - Current date
+        - Current timestamp (nanosecond resolution)
+
+    It uses C++'s std::chrono timing API for all of this, and additionally
+    leverages as much modern functionality from C++23 as is possible, both
+    to provide examples to users and to serve as a sanity test for modern
+    C++ features in the toolchain for us KOS devs. :)
+*/
 
 #include <kos.h>
-#include <time.h>
 #include <dcplib/fnt.h>
 
-fntRenderer *text;
-fntTexFont *font;
+#include <cmath>
+#include <cstdlib>
 
-const char *days[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
-const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
-                         "Aug", "Sep", "Oct", "Nov", "Dec"
-                       };
+#include <array>
+#include <algorithm>
+#include <functional>
+#include <chrono>
+#include <print>
+#include <format>
 
-float bg[3];                        /* Current bg */
-float bg_delta[3] = { 0.01f };      /* bg per-frame delta */
-int   bg_cur = 1;
-float bgarray[][3] = {
-    { 0.0f, 0.0f, 0.0f },
-    { 0.5f, 0.0f, 0.0f },
-    { 0.0f, 0.5f, 0.0f },
-    { 0.0f, 0.0f, 0.5f },
-    { 0.5f, 0.0f, 0.5f },
-    { 0.0f, 0.5f, 0.5f },
-    { 0.5f, 0.5f, 0.0f },
-    { 0.5f, 0.5f, 0.5f }
+namespace {
+
+struct bg_state {
+    std::array<float, 3> color = { 0.0f };
+    std::array<float, 3> delta = { 0.01f };
+    size_t index = 1;
+
+    constexpr static const
+    std::array<std::array<float, 3>, 8> presets = {{
+        { 0.0f, 0.0f, 0.0f },
+        { 0.5f, 0.0f, 0.0f },
+        { 0.0f, 0.5f, 0.0f },
+        { 0.0f, 0.0f, 0.5f },
+        { 0.5f, 0.0f, 0.5f },
+        { 0.0f, 0.5f, 0.5f },
+        { 0.5f, 0.5f, 0.0f },
+        { 0.5f, 0.5f, 0.5f }
+    }};
 };
-#define BG_COUNT 8
 
-#define fabs(a) ( (a) < 0 ? -(a) : (a) )
-void bgframe() {
-    pvr_set_bg_color(bg[0], bg[1], bg[2]);
+void update_bg(bg_state* bg) {
+    pvr_set_bg_color(bg->color[0], bg->color[1], bg->color[2]);
 
-    bg[0] += bg_delta[0];
-    bg[1] += bg_delta[1];
-    bg[2] += bg_delta[2];
+    std::ranges::transform(bg->color, bg->delta, bg->color.begin(), std::plus<float>());
 
-    if(fabs(bg[0] - bgarray[bg_cur][0]) < 0.01f
-            && fabs(bg[1] - bgarray[bg_cur][1]) < 0.01f
-            && fabs(bg[2] - bgarray[bg_cur][2]) < 0.01f) {
-        bg_cur++;
+    if(std::ranges::equal(bg->color, bg->presets[bg->index],
+                          [](float a, float b) { return std::abs(a - b) < 0.01f; }))
+    {
+        if(++bg->index >= bg->presets.size())
+            bg->index = 0;
 
-        if(bg_cur >= BG_COUNT)
-            bg_cur = 0;
-
-        bg_delta[0] = (bgarray[bg_cur][0] - bg[0]) / (0.5f / 0.01f);
-        bg_delta[1] = (bgarray[bg_cur][1] - bg[1]) / (0.5f / 0.01f);
-        bg_delta[2] = (bgarray[bg_cur][2] - bg[2]) / (0.5f / 0.01f);
+        std::ranges::transform(bg->presets[bg->index], bg->color, bg->delta.begin(),
+                               [](float a, float b) { return (a - b) / (0.5f / 0.01f); });
     }
 }
 
-void drawFrame() {
-    struct timespec spec;
-    struct tm tm;
-    char tmpbuf[256];
+void draw_scene(fntRenderer* text) {
     int y = 50;
 
-    bgframe();
-
-    timespec_get(&spec, TIME_UTC);
-    localtime_r(&spec.tv_sec, &tm);
+    auto timestamp = std::chrono::high_resolution_clock::now();
+    auto duration  = timestamp.time_since_epoch();
+    auto seconds   = std::chrono::duration_cast<std::chrono::seconds>(duration);
+    auto unix_secs = std::chrono::system_clock::to_time_t(timestamp);
+    auto nanosecs  = std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds);
 
     pvr_scene_begin();
     pvr_list_begin(PVR_LIST_TR_POLY);
-
-    text->setFilterMode(PVR_FILTER_NEAREST);
-
-    text->setFont(font);
-    text->setPointSize(30);
 
     text->begin();
     text->setColor(1, 1, 1);
@@ -79,82 +88,71 @@ void drawFrame() {
     text->end();
     y += 50;
 
-    sprintf(tmpbuf, "Unix: %lld", spec.tv_sec);
+    text->begin();
+    text->setColor(1, 1, 1);
+    text->start2f(20, y);
+    text->puts(std::format("Unix: {}", unix_secs).c_str());
+    text->end();
+    y += 50;
 
     text->begin();
     text->setColor(1, 1, 1);
     text->start2f(20, y);
-    text->puts(tmpbuf);
+    text->puts(std::format("{0:%A} {0:%B} {0:%d}, {0:%Y}", timestamp).c_str());
     text->end();
     y += 50;
-
-    sprintf(tmpbuf, "%s %s %02d %04d",
-            days[tm.tm_wday], months[tm.tm_mon], tm.tm_mday, 1900 + tm.tm_year);
 
     text->begin();
     text->setColor(1, 1, 1);
     text->start2f(20, y);
-    text->puts(tmpbuf);
+    text->puts(std::format("{:%H:%M:%S}", timestamp).c_str());
     text->end();
     y += 50;
 
-    sprintf(tmpbuf, "%02d:%02d:%02d.%lu",
-            tm.tm_hour, tm.tm_min, tm.tm_sec, spec.tv_nsec);
-
-    text->begin();
-    text->setColor(1, 1, 1);
-    text->start2f(20, y);
-    text->puts(tmpbuf);
-    text->end();
-    y += 50;
-
-    pvr_list_finish();
     pvr_scene_finish();
 }
 
+bool read_input() {
+    if(auto *cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER); cont) {
+        /* Check for start on the controller */
+        auto *state = static_cast<cont_state_t *>(maple_dev_status(cont));
 
-/* This is really more complicated than it needs to be in this particular
-   case, but it's nice and verbose. */
-int read_input() {
-    maple_device_t *cont;
-    cont_state_t *state;
+        if(!state) {
+            std::println(stderr, "Error getting controller status.");
+            return true;
+        }
 
-    cont = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
-
-    if(!cont) {
-        return 0;
+        if(state->start) {
+            std::println("Pressed start.");
+            return true;
+        }
     }
 
-    /* Check for start on the controller */
-    state = (cont_state_t *)maple_dev_status(cont);
+    return false;
+}
 
-    if(!state) {
-        printf("Error getting controller status\n");
-        return 1;
-    }
-
-    if(state->buttons & CONT_START) {
-        printf("Pressed start\n");
-        return 1;
-    }
-
-    return 0;
 }
 
 int main(int argc, char **argv) {
-    pvr_init_params_t pvrInit = {
-        {PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_32, PVR_BINSIZE_0, PVR_BINSIZE_0},
+    const pvr_init_params_t pvrInit = {
+        { PVR_BINSIZE_0, PVR_BINSIZE_0, PVR_BINSIZE_32, PVR_BINSIZE_0, PVR_BINSIZE_0 },
         512 * 1024, 0, 0, 0, 0, 0
     };
 
     pvr_init(&pvrInit);
 
-    text = new fntRenderer();
-    font = new fntTexFont("/rd/default.txf");
+    fntRenderer text;
+    fntTexFont font("/rd/default.txf");
+    bg_state bg;
+
+    text.setFilterMode(PVR_FILTER_NEAREST);
+    text.setFont(&font);
+    text.setPointSize(30);
 
     while(!read_input()) {
-        drawFrame();
+        update_bg(&bg);
+        draw_scene(&text);
     }
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/include/kos/timer.h
+++ b/include/kos/timer.h
@@ -35,7 +35,7 @@ typedef struct timespec timespec_t;
 
     \return                 The current uptime of the system as a timespec struct.
 */
-static inline timespec_t timer_gettime(void) {
+static inline timespec_t timer_gettimespec(void) {
     return arch_timer_gettime();
 }
 
@@ -49,7 +49,7 @@ static inline timespec_t timer_gettime(void) {
     \return                 The number of milliseconds since KOS started.
 */
 static inline uint64_t timer_ms_gettime64(void) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     return (uint64_t)time.tv_sec * 1000 + (uint64_t)(time.tv_nsec / 1000000);
 }
@@ -62,7 +62,7 @@ static inline uint64_t timer_ms_gettime64(void) {
     \return                 The uptime in microseconds.
 */
 static inline uint64_t timer_us_gettime64(void) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     return (uint64_t)time.tv_sec * 1000000 + (uint64_t)(time.tv_nsec / 1000);
 }
@@ -75,7 +75,7 @@ static inline uint64_t timer_us_gettime64(void) {
     \return                 The uptime in nanoseconds.
 */
 static inline uint64_t timer_ns_gettime64(void) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     return (uint64_t)time.tv_sec * 1000000000 + (uint64_t)time.tv_nsec;
 }
@@ -95,7 +95,7 @@ static inline uint64_t timer_ns_gettime64(void) {
                             timer_ms_gettime64() function.
 */
 static inline void timer_ms_gettime(uint32_t *secs, uint32_t *msecs) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     if(secs)  *secs = time.tv_sec;
     if(msecs) *msecs = (uint32_t)(time.tv_nsec / 1000000);
@@ -117,7 +117,7 @@ static inline void timer_ms_gettime(uint32_t *secs, uint32_t *msecs) {
                             a second since boot.
 */
 static inline void timer_us_gettime(uint32_t *secs, uint32_t *usecs) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     if(secs)  *secs = time.tv_sec;
     if(usecs) *usecs = (uint32_t)(time.tv_nsec / 1000);
@@ -139,7 +139,7 @@ static inline void timer_us_gettime(uint32_t *secs, uint32_t *usecs) {
                             a second since boot.
 */
 static inline void timer_ns_gettime(uint32_t *secs, uint32_t *nsecs) {
-    timespec_t time = timer_gettime();
+    timespec_t time = timer_gettimespec();
 
     if(secs)  *secs = time.tv_sec;
     if(nsecs) *nsecs = (uint32_t)time.tv_nsec;

--- a/include/machine/time.h
+++ b/include/machine/time.h
@@ -92,35 +92,25 @@ extern __time_t timegm(struct tm *timeptr);
 
 #endif
 
-/* =========== Enable the following for POSIX POSIX.1b (1993) =========== */
-#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 199309L)
+/* ================= POSIX.1b (1993) realtime option macros ================= */
 
-/* We do not support POSIX timers!
+/* KOS implements the clock half of the POSIX Timers option (clock_gettime(),
+   clock_settime(), clock_getres() and nanosleep()) along with the monotonic
+   and CPU-time clocks. */
 #ifndef _POSIX_TIMERS
-#define _POSIX_TIMERS 1
-#endif */
+#define _POSIX_TIMERS           200809L
+#endif
 
 #ifndef _POSIX_MONOTONIC_CLOCK
-#define _POSIX_MONOTONIC_CLOCK 1
+#define _POSIX_MONOTONIC_CLOCK  200809L
 #endif
 
 #ifndef _POSIX_CPUTIME
-#define _POSIX_CPUTIME 1
+#define _POSIX_CPUTIME          200809L
 #endif
 
 #ifndef _POSIX_THREAD_CPUTIME
-#define _POSIX_THREAD_CPUTIME 1
-#endif
-
-/* Explicitly provided function declarations for POSIX clock API, since
-   getting them from Newlib requires supporting the rest of the _POSIX_TIMERS
-   API, which is not implemented yet. */
-extern int clock_settime(__clockid_t clock_id, const struct timespec *ts);
-extern int clock_gettime(__clockid_t clock_id, struct timespec *ts);
-extern int clock_getres(__clockid_t clock_id, struct timespec *res);
-
-extern int nanosleep(const struct timespec *req, struct timespec *rem);
-
+#define _POSIX_THREAD_CPUTIME   200809L
 #endif
 
 /** \endcond */

--- a/kernel/libc/posix/Makefile
+++ b/kernel/libc/posix/Makefile
@@ -1,7 +1,7 @@
 # KallistiOS ##version##
 #
 # kernel/libc/posix/Makefile
-# Copyright (C) 2023 Falco Girgis
+# Copyright (C) 2023, 2026 Falco Girgis
 #
 
 #
@@ -11,6 +11,6 @@
 #
 
 CFLAGS += -std=gnu11
-OBJS = posix_memalign.o clock_gettime.o settimeofday.o sysconf.o resource.o
+OBJS = posix_memalign.o clock_gettime.o posix_timer.o settimeofday.o sysconf.o resource.o
 
 include $(KOS_BASE)/Makefile.prefab

--- a/kernel/libc/posix/posix_timer.c
+++ b/kernel/libc/posix/posix_timer.c
@@ -1,0 +1,56 @@
+/* KallistiOS ##version##
+
+   posix_timer.c
+   Copyright (C) 2026 Falco Girgis
+*/
+
+/* Stubbed implementations of the asynchronous half of the POSIX Timers
+   option (timer_create() and friends). */
+
+#include <time.h>
+#include <signal.h>
+#include <errno.h>
+
+int timer_create(clockid_t clock_id, struct sigevent *__restrict evp,
+                 timer_t *__restrict timerid) {
+    (void)clock_id;
+    (void)evp;
+    (void)timerid;
+
+    errno = ENOSYS;
+    return -1;
+}
+
+int timer_delete(timer_t timerid) {
+    (void)timerid;
+
+    errno = EINVAL;
+    return -1;
+}
+
+int timer_settime(timer_t timerid, int flags,
+                  const struct itimerspec *__restrict value,
+                  struct itimerspec *__restrict ovalue) {
+    (void)timerid;
+    (void)flags;
+    (void)value;
+    (void)ovalue;
+
+    errno = EINVAL;
+    return -1;
+}
+
+int timer_gettime(timer_t timerid, struct itimerspec *value) {
+    (void)timerid;
+    (void)value;
+
+    errno = EINVAL;
+    return -1;
+}
+
+int timer_getoverrun(timer_t timerid) {
+    (void)timerid;
+
+    errno = EINVAL;
+    return -1;
+}

--- a/utils/kos-chain/doc/mingw/packages/fixup-sh4-newlib.sh
+++ b/utils/kos-chain/doc/mingw/packages/fixup-sh4-newlib.sh
@@ -17,3 +17,4 @@ cp -r $kos_base/kernel/arch/dreamcast/include/dc $newlib_inc
 # they are already "cp" instructions.
 cp $kos_base/include/pthread.h $newlib_inc
 cp $kos_base/include/sys/_pthread.h $newlib_inc/sys
+cp $kos_base/include/machine/time.h $newlib_inc/machine

--- a/utils/kos-chain/patches/README.md
+++ b/utils/kos-chain/patches/README.md
@@ -25,6 +25,7 @@ Generic `newlib` fixups (applied directly after `newlib` is installed):
 ```
 cp $(kos_base)/include/pthread.h $(newlib_inc)                       # KOS pthread.h is modified
 cp $(kos_base)/include/sys/_pthread.h $(newlib_inc)/sys              # to define _POSIX_THREADS
+cp $(kos_base)/include/machine/time.h $(newlib_inc)/machine       # KOS machine/time.h defines _POSIX_TIMERS & co.
 ln -nsf $(kos_base)/include/kos $(newlib_inc)                        # so KOS includes are available as kos/file.h
 ln -nsf $(kos_base)/kernel/arch/dreamcast/include/arch $(newlib_inc) # kos/thread.h requires arch/arch.h
 ln -nsf $(kos_base)/kernel/arch/dreamcast/include/dc   $(newlib_inc) # arch/arch.h requires dc/video.h

--- a/utils/kos-chain/patches/targets/gcc-13.2.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-13.2.0-kos.diff
@@ -145,6 +145,21 @@ diff --color -ruN gcc-13.2.0/libstdc++-v3/configure gcc-13.2.0-kos/libstdc++-v3/
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+@@ -20604,6 +20605,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-13.2.0/libgcc/config/sh/t-sh gcc-13.2.0-kos/libgcc/config/sh/t-sh
 --- gcc-13.2.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-13.2.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-13.4.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-13.4.0-kos.diff
@@ -145,6 +145,21 @@ diff --color -ruN gcc-13.4.0/libstdc++-v3/configure gcc-13.4.0-kos/libstdc++-v3/
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+@@ -20620,6 +20621,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-13.4.0/libgcc/config/sh/t-sh gcc-13.4.0-kos/libgcc/config/sh/t-sh
 --- gcc-13.4.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-13.4.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-13.4.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-13.4.1-kos.diff
@@ -145,6 +145,21 @@ diff --color -ruN gcc-13.4.1/libstdc++-v3/configure gcc-13.4.1-kos/libstdc++-v3/
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+@@ -20620,6 +20621,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-13.4.1/libgcc/config/sh/t-sh gcc-13.4.1-kos/libgcc/config/sh/t-sh
 --- gcc-13.4.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-13.4.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-14.4.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-14.4.0-kos.diff
@@ -145,6 +145,21 @@ diff -ruN gcc-14.4.0/libstdc++-v3/configure gcc-14.4.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+@@ -21303,6 +21304,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-14.4.0/libgcc/config/sh/t-sh gcc-14.4.0-kos/libgcc/config/sh/t-sh
 --- gcc-14.4.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-14.4.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-14.4.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-14.4.1-kos.diff
@@ -145,6 +145,21 @@ diff -ruN gcc-14.4.1/libstdc++-v3/configure gcc-14.4.1-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+@@ -21303,6 +21304,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-14.4.1/libgcc/config/sh/t-sh gcc-14.4.1-kos/libgcc/config/sh/t-sh
 --- gcc-14.4.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-14.4.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-15.2.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-15.2.0-kos.diff
@@ -145,6 +145,21 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+@@ -21306,6 +21307,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-15.2.0/libgcc/config/sh/t-sh gcc-15.2.0-kos/libgcc/config/sh/t-sh
 --- gcc-15.2.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-15.2.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-15.3.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-15.3.0-kos.diff
@@ -145,6 +145,21 @@ diff -ruN gcc-15.3.0/libstdc++-v3/configure gcc-15.3.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+@@ -21306,6 +21307,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-15.3.0/libgcc/config/sh/t-sh gcc-15.3.0-kos/libgcc/config/sh/t-sh
 --- gcc-15.3.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-15.3.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-15.3.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-15.3.1-kos.diff
@@ -145,6 +145,21 @@ diff -ruN gcc-15.3.1/libstdc++-v3/configure gcc-15.3.1-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
  esac
  
+@@ -21306,6 +21307,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-15.3.1/libgcc/config/sh/t-sh gcc-15.3.1-kos/libgcc/config/sh/t-sh
 --- gcc-15.3.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-15.3.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-16.2.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.2.0-kos.diff
@@ -145,6 +145,21 @@ diff -ruN gcc-16.2.0/libstdc++-v3/configure gcc-16.2.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
+@@ -21486,6 +21487,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-16.2.0/libgcc/config/sh/t-sh gcc-16.2.0-kos/libgcc/config/sh/t-sh
 --- gcc-16.2.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-16.2.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-16.2.1-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-16.2.1-kos.diff
@@ -146,6 +146,21 @@ diff -ruN gcc-16.2.1/libstdc++-v3/configure gcc-16.2.1-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
+@@ -21486,6 +21487,14 @@
+       vxworks*)
+         ac_has_nanosleep=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-16.2.1/libgcc/config/sh/t-sh gcc-16.2.1-kos/libgcc/config/sh/t-sh
 --- gcc-16.2.1/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-16.2.1-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-17.0.0-kos.diff
@@ -146,6 +146,21 @@ diff -ruN gcc-17.0.0/libstdc++-v3/configure gcc-17.0.0-kos/libstdc++-v3/configur
      mcf)	thread_header=config/i386/gthr-mcf.h ;;
      *)
          as_fn_error $? "No known header for threading model '$target_thread_file'." "$LINENO" 5
+@@ -21471,6 +21472,14 @@
+         ac_has_nanosleep=yes
+         ac_has_sched_yield=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then
 diff -ruN gcc-17.0.0/libgcc/config/sh/t-sh gcc-17.0.0-kos/libgcc/config/sh/t-sh
 --- gcc-17.0.0/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600
 +++ gcc-17.0.0-kos/libgcc/config/sh/t-sh	2026-07-24 00:00:00.000000000 -0600

--- a/utils/kos-chain/patches/targets/gcc-9.5.0-kos.diff
+++ b/utils/kos-chain/patches/targets/gcc-9.5.0-kos.diff
@@ -145,3 +145,18 @@ diff --color -ruN gcc-9.5.0/libstdc++-v3/configure gcc-9.5.0-kos/libstdc++-v3/co
  esac
  
  
+@@ -20408,6 +20409,14 @@
+         ac_has_nanosleep=yes
+         ac_has_sched_yield=yes
+         ;;
++      # KallistiOS: libkallisti provides clock_gettime(), nanosleep() and
++      # sched_yield(), but is not available to link tests at this point.
++      elf*)
++        ac_has_clock_monotonic=yes
++        ac_has_clock_realtime=yes
++        ac_has_nanosleep=yes
++        ac_has_sched_yield=yes
++        ;;
+       gnu* | linux* | kfreebsd*-gnu | knetbsd*-gnu)
+         # Don't use link test for freestanding library, in case gcc_no_link=yes
+         if test x"$is_hosted" = xyes; then

--- a/utils/kos-chain/scripts/newlib.mk
+++ b/utils/kos-chain/scripts/newlib.mk
@@ -32,6 +32,7 @@ endif
 fixup-newlib-init: $(build_newlib)
 	-mkdir -p $(newlib_inc)
 	-mkdir -p $(newlib_inc)/sys
+	-mkdir -p $(newlib_inc)/machine
 
 fixup-newlib-apply: fixup-newlib-init
 	@echo "+++ Fixing up newlib includes..."
@@ -42,6 +43,8 @@ fixup-newlib-apply: fixup-newlib-init
 	cp $(kos_base)/include/pthread.h $(newlib_inc)
 	cp $(kos_base)/include/sys/_pthreadtypes.h $(newlib_inc)/sys
 	cp $(kos_base)/include/sys/dirent.h $(newlib_inc)/sys
+# KOS machine/time.h defines _POSIX_TIMERS & co.
+	cp $(kos_base)/include/machine/time.h $(newlib_inc)/machine
 ifndef MINGW32
 	ln -nsf $(kos_base)/include/kos $(newlib_inc)
 else


### PR DESCRIPTION
Redo of #1387 by @gyrovorbis, which fixes `std::chrono`'s useless 1-second resolution. I've reworked the approach to address the review feedback there and rebased onto current master.