### PR TITLE
maple: read the devinfo response once when attaching

### DIFF
--- a/kernel/arch/dreamcast/hardware/maple/maple_driver.c
+++ b/kernel/arch/dreamcast/hardware/maple/maple_driver.c
@@ -69,18 +69,24 @@ int maple_driver_unreg(maple_driver_t *driver) {
 int maple_driver_attach(maple_frame_t *det) {
     maple_driver_t      *i;
     maple_response_t    *resp;
-    maple_devinfo_t     *devinfo;
+    maple_devinfo_t     devinfo;
     maple_device_t      *dev = maple_state.ports[det->dst_port].units[det->dst_unit];
     bool                dev_allocated = false;
 
     /* Resolve some pointers first */
     resp = (maple_response_t *)det->recv_buf;
-    devinfo = (maple_devinfo_t *)resp->data;
+
+    /* recv_buf is uncached: read the response once, the DMA may still be
+       filling it. A zero mask means the payload has not landed. */
+    devinfo = *(maple_devinfo_t *)resp->data;
+
+    if(!devinfo.functions)
+        return -1;
 
     /* Go through the list and look for a matching driver */
     LIST_FOREACH(i, &maple_state.driver_list, drv_list) {
         /* For now we just pick the first matching driver */
-        if(i->functions & devinfo->functions) {
+        if(i->functions & devinfo.functions) {
 
             /* Driver matches. Alloc a device if needed. */
             if(!dev) {
@@ -95,7 +101,7 @@ int maple_driver_attach(maple_frame_t *det) {
                 dev_allocated = true;
             }
 
-            memcpy(&dev->info, devinfo, sizeof(maple_devinfo_t));
+            dev->info = devinfo;
 
             /* Now lets allocate a new status buffer */
             if(i->status_size && !dev->status) {


### PR DESCRIPTION
So in Bloom, when I turn off the threaded compiler and load from a save state, I get no controller input at all.
Maple was attaching a device with functions `0` and marking it as valid, so the port looks taken and autodetect never retries it.
TL;DR: `recv_buf` gets read twice, and the DMA might not be done yet. So the function mask the driver matched against isn’t necessarily the same mask that ends up being stored.

this change in kos is what worked for me, but I dont know  maple that well so if anyone got a better solution that's all good and i'd be happy to test it. 

```
KallistiOS v2.3.0 [dreamcast/pristine]
  Git revision: 4fdde8b2-dirty
  Fri Sep 11 10:02:40 AM BST 2026
  bruce@bruce-HP-Z240-Tower-Workstation:/opt/toolchains/dc/kos
  sh-elf-gcc (GCC) 17.0.0 20260703 (experimental)
maple: active drivers:
    Dreameye (Camera): Camera
    Sound Input Peripheral: Microphone
    PuruPuru (Vibration) Pack: JumpPack
    VMU Driver: Clock, LCD, MemoryCard
    Mouse Driver: Mouse
    Keyboard Driver: Keyboard
    Controller Driver: Controller
    Lightgun: LightGun
vid_set_mode: 640x480 VGA with 1 framebuffers.
dc-load console support enabled
maple: attached devices:
  A0:                                (00000000: LightGun)

Found IDE partition 0
Mounted IDE partition 0 to /ide
maple: attached devices:
  A0:                                (00000000: LightGun)    <---- Problem
  A1: Visual Memory                  (0e000000: Clock, LCD, MemoryCard)
RAM mapped
Scratchpad / IO mapped
Parallel port mapped
BIOS mapped
Memory-map succeeded.

```

If you wanna recreate the conditions then I can probably help someone set up the right scenario with bloom. 

