### PR TITLE
Simplify dma blocking checks

### DIFF
--- a/kernel/arch/dreamcast/hardware/g1ata.c
+++ b/kernel/arch/dreamcast/hardware/g1ata.c
@@ -177,7 +177,6 @@ static uint8_t orig_dev = 0x00;
 
 /* Variables related to DMA. */
 static int dma_in_progress = 0;
-static int dma_blocking = 0;
 static uint8_t dma_cmd = 0;
 static size_t dma_nb_sectors = 0;
 static uint64_t dma_sector = 0;
@@ -240,10 +239,9 @@ static void g1_ata_set_sector_and_count(uint64_t sector, size_t count, int lba28
 
 static void g1_dma_done(void) {
     /* Signal the calling thread to continue, if it is blocking. */
-    if(dma_blocking) {
+    if(sem_count(&dma_done)) {
         sem_signal(&dma_done);
         thd_schedule(true);
-        dma_blocking = 0;
     }
 
     dma_in_progress = 0;
@@ -727,7 +725,6 @@ int g1_ata_read_lba_dma(uint64_t sector, size_t count, void *buf,
     }
 
     /* Set the settings for this transfer and re-enable IRQs. */
-    dma_blocking = block;
     dma_in_progress = 1;
     dma_nb_sectors = count;
     dma_sector = sector;
@@ -918,7 +915,6 @@ int g1_ata_write_lba_dma(uint64_t sector, size_t count, const void *buf,
     }
 
     /* Set the settings for this transfer and re-enable IRQs. */
-    dma_blocking = block;
     dma_in_progress = 1;
     dma_nb_sectors = count;
     dma_sector = sector;

--- a/kernel/arch/dreamcast/hardware/g2dma.c
+++ b/kernel/arch/dreamcast/hardware/g2dma.c
@@ -41,7 +41,6 @@ typedef struct {
 /* Signaling semaphore */
 static semaphore_t dma_done[4];
 static int dma_progress[4];
-static int dma_blocking[4];
 static g2_dma_callback_t dma_callback[4];
 static void *dma_cbdata[4];
 
@@ -147,8 +146,7 @@ static void g2_dma_irq_hnd(uint32_t code, void *data) {
         dma_progress[chn] = 0;
 
         /* Signal the calling thread to continue, if any. */
-        if(dma_blocking[chn]) {
-            dma_blocking[chn] = 0;
+        if(sem_count(&dma_done[chn])) {
             sem_signal(&dma_done[chn]);
             thd_schedule(true);
         }
@@ -196,7 +194,6 @@ int g2_dma_transfer(void *sh4, void *g2bus, size_t length, uint32_t block,
     /* Make sure length is a multiple of 32 */
     length = __align_up(length, 32);
 
-    dma_blocking[g2chn] = block;
     dma_callback[g2chn] = callback;
     dma_cbdata[g2chn] = cbdata;
 
@@ -237,7 +234,6 @@ int g2_dma_init(void) {
         /* Create an initially blocked semaphore */
         sem_init(&dma_done[i], 0);
         dma_progress[i] = 0;
-        dma_blocking[i] = 0;
         dma_callback[i] = NULL;
         dma_cbdata[i] = 0;
 

--- a/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
+++ b/kernel/arch/dreamcast/hardware/pvr/pvr_dma.c
@@ -25,7 +25,6 @@
 
 /* Signaling semaphore */
 static semaphore_t dma_done;
-static bool dma_blocking;
 static pvr_dma_callback_t dma_callback;
 static void *dma_cbdata;
 
@@ -60,10 +59,9 @@ static void pvr_dma_irq_hnd(uint32_t code, void *data) {
     }
 
     /* Signal the calling thread to continue, if any. */
-    if(dma_blocking) {
+    if(sem_count(&dma_done)) {
         sem_signal(&dma_done);
         thd_schedule(true);
-        dma_blocking = false;
     }
 }
 
@@ -128,7 +126,6 @@ int pvr_dma_transfer(const void *src, uintptr_t dest, size_t count,
     if(dma_transfer(&pvr_dma_config, 0, src_addr, count, NULL))
         return -1;
 
-    dma_blocking = block;
     dma_callback = callback;
     dma_cbdata = cbdata;
 
@@ -167,7 +164,6 @@ bool pvr_dma_ready(void) {
 void pvr_dma_init(void) {
     /* Create an initially blocked semaphore */
     sem_init(&dma_done, 0);
-    dma_blocking = false;
     dma_callback = NULL;
     dma_cbdata = 0;
 


### PR DESCRIPTION
Unless I'm missing something the usage of the static bools to track dma blocking are superfluous because you can simply test if the semaphore is waiting before signaling it. Update it in the three locations.