### PR TITLE
rwsem: Fix the expired-deadline check on an unsigned timeout

### DIFF
--- a/kernel/thread/rwsem.c
+++ b/kernel/thread/rwsem.c
@@ -53,7 +53,7 @@ static int rwsem_update_timed(rw_semaphore_t *s, unsigned int timeout,
         if(timeout) {
             /* Update the timeout value to the remaining time */
             timeout = deadline - timer_ms_gettime64();
-            if(timeout <= 0) {
+            if((int)timeout <= 0) {
                 if(type == UPDATE_TYPE_READ)
                     atomic_fetch_sub(&s->read_count, 1);
                 mutex_unlock(&s->write_lock);


### PR DESCRIPTION
rwsem_update_timed() recomputes the time left after taking the write mutex, but timeout is unsigned, so "timeout <= 0" is only ever true at exactly zero. An expired deadline wraps around to a huge timeout instead of returning ETIMEDOUT, and the sem_wait_timed() below it waits on that rather than giving up.

mutex_lock_timed() does the same computation and already casts to signed so lets do the same here.