### PR TITLE
Improved export_lookup_addr()

### DIFF
--- a/include/kos/exports.h
+++ b/include/kos/exports.h
@@ -81,9 +81,9 @@ export_sym_t *export_lookup(const char *name);
 */
 export_sym_t *export_lookup_path(const char *name, const char *path);
 
-/** \brief  Look up a symbol by approx addr.
-            It can be useful for unhandled exceptions messages.
-    \param  addr            The symbol to look up
+/** \brief  Look up the nearest exported symbol at or before addr.
+            Useful for exception messages.
+    \param  addr            The address to look up
     \return                 The export structure, or NULL on failure
 */
 export_sym_t *export_lookup_addr(uintptr_t addr);

--- a/kernel/exports/exports.c
+++ b/kernel/exports/exports.c
@@ -119,8 +119,9 @@ export_sym_t *export_lookup_addr(uintptr_t addr) {
     nmmgr_list_t *nmmgrs;
     int i;
     symtab_handler_t *sth;
-
+    uintptr_t sym_addr;
     uintptr_t dist = ~0;
+    uintptr_t off;
     export_sym_t *best = NULL;
 
     /* Get the name manager list */
@@ -136,8 +137,15 @@ export_sym_t *export_lookup_addr(uintptr_t addr) {
 
         /* First look through the kernel table */
         for(i = 0; sth->table[i].name; i++) {
-            if(addr - sth->table[i].ptr < dist) {
-                dist = addr - sth->table[i].ptr;
+            sym_addr = sth->table[i].ptr;
+
+            if(sym_addr > addr)
+                continue;
+
+            off = addr - sym_addr;
+
+            if(off < dist) {
+                dist = off;
                 best = sth->table + i;
             }
         }


### PR DESCRIPTION
Enhanced the logic to ensure it correctly identifies the nearest exported symbol at or before the specified address. Also update docs.