### PR TITLE
Add initial support for VideoLogic Elan T&L and second PowerVR (CLXB) on NAOMI 2.

### DIFF
--- a/kernel/arch/dreamcast/hardware/Makefile
+++ b/kernel/arch/dreamcast/hardware/Makefile
@@ -25,7 +25,7 @@ OBJS += spu.o
 OBJS += asic.o g2bus.o
 
 # Video-related
-OBJS += video.o vblank.o
+OBJS += video.o vblank.o elan.o
 
 # CPU-related
 OBJS += sq.o sq_fast_cpy.o scif.o sci.o ubc.o dmac.o wdt.o

--- a/kernel/arch/dreamcast/hardware/elan.c
+++ b/kernel/arch/dreamcast/hardware/elan.c
@@ -1,0 +1,48 @@
+/* KallistiOS ##version##
+
+   elan.c
+   Copyright (C) 2026 Ruslan Rostovtsev
+*/
+
+#include <arch/arch.h>
+#include <dc/elan.h>
+
+bool elan_present(void) {
+    if(hardware_sys_mode(NULL) != HW_TYPE_NAOMI) {
+        return false;
+    }
+    return ELAN_GET(ELAN_REG_ID) == ELAN_MAGIC;
+}
+
+uint32_t elan_revision(void) {
+    if(!elan_present()) {
+        return 0;
+    }
+    return ELAN_GET(ELAN_REG_REVISION);
+}
+
+uint32_t elan_ifctl_get(void) {
+    if(!elan_present()) {
+        return 0;
+    }
+    return ELAN_GET(ELAN_REG_IFCTL);
+}
+
+void elan_ifctl_set(uint32_t value) {
+    if(!elan_present()) {
+        return;
+    }
+    ELAN_SET(ELAN_REG_IFCTL, value);
+}
+
+void elan_pvr2_enable(void) {
+    elan_ifctl_set(ELAN_IFCTL_PVR2);
+}
+
+void elan_pvr2_disable(void) {
+    elan_ifctl_set(0);
+}
+
+bool elan_pvr2_enabled(void) {
+    return (elan_ifctl_get() & ELAN_IFCTL_PVR2) != 0;
+}

--- a/kernel/arch/dreamcast/hardware/pvr/Makefile
+++ b/kernel/arch/dreamcast/hardware/pvr/Makefile
@@ -28,6 +28,7 @@ OBJS += pvr_prim.o pvr_scene.o
 # Texture handling
 OBJS += pvr_texture.o pvr_dma.o
 
+# Second PVR
+OBJS += pvr2.o
+
 include $(KOS_BASE)/Makefile.prefab
-
-

--- a/kernel/arch/dreamcast/hardware/pvr/pvr2.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr2.c
@@ -1,0 +1,59 @@
+/* KallistiOS ##version##
+
+   pvr2.c
+   Copyright (C) 2026 Ruslan Rostovtsev
+*/
+
+#include <dc/elan.h>
+#include <dc/pvr.h>
+#include <kos/irq.h>
+
+#define PVR2_FB_CFG_OFF         0x00800000
+#define PVR2_SDRAM_CFG_VAL      0x15d1c955
+#define PVR2_SDRAM_ARB_CFG_VAL  0x0000001f
+
+static int pvr2_initted;
+
+int pvr2_init(void) {
+    if(!elan_present()) {
+        return -1;
+    }
+    if(pvr2_initted) {
+        return 0;
+    }
+
+    irq_disable_scoped();
+    elan_pvr2_enable();
+
+    PVR2_SET(PVR_RESET, PVR_RESET_ALL);
+    PVR2_SET(PVR_RESET, PVR_RESET_NONE);
+    PVR2_SET(PVR_FB_CFG_1, PVR2_FB_CFG_OFF);
+    PVR2_SET(PVR_SDRAM_CFG, PVR2_SDRAM_CFG_VAL);
+    PVR2_SET(PVR_SDRAM_REFRESH, 0x00000020);
+    PVR2_SET(PVR_SDRAM_ARB_CFG, PVR2_SDRAM_ARB_CFG_VAL);
+    PVR2_SET(PVR_FPU_PARAM_CFG, 0x0027df77);
+    PVR2_SET(PVR_HALF_OFFSET, 0x00000007);
+    PVR2_SET(PVR_ISP_FEED_CFG, 0x00800408);
+    PVR2_SET(PVR_FB_BURSTCTRL, 0x00093f39);
+    PVR2_SET(PVR_Y_COEFF, 0x00008040);
+
+    pvr2_initted = 1;
+    return 0;
+}
+
+int pvr2_shutdown(void) {
+    if(!pvr2_initted) {
+        return -1;
+    }
+
+    irq_disable_scoped();
+    PVR2_SET(PVR_RESET, PVR_RESET_ALL);
+    PVR2_SET(PVR_RESET, PVR_RESET_NONE);
+    elan_pvr2_disable();
+    pvr2_initted = 0;
+    return 0;
+}
+
+int pvr2_enabled(void) {
+    return pvr2_initted;
+}

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_init_shutdown.c
@@ -151,23 +151,23 @@ int pvr_init(const pvr_init_params_t *params) {
     /* 3d-specific parameters; these are all about rendering and
        nothing to do with setting up the video; some stuff in here
        is still unknown. */
-    PVR_SET(PVR_UNK_00A8, 0x15d1c951);          /* M (Unknown magic value) */
-    PVR_SET(PVR_UNK_00A0, 0x00000020);          /* M */
+    PVR_SET(PVR_SDRAM_CFG, 0x15d1c951);         /* M (Unknown magic value) */
+    PVR_SET(PVR_SDRAM_REFRESH, 0x00000020);     /* M */
     /* PVR_FB_CFG_2 is configured in vid_set_mode() */
-    PVR_SET(PVR_UNK_0110, 0x00093f39);          /* M */
-    PVR_SET(PVR_UNK_0098, 0x00800408);          /* M */
+    PVR_SET(PVR_FB_BURSTCTRL, 0x00093f39);      /* M */
+    PVR_SET(PVR_ISP_FEED_CFG, 0x00800408);      /* M */
     PVR_SET(PVR_TEXTURE_CLIP, 0x00000000);      /* texture clip distance */
     PVR_SET(PVR_SPANSORT_CFG, 0x00000101);      /* M */
     pvr_fog_table_color(0.0f, 0.5f, 0.5f, 0.5f);/* Fog table color */
     pvr_fog_vertex_color(0.5f, 0.5f, 0.5f);     /* Fog vertex color */
     PVR_SET(PVR_COLOR_CLAMP_MIN, PVR_PACK_COLOR(0, 0, 0, 0));   /* color clamp min */
     PVR_SET(PVR_COLOR_CLAMP_MAX, PVR_PACK_COLOR(1, 1, 1, 1));   /* color clamp max */
-    PVR_SET(PVR_UNK_0080, 0x00000007);          /* M */
+    PVR_SET(PVR_HALF_OFFSET, 0x00000007);       /* M */
     PVR_SET(PVR_CHEAP_SHADOW, 0x00000001);      /* cheap shadow */
-    PVR_SET(PVR_UNK_007C, 0x0027df77);          /* M */
+    PVR_SET(PVR_FPU_PARAM_CFG, 0x0027df77);     /* M */
     PVR_SET(PVR_TEXTURE_MODULO, 0x00000000);    /* stride width */
     PVR_SET(PVR_FOG_DENSITY, 0x0000ff07);       /* fog density */
-    PVR_SET(PVR_UNK_0118, 0x00008040);          /* M */
+    PVR_SET(PVR_Y_COEFF, 0x00008040);           /* M */
 
     /* Initialize PVR DMA */
     sem_init((semaphore_t *)&pvr_state.dma_lock, 1);

--- a/kernel/arch/dreamcast/include/arch/kos.h
+++ b/kernel/arch/dreamcast/include/arch/kos.h
@@ -52,6 +52,7 @@ __BEGIN_DECLS
 #include <dc/net/lan_adapter.h>
 #include <dc/perfctr.h>
 #include <dc/pvr.h>
+#include <dc/elan.h>
 #include <dc/scif.h>
 #include <dc/sci.h>
 #include <dc/sd.h>

--- a/kernel/arch/dreamcast/include/dc/elan.h
+++ b/kernel/arch/dreamcast/include/dc/elan.h
@@ -1,0 +1,117 @@
+/* KallistiOS ##version##
+
+   dc/elan.h
+   Copyright (C) 2026 Ruslan Rostovtsev
+
+*/
+
+/** \file    dc/elan.h
+    \brief   VideoLogic Elan T&L coprocessor (NAOMI 2).
+    \ingroup elan
+
+    Elan is the geometry processor on NAOMI 2 and has 32 MB of local RAM.
+    IFCTL bit 2 enables CLXB's register and VRAM windows; they are left
+    disabled at boot.
+
+    Call \ref pvr2_init() when CPU access to CLXB VRAM is required. Do not
+    set \ref ELAN_IFCTL_CS1_BCAST unless you intend to broadcast CS1 writes
+    to both GPUs.
+
+    \author Ruslan Rostovtsev
+*/
+
+#ifndef __DC_ELAN_H
+#define __DC_ELAN_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <kos/regfield.h>
+#include <dc/memory.h>
+
+/** \defgroup elan  Elan
+    \brief          VideoLogic Elan T&L coprocessor (NAOMI 2)
+    \ingroup        video
+
+    @{
+*/
+
+/** \brief  Elan register block, P2. */
+#define ELAN_BASE               0xa8800000
+
+/** \brief  Value of \ref ELAN_REG_ID on a present Elan. */
+#define ELAN_MAGIC              0xe1ad0000
+
+/** \brief  Elan local RAM, P0. */
+#define ELAN_RAM_BASE_P0        0x0a000000
+/** \brief  Elan local RAM, P2. */
+#define ELAN_RAM_BASE           (MEM_AREA_P2_BASE | ELAN_RAM_BASE_P0)
+/** \brief  Elan local RAM size in bytes. */
+#define ELAN_RAM_SIZE           (32 * 1024 * 1024)
+
+/** \defgroup elan_regs Register offsets
+    \brief              Offsets from \ref ELAN_BASE
+    \ingroup            elan
+
+    @{
+*/
+#define ELAN_REG_ID             0x00    /**< \brief Magic (\ref ELAN_MAGIC) */
+#define ELAN_REG_REVISION       0x04    /**< \brief Chip revision */
+#define ELAN_REG_CMDQ           0x0c    /**< \brief Command queue occupancy */
+#define ELAN_REG_IFCTL          0x10    /**< \brief SH-4 / PVR interface */
+#define ELAN_REG_REFRESH        0x14    /**< \brief SDRAM refresh */
+#define ELAN_REG_SDRAMCFG       0x1c    /**< \brief SDRAM config */
+#define ELAN_REG_TILER          0x30    /**< \brief Macro tiler */
+#define ELAN_REG_IRQSTAT        0x74    /**< \brief IRQ status */
+#define ELAN_REG_IRQMASK        0x78    /**< \brief IRQ mask */
+/** @} */
+
+/** \defgroup elan_ifctl IFCTL bits
+    \brief               Fields of \ref ELAN_REG_IFCTL
+    \ingroup             elan
+
+    @{
+*/
+#define ELAN_IFCTL_CS1_BCAST    BIT(0)  /**< \brief Broadcast writes on CS1 (both PVRs) */
+#define ELAN_IFCTL_CH2          BIT(1)  /**< \brief Elan channel 2 */
+#define ELAN_IFCTL_PVR2         BIT(2)  /**< \brief Enable CLXB address windows */
+/** @} */
+
+/** \brief  Read an Elan register. */
+#define ELAN_GET(reg)           (*(volatile uint32_t *)(ELAN_BASE + (reg)))
+/** \brief  Write an Elan register. */
+#define ELAN_SET(reg, value)    (ELAN_GET(reg) = (value))
+
+/** \brief  True when Elan is present (NAOMI 2). */
+bool elan_present(void);
+
+/** \brief  Elan revision register, or 0 if absent. */
+uint32_t elan_revision(void);
+
+/** \brief  Current IFCTL value, or 0 if Elan is absent. */
+uint32_t elan_ifctl_get(void);
+
+/** \brief  Write IFCTL.
+
+    \warning
+    Bit 0 (\ref ELAN_IFCTL_CS1_BCAST) broadcasts CS1 to both GPUs. Leave it
+    clear unless you are duplicating textures on purpose.
+*/
+void elan_ifctl_set(uint32_t value);
+
+/** \brief  Enable CLXB address windows (IFCTL bit 2, never bit 0). */
+void elan_pvr2_enable(void);
+
+/** \brief  Disable CLXB address windows (IFCTL = 0). */
+void elan_pvr2_disable(void);
+
+/** \brief  True if IFCTL bit 2 is set. */
+bool elan_pvr2_enabled(void);
+
+/** @} */
+
+__END_DECLS
+
+#endif /* __DC_ELAN_H */

--- a/kernel/arch/dreamcast/include/dc/pvr.h
+++ b/kernel/arch/dreamcast/include/dc/pvr.h
@@ -1319,6 +1319,7 @@ pvr_ptr_t pvr_get_back_buffer(void);
 /*********************************************************************/
 
 #include "pvr/pvr_regs.h"
+#include "pvr/pvr2.h"
 #include "pvr/pvr_misc.h"
 #include "pvr/pvr_dma.h"
 #include "pvr/pvr_fog.h"

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr2.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr2.h
@@ -1,0 +1,54 @@
+/* KallistiOS ##version##
+
+   dc/pvr/pvr2.h
+   Copyright (C) 2026 Ruslan Rostovtsev
+*/
+
+/** \file       dc/pvr/pvr2.h
+    \brief      Second PowerVR (CLXB) on NAOMI 2
+    \ingroup    pvr2
+
+    Second PowerVR (CLXB) on NAOMI 2. Same registers and VRAM as CLXA,
+    at \ref PVR2_ADDR_STRIDE. Those addresses do not decode until Elan
+    IFCTL bit 2 is set (cleared at boot). \ref pvr2_init() sets that bit
+    and initializes the memory controller so \ref PVR2_RAM_BASE can be
+    used. Display output on this chip stays off.
+
+    \author Ruslan Rostovtsev
+*/
+
+#ifndef __DC_PVR_PVR2_H
+#define __DC_PVR_PVR2_H
+
+#include <kos/cdefs.h>
+__BEGIN_DECLS
+
+/** \defgroup pvr2  Second PVR (NAOMI 2)
+    \brief          CLXB bring-up and VRAM mapping
+    \ingroup        pvr
+
+    @{
+*/
+
+/** \brief   Enable CLXB windows and initialize its memory controller.
+
+    \retval 0               On success (or already initialized)
+    \retval -1              If Elan is not present
+*/
+int pvr2_init(void);
+
+/** \brief   Reset CLXB and disable its address windows.
+
+    \retval 0               On success
+    \retval -1              If it was not initialized
+*/
+int pvr2_shutdown(void);
+
+/** \brief   True if \ref pvr2_init() has succeeded in this process. */
+int pvr2_enabled(void);
+
+/** @} */
+
+__END_DECLS
+
+#endif /* __DC_PVR_PVR2_H */

--- a/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
+++ b/kernel/arch/dreamcast/include/dc/pvr/pvr_regs.h
@@ -3,7 +3,7 @@
    dc/pvr/pvr_regs.h
    Copyright (C) 2002 Megan Potter
    Copyright (C) 2014 Lawrence Sebald
-   Copyright (C) 2023, 2025 Ruslan Rostovtsev
+   Copyright (C) 2023, 2025, 2026 Ruslan Rostovtsev
    Copyright (C) 2024 Falco Girgis
 */
 
@@ -58,6 +58,22 @@ __BEGIN_DECLS
 */
 #define PVR_SET(REG, VALUE) PVR_GET(REG) = (VALUE)
 
+/** \brief   Address stride from CLXA to CLXB (registers and VRAM windows).
+
+    NAOMI 2 only. The second PVR is not mapped until \ref pvr2_init().
+*/
+#define PVR2_ADDR_STRIDE 0x02000000
+
+/** \brief   Retrieve a register from the second PVR (CLXB). */
+#define PVR2_GET(REG) (* ( (volatile uint32_t *)( 0xa25f8000 + (REG) ) ) )
+
+/** \brief   Set a register on the second PVR (CLXB). */
+#define PVR2_SET(REG, VALUE) PVR2_GET(REG) = (VALUE)
+
+/** \brief   Write a PVR register to both chips (write-only broadcast). */
+#define PVR_BCAST_SET(REG, VALUE) \
+    (* ( (volatile uint32_t *)( 0xa85f8000 + (REG) ) ) = (VALUE))
+
 /** @} */
 
 /** \defgroup pvr_regs   Offsets
@@ -78,12 +94,12 @@ __BEGIN_DECLS
 #define PVR_RESET               0x0008  /**< \brief Reset pins */
 
 #define PVR_ISP_START           0x0014  /**< \brief Start the ISP/TSP */
-#define PVR_UNK_0018            0x0018  /**< \brief ?? */
+#define PVR_TEST_SELECT         0x0018  /**< \brief Test select (writes prohibited) */
 
 #define PVR_ISP_VERTBUF_ADDR    0x0020  /**< \brief Vertex buffer address for scene rendering */
 
 #define PVR_ISP_TILEMAT_ADDR    0x002c  /**< \brief Tile matrix address for scene rendering */
-#define PVR_SPANSORT_CFG        0x0030  /**< \brief ?? -- write 0x101 for now */
+#define PVR_SPANSORT_CFG        0x0030  /**< \brief Span sorter control -- write 0x101 for now */
 
 #define PVR_BORDER_COLOR        0x0040  /**< \brief Border Color in RGB888 */
 #define PVR_FB_CFG_1            0x0044  /**< \brief Framebuffer config 1 */
@@ -100,17 +116,18 @@ __BEGIN_DECLS
 
 #define PVR_CHEAP_SHADOW        0x0074  /**< \brief Cheap shadow control */
 #define PVR_OBJECT_CLIP         0x0078  /**< \brief Distance for polygon culling */
-#define PVR_UNK_007C            0x007c  /**< \brief ?? -- write 0x0027df77 for now */
-#define PVR_UNK_0080            0x0080  /**< \brief ?? -- write 7 for now */
+#define PVR_FPU_PARAM_CFG       0x007c  /**< \brief Parameter read control -- write 0x0027df77 for now */
+#define PVR_HALF_OFFSET         0x0080  /**< \brief Pixel sampling control -- write 7 for now */
 #define PVR_TEXTURE_CLIP        0x0084  /**< \brief Distance for texture clipping */
 #define PVR_BGPLANE_Z           0x0088  /**< \brief Distance for background plane */
 #define PVR_BGPLANE_CFG         0x008c  /**< \brief Background plane config */
 
-#define PVR_UNK_0098            0x0098  /**< \brief ?? -- write 0x00800408 for now */
+#define PVR_ISP_FEED_CFG        0x0098  /**< \brief Translucent polygon sort mode -- write 0x00800408 for now */
 
-#define PVR_UNK_00A0            0x00a0  /**< \brief ?? -- write 0x20 for now */
+#define PVR_SDRAM_REFRESH       0x00a0  /**< \brief Texture memory refresh counter -- write 0x20 for now */
+#define PVR_SDRAM_ARB_CFG       0x00a4  /**< \brief Texture memory arbiter control -- write 0x1f on NAOMI */
 
-#define PVR_UNK_00A8            0x00a8  /**< \brief ?? -- write 0x15d1c951 for now */
+#define PVR_SDRAM_CFG           0x00a8  /**< \brief Texture memory control -- write 0x15d1c951 (DC) / 0x15d1c955 (NAOMI) */
 
 #define PVR_FOG_TABLE_COLOR     0x00b0  /**< \brief Table fog color */
 #define PVR_FOG_VERTEX_COLOR    0x00b4  /**< \brief Vertex fog color */
@@ -133,9 +150,9 @@ __BEGIN_DECLS
 
 #define PVR_PALETTE_CFG         0x0108  /**< \brief Palette format */
 #define PVR_SYNC_STATUS         0x010c  /**< \brief V/H blank status */
-#define PVR_UNK_0110            0x0110  /**< \brief ?? -- write 0x93f39 for now */
-#define PVR_UNK_0114            0x0114  /**< \brief ?? -- write 0x200000 for now */
-#define PVR_UNK_0118            0x0118  /**< \brief ?? -- write 0x8040 for now */
+#define PVR_FB_BURSTCTRL        0x0110  /**< \brief Framebuffer burst control -- write 0x93f39 for now */
+#define PVR_FB_C_SOF            0x0114  /**< \brief Current framebuffer start address (read) */
+#define PVR_Y_COEFF             0x0118  /**< \brief Y scaling coefficient -- write 0x8040 for now */
 
 #define PVR_PT_ALPHA_REF        0x011c  /**< \brief Only pixels with alpha >= this value are drawn for Punch Through polygons */
 
@@ -152,7 +169,7 @@ __BEGIN_DECLS
 #define PVR_YUV_CFG             0x014c  /**< \brief YUV configuration */
 #define PVR_YUV_STAT            0x0150  /**< \brief The number of YUV macroblocks converted */
 
-#define PVR_UNK_0160            0x0160  /**< \brief ?? */
+#define PVR_TA_LIST_CONT        0x0160  /**< \brief TA list continuation */
 #define PVR_TA_OPB_INIT         0x0164  /**< \brief Object pointer buffer position init */
 
 #define PVR_FOG_TABLE_BASE      0x0200  /**< \brief Base of the fog table */
@@ -182,6 +199,13 @@ __BEGIN_DECLS
 
 #define PVR_RAM_TOP         (PVR_RAM_BASE + PVR_RAM_SIZE)       /**< \brief Top of raw PVR RAM */
 #define PVR_RAM_INT_TOP     (PVR_RAM_INT_BASE + PVR_RAM_SIZE)   /**< \brief Top of int PVR RAM */
+
+#define PVR2_RAM_BASE_32_P0 (PVR_RAM_BASE_32_P0 + PVR2_ADDR_STRIDE) /**< \brief CLXB VRAM 32-bit, P0 */
+#define PVR2_RAM_BASE_64_P0 (PVR_RAM_BASE_64_P0 + PVR2_ADDR_STRIDE) /**< \brief CLXB VRAM 64-bit, P0 */
+#define PVR2_RAM_BASE       (PVR_RAM_BASE + PVR2_ADDR_STRIDE)       /**< \brief CLXB VRAM 32-bit, P2 */
+#define PVR2_RAM_INT_BASE   (PVR_RAM_INT_BASE + PVR2_ADDR_STRIDE)   /**< \brief CLXB VRAM 64-bit, P2 */
+#define PVR2_RAM_TOP        (PVR2_RAM_BASE + PVR_RAM_SIZE)          /**< \brief Top of CLXB 32-bit VRAM */
+#define PVR2_RAM_INT_TOP    (PVR2_RAM_INT_BASE + PVR_RAM_SIZE)      /**< \brief Top of CLXB 64-bit VRAM */
 /** @} */
 
 /* Register content defines, as needed; these will be filled in over time


### PR DESCRIPTION
The support is very basic, but at least it allows to enable all the features on the NAOMI 2.
Next, need to adapt the main PVR driver to second PVR (CLXB) and broadcast (CLXC). Also add Elan T&L support.

- Add initial support for VideoLogic Elan T&L coprocessor on NAOMI 2.
- Add initial support for second PowerVR and its memory on NAOMI 2.
- Updated PVR register definitions (fix unnamed ones).
- All memory tested on real hardware - https://www.youtube.com/watch?v=_VmQELfsrko