### PR TITLE
Misc threading cleanups and fixes

### DIFF
--- a/include/kos/genwait.h
+++ b/include/kos/genwait.h
@@ -123,27 +123,10 @@ void genwait_wake_one_err(const void *obj, int err);
 */
 int genwait_wake_thd(const void *obj, kthread_t *thd, int err) __nonnull((2));
 
-/** \brief  Look for timed out genwait_wait() calls.
-
-    There should be no reason you need to call this function, it is called
-    internally by the scheduler for you.
-
-    \param  now             The current system time, in milliseconds since boot
-*/
+/** \cond */
+/* Look for timed out genwait_wait() calls */
 void genwait_check_timeouts(uint64_t now);
 
-/** \brief  Look for the next timeout event time.
-
-    This function looks up when the next genwait_wait() call will timeout. This
-    function is for the internal use of the scheduler, and should not be called
-    from user code.
-
-    \return                 The next timeout time in milliseconds since boot, or
-                            0 if there are no pending genwait_wait() calls
-*/
-uint64_t genwait_next_timeout(void);
-
-/** \cond */
 /* Initialize the genwait system */
 int genwait_init(void);
 
@@ -151,8 +134,6 @@ int genwait_init(void);
 void genwait_shutdown(void);
 /** \endcond */
 
-
 __END_DECLS
 
 #endif  /* __KOS_GENWAIT_H */
-

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -452,11 +452,9 @@ void thd_exit(void *rv) __noreturn;
     This function is the thread scheduler, and MUST be called in an interrupt
     context (typically from the primary timer interrupt).
 
-    For most cases, you'll want to set front_of_line to zero, but read the
+    For most cases, you'll want to set front_of_line to false, but read the
     comments in kernel/thread/thread.c for more info, especially if you need to
-    guarantee low latencies. This function just updates irq_srt_addr and
-    thd_current. Set 'now' to non-zero if you want to use a particular system
-    time for checking timeouts.
+    guarantee low latencies.
 
     \param  front_of_line   Set to false, unless you have a good reason not to.
 

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -355,7 +355,7 @@ kthread_t *thd_by_tid(tid_t tid);
     \relatesalso kthread_t
 
     This function adds a thread to the runnable queue after the process group of
-    the same priority if front_of_line is zero, otherwise queues it at the front
+    the same priority if front_of_line is false, otherwise queues it at the front
     of its priority group. Generally, you will not have to do this manually.
 
     \param  t               The thread to queue.

--- a/include/kos/thread.h
+++ b/include/kos/thread.h
@@ -274,7 +274,7 @@ typedef struct __attribute__((aligned(32))) kthread {
     \headerfile kos/thread.h
 */
 typedef struct kthread_attr {
-    /** \brief  1 for a detached thread. */
+    /** \brief  true for a detached thread. */
     bool create_detached;
 
     /** \brief  Set the size of the stack to be created. */
@@ -290,7 +290,7 @@ typedef struct kthread_attr {
     /** \brief  Thread label. */
     const char *label;
 
-    /** \brief 1 if the thread doesn't use thread_local variables. */
+    /** \brief true if the thread doesn't use thread_local variables. */
     bool disable_tls;
 } kthread_attr_t;
 

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <reent.h>
+
 #include <kos/banner.h>
 #include <kos/dbgio.h>
 #include <kos/dbglog.h>
@@ -33,6 +35,9 @@
 #include <dc/dcload.h>
 
 #include "initall_hdrs.h"
+
+/* A reent struct for newlib to point to before/after threading */
+static struct _reent nonthread_reent;
 
 /* ctor/dtor stuff from libgcc. */
 extern void _init(void);
@@ -281,6 +286,10 @@ void arch_main(void) {
     /* Enable caches */
     cache_write_ccr((uint32_t)~0, CCR_DEFAULT);
 
+    /* Init then set newlib's reent, for errno usage */
+    _REENT_INIT_PTR(&nonthread_reent);
+    _impure_ptr = &nonthread_reent;
+
     dma_init();
 
     /* Ensure the WDT is not enabled from a previous session */
@@ -351,6 +360,9 @@ void arch_shutdown(void) {
     /* Shut down any other hardware things */
     hardware_shutdown();
 #endif
+
+    /* Clean up newlib reent */
+    _reclaim_reent(&nonthread_reent);
 
     if(__kos_init_flags & INIT_MALLOCSTATS) {
         malloc_stats();

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -131,7 +131,7 @@ static void __nonnull_all genwait_unqueue(kthread_t *thd, int err) {
 
     /* Make it runnable again */
     thd->state = STATE_READY;
-    thd_add_to_runnable(thd, 0);
+    thd_add_to_runnable(thd, false);
 }
 
 static int genwait_wake_thd_cnt(const void *obj, int cntmax, kthread_t *thd, int err) {

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -199,15 +199,6 @@ void genwait_check_timeouts(uint64_t tm) {
     }
 }
 
-uint64_t genwait_next_timeout(void) {
-    kthread_t *t = tq_next();
-
-    if(t == NULL)
-        return 0;
-    else
-        return t->wait_timeout;
-}
-
 int genwait_init(void) {
     for(size_t i = 0; i < TABLESIZE; i++)
         TAILQ_INIT(&slpque[i]);
@@ -219,5 +210,4 @@ int genwait_init(void) {
 void genwait_shutdown(void) {
     /* XXX Do something about queued up procs */
 }
-
 

--- a/kernel/thread/mutex.c
+++ b/kernel/thread/mutex.c
@@ -89,17 +89,8 @@ int mutex_lock_timed(mutex_t *m, unsigned int timeout) {
 
         for(;;) {
             /* Check whether we should boost priority. */
-            if (m->holder->prio >= thd_current->prio) {
+            if(m->holder->prio >= thd_current->prio)
                 m->holder->prio = thd_current->prio;
-
-                /* Reschedule if currently scheduled. */
-                if(m->holder->state == STATE_READY) {
-                    /* Thread list is sorted by priority, update the position
-                     * of the thread holding the lock */
-                    thd_remove_from_runnable(m->holder);
-                    thd_add_to_runnable(m->holder, true);
-                }
-            }
 
             rv = genwait_wait(m, timeout ? "mutex_lock_timed" : "mutex_lock",
                               timeout);

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -79,6 +79,8 @@ static struct ktqueue run_queue;
 /* The currently executing thread. This thread should not be on any queues. */
 kthread_t *thd_current = NULL;
 
+static struct _reent *old_impure;
+
 /* Thread mode: uninitialized or pre-emptive. */
 static kthread_mode_t thd_mode = THD_MODE_NONE;
 
@@ -1067,6 +1069,9 @@ int thd_init(void) {
         return -1;
     }
 
+    /* Preserve the newlib reent struct before we switch to kern's */
+    old_impure = _impure_ptr;
+
     /* Main thread -- the kern thread */
     thd_current = kern;
     thd_schedule_inner(kern, timer_ms_gettime64());
@@ -1103,6 +1108,9 @@ void thd_shutdown(void) {
     /* Remove our pre-emption handler */
     timer_primary_set_callback(NULL);
 
+    /* Restore the newlib reent struct */
+    _impure_ptr = old_impure;
+
     /* Kill remaining live threads */
     LIST_FOREACH_SAFE(cur, &thd_list, t_list, tmp) {
         if(cur->tid != 1)
@@ -1119,6 +1127,4 @@ void thd_shutdown(void) {
     /* Not running */
     thd_mode = THD_MODE_NONE;
     thd_count = 0;
-
-    // XXX _impure_ptr is borked
 }

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -352,23 +352,19 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
     kthread_t *nt = NULL;
     tid_t tid;
     uintptr_t params[4];
-    kthread_attr_t real_attr = { false, THD_STACK_SIZE, NULL, PRIO_DEFAULT, NULL, false };
+    kthread_attr_t real_attr = { false, THD_STACK_SIZE, NULL, PRIO_DEFAULT, "unnamed", false };
 
-    if(attr)
-        real_attr = *attr;
+    if(attr) {
+        /* Check for invalid */
+        assert_msg(!attr->stack_ptr || attr->stack_size, "thd_create_ex: No size provided for stack pointer\n");
 
-    /* Look through the attributes and see what we have. If any are set to 0,
-       then default them now to save ourselves trouble later. */
-    if(real_attr.stack_ptr && !real_attr.stack_size) {
-        errno = EINVAL;
-        return NULL;
+        real_attr.create_detached = attr->create_detached;
+        if(attr->stack_size) real_attr.stack_size = attr->stack_size;
+        real_attr.stack_ptr = attr->stack_ptr;
+        if(attr->prio) real_attr.prio = attr->prio;
+        if(attr->label) real_attr.label = attr->label;
+        real_attr.disable_tls = attr->disable_tls;
     }
-
-    if(!real_attr.stack_size)
-        real_attr.stack_size = THD_STACK_SIZE;
-
-    if(!real_attr.prio)
-        real_attr.prio = PRIO_DEFAULT;
 
     /* Get a new thread id */
     tid = atomic_fetch_add(&tid_highest, 1);
@@ -386,7 +382,7 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
 
     /* Create a new thread stack */
     if(!real_attr.stack_ptr) {
-        nt->stack = (uint32_t*)aligned_alloc(THD_STACK_ALIGNMENT,
+        nt->stack = (uint32_t *)aligned_alloc(THD_STACK_ALIGNMENT,
                                              real_attr.stack_size);
 
         if(!nt->stack) {
@@ -434,13 +430,7 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
     nt->prio = real_attr.prio;
     nt->state = STATE_READY;
 
-    if(!real_attr.label) {
-        strcpy(nt->label, "unnamed");
-    }
-    else {
-        strncpy(nt->label, real_attr.label, 255);
-        nt->label[255] = 0;
-    }
+    strncpy(nt->label, real_attr.label, 254);
 
     if(thd_current)
         strcpy(nt->pwd, thd_current->pwd);

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -650,13 +650,6 @@ void thd_schedule(bool front_of_line) {
         arch_exit();
     }
 
-    /* If the current thread is supposed to be in the front of the line, and it
-       did not die, re-enqueue it to the front of the line now. */
-    if(front_of_line && thd_current->state == STATE_RUNNING) {
-        thd_current->state = STATE_READY;
-        thd_add_to_runnable(thd_current, front_of_line);
-    }
-
     /* Look for timed out waits */
     genwait_check_timeouts(now);
 
@@ -692,15 +685,15 @@ void thd_schedule(bool front_of_line) {
         }
     }
 
-    /* If we didn't already re-enqueue the thread and we are supposed to do so,
-       do it now. */
-    if(!front_of_line && thd_current->state == STATE_RUNNING) {
+    /* If the thread is still running, or has been set to poll re-enqueue. */
+    if(thd_current->state == STATE_RUNNING) {
         thd_current->state = STATE_READY;
         thd_add_to_runnable(thd_current, front_of_line);
 
-        /* Make sure we have a thread, just in case we couldn't find anything
-           above. */
-        if(next_thd == NULL || next_thd == thd_idle_thd)
+        /* If current thread is running return to it if: no thread could be found,
+            we would otherwise go to idle, or it was requested to be prioritized. */
+        if(next_thd == NULL || next_thd == thd_idle_thd ||
+            (front_of_line && (thd_current->prio <= max_prio)))
             next_thd = thd_current;
     }
     else if(__predict_false(thd_current->state == STATE_POLLING)) {

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -241,14 +241,7 @@ static bool thd_has_polls(void) {
 
 /* An idle function. This function literally does nothing but loop
    forever. It's meant to be used for an idle task. */
-static void *thd_idle_task(void *param) {
-    /* Uncomment these if you want some debug for deadlocking */
-    /*  int old = irq_disable();
-    #ifndef NDEBUG
-        thd_pslist();
-        printf("Inside idle task now\n");
-    #endif
-        irq_restore(old); */
+static _Noreturn void *thd_idle_task(void *param) {
     (void)param;
 
     for(;;) {
@@ -258,13 +251,12 @@ static void *thd_idle_task(void *param) {
             arch_sleep();   /* We can safely enter sleep mode here */
     }
 
-    /* Never reached */
-    abort();
+    __unreachable();
 }
 
 /* Reaper function. This function is here to reap old zombie threads as they are
    created. */
-static void *thd_reaper(void *param) {
+static _Noreturn void *thd_reaper(void *param) {
     kthread_t *thd, *tmp;
 
     (void)param;
@@ -283,14 +275,13 @@ static void *thd_reaper(void *param) {
         }
     }
 
-    /* Never reached */
-    abort();
+    __unreachable();
 }
 
 /* Thread execution wrapper; when the thd_create function below
    adds a new thread to the thread chain, this function is the one
    that gets called in the new context. */
-static void thd_birth(void *(*routine)(void *param), void *param) {
+static _Noreturn void thd_birth(void *(*routine)(void *param), void *param) {
     /* Call the thread function */
     void *rv = routine(param);
 
@@ -327,8 +318,7 @@ void thd_exit(void *rv) {
     /* Manually reschedule */
     thd_block_now(&thd_current->context);
 
-    /* not reached */
-    abort();
+    __unreachable();
 }
 
 

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -372,103 +372,101 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
 
     /* Get a new thread id */
     tid = atomic_fetch_add(&tid_highest, 1);
+    if(tid < 0) return NULL;
 
-    if(tid >= 0) {
-        /* Create a new thread structure */
-        nt = aligned_alloc(32, sizeof(kthread_t));
+    /* Create a new thread structure */
+    nt = aligned_alloc(32, sizeof(kthread_t));
+    if(!nt) return NULL;
 
-        if(nt != NULL) {
-            /* Clear out potentially unused stuff */
-            memset(nt, 0, sizeof(kthread_t));
+    /* Clear out potentially unused stuff */
+    memset(nt, 0, sizeof(kthread_t));
 
-            /* Initialize the flags to defaults immediately. */
-            nt->flags = THD_DEFAULTS;
+    /* Initialize the flags to defaults immediately. */
+    nt->flags = THD_DEFAULTS;
 
-            /* Create a new thread stack */
-            if(!real_attr.stack_ptr) {
-                nt->stack = (uint32_t*)aligned_alloc(THD_STACK_ALIGNMENT,
-                                                     real_attr.stack_size);
+    /* Create a new thread stack */
+    if(!real_attr.stack_ptr) {
+        nt->stack = (uint32_t*)aligned_alloc(THD_STACK_ALIGNMENT,
+                                             real_attr.stack_size);
 
-                if(!nt->stack) {
-                    free(nt);
-                    return NULL;
-                }
-
-                /* Since we allocated the stack, we own the stack! */
-                nt->flags |= THD_OWNS_STACK;
-            }
-            else {
-                nt->stack = (uint32_t*)real_attr.stack_ptr;
-            }
-
-            nt->stack_size = real_attr.stack_size;
-
-            /* Populate the context */
-            params[0] = (uintptr_t)routine;
-            params[1] = (uintptr_t)param;
-            params[2] = 0;
-            params[3] = 0;
-            irq_create_context(&nt->context,
-                               ((uintptr_t)nt->stack) + nt->stack_size,
-                               (uintptr_t)thd_birth, params);
-
-            /* Some architectures require setting up a new stack before use.
-               We won't do this if routine is NULL, however, as this means
-               we are creating the kernel thread, which is already running. */
-            if(routine) {
-                arch_stk_setup(nt);
-            }
-
-            /* Create static TLS data if the thread hasn't disabled it. */
-            if(real_attr.disable_tls) {
-                nt->flags |= THD_DISABLE_TLS;
-            } else if(!arch_tls_setup_data(nt)) {
-                if(nt->flags & THD_OWNS_STACK)
-                    free(nt->stack);
-                free(nt);
-                return NULL;
-            }
-
-            nt->tid = tid;
-            nt->real_prio = real_attr.prio;
-            nt->prio = real_attr.prio;
-            nt->state = STATE_READY;
-
-            if(!real_attr.label) {
-                strcpy(nt->label, "unnamed");
-            }
-            else {
-                strncpy(nt->label, real_attr.label, 255);
-                nt->label[255] = 0;
-            }
-
-            if(thd_current)
-                strcpy(nt->pwd, thd_current->pwd);
-            else
-                strcpy(nt->pwd, "/");
-
-            _REENT_INIT_PTR((&(nt->thd_reent)));
-
-            /* Should we detach the thread? */
-            if(real_attr.create_detached)
-                nt->flags |= THD_DETACHED;
-
-            /* Initialize thread-local storage. */
-            LIST_INIT(&nt->tls_list);
-
-            /* Now that the thread is created, add it into the lists */
-            irq_disable_scoped();
-
-            /* Insert it into the thread list */
-            LIST_INSERT_HEAD(&thd_list, nt, t_list);
-
-            /* Add it to our count */
-            ++thd_count;
-
-            /* Schedule it */
-            thd_add_to_runnable(nt, false);
+        if(!nt->stack) {
+            free(nt);
+            return NULL;
         }
+
+        /* Since we allocated the stack, we own the stack! */
+        nt->flags |= THD_OWNS_STACK;
     }
+    else {
+        nt->stack = (uint32_t*)real_attr.stack_ptr;
+    }
+
+    nt->stack_size = real_attr.stack_size;
+
+    /* Populate the context */
+    params[0] = (uintptr_t)routine;
+    params[1] = (uintptr_t)param;
+    params[2] = 0;
+    params[3] = 0;
+    irq_create_context(&nt->context,
+                       ((uintptr_t)nt->stack) + nt->stack_size,
+                       (uintptr_t)thd_birth, params);
+
+    /* Some architectures require setting up a new stack before use.
+       We won't do this if routine is NULL, however, as this means
+       we are creating the kernel thread, which is already running. */
+    if(routine) {
+        arch_stk_setup(nt);
+    }
+
+    /* Create static TLS data if the thread hasn't disabled it. */
+    if(real_attr.disable_tls) {
+        nt->flags |= THD_DISABLE_TLS;
+    } else if(!arch_tls_setup_data(nt)) {
+        if(nt->flags & THD_OWNS_STACK)
+            free(nt->stack);
+        free(nt);
+        return NULL;
+    }
+
+    nt->tid = tid;
+    nt->real_prio = real_attr.prio;
+    nt->prio = real_attr.prio;
+    nt->state = STATE_READY;
+
+    if(!real_attr.label) {
+        strcpy(nt->label, "unnamed");
+    }
+    else {
+        strncpy(nt->label, real_attr.label, 255);
+        nt->label[255] = 0;
+    }
+
+    if(thd_current)
+        strcpy(nt->pwd, thd_current->pwd);
+    else
+        strcpy(nt->pwd, "/");
+
+    _REENT_INIT_PTR((&(nt->thd_reent)));
+
+    /* Should we detach the thread? */
+    if(real_attr.create_detached)
+        nt->flags |= THD_DETACHED;
+
+    /* Initialize thread-local storage. */
+    LIST_INIT(&nt->tls_list);
+
+    /* Now that the thread is created, add it into the lists */
+    irq_disable_scoped();
+
+    /* Insert it into the thread list */
+    LIST_INSERT_HEAD(&thd_list, nt, t_list);
+
+    /* Add it to our count */
+    ++thd_count;
+
+    /* Schedule it */
+    thd_add_to_runnable(nt, false);
 
     return nt;
 }

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -333,46 +333,15 @@ void thd_exit(void *rv) {
 /*****************************************************************************/
 /* Thread creation and deletion */
 
-/* Enqueue a process in the runnable queue; adds it right after the
-   process group of the same priority (front_of_line==0) or
-   right before the process group of the same priority (front_of_line!=0).
-   See thd_schedule for why this is helpful. */
+/* Enqueue a process in the runnable queue. */
 void thd_add_to_runnable(kthread_t *t, bool front_of_line) {
-    kthread_t *i;
-    int done;
 
     if(t->flags & THD_QUEUED)
         return;
 
-    done = 0;
-
-    if(!front_of_line) {
-        /* Look for a thread of lower priority and insert
-           before it. If there is nothing on the run queue, we'll
-           fall through to the bottom. */
-        TAILQ_FOREACH(i, &run_queue, thdq) {
-            if(i->prio > t->prio) {
-                TAILQ_INSERT_BEFORE(i, t, thdq);
-                done = 1;
-                break;
-            }
-        }
-    }
-    else {
-        /* Look for a thread of the same or lower priority and
-           insert before it. If there is nothing on the run queue,
-           we'll fall through to the bottom. */
-        TAILQ_FOREACH(i, &run_queue, thdq) {
-            if(i->prio >= t->prio) {
-                TAILQ_INSERT_BEFORE(i, t, thdq);
-                done = 1;
-                break;
-            }
-        }
-    }
-
-    /* Didn't find one, put it at the end */
-    if(!done)
+    if(front_of_line)
+        TAILQ_INSERT_HEAD(&run_queue, t, thdq);
+    else
         TAILQ_INSERT_TAIL(&run_queue, t, thdq);
 
     t->flags |= THD_QUEUED;
@@ -511,7 +480,7 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
             ++thd_count;
 
             /* Schedule it */
-            thd_add_to_runnable(nt, 0);
+            thd_add_to_runnable(nt, false);
         }
     }
 
@@ -772,7 +741,7 @@ void thd_schedule_next(kthread_t *thd) {
     }
     else if(thd_current->state == STATE_RUNNING) {
         thd_current->state = STATE_READY;
-        thd_add_to_runnable(thd_current, 0);
+        thd_add_to_runnable(thd_current, false);
     }
 
     thd_schedule_inner(thd, timer_ms_gettime64());

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -620,17 +620,14 @@ static inline prio_t thd_calc_prio(const kthread_t *thd, uint32_t now) {
 }
 
 /* Thread scheduler; this function will find a new thread to run when a
-   context switch is requested. No work is done in here except to change
-   out the thd_current variable contents. Assumed that we are in an
-   interrupt context.
+   context switch is requested. Assumed that we are in an interrupt context.
 
    In the normal operation mode, the current thread is pushed back onto
-   the run queue at the end of its priority group. This implements the
-   standard round robin scheduling within priority groups. If you set the
-   front_of_line parameter to non-zero, then this behavior is modified:
-   the current thread is pushed onto the run queue at the _front_ of its
-   priority group. The effect is that no context switching is done, but
-   priority groups are re-checked. This is useful when returning from an
+   the end of the run queue. This implements the standard round robin
+   scheduling within priority groups. If you set the front_of_line parameter
+   to true, then this behavior is modified: the current thread is pushed onto
+   the _front_ of the run queue. The effect is that no context switching is
+   done, but priority groups are re-checked. This is useful when returning from an
    IRQ after doing something like a sem_signal, where you'd ideally like
    to make sure the priorities are all straight before returning, but you
    don't want a full context switch inside the same priority group.
@@ -638,17 +635,10 @@ static inline prio_t thd_calc_prio(const kthread_t *thd, uint32_t now) {
 void thd_schedule(bool front_of_line) {
     kthread_t *thd, *next_thd = NULL;
     prio_t prio, max_prio = INT_MAX;
-    uint64_t now;
-    int ret;
+    uint64_t now = timer_ms_gettime64();
 
-    now = timer_ms_gettime64();
-
-    /* If there's only two thread left, it's the idle task and the reaper task:
-       exit the OS */
-    if(thd_count == 2) {
-        dbgio_printf("\nthd_schedule: idle tasks are the only things left; exiting\n");
-        arch_exit();
-    }
+    /* If idle and reaper are the only things left, something is wrong. */
+    assert_msg(thd_count != 2, "thd_schedule: idle tasks are the only things left\n");
 
     /* Look for timed out waits */
     genwait_check_timeouts(now);
@@ -665,7 +655,7 @@ void thd_schedule(bool front_of_line) {
                 CONTEXT_RET(thd->context) = 0;
             }
             else {
-                ret = thd->poll_cb(thd->wait_obj);
+                int ret = thd->poll_cb(thd->wait_obj);
 
                 if(ret) {
                     thd->state = STATE_READY;
@@ -701,10 +691,7 @@ void thd_schedule(bool front_of_line) {
     }
 
     /* Didn't find one? Big problem here... */
-    if(next_thd == NULL) {
-        thd_pslist(printf);
-        arch_panic("couldn't find a runnable thread");
-    }
+    assert_msg(next_thd != NULL, "thd_schedule: couldn't find a runnable thread");
 
     /* We should now have a runnable thread, so remove it from the
        run queue and switch to it. */

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -17,6 +17,7 @@
 #include <reent.h>
 #include <errno.h>
 #include <stdalign.h>
+#include <stdatomic.h>
 
 #include <kos/thread.h>
 #include <kos/dbgio.h>
@@ -199,17 +200,6 @@ int thd_pslist_queue(int (*pf)(const char *fmt, ...)) {
 /*****************************************************************************/
 /* Returns a fresh thread ID for each new thread */
 
-/* Highest thread id (used when assigning next thread id) */
-static tid_t tid_highest;
-
-/* Return the next available thread id (assumes wraparound will not run
-   into old processes). */
-static tid_t thd_next_free(void) {
-    int id;
-    id = tid_highest++;
-    return id;
-}
-
 /* Given a thread ID, locates the thread structure */
 kthread_t *thd_by_tid(tid_t tid) {
     kthread_t *np;
@@ -348,6 +338,9 @@ int thd_remove_from_runnable(kthread_t *thd) {
     return 0;
 }
 
+/* Highest thread id (used when assigning next thread id) */
+static atomic_int tid_highest = 1;
+
 /* New thread function; given a routine address, it will create a
    new thread with the given attributes. When the routine returns,
    the thread will exit. Returns the new thread struct.
@@ -377,10 +370,8 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
     if(!real_attr.prio)
         real_attr.prio = PRIO_DEFAULT;
 
-    irq_disable_scoped();
-
     /* Get a new thread id */
-    tid = thd_next_free();
+    tid = atomic_fetch_add(&tid_highest, 1);
 
     if(tid >= 0) {
         /* Create a new thread structure */
@@ -464,6 +455,9 @@ kthread_t *thd_create_ex(const kthread_attr_t *restrict attr,
 
             /* Initialize thread-local storage. */
             LIST_INIT(&nt->tls_list);
+
+            /* Now that the thread is created, add it into the lists */
+            irq_disable_scoped();
 
             /* Insert it into the thread list */
             LIST_INSERT_HEAD(&thd_list, nt, t_list);

--- a/kernel/thread/thread.c
+++ b/kernel/thread/thread.c
@@ -506,11 +506,12 @@ int thd_destroy(kthread_t *thd) {
 
     /* If this thread was waiting on something, we need to remove it from
        genwait so that it doesn't try to notify a dead thread later. */
-    if(thd->wait_obj)
+    if(thd->state == STATE_WAIT)
         genwait_wake_thd(thd->wait_obj, thd, ECANCELED);
 
     /* De-schedule the thread if it's scheduled. */
-    thd_remove_from_runnable(thd);
+    if(thd->flags & THD_QUEUED)
+        thd_remove_from_runnable(thd);
 
     /* Remove it from the thread list. */
     LIST_REMOVE(thd, t_list);
@@ -523,11 +524,8 @@ int thd_destroy(kthread_t *thd) {
     }
 
     /* Free TLS entries. */
-    i = LIST_FIRST(&thd->tls_list);
-    while(i != NULL) {
-        i2 = LIST_NEXT(i, kv_list);
+    LIST_FOREACH_SAFE(i, &thd->tls_list, kv_list, i2) {
         free(i);
-        i = i2;
     }
 
     /* Free its stack (if we're managing it). */


### PR DESCRIPTION
The majority of these changes have to do with removing code that was attempting to enforce strict ordering of the thread queue, which was required prior to #1296 when we switched to always scanning through the full run queue vs the old behavior of maintaining ordered by priority and only searching until a good thread was found to switch to.

Contains the following changes:
- Don't reschedule a mutex holder thread when priority boosting. This was necessary when the queue was strictly ordered, but now is not.
- When adding to runnable, only add to front or end, as the strict ordering does not apply anymore. Front and end is still required in order to maintain virtual 'priority groups' judged by their order in the queue as the scheduler takes the first it finds of a certain priority.
- Refactor of `thd_schedule()` based on the new queue structure. Rather than inserting the current thread before searching the queue, just check if the current thread should be chosen after searching the full queue.
- Clean up `thd_schedule()` to allow debug to be ignored when building with `NDEBUG`
- Update `thd_destroy()` to account for `thd_poll()`'s reuse of the `kthread::wait_obj`. Instead of testing for it existing, test the state to know if the thread is waiting on anything. Also use `FOREACH_SAFE` rather than inventing it from components.
- Drop dead function in genwait, update header to stop exposing documentation for internal function.
- Add static reent struct so that `errno` (and potentially other reent struct internals from newlib) can function correctly before/after threading is initialized/shutdown.
- Clean up usage of noreturn and unreachable, avoiding the use of `abort()` to signal unreachable paths.
- Use atomics to track `tid_highest` in order to shrink the irq disable required for `thd_create_ex()`
- Clean up `thd_create_ex()`: unnest its main body, make the initialization with custom/default attrs simpler, replace param error return with assert.

Marking as draft solely because these haven't been tested much and all have the possibility for significant negative impact. Wanted to get them public early though for others to review.